### PR TITLE
Add Cohere Transcribe ONNX inference and Avalonia integration

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,3 +84,12 @@ Exports DeepFilterNet3 as three streaming ONNX models with explicit GRU hidden-s
 ## diarizen_export/
 
 Exports the DiariZen diarization pipeline: segmentation model, WeSpeaker embedding model, and LDA/PLDA transform parameters. See [diarizen_export/README.md](diarizen_export/README.md) for full documentation.
+
+---
+
+## cohere_export/
+
+Exports `CohereLabs/cohere-transcribe-03-2026` to the ONNX package used by Vernacula. See [cohere_export/README.md](cohere_export/README.md) for full documentation.
+
+- `export_cohere_transcribe_to_onnx.py` — exports the base Cohere encoder, mel frontend, config, tokenizer assets, and by default the KV-cache decoder pair
+- `requirements.txt` — export dependencies

--- a/scripts/cohere_export/README.md
+++ b/scripts/cohere_export/README.md
@@ -41,6 +41,7 @@ Useful options:
 
 - `--device cuda` to export on GPU
 - `--dtype float16` to reduce exported weight size
+- `--revision <commit-or-tag>` to pin Hugging Face remote code and weights
 - `--overwrite` to replace an existing export
 - `--skip-encoder`, `--skip-decoder`, or `--skip-mel` to rerun only part of the export
 - `--conventional-decoder` to export the older `decoder.onnx` path instead of `decoder_init.onnx` + `decoder_step.onnx`
@@ -76,3 +77,4 @@ This produces `decoder.onnx` instead of `decoder_init.onnx` and `decoder_step.on
 
 - The main exporter is the primary supported path today.
 - KV-cache export is now the default decoder mode.
+- If Hugging Face warns that remote-code files changed, rerun with `--revision <commit-hash>` to pin the exact model snapshot you want to trust.

--- a/scripts/cohere_export/README.md
+++ b/scripts/cohere_export/README.md
@@ -1,0 +1,78 @@
+# Cohere Transcribe Export
+
+Exports `CohereLabs/cohere-transcribe-03-2026` into the ONNX package consumed by Vernacula.
+
+This folder contains the export scripts only. Investigation and smoke-test scripts remain in the root `scripts/cohere_export` area for now.
+
+## Files
+
+- `export_cohere_transcribe_to_onnx.py` - exports the main Cohere package: `encoder.onnx`, `mel.onnx`, `config.json`, tokenizer assets, and by default the KV-cache decoder pair
+- `requirements.txt` - Python dependencies for the export environment
+
+## Environment
+
+Use Python `3.11` or `3.12`.
+
+The model is gated on Hugging Face, so log in before export:
+
+```bash
+huggingface-cli login
+```
+
+Install dependencies:
+
+```bash
+pip install -r public/scripts/cohere_export/requirements.txt
+```
+
+`onnxruntime-gpu` is listed by default. If you want a CPU-only environment, install `onnxruntime` instead.
+
+## Main Export
+
+Export the standard Cohere ONNX package. This now exports the KV-cache decoder path by default:
+
+```bash
+python public/scripts/cohere_export/export_cohere_transcribe_to_onnx.py \
+  --output-dir ./models/cohere_transcribe \
+  --opset 17
+```
+
+Useful options:
+
+- `--device cuda` to export on GPU
+- `--dtype float16` to reduce exported weight size
+- `--overwrite` to replace an existing export
+- `--skip-encoder`, `--skip-decoder`, or `--skip-mel` to rerun only part of the export
+- `--conventional-decoder` to export the older `decoder.onnx` path instead of `decoder_init.onnx` + `decoder_step.onnx`
+
+Outputs:
+
+- `encoder.onnx`
+- `mel.onnx`
+- `decoder_init.onnx`
+- `decoder_step.onnx`
+- `config.json`
+- `vocab.json`
+- `tokenizer.json`
+- `tokenizer.model`
+- `tokenizer_config.json`
+- `special_tokens_map.json`
+- `export-report.json`
+
+## Conventional Decoder Export
+
+If you want the older full-sequence decoder graph instead of the default KV-cache export:
+
+```bash
+python public/scripts/cohere_export/export_cohere_transcribe_to_onnx.py \
+  --output-dir ./models/cohere_transcribe \
+  --opset 17 \
+  --conventional-decoder
+```
+
+This produces `decoder.onnx` instead of `decoder_init.onnx` and `decoder_step.onnx`.
+
+## Notes
+
+- The main exporter is the primary supported path today.
+- KV-cache export is now the default decoder mode.

--- a/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
+++ b/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
@@ -77,6 +77,11 @@ def parse_args() -> argparse.Namespace:
         help="HuggingFace repo ID (default: CohereLabs/cohere-transcribe-03-2026).",
     )
     parser.add_argument(
+        "--revision",
+        default=None,
+        help="Optional Hugging Face revision or commit hash to pin remote code and weights.",
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
         required=True,
@@ -197,17 +202,23 @@ def ensure_output_dir(path: Path, overwrite: bool) -> None:
 # ---------------------------------------------------------------------------
 
 def load_model_and_processor(
-    repo_id: str, device: str, dtype: Any, torch: Any
+    repo_id: str, revision: str | None, device: str, dtype: Any, torch: Any
 ) -> tuple[Any, Any]:
     """Load CohereAsrForConditionalGeneration and its processor."""
     from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq
 
-    print(f"Loading processor from {repo_id} …")
-    processor = AutoProcessor.from_pretrained(repo_id, trust_remote_code=True)
+    revision_suffix = f" @ {revision}" if revision else ""
+    print(f"Loading processor from {repo_id}{revision_suffix} …")
+    processor = AutoProcessor.from_pretrained(
+        repo_id,
+        revision=revision,
+        trust_remote_code=True,
+    )
 
-    print(f"Loading model from {repo_id} onto {device} as {dtype} …")
+    print(f"Loading model from {repo_id}{revision_suffix} onto {device} as {dtype} …")
     model = AutoModelForSpeechSeq2Seq.from_pretrained(
         repo_id,
+        revision=revision,
         trust_remote_code=True,
         dtype=dtype,
         low_cpu_mem_usage=True,
@@ -243,14 +254,19 @@ def make_encoder_wrapper(torch: Any, model: Any, model_dtype: Any = None) -> Any
 
       2. ConvSubsampling.forward (line 170):
              if self._needs_conv_split(x): ...
-         _needs_conv_split checks whether the projected conv output would exceed 2^31
-         elements (a CUDA int32 indexing limit).  For practical batch sizes on modern
-         hardware this is always False.  The @_dynamo_disable decorator means the
-         function cannot be traced symbolically; with B=1 it always traces the non-split
-         branch.  At runtime with B>1 the graph still runs the non-split path, which is
-         correct as long as the projected numel stays under 2^31.
-         Fix: replace _needs_conv_split with a lambda that always returns False.
+             self._check_input_shape(x)
+         These helpers gate large-batch safety checks using Python conditionals. For
+         practical batch sizes on modern hardware the split path is never needed, and
+         tracing those checks bakes export-time constants into the graph.
+         Fix: replace _needs_conv_split with a lambda that always returns False and
+         _check_input_shape with a no-op during export.
          This is safe for batch sizes up to ~100 at typical segment lengths (see below).
+
+      3. RelPositionalEncoding._materialize_pe (line 200):
+             if hasattr(self, "pe") and self.pe.size(1) >= needed_size: ...
+         The cached positional-encoding reuse path converts tensor-dependent shape checks
+         into Python booleans during tracing.  Fix: rebuild the positional encoding
+         deterministically for each traced call instead of branching on the cached buffer.
 
     Safety note for _needs_conv_split=False:
         projected = B * conv_channels * out_T * out_F
@@ -306,9 +322,31 @@ def make_encoder_wrapper(torch: Any, model: Any, model_dtype: Any = None) -> Any
             layer.self_attn,
         )
 
-    # --- Patch 2: ConvSubsampling._needs_conv_split → always False ---
+    # --- Patch 2: ConvSubsampling export guards ---
     # Safe for all practical batch sizes; see docstring above.
-    encoder.pre_encode._needs_conv_split = lambda x: False
+    if hasattr(encoder.pre_encode, "_needs_conv_split"):
+        encoder.pre_encode._needs_conv_split = lambda x: False
+    if hasattr(encoder.pre_encode, "_check_input_shape"):
+        encoder.pre_encode._check_input_shape = lambda x: None
+
+    # --- Patch 3: RelPositionalEncoding._materialize_pe ---
+    # Rebuild the cached buffer unconditionally to avoid tracing Python boolean guards.
+    if hasattr(encoder, "pos_enc") and hasattr(encoder.pos_enc, "_materialize_pe"):
+        def _patched_materialize_pe(self_pos, length: int, device: Any, dtype: Any) -> None:
+            positions = torch.arange(
+                length - 1,
+                -length,
+                -1,
+                dtype=torch.float32,
+                device=device,
+            ).unsqueeze(1)
+            pe = self_pos._create_pe(positions=positions, dtype=dtype)
+            if hasattr(self_pos, "pe"):
+                self_pos.pe = pe
+            else:
+                self_pos.register_buffer("pe", pe, persistent=False)
+
+        encoder.pos_enc._materialize_pe = types.MethodType(_patched_materialize_pe, encoder.pos_enc)
 
     _dtype = model_dtype  # None or torch.float16
 
@@ -650,12 +688,15 @@ def _consolidate_external_data(onnx_path: Path) -> None:
     )
 
     # --- Delete the now-superseded scattered files ---
-    # Also sweep for stale Constant_* files left by previous partial or failed exports.
+    # Also sweep for stale exporter-emitted Constant_* files left by previous
+    # partial or failed exports. Torch may prefix these with node paths such as
+    # `_encoder_pos_enc_Constant_*`, so match any filename containing Constant.
     keep = {onnx_path.resolve(), data_path.resolve()}
     deleted = 0
     candidates = set(scattered)
-    for stale in onnx_path.parent.glob("Constant_*"):
-        candidates.add(stale.resolve())
+    for pattern in ("Constant_*", "*Constant*"):
+        for stale in onnx_path.parent.glob(pattern):
+            candidates.add(stale.resolve())
     for f in candidates:
         if f not in keep and f.exists() and f.is_file():
             f.unlink()
@@ -1535,6 +1576,7 @@ def update_config_with_kv_decoder(output_dir: Path) -> None:
 
 def export_tokenizer_assets(
     repo_id: str,
+    revision: str | None,
     processor: Any,
     output_dir: Path,
 ) -> None:
@@ -1563,6 +1605,7 @@ def export_tokenizer_assets(
     snapshot_dir = Path(
         snapshot_download(
             repo_id=repo_id,
+            revision=revision,
             allow_patterns=[
                 "tokenizer.json",
                 "tokenizer.model",
@@ -1622,7 +1665,7 @@ def main() -> None:
         args.skip_decoder = True
 
     # ---- Load model ---------------------------------------------------------
-    model, processor = load_model_and_processor(args.model_repo, device, dtype, torch)
+    model, processor = load_model_and_processor(args.model_repo, args.revision, device, dtype, torch)
 
     # ---- Build wrappers -----------------------------------------------------
     encoder_wrapper = make_encoder_wrapper(torch, model, model_dtype=dtype).to(device)
@@ -1704,7 +1747,7 @@ def main() -> None:
             print("\nSkipping KV-cache decoder export (--skip-decoder).")
 
     # ---- Config / report ----------------------------------------------------
-    export_tokenizer_assets(args.model_repo, processor, args.output_dir)
+    export_tokenizer_assets(args.model_repo, args.revision, processor, args.output_dir)
 
     config = extract_config(args.model_repo, model, processor, args.opset, args.dtype)
     write_export_report(
@@ -1719,6 +1762,7 @@ def main() -> None:
             "encoder.onnx: input_features [B,128,F] float32 → encoder_hidden_states [B,F/8,1280] float32.",
             "Default decoder export is KV-cache based: decoder_init.onnx + decoder_step.onnx.",
             "Pass --conventional-decoder to export decoder.onnx instead.",
+            "Pass --revision <commit-or-tag> to pin the Hugging Face remote code and model files.",
             "vocab.json is generated from the tokenizer ID mapping; tokenizer.json/model metadata are copied from the Hugging Face snapshot cache when available.",
             "The model is gated on HuggingFace; run `huggingface-cli login` before export.",
         ],

--- a/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
+++ b/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
@@ -1,0 +1,1734 @@
+#!/usr/bin/env python3
+"""
+Export CohereLabs/cohere-transcribe-03-2026 to ONNX format.
+
+Exports the Cohere ONNX package and a metadata file:
+
+  encoder.onnx
+      input_features  [batch, n_mels, time_frames]  float32
+      -> encoder_hidden_states  [batch, enc_seq_len, d_model]  float32
+
+  decoder_init.onnx / decoder_step.onnx   (default KV-cache decoder)
+      First token uses decoder_init.onnx, then subsequent tokens use
+      decoder_step.onnx with carried KV tensors for O(n) generation.
+
+  decoder.onnx   (optional conventional decoder)
+      decoder_input_ids      [batch, dec_seq_len]   int64
+      encoder_hidden_states  [batch, enc_seq_len, d_model]  float32
+      -> logits              [batch, dec_seq_len, vocab_size]  float32
+
+  config.json
+      Feature extractor parameters, special token IDs, vocabulary size, etc.
+      Everything the C# inference layer needs to reconstruct mel features
+      and run greedy/beam decoding.
+
+Decoder strategy
+----------------
+KV-cache export is the default. The main exporter writes decoder_init.onnx
+and decoder_step.onnx in the same pass as mel/encoder export, then patches
+config.json with the KV metadata needed by downstream runtimes.
+
+For compatibility or debugging, pass --conventional-decoder to export the
+older decoder.onnx graph instead. That path performs full-sequence decode
+at every step and is O(n²) in sequence length.
+
+Usage
+-----
+    # Requires a HuggingFace account with access to the gated model.
+    huggingface-cli login
+
+    python public/scripts/cohere_export/export_cohere_transcribe_to_onnx.py \\
+        --output-dir ./models/cohere_transcribe \\
+        --opset 17
+
+    # Export on GPU:
+    python public/scripts/cohere_export/export_cohere_transcribe_to_onnx.py \\
+        --output-dir ./models/cohere_transcribe \\
+        --device cuda
+
+Dependencies
+------------
+    pip install torch transformers accelerate onnx onnxruntime huggingface_hub
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export CohereLabs/cohere-transcribe-03-2026 to ONNX with KV-cache decoder by default."
+        )
+    )
+    parser.add_argument(
+        "--model-repo",
+        default="CohereLabs/cohere-transcribe-03-2026",
+        help="HuggingFace repo ID (default: CohereLabs/cohere-transcribe-03-2026).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory that will receive encoder/mel ONNX files, decoder export(s), config.json, and tokenizer assets.",
+    )
+    parser.add_argument(
+        "--opset",
+        type=int,
+        default=17,
+        help="ONNX opset version (default: 17).",
+    )
+    parser.add_argument(
+        "--device",
+        choices=("auto", "cpu", "cuda"),
+        default="auto",
+        help="Device for model loading and export (default: auto).",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=("float32", "float16"),
+        default="float32",
+        help=(
+            "Torch dtype for model weights (default: float32).  "
+            "float16 halves the checkpoint size but some ONNX runtimes "
+            "require fp32 inputs regardless."
+        ),
+    )
+    parser.add_argument(
+        "--dummy-seconds",
+        type=float,
+        default=5.0,
+        help="Dummy audio length in seconds used to produce export dummy inputs (default: 5.0).",
+    )
+    parser.add_argument(
+        "--skip-encoder",
+        action="store_true",
+        help="Skip encoder.onnx export (useful if it already exists).",
+    )
+    parser.add_argument(
+        "--skip-decoder",
+        action="store_true",
+        help="Skip decoder export for the selected mode.",
+    )
+    parser.add_argument(
+        "--conventional-decoder",
+        action="store_true",
+        help="Export conventional decoder.onnx instead of the default KV-cache decoder pair.",
+    )
+    parser.add_argument(
+        "--skip-mel",
+        action="store_true",
+        help="Skip mel.onnx export.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing files in the output directory.",
+    )
+    return parser.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Device / dtype helpers
+# ---------------------------------------------------------------------------
+
+def resolve_device(torch: Any, requested: str) -> str:
+    if requested == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if requested == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("CUDA was requested but torch.cuda.is_available() is False.")
+    return requested
+
+
+def resolve_dtype(torch: Any, name: str) -> Any:
+    return torch.float16 if name == "float16" else torch.float32
+
+
+NUM_LAYERS = 8
+NUM_HEADS = 8
+HEAD_DIM = 128
+ENC_DIM = 1280
+
+
+# ---------------------------------------------------------------------------
+# Output directory guard
+# ---------------------------------------------------------------------------
+
+_EXPORT_FILES = (
+    "encoder.onnx",
+    "decoder.onnx",
+    "decoder_init.onnx",
+    "decoder_step.onnx",
+    "mel.onnx",
+    "config.json",
+    "vocab.json",
+    "tokenizer.json",
+    "tokenizer.model",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "export-report.json",
+)
+
+
+def ensure_output_dir(path: Path, overwrite: bool) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if not overwrite:
+        collisions = [name for name in _EXPORT_FILES if (path / name).exists()]
+        if collisions:
+            raise SystemExit(
+                "Output directory already contains export targets. "
+                "Re-run with --overwrite to replace them.\n"
+                f"Existing files: {', '.join(collisions)}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+def load_model_and_processor(
+    repo_id: str, device: str, dtype: Any, torch: Any
+) -> tuple[Any, Any]:
+    """Load CohereAsrForConditionalGeneration and its processor."""
+    from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq
+
+    print(f"Loading processor from {repo_id} …")
+    processor = AutoProcessor.from_pretrained(repo_id, trust_remote_code=True)
+
+    print(f"Loading model from {repo_id} onto {device} as {dtype} …")
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(
+        repo_id,
+        trust_remote_code=True,
+        dtype=dtype,
+        low_cpu_mem_usage=True,
+    )
+    model.to(device)
+    model.eval()
+
+    param_count = sum(p.numel() for p in model.parameters())
+    print(f"  Loaded {param_count:,} parameters ({param_count / 1e9:.2f}B)")
+
+    return model, processor
+
+
+# ---------------------------------------------------------------------------
+# Wrapper modules
+# ---------------------------------------------------------------------------
+
+def make_encoder_wrapper(torch: Any, model: Any, model_dtype: Any = None) -> Any:
+    """
+    Patched nn.Module wrapper that produces a batch-dynamic encoder.onnx.
+
+        input_features [batch, n_mels, time_frames] -> encoder_hidden_states [batch, T_enc, encoder_d_model]
+
+    The Cohere Conformer contains two data-dependent branches that get baked as
+    constants during TorchScript tracing, locking the graph to the dummy batch size:
+
+      1. RelPositionMultiHeadAttention.forward (line 310):
+             if pos_emb.size(0) == 1 and batch_size > 1: pos_emb = pos_emb.expand(...)
+         With B=1 dummy this traces as False and the expand is omitted.  At runtime
+         with B>1 the un-expanded pos_emb [1, 2T-1, D] is passed to linear_pos which
+         tries view(batch_size, -1, h, d_k) → wrong shape.
+         Fix: monkey-patch forward to always expand pos_emb unconditionally.
+
+      2. ConvSubsampling.forward (line 170):
+             if self._needs_conv_split(x): ...
+         _needs_conv_split checks whether the projected conv output would exceed 2^31
+         elements (a CUDA int32 indexing limit).  For practical batch sizes on modern
+         hardware this is always False.  The @_dynamo_disable decorator means the
+         function cannot be traced symbolically; with B=1 it always traces the non-split
+         branch.  At runtime with B>1 the graph still runs the non-split path, which is
+         correct as long as the projected numel stays under 2^31.
+         Fix: replace _needs_conv_split with a lambda that always returns False.
+         This is safe for batch sizes up to ~100 at typical segment lengths (see below).
+
+    Safety note for _needs_conv_split=False:
+        projected = B * conv_channels * out_T * out_F
+        conv_channels = 256 (from model config)
+        For 30s audio at 8x downsampling: out_T ≈ 376, out_F ≈ 32
+        projected(B=16) = 16 * 256 * 376 * 32 ≈ 49M  <<  2^31 = 2.1B   ✅
+        projected(B=64) = 64 * 256 * 376 * 32 ≈ 196M  <<  2^31          ✅
+    For all realistic inference batch sizes the guard is never triggered.
+
+    encoder_decoder_proj is NOT applied — the encoder ONNX output is raw d_model=1280,
+    not the projected decoder d_model (1024).
+    """
+    nn = torch.nn
+
+    # --- Patch 1: RelPositionMultiHeadAttention.forward ---
+    # Always expand pos_emb to batch_size, removing the data-dependent branch.
+    def _patched_rel_pos_attn_forward(self_attn, x, pos_emb, mask=None):
+        batch_size = x.size(0)
+        q = self_attn.linear_q(x).view(batch_size, -1, self_attn.h, self_attn.d_k).transpose(1, 2)
+        k = self_attn.linear_k(x).view(batch_size, -1, self_attn.h, self_attn.d_k).transpose(1, 2)
+        v = self_attn.linear_v(x).view(batch_size, -1, self_attn.h, self_attn.d_k).transpose(1, 2)
+        # Always expand — removes the `if pos_emb.size(0) == 1 and batch_size > 1` branch.
+        pos_emb = pos_emb.expand(batch_size, -1, -1)
+        p = self_attn.linear_pos(pos_emb).view(batch_size, -1, self_attn.h, self_attn.d_k).transpose(1, 2)
+        q_with_u = q + self_attn.pos_bias_u.unsqueeze(0).unsqueeze(2)
+        q_with_v = q + self_attn.pos_bias_v.unsqueeze(0).unsqueeze(2)
+        matrix_ac = torch.matmul(q_with_u, k.transpose(-1, -2))
+        matrix_bd = torch.matmul(q_with_v, p.transpose(-1, -2))
+        matrix_bd = self_attn.rel_shift(matrix_bd)
+        matrix_bd = matrix_bd[:, :, :, :matrix_ac.size(-1)]
+        scores = (matrix_ac + matrix_bd) * self_attn.scaling
+        if mask is not None:
+            expanded_mask = mask.unsqueeze(1)
+            # Use -1e4 instead of -1e9: fp16 max is ~65504, so -1e9 overflows.
+            # -1e4 is sufficient to drive softmax to zero after exponentiation.
+            fill_val = -1e4 if scores.dtype == torch.float16 else -1e9
+            scores = scores.masked_fill(expanded_mask, fill_val)
+        attn = torch.softmax(scores, dim=-1)
+        if mask is not None:
+            attn = attn.masked_fill(expanded_mask, 0.0)
+        x = torch.matmul(self_attn.dropout(attn), v)
+        x = x.transpose(1, 2).contiguous().view(batch_size, -1, self_attn.h * self_attn.d_k)
+        return self_attn.linear_out(x)
+
+    import types
+    encoder = model.encoder
+
+    # Apply patch to every ConformerLayer's self_attn
+    for layer in encoder.layers:
+        layer.self_attn.forward = types.MethodType(
+            lambda self, x, pos_emb, mask=None, _fn=_patched_rel_pos_attn_forward:
+                _fn(self, x, pos_emb, mask),
+            layer.self_attn,
+        )
+
+    # --- Patch 2: ConvSubsampling._needs_conv_split → always False ---
+    # Safe for all practical batch sizes; see docstring above.
+    encoder.pre_encode._needs_conv_split = lambda x: False
+
+    _dtype = model_dtype  # None or torch.float16
+
+    class EncoderWrapper(nn.Module):
+        def __init__(self, enc: nn.Module) -> None:
+            super().__init__()
+            self.encoder = enc
+
+        def forward(self, input_features: Any, input_lengths: Any) -> Any:
+            # input_lengths: int64 [B] — actual mel-frame count per batch item.
+            # The ConformerEncoder uses this to compute a padding mask so that
+            # self-attention does not attend to zero-padded positions beyond each
+            # segment's true length.  This eliminates cross-contamination when
+            # multiple segments of different lengths are batched together.
+            #
+            # When exporting fp16: cast float32 graph input → fp16 at the boundary,
+            # run the Conformer in fp16, then cast hidden_states back to float32 so
+            # C# can read the output without changes.  When _dtype is None/float32
+            # these are no-ops and the graph stays fully float32.
+            if _dtype is not None and _dtype != torch.float32:
+                input_features = input_features.to(_dtype)
+            hidden_states, _lengths = self.encoder(input_features, length=input_lengths)
+            if _dtype is not None and _dtype != torch.float32:
+                hidden_states = hidden_states.float()
+            return hidden_states
+
+    return EncoderWrapper(encoder)
+
+
+def make_decoder_wrapper(torch: Any, model: Any) -> Any:
+    """
+    Wrapper that runs a full decoder forward pass (no KV cache) via the top-level model.
+
+        decoder_input_ids      [batch, dec_seq_len]          int64
+        encoder_hidden_states  [batch, enc_seq_len, d_model]  float32
+        -> logits              [batch, dec_seq_len, vocab]    float32
+
+    We call model.forward() with encoder_outputs=encoder_hidden_states (plain tensor is
+    accepted), which lets the model build the causal mask and compute positions internally.
+    Returning only logits keeps the output shape simple for ONNX export.
+    """
+    nn = torch.nn
+
+    from transformers.modeling_outputs import BaseModelOutput
+
+    class DecoderWrapper(nn.Module):
+        def __init__(self, full_model: nn.Module) -> None:
+            super().__init__()
+            self.full_model = full_model
+
+        def forward(self, decoder_input_ids: Any, encoder_hidden_states: Any) -> Any:
+            # model.forward() accesses encoder_outputs.last_hidden_state unconditionally
+            # at return time, so wrap in BaseModelOutput rather than passing a plain tensor.
+            encoder_outputs = BaseModelOutput(last_hidden_state=encoder_hidden_states)
+            out = self.full_model(
+                decoder_input_ids=decoder_input_ids,
+                encoder_outputs=encoder_outputs,
+            )
+            return out.logits
+
+    return DecoderWrapper(model)
+
+
+def make_kv_init_wrapper(torch: Any, model: Any, model_dtype: Any) -> Any:
+    """Decoder-init wrapper: context tokens + encoder states -> logits + all KV."""
+    F = torch.nn.functional
+    _dtype = model_dtype
+
+    class DecoderInitWrapper(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embedding = model.transf_decoder._embedding
+            self.layers = model.transf_decoder._decoder.layers
+            self.final_norm = model.transf_decoder._decoder.final_layer_norm
+            self.proj = model.encoder_decoder_proj
+            self.lm_head = model.log_softmax
+
+        def forward(self, decoder_input_ids: Any, encoder_hidden_states: Any) -> tuple:
+            if _dtype != torch.float32:
+                encoder_hidden_states = encoder_hidden_states.to(_dtype)
+
+            enc = self.proj(encoder_hidden_states) if self.proj is not None else encoder_hidden_states
+            batch, seq = decoder_input_ids.shape
+            positions = torch.arange(seq, device=decoder_input_ids.device).unsqueeze(0).expand(batch, -1)
+            hidden = self.embedding(decoder_input_ids, positions)
+
+            self_keys: list = []
+            self_vals: list = []
+            cross_keys: list = []
+            cross_vals: list = []
+
+            for layer in self.layers:
+                residual = hidden
+                h = layer.layer_norm_1(hidden)
+                sa = layer.first_sub_layer
+                q = sa._reshape(sa.query_net(h))
+                sk = sa._reshape(sa.key_net(h))
+                sv = sa._reshape(sa.value_net(h))
+                ao = F.scaled_dot_product_attention(q, sk, sv, attn_mask=None, dropout_p=0.0, scale=sa.scale)
+                ao = sa.out_projection(ao.transpose(1, 2).contiguous().view(batch, seq, sa.hidden_size))
+                hidden = residual + ao
+                self_keys.append(sk)
+                self_vals.append(sv)
+
+                residual = hidden
+                h = layer.layer_norm_2(hidden)
+                ca = layer.second_sub_layer
+                cq = ca._reshape(ca.query_net(h))
+                ck = ca._reshape(ca.key_net(enc))
+                cv = ca._reshape(ca.value_net(enc))
+                ao = F.scaled_dot_product_attention(cq, ck, cv, attn_mask=None, dropout_p=0.0, scale=ca.scale)
+                ao = ca.out_projection(ao.transpose(1, 2).contiguous().view(batch, seq, ca.hidden_size))
+                hidden = residual + ao
+                cross_keys.append(ck)
+                cross_vals.append(cv)
+
+                residual = hidden
+                h = layer.layer_norm_3(hidden)
+                hidden = residual + layer.third_sub_layer(h)
+
+            hidden = self.final_norm(hidden)
+            logits = self.lm_head(hidden)
+            if _dtype != torch.float32:
+                logits = logits.float()
+
+            return (logits, *self_keys, *self_vals, *cross_keys, *cross_vals)
+
+    return DecoderInitWrapper()
+
+
+def make_kv_step_wrapper(torch: Any, model: Any, model_dtype: Any) -> Any:
+    """Decoder-step wrapper: next token + past KV + fixed cross KV -> next logits + updated self KV."""
+    F = torch.nn.functional
+    _dtype = model_dtype
+
+    class DecoderStepWrapper(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embedding = model.transf_decoder._embedding
+            self.layers = model.transf_decoder._decoder.layers
+            self.final_norm = model.transf_decoder._decoder.final_layer_norm
+            self.lm_head = model.log_softmax
+
+        def forward(
+            self,
+            decoder_input_ids: Any,
+            positions: Any,
+            sk0: Any, sk1: Any, sk2: Any, sk3: Any, sk4: Any, sk5: Any, sk6: Any, sk7: Any,
+            sv0: Any, sv1: Any, sv2: Any, sv3: Any, sv4: Any, sv5: Any, sv6: Any, sv7: Any,
+            ck0: Any, ck1: Any, ck2: Any, ck3: Any, ck4: Any, ck5: Any, ck6: Any, ck7: Any,
+            cv0: Any, cv1: Any, cv2: Any, cv3: Any, cv4: Any, cv5: Any, cv6: Any, cv7: Any,
+        ) -> tuple:
+            past_sk = [sk0, sk1, sk2, sk3, sk4, sk5, sk6, sk7]
+            past_sv = [sv0, sv1, sv2, sv3, sv4, sv5, sv6, sv7]
+            cross_k = [ck0, ck1, ck2, ck3, ck4, ck5, ck6, ck7]
+            cross_v = [cv0, cv1, cv2, cv3, cv4, cv5, cv6, cv7]
+
+            batch, seq = decoder_input_ids.shape
+            hidden = self.embedding(decoder_input_ids, positions)
+
+            new_sk: list = []
+            new_sv: list = []
+
+            for i, layer in enumerate(self.layers):
+                residual = hidden
+                h = layer.layer_norm_1(hidden)
+                sa = layer.first_sub_layer
+                q = sa._reshape(sa.query_net(h))
+                sk_new = sa._reshape(sa.key_net(h))
+                sv_new = sa._reshape(sa.value_net(h))
+                k = torch.cat([past_sk[i], sk_new], dim=2)
+                v = torch.cat([past_sv[i], sv_new], dim=2)
+                ao = F.scaled_dot_product_attention(q, k, v, attn_mask=None, dropout_p=0.0, scale=sa.scale)
+                ao = sa.out_projection(ao.transpose(1, 2).contiguous().view(batch, seq, sa.hidden_size))
+                hidden = residual + ao
+                new_sk.append(k)
+                new_sv.append(v)
+
+                residual = hidden
+                h = layer.layer_norm_2(hidden)
+                ca = layer.second_sub_layer
+                cq = ca._reshape(ca.query_net(h))
+                ao = F.scaled_dot_product_attention(cq, cross_k[i], cross_v[i], attn_mask=None, dropout_p=0.0, scale=ca.scale)
+                ao = ca.out_projection(ao.transpose(1, 2).contiguous().view(batch, seq, ca.hidden_size))
+                hidden = residual + ao
+
+                residual = hidden
+                h = layer.layer_norm_3(hidden)
+                hidden = residual + layer.third_sub_layer(h)
+
+            hidden = self.final_norm(hidden)
+            logits = self.lm_head(hidden)
+            if _dtype != torch.float32:
+                logits = logits.float()
+
+            return (logits, *new_sk, *new_sv)
+
+    return DecoderStepWrapper()
+
+
+# ---------------------------------------------------------------------------
+# Dummy inputs
+# ---------------------------------------------------------------------------
+
+def make_encoder_dummy_inputs(
+    torch: Any,
+    processor: Any,
+    device: str,
+    dtype: Any,
+    dummy_seconds: float,
+) -> tuple:
+    """Return (input_features, input_lengths) dummy tensors for the encoder.
+
+    Uses B=2 where item 0 is full-length and item 1 is half-length (zero-padded).
+    This forces the attention-mask branch to be traced into the ONNX graph so
+    the exported model correctly handles batches with mixed-length segments.
+    """
+    import numpy as np
+
+    sample_rate = processor.feature_extractor.sampling_rate
+    num_samples = int(sample_rate * dummy_seconds)
+
+    # Item 0: full-length audio.  Item 1: half-length (the rest will be padded zeros).
+    audio_full = np.zeros(num_samples, dtype=np.float32)
+    audio_half = np.zeros(num_samples // 2, dtype=np.float32)
+
+    inputs_full = processor(
+        audio_full,
+        sampling_rate=sample_rate,
+        return_tensors="pt",
+        language="en",
+    )
+    inputs_half = processor(
+        audio_half,
+        sampling_rate=sample_rate,
+        return_tensors="pt",
+        language="en",
+    )
+
+    # Dummy input is always float32 — the wrapper casts internally for fp16 exports
+    # so the ONNX graph I/O stays float32 and C# code requires no changes.
+    feat_full = inputs_full["input_features"].to(device=device, dtype=torch.float32)  # [1, mels, T]
+    feat_half = inputs_half["input_features"].to(device=device, dtype=torch.float32)  # [1, mels, T//2]
+
+    T_full = feat_full.shape[2]
+    T_half = feat_half.shape[2]
+
+    # Pad feat_half to T_full along the time axis so we can stack into a batch.
+    pad_len = T_full - T_half
+    if pad_len > 0:
+        feat_half = torch.nn.functional.pad(feat_half, (0, pad_len))
+
+    # Stack into [2, mels, T_full]
+    features = torch.cat([feat_full, feat_half], dim=0)
+    # lengths: actual mel-frame count for each item (int64)
+    lengths = torch.tensor([T_full, T_half], dtype=torch.int64, device=device)
+
+    print(f"  Encoder dummy input shape: {tuple(features.shape)}  lengths: {lengths.tolist()}")
+    return features, lengths
+
+
+def make_decoder_dummy_inputs(
+    torch: Any,
+    model: Any,
+    encoder_hidden_states: Any,
+    device: str,
+) -> tuple[Any, Any]:
+    """Return (decoder_input_ids, encoder_hidden_states) for a minimal decode step."""
+    # Token IDs live in generation_config for this model, not model.config.
+    gen_cfg = getattr(model, "generation_config", None)
+    bos_id = None
+    for attr in ("decoder_start_token_id", "bos_token_id"):
+        bos_id = getattr(gen_cfg, attr, None) if gen_cfg is not None else None
+        if bos_id is not None:
+            break
+        bos_id = getattr(model.config, attr, None)
+        if bos_id is not None:
+            break
+    if bos_id is None:
+        raise RuntimeError(
+            "Could not determine decoder start token ID from model.generation_config "
+            "or model.config. Pass --bos-token-id explicitly."
+        )
+
+    # Shape: (batch=1, seq_len=1)
+    decoder_input_ids = torch.tensor([[bos_id]], dtype=torch.long, device=device)
+    print(f"  Decoder dummy decoder_input_ids shape: {tuple(decoder_input_ids.shape)}")
+    print(f"  Decoder dummy encoder_hidden_states shape: {tuple(encoder_hidden_states.shape)}")
+    return decoder_input_ids, encoder_hidden_states
+
+
+# ---------------------------------------------------------------------------
+# ONNX external-data consolidation
+# ---------------------------------------------------------------------------
+
+def _consolidate_external_data(onnx_path: Path) -> None:
+    """
+    The legacy TorchScript exporter scatters weights into many individual files
+    alongside the .onnx.  This function:
+      1. Collects the scattered file paths from the model's external-data references.
+      2. Loads the model with all weights into memory.
+      3. Re-saves as a single <name>.onnx.data file.
+      4. Deletes every scattered file that is no longer needed.
+    """
+    import onnx
+
+    data_file = onnx_path.name + ".data"
+    data_path = onnx_path.parent / data_file
+
+    # --- Collect the scattered file paths before overwriting ---
+    # Load without data so we can read the location strings cheaply.
+    proto = onnx.load(str(onnx_path), load_external_data=False)
+    scattered: set[Path] = set()
+    for init in proto.graph.initializer:
+        if init.data_location == onnx.TensorProto.EXTERNAL:
+            for entry in init.external_data:
+                if entry.key == "location":
+                    candidate = (onnx_path.parent / entry.value).resolve()
+                    # Skip the target data file itself in case it already exists.
+                    if candidate != data_path.resolve():
+                        scattered.add(candidate)
+
+    # --- Delete any pre-existing data file before writing the new one ---
+    # onnx.save_model opens the data file in append mode, so without this
+    # every re-export would grow the file by one model's worth of weights.
+    if data_path.exists():
+        data_path.unlink()
+
+    # --- Load with weights, save consolidated ---
+    print(f"  Consolidating external data → {data_file} …")
+    model = onnx.load(str(onnx_path), load_external_data=True)
+    onnx.save_model(
+        model,
+        str(onnx_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=data_file,
+        size_threshold=1024,
+    )
+
+    # --- Delete the now-superseded scattered files ---
+    # Also sweep for stale Constant_* files left by previous partial or failed exports.
+    keep = {onnx_path.resolve(), data_path.resolve()}
+    deleted = 0
+    candidates = set(scattered)
+    for stale in onnx_path.parent.glob("Constant_*"):
+        candidates.add(stale.resolve())
+    for f in candidates:
+        if f not in keep and f.exists() and f.is_file():
+            f.unlink()
+            deleted += 1
+    if deleted:
+        print(f"  Removed {deleted} scattered weight file(s).")
+
+    total_mb = (onnx_path.stat().st_size + (data_path.stat().st_size if data_path.exists() else 0)) / 1024 / 1024
+    print(f"  Saved {onnx_path.name} ({onnx_path.stat().st_size / 1024:.0f} KB graph) + "
+          f"{data_file} ({data_path.stat().st_size / 1024 / 1024:.1f} MB weights)  "
+          f"[total {total_mb:.1f} MB]")
+
+
+# ---------------------------------------------------------------------------
+# ONNX export helpers
+# ---------------------------------------------------------------------------
+
+def export_encoder(
+    torch: Any,
+    wrapper: Any,
+    dummy_features: Any,
+    dummy_lengths: Any,
+    output_path: Path,
+    opset: int,
+) -> None:
+    print(f"\nExporting encoder to {output_path} …")
+
+    with torch.no_grad():
+        test_out = wrapper(dummy_features, dummy_lengths)
+    print(f"  PyTorch encoder output shape: {tuple(test_out.shape)}")
+
+    # Legacy TorchScript tracing (dynamo=False) with patched EncoderWrapper.
+    # The data-dependent branches have been removed in make_encoder_wrapper(), so
+    # dynamic_axes correctly covers both batch and time.
+    # IMPORTANT: do_constant_folding=False — with constant folding enabled, the
+    # tracer materialises pos_emb.expand() into each of the 48 attention layers
+    # separately (since the B=1 dummy makes expand a no-op that looks foldable),
+    # duplicating the PE tensor 48× and inflating the weight file by ~7 GB.
+    # Without folding the PE buffer stays as a shared graph reference, keeping
+    # the export size close to the raw model weight size.
+    #
+    # input_lengths [B] int64: actual mel-frame count per item.  The Conformer
+    # encoder uses this to compute a padding mask so that self-attention does not
+    # attend to zero-padded positions, preventing cross-contamination when items
+    # of different lengths are batched together.
+    torch.onnx.export(
+        wrapper,
+        (dummy_features, dummy_lengths),
+        str(output_path),
+        input_names=["input_features", "input_lengths"],
+        output_names=["encoder_hidden_states"],
+        dynamic_axes={
+            "input_features":        {0: "batch", 2: "time_frames"},
+            "input_lengths":         {0: "batch"},
+            "encoder_hidden_states": {0: "batch", 1: "enc_seq_len"},
+        },
+        opset_version=opset,
+        do_constant_folding=False,
+        dynamo=False,
+    )
+    _consolidate_external_data(output_path)
+
+
+def export_decoder(
+    torch: Any,
+    wrapper: Any,
+    decoder_input_ids: Any,
+    encoder_hidden_states: Any,
+    output_path: Path,
+    opset: int,
+) -> None:
+    print(f"\nExporting decoder to {output_path} …")
+
+    with torch.no_grad():
+        test_out = wrapper(decoder_input_ids, encoder_hidden_states)
+    print(f"  PyTorch decoder output shape: {tuple(test_out.shape)}")
+
+    torch.onnx.export(
+        wrapper,
+        (decoder_input_ids, encoder_hidden_states),
+        str(output_path),
+        input_names=["decoder_input_ids", "encoder_hidden_states"],
+        output_names=["logits"],
+        dynamic_axes={
+            "decoder_input_ids": {0: "batch", 1: "dec_seq_len"},
+            "encoder_hidden_states": {0: "batch", 1: "enc_seq_len"},
+            "logits": {0: "batch", 1: "dec_seq_len"},
+        },
+        opset_version=opset,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    _consolidate_external_data(output_path)
+
+
+# ---------------------------------------------------------------------------
+# ONNX validation
+# ---------------------------------------------------------------------------
+
+def validate_onnx(onnx: Any, path: Path, label: str) -> None:
+    print(f"\nValidating {label} ONNX model …")
+    # Pass the file path as a string so the checker resolves external data
+    # relative to the file's directory.  Loading into memory first loses the
+    # base-directory context and breaks serialization for large models.
+    onnx.checker.check_model(str(path))
+    print(f"  onnx.checker passed for {path.name}")
+
+
+def _kv_names(prefix: str, n: int = NUM_LAYERS) -> list[str]:
+    return [f"{prefix}_{i}" for i in range(n)]
+
+
+def export_kv_init(
+    torch: Any,
+    wrapper: Any,
+    output_dir: Path,
+    opset: int,
+    device: str,
+    enc_t: int = 80,
+) -> None:
+    out_path = output_dir / "decoder_init.onnx"
+    print(f"\nExporting decoder_init to {out_path} …")
+
+    bos = torch.tensor([[13764]], dtype=torch.long, device=device)
+    enc_h = torch.randn(1, enc_t, ENC_DIM, device=device, dtype=torch.float32)
+
+    with torch.no_grad():
+        out = wrapper(bos, enc_h)
+    print(
+        f"  PyTorch output shapes: logits={tuple(out[0].shape)}, "
+        f"sk0={tuple(out[1].shape)}, ck0={tuple(out[1 + 2 * NUM_LAYERS].shape)}"
+    )
+
+    input_names = ["decoder_input_ids", "encoder_hidden_states"]
+    output_names = (
+        ["logits"]
+        + _kv_names("self_key")
+        + _kv_names("self_val")
+        + _kv_names("cross_key")
+        + _kv_names("cross_val")
+    )
+
+    dynamic_axes: dict[str, dict[int, str]] = {
+        "decoder_input_ids": {0: "batch", 1: "init_seq_len"},
+        "encoder_hidden_states": {0: "batch", 1: "enc_seq_len"},
+        "logits": {0: "batch", 1: "init_seq_len"},
+    }
+    for name in _kv_names("self_key") + _kv_names("self_val"):
+        dynamic_axes[name] = {0: "batch", 2: "init_seq_len"}
+    for name in _kv_names("cross_key") + _kv_names("cross_val"):
+        dynamic_axes[name] = {0: "batch", 2: "enc_seq_len"}
+
+    torch.onnx.export(
+        wrapper,
+        (bos, enc_h),
+        str(out_path),
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+        opset_version=opset,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    _consolidate_external_data(out_path)
+
+
+def export_kv_step(
+    torch: Any,
+    wrapper: Any,
+    output_dir: Path,
+    opset: int,
+    device: str,
+    past_len: int = 1,
+    enc_t: int = 80,
+) -> None:
+    out_path = output_dir / "decoder_step.onnx"
+    print(f"\nExporting decoder_step to {out_path} …")
+
+    kv_dtype = next(wrapper.parameters()).dtype
+    tok = torch.tensor([[42]], dtype=torch.long, device=device)
+    positions = torch.tensor([[past_len]], dtype=torch.long, device=device)
+    dummy_sk = [torch.randn(1, NUM_HEADS, past_len, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    dummy_sv = [torch.randn(1, NUM_HEADS, past_len, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    dummy_ck = [torch.randn(1, NUM_HEADS, enc_t, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    dummy_cv = [torch.randn(1, NUM_HEADS, enc_t, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    dummy_inputs = (tok, positions, *dummy_sk, *dummy_sv, *dummy_ck, *dummy_cv)
+
+    with torch.no_grad():
+        out = wrapper(*dummy_inputs)
+    print(f"  PyTorch output shapes: logits={tuple(out[0].shape)}, sk0={tuple(out[1].shape)}")
+
+    input_names = (
+        ["decoder_input_ids", "positions"]
+        + _kv_names("self_key")
+        + _kv_names("self_val")
+        + _kv_names("cross_key")
+        + _kv_names("cross_val")
+    )
+    output_names = ["logits"] + _kv_names("new_self_key") + _kv_names("new_self_val")
+
+    dynamic_axes: dict[str, dict[int, str]] = {
+        "decoder_input_ids": {0: "batch"},
+        "positions": {0: "batch"},
+        "logits": {0: "batch"},
+    }
+    for name in _kv_names("self_key") + _kv_names("self_val"):
+        dynamic_axes[name] = {0: "batch", 2: "kv_seq_len"}
+    for name in _kv_names("new_self_key") + _kv_names("new_self_val"):
+        dynamic_axes[name] = {0: "batch", 2: "kv_seq_len_plus_1"}
+    for name in _kv_names("cross_key") + _kv_names("cross_val"):
+        dynamic_axes[name] = {0: "batch", 2: "enc_seq_len"}
+
+    torch.onnx.export(
+        wrapper,
+        dummy_inputs,
+        str(out_path),
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+        opset_version=opset,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    _consolidate_external_data(out_path)
+
+
+def parity_check_encoder(
+    ort: Any,
+    torch: Any,
+    encoder_wrapper: Any,
+    dummy_features: Any,
+    dummy_lengths: Any,
+    onnx_path: Path,
+) -> None:
+    import numpy as np
+    print("\nEncoder parity check (PyTorch vs ONNX Runtime) …")
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+
+    # B=2 parity (dummy already has B=2 with one padded item)
+    feat_np = dummy_features.float().cpu().numpy()
+    lens_np = dummy_lengths.cpu().numpy()
+    ort_out = session.run(None, {"input_features": feat_np, "input_lengths": lens_np})[0]
+    with torch.no_grad():
+        pt_out = encoder_wrapper(dummy_features, dummy_lengths).float().cpu().numpy()
+    max_diff = abs(ort_out - pt_out).max()
+    print(f"  B=2 (one padded)  max absolute diff: {max_diff:.6f}")
+    if max_diff > 5e-3:
+        print("  WARNING: parity difference is large — check dtype or op support.")
+    else:
+        print("  B=2  parity OK.")
+
+    # B=4 batch shape test — verifies batch dimension is dynamic
+    B, n_mels, n_frames = dummy_features.shape
+    feat4_np = np.random.randn(4, n_mels, n_frames).astype(np.float32)
+    lens4_np = np.array([n_frames, n_frames * 3 // 4, n_frames // 2, n_frames // 4],
+                        dtype=np.int64)
+    try:
+        ort_out4 = session.run(None, {"input_features": feat4_np, "input_lengths": lens4_np})[0]
+        print(f"  B=4  output shape: {ort_out4.shape}  ✅ batch-dynamic export confirmed")
+    except Exception as e:
+        print(f"  B=4  FAILED: {e}")
+        print("  ❌ Encoder is not batch-dynamic — patch did not take effect.")
+
+
+def parity_check_decoder(
+    ort: Any,
+    torch: Any,
+    decoder_wrapper: Any,
+    decoder_input_ids: Any,
+    encoder_hidden_states: Any,
+    onnx_path: Path,
+) -> None:
+    print("\nDecoder parity check (PyTorch vs ONNX Runtime) …")
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    ids_np = decoder_input_ids.cpu().numpy()
+    enc_np = encoder_hidden_states.float().cpu().numpy()
+    ort_out = session.run(None, {"decoder_input_ids": ids_np, "encoder_hidden_states": enc_np})[0]
+
+    with torch.no_grad():
+        pt_out = decoder_wrapper(decoder_input_ids, encoder_hidden_states).float().cpu().numpy()
+
+    max_diff = abs(ort_out - pt_out).max()
+    print(f"  Max absolute diff decoder: {max_diff:.6f}")
+    if max_diff > 1e-3:
+        print("  WARNING: decoder parity difference is large — check dtype or op support.")
+    else:
+        print("  Decoder parity OK.")
+
+
+def parity_check_kv(torch: Any, ort: Any, model: Any, output_dir: Path, device: str) -> None:
+    print("\nParity check (PyTorch reference vs ONNX KV-cache) …")
+    from transformers.modeling_outputs import BaseModelOutput
+    import numpy as np
+
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"] if device == "cuda" else ["CPUExecutionProvider"]
+    init_sess = ort.InferenceSession(str(output_dir / "decoder_init.onnx"), providers=providers)
+    step_sess = ort.InferenceSession(str(output_dir / "decoder_step.onnx"), providers=providers)
+
+    bos_id = 13764
+    tok1_id = 42
+    model_dtype = next(model.parameters()).dtype
+    dummy_enc = torch.randn(1, 80, ENC_DIM, device=device, dtype=model_dtype)
+
+    with torch.no_grad():
+        out0 = model(
+            decoder_input_ids=torch.tensor([[bos_id]], device=device),
+            encoder_outputs=BaseModelOutput(last_hidden_state=dummy_enc),
+        )
+        logits_ref0 = out0.logits[0, -1, :].float().cpu().numpy()
+
+        out1 = model(
+            decoder_input_ids=torch.tensor([[bos_id, tok1_id]], device=device),
+            encoder_outputs=BaseModelOutput(last_hidden_state=dummy_enc),
+        )
+        logits_ref1 = out1.logits[0, -1, :].float().cpu().numpy()
+
+    enc_np = dummy_enc.float().cpu().numpy()
+    bos_np = np.array([[bos_id]], dtype=np.int64)
+
+    init_out = init_sess.run(None, {
+        "decoder_input_ids": bos_np,
+        "encoder_hidden_states": enc_np,
+    })
+    logits_onnx0 = init_out[0][0, -1, :]
+    kv_cache = init_out[1:]
+    diff0 = abs(logits_ref0 - logits_onnx0).max()
+    print(f"  Step 0 (init) max logit diff: {diff0:.2e}  top-ref={logits_ref0.argmax()}  top-onnx={logits_onnx0.argmax()}")
+    if diff0 > 0.05:
+        print("  WARNING: step 0 difference is large!")
+
+    n = NUM_LAYERS
+    sk = list(kv_cache[:n])
+    sv = list(kv_cache[n:2 * n])
+    ck = list(kv_cache[2 * n:3 * n])
+    cv = list(kv_cache[3 * n:4 * n])
+
+    step_inputs: dict[str, Any] = {
+        "decoder_input_ids": np.array([[tok1_id]], dtype=np.int64),
+        "positions": np.array([[1]], dtype=np.int64),
+    }
+    for i in range(n):
+        step_inputs[f"self_key_{i}"] = sk[i]
+        step_inputs[f"self_val_{i}"] = sv[i]
+        step_inputs[f"cross_key_{i}"] = ck[i]
+        step_inputs[f"cross_val_{i}"] = cv[i]
+
+    step_out = step_sess.run(None, step_inputs)
+    logits_onnx1 = step_out[0][0, -1, :]
+    diff1 = abs(logits_ref1 - logits_onnx1).max()
+    print(f"  Step 1 (step) max logit diff: {diff1:.2e}  top-ref={logits_ref1.argmax()}  top-onnx={logits_onnx1.argmax()}")
+    if diff1 > 0.05:
+        print("  WARNING: step 1 difference is large!")
+    if diff0 < 0.05 and diff1 < 0.05:
+        print("  Parity OK.")
+
+
+# ---------------------------------------------------------------------------
+# Mel preprocessor export (DFT conv1d — same approach as nemo128.onnx "dft" mode)
+# ---------------------------------------------------------------------------
+
+def make_mel_wrapper(torch: Any, processor: Any) -> Any:
+    """
+    Build a DFT-conv1d mel spectrogram wrapper from the feature extractor's _fb_config.
+
+    Input / output contract:
+        waveforms      [batch, samples]   float32   — raw 16 kHz PCM, dither removed
+        waveforms_lens [batch]            int64     — valid sample counts
+        -> features      [batch, n_mels, frames]  float32
+        -> features_lens [batch]                  int64
+
+    Uses conv1d with a precomputed windowed DFT basis matrix to avoid the ONNX STFT
+    op (which diverges in ONNX Runtime on this toolchain).  The pipeline is:
+        preemphasis → time-mask → center-pad → conv1d DFT → magnitude → power
+        → mel filterbank → log → per-feature norm → frame-mask
+    """
+    import math
+    nn = torch.nn
+
+    fb_cfg = processor.feature_extractor._fb_config
+
+    sample_rate = int(fb_cfg.get("sample_rate", 16000))
+    win_length = int(fb_cfg.get("n_window_size", 400))
+    hop_length = int(fb_cfg.get("n_window_stride", 160))
+    n_fft_cfg = fb_cfg.get("n_fft")
+    n_fft = int(n_fft_cfg) if n_fft_cfg else 2 ** math.ceil(math.log2(win_length))
+    preemph = float(fb_cfg.get("preemph", 0.97))
+    mag_power = float(fb_cfg.get("mag_power", 2.0))
+    log_guard_t = str(fb_cfg.get("log_zero_guard_type", "add"))
+    log_guard_v = float(fb_cfg.get("log_zero_guard_value", 2.0 ** -24))
+    normalize = str(fb_cfg.get("normalize", "per_feature"))
+    # pad_to: 0 means no temporal padding needed (Cohere default)
+    pad_to = int(fb_cfg.get("pad_to", 0) or 0)
+    pad_value = float(fb_cfg.get("pad_value", fb_cfg.get("padding_value", 0.0)))
+    # exact_pad is not in Cohere's preprocessor_config — default False
+    exact_pad = bool(fb_cfg.get("exact_pad", False))
+    stft_pad_amount = (n_fft - hop_length) // 2 if exact_pad else None
+
+    # Build windowed DFT basis.
+    # The processor's AudioToMelSpectrogramPreprocessor stores its window as bfloat16
+    # (see processing_cohere_asr.py line ~147: self.window = self.window.to(bfloat16)).
+    # The STFT then casts it back to float32 at call time.  We must use the same
+    # bfloat16→float32 round-trip here so the DFT basis matches the processor exactly;
+    # using a native float32 hann window differs by up to 0.002 per sample, and that
+    # error squares under mag_power=2 (power spectrum), causing ~4 unit divergence in
+    # the log-mel output.
+    #
+    # We extract the window from the lazily-initialised _filterbank object.  If it
+    # hasn't been initialised yet, force one forward pass to trigger it.
+    fe = processor.feature_extractor
+    fb_obj = getattr(fe, "_filterbank", None)
+    if fb_obj is None:
+        import numpy as _np
+        _dummy = _np.zeros(win_length * 2, dtype=_np.float32)
+        fe([_dummy], sampling_rate=sample_rate, return_tensors="pt")
+        fb_obj = fe._filterbank
+
+    # window: bfloat16 on the object → cast to float32 for DFT basis construction
+    win = fb_obj.window.to(dtype=torch.float32).cpu()
+
+    # Zero-pad window to n_fft (centre-pad, same as torch.stft internal convention)
+    if win.shape[0] < n_fft:
+        left = (n_fft - win.shape[0]) // 2
+        right = n_fft - win.shape[0] - left
+        win = torch.nn.functional.pad(win, [left, right])
+
+    n_bins = n_fft // 2 + 1
+    n_range = torch.arange(n_fft, dtype=torch.float64)
+    k_range = torch.arange(n_bins, dtype=torch.float64)
+    angles = 2.0 * math.pi * k_range.unsqueeze(1) * n_range.unsqueeze(0) / n_fft
+    win64 = win.to(dtype=torch.float64)
+    cos_basis = (torch.cos(angles) * win64.unsqueeze(0)).to(torch.float32)
+    sin_basis = (torch.sin(angles) * win64.unsqueeze(0)).to(torch.float32)
+    dft_matrix = torch.cat([cos_basis, sin_basis], dim=0).unsqueeze(1)  # [2*n_bins, 1, n_fft]
+
+    # Mel filterbank: use the processor's fb buffer (also bfloat16→float32) so the
+    # filterbank coefficients are bit-identical to what the processor uses.
+    fb = fb_obj.fb.to(dtype=torch.float32).cpu()  # [1, nfilt, n_bins]
+
+    class MelDFTWrapper(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.preemph = preemph
+            self.n_fft = n_fft
+            self.hop_length = hop_length
+            self.mag_power = mag_power
+            self.exact_pad = exact_pad
+            self.stft_pad_amount = stft_pad_amount
+            self.log_guard_type = log_guard_t
+            self.log_guard_value = log_guard_v
+            self.normalize = normalize
+            self.pad_to = pad_to
+            self.pad_value        = pad_value
+            self.register_buffer("dft_matrix", dft_matrix)
+            self.register_buffer("fb",         fb)
+
+        def _get_seq_len(self, waveforms_lens: Any) -> Any:
+            pad_amount = (
+                self.stft_pad_amount * 2
+                if self.stft_pad_amount is not None
+                else self.n_fft // 2 * 2
+            )
+            return torch.floor_divide(
+                (waveforms_lens + pad_amount - self.n_fft), self.hop_length
+            ).to(dtype=torch.long)
+
+        def _normalize_per_feature(self, features: Any, seq_len: Any) -> Any:
+            max_time   = features.shape[2]
+            time_steps = torch.arange(max_time, device=features.device).unsqueeze(0).expand(features.shape[0], -1)
+            valid      = time_steps < seq_len.unsqueeze(1)
+            masked     = torch.where(valid.unsqueeze(1), features, 0.0)
+            denom      = valid.sum(dim=1).unsqueeze(1).to(features.dtype)
+            mean       = masked.sum(dim=2) / denom
+            variance   = (
+                torch.where(valid.unsqueeze(1), features - mean.unsqueeze(2), 0.0).pow(2).sum(dim=2)
+                / (denom - 1.0)
+            )
+            std = torch.sqrt(variance).masked_fill(variance.isnan(), 0.0) + 1e-5
+            return (features - mean.unsqueeze(2)) / std.unsqueeze(2)
+
+        def forward(self, waveforms: Any, waveforms_lens: Any) -> tuple[Any, Any]:
+            seq_len = torch.where(
+                waveforms_lens == 0,
+                torch.zeros_like(waveforms_lens),
+                self._get_seq_len(waveforms_lens),
+            )
+
+            # exact_pad: pad before dither/preemphasis (matches processor order)
+            if self.stft_pad_amount is not None:
+                waveforms = torch.nn.functional.pad(
+                    waveforms.unsqueeze(1), (self.stft_pad_amount, self.stft_pad_amount), "constant",
+                ).squeeze(1)
+
+            # Pre-emphasis then time mask (dither is zero — deterministic export)
+            waveforms = torch.cat(
+                (waveforms[:, :1], waveforms[:, 1:] - self.preemph * waveforms[:, :-1]),
+                dim=1,
+            )
+            time_mask = (
+                torch.arange(waveforms.shape[1], device=waveforms.device)
+                .unsqueeze(0) < waveforms_lens.unsqueeze(1)
+            )
+            waveforms = waveforms.masked_fill(~time_mask, 0.0)
+
+            # center pad for non-exact-pad path.
+            # torch.stft(center=True, pad_mode="constant") zero-pads by n_fft//2 on
+            # each side — the processor passes pad_mode="constant" explicitly.
+            if self.stft_pad_amount is None:
+                half = self.n_fft // 2
+                waveforms = torch.nn.functional.pad(
+                    waveforms.unsqueeze(1), (half, half), "constant",
+                ).squeeze(1)
+
+            # DFT via conv1d  →  [batch, 2*n_bins, frames]
+            frames = torch.nn.functional.conv1d(
+                waveforms.unsqueeze(1),
+                self.dft_matrix.to(dtype=waveforms.dtype, device=waveforms.device),
+                stride=self.hop_length,
+                padding=0,
+            )
+            n_bins = self.n_fft // 2 + 1
+            features = torch.sqrt(frames[:, :n_bins].pow(2) + frames[:, n_bins:].pow(2))
+
+            if self.mag_power != 1.0:
+                features = features.pow(self.mag_power)
+
+            # Mel filterbank: [1, nfilt, n_bins] @ [batch, n_bins, frames] → [batch, nfilt, frames]
+            features = torch.matmul(
+                self.fb.to(dtype=features.dtype, device=features.device),
+                features,
+            )
+
+            # Log compression
+            if self.log_guard_type == "add":
+                features = torch.log(features + self.log_guard_value)
+            else:
+                features = torch.log(torch.clamp(features, min=self.log_guard_value))
+
+            # Per-feature normalization
+            if self.normalize == "per_feature":
+                features = self._normalize_per_feature(features, seq_len)
+
+            # Frame mask
+            max_len = features.size(-1)
+            frame_mask = (
+                torch.arange(max_len, device=features.device)
+                .unsqueeze(0) >= seq_len.unsqueeze(1)
+            )
+            features = features.masked_fill(frame_mask.unsqueeze(1), self.pad_value)
+
+            # Temporal padding to multiple of pad_to (disabled when pad_to=0)
+            if self.pad_to > 0:
+                pad_amt = features.size(-1) % self.pad_to
+                if pad_amt != 0:
+                    features = torch.nn.functional.pad(
+                        features, (0, self.pad_to - pad_amt), value=self.pad_value,
+                    )
+
+            return features, seq_len
+
+    return MelDFTWrapper()
+
+
+def export_mel(
+    torch: Any,
+    wrapper: Any,
+    processor: Any,
+    output_path: Path,
+    opset: int,
+    dummy_seconds: float,
+) -> tuple[Any, Any]:
+    """Export mel.onnx and return (dummy_waveforms, dummy_lens) for parity check."""
+    sample_rate = int(processor.feature_extractor._fb_config.get("sample_rate", 16000))
+    num_samples = max(int(sample_rate * dummy_seconds), sample_rate)
+
+    dummy_wave = torch.zeros((1, num_samples), dtype=torch.float32)
+    dummy_lens = torch.tensor([num_samples], dtype=torch.int64)
+
+    print(f"\nExporting mel preprocessor to {output_path} …")
+    with torch.no_grad():
+        test_feat, test_lens = wrapper(dummy_wave, dummy_lens)
+    print(f"  PyTorch mel output shape: {tuple(test_feat.shape)}, lens: {test_lens.tolist()}")
+
+    torch.onnx.export(
+        wrapper,
+        (dummy_wave, dummy_lens),
+        str(output_path),
+        input_names=["waveforms", "waveforms_lens"],
+        output_names=["features", "features_lens"],
+        dynamic_axes={
+            "waveforms":      {0: "batch", 1: "samples"},
+            "waveforms_lens": {0: "batch"},
+            "features":       {0: "batch", 2: "frames"},
+            "features_lens":  {0: "batch"},
+        },
+        opset_version=opset,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+    print(f"  Saved {output_path.stat().st_size / 1024 / 1024:.1f} MB")
+    return dummy_wave, dummy_lens
+
+
+def parity_check_mel(
+    ort: Any,
+    torch: Any,
+    wrapper: Any,
+    processor: Any,
+    dummy_wave: Any,
+    dummy_lens: Any,
+    onnx_path: Path,
+) -> None:
+    """
+    Compare DFT wrapper output against the Python feature extractor.
+
+    Uses band-limited noise rather than the silent dummy input because per-feature
+    normalization on a constant signal (all-zeros → all-same log values) is a
+    degenerate case: variance=0, std=1e-5, output≈0, and any tiny numerical
+    divergence between ORT and PyTorch appears amplified.  Real-ish noise exercises
+    the full normalization path.
+    """
+    import numpy as np
+
+    sample_rate = int(processor.feature_extractor._fb_config.get("sample_rate", 16000))
+    duration_s  = max(dummy_wave.shape[-1] / sample_rate, 1.0)
+    n_samples   = int(duration_s * sample_rate)
+
+    rng      = np.random.default_rng(42)
+    noise_np = rng.standard_normal(n_samples).astype(np.float32) * 0.1
+    noise_t  = torch.from_numpy(noise_np).unsqueeze(0)          # [1, T]
+    lens_t   = torch.tensor([n_samples], dtype=torch.int64)
+    lens_np  = np.array([n_samples], dtype=np.int64)
+
+    print("\nMel parity check (DFT wrapper vs Python processor) …")
+
+    # ---- ORT vs PyTorch wrapper (should be near-zero) -------------------------
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    ort_feat, ort_lens = session.run(None, {
+        "waveforms":      noise_t.numpy(),
+        "waveforms_lens": lens_np,
+    })
+    with torch.no_grad():
+        pt_feat, pt_lens = wrapper(noise_t, lens_t)
+    pt_feat_np = pt_feat.numpy()
+
+    feat_diff  = abs(ort_feat - pt_feat_np).max()
+    lens_match = bool((ort_lens == pt_lens.numpy()).all())
+    print(f"  ORT vs PT wrapper — max abs diff: {feat_diff:.6f}  |  lens match: {lens_match}")
+    if feat_diff > 5e-3:
+        print("  WARNING: ONNX export diverges from PyTorch wrapper — check pipeline.")
+    else:
+        print("  ONNX export parity OK.")
+
+    # ---- ORT vs Python processor (dither zeroed for determinism) ---------------
+    fe     = processor.feature_extractor
+    fb_obj = getattr(fe, "_filterbank", None)
+    # Ensure filterbank is initialised before we patch dither
+    if fb_obj is None:
+        fe([noise_np], sampling_rate=sample_rate, return_tensors="pt")
+        fb_obj = getattr(fe, "_filterbank", None)
+
+    orig_dither = getattr(fb_obj, "dither", 0.0) if fb_obj is not None else 0.0
+    if fb_obj is not None:
+        fb_obj.dither = 0.0
+    try:
+        proc_out  = processor(noise_np, sampling_rate=sample_rate,
+                              return_tensors="pt", language="en")
+    finally:
+        if fb_obj is not None:
+            fb_obj.dither = orig_dither
+
+    proc_feat   = proc_out["input_features"].numpy()
+    frames_onnx = ort_feat.shape[2]
+    frames_proc = proc_feat.shape[2]
+    proc_diff   = abs(ort_feat - proc_feat[:, :, :frames_onnx]).max()
+    print(f"  ORT vs Python proc — max abs diff: {proc_diff:.6f}")
+    print(f"  ONNX frames: {frames_onnx}  |  Python frames: {frames_proc}")
+    if proc_diff > 0.1:
+        print("  WARNING: DFT pipeline diverges from Python processor — check preemphasis/padding/norm.")
+
+@dataclass
+class ExportConfig:
+    model_repo: str
+    # Feature extractor
+    sampling_rate: int
+    num_mel_bins: int
+    n_fft: int | None
+    hop_length: int | None
+    win_length: int | None
+    chunk_length: int | None          # max audio seconds (model hard limit)
+    # Tokenizer / generation
+    vocab_size: int
+    bos_token_id: int | None
+    eos_token_id: int | None
+    pad_token_id: int | None
+    decoder_start_token_id: int | None
+    # Model shape
+    d_model: int | None           # encoder d_model (raw output of encoder.onnx)
+    encoder_layers: int | None
+    decoder_layers: int | None
+    decoder_hidden_size: int | None  # decoder d_model (after encoder_decoder_proj)
+    # Export
+    opset: int
+    dtype: str
+
+
+def _tok_id(model: Any, attr: str) -> Any:
+    """Read a token ID from generation_config first, falling back to model.config."""
+    gen_cfg = getattr(model, "generation_config", None)
+    val = getattr(gen_cfg, attr, None) if gen_cfg is not None else None
+    if val is None:
+        val = getattr(model.config, attr, None)
+    return val
+
+
+def _nested_get(obj: Any, *keys: str, default: Any = None) -> Any:
+    """Walk a chain of dict/attr lookups, returning default if any step is missing."""
+    cur = obj
+    for key in keys:
+        if isinstance(cur, dict):
+            cur = cur.get(key)
+        else:
+            cur = getattr(cur, key, None)
+        if cur is None:
+            return default
+    return cur
+
+
+def extract_config(
+    repo_id: str,
+    model: Any,
+    processor: Any,
+    opset: int,
+    dtype_name: str,
+) -> ExportConfig:
+    fe = processor.feature_extractor
+    cfg = model.config
+
+    # CohereAsrFeatureExtractor stores mel params in a private _fb_config dict
+    # (passed later to a lazily-constructed filterbank).  Flat getattr misses them.
+    fb = getattr(fe, "_fb_config", {}) or {}
+
+    def _fe(attr: str, fb_key: str | None = None) -> Any:
+        """Check fe directly, then _fb_config under attr or an alternate key."""
+        val = getattr(fe, attr, None)
+        if val is None:
+            val = fb.get(fb_key or attr)
+        return val
+
+    # This model stores encoder/decoder shape params in nested config dicts.
+    enc_cfg = getattr(cfg, "encoder", {}) or {}
+    dec_cfg = _nested_get(cfg, "transf_decoder", "config_dict") or {}
+
+    return ExportConfig(
+        model_repo=repo_id,
+        sampling_rate=_fe("sampling_rate") or 16000,
+        num_mel_bins=_fe("feature_size") or _fe("num_mel_bins"),
+        n_fft=_fe("n_fft"),
+        hop_length=_fe("hop_length", "n_window_stride"),
+        win_length=_fe("win_length", "n_window_size"),
+        chunk_length=_fe("chunk_length"),
+        vocab_size=(getattr(cfg, "vocab_size", None)
+                    or _nested_get(cfg, "head", "num_classes")),
+        bos_token_id=_tok_id(model, "bos_token_id"),
+        eos_token_id=_tok_id(model, "eos_token_id"),
+        pad_token_id=_tok_id(model, "pad_token_id"),
+        decoder_start_token_id=_tok_id(model, "decoder_start_token_id"),
+        d_model=enc_cfg.get("d_model"),
+        encoder_layers=enc_cfg.get("n_layers"),
+        decoder_layers=dec_cfg.get("num_layers"),
+        decoder_hidden_size=dec_cfg.get("hidden_size"),
+        opset=opset,
+        dtype=dtype_name,
+    )
+
+
+def write_export_report(
+    config: ExportConfig,
+    output_dir: Path,
+    conventional_decoder: bool,
+    skip_decoder: bool,
+    notes: list[str],
+) -> None:
+    if skip_decoder:
+        files = {
+            "mel": "mel.onnx",
+            "encoder": "encoder.onnx",
+            "config": "config.json",
+        }
+        decoder_strategy = "skipped"
+        decoder_notes = "Decoder export was skipped for this run."
+    elif conventional_decoder:
+        files = {
+            "mel": "mel.onnx",
+            "encoder": "encoder.onnx",
+            "decoder": "decoder.onnx",
+            "config": "config.json",
+        }
+        decoder_strategy = "no_kv_cache"
+        decoder_notes = (
+            "decoder.onnx takes the full token sequence at each step (no KV cache). "
+            "For greedy decoding: call encoder once, then call decoder with growing "
+            "decoder_input_ids, taking argmax of logits[:, -1, :] at each step."
+        )
+    else:
+        files = {
+            "mel": "mel.onnx",
+            "encoder": "encoder.onnx",
+            "decoder_init": "decoder_init.onnx",
+            "decoder_step": "decoder_step.onnx",
+            "config": "config.json",
+        }
+        decoder_strategy = "kv_cache"
+        decoder_notes = (
+            "decoder_init.onnx produces logits plus self/cross-attention KV for the "
+            "initial context, then decoder_step.onnx consumes one token at a time "
+            "with carried KV tensors for O(n) generation."
+        )
+
+    report = {
+        **asdict(config),
+        "files": files,
+        "decoder_strategy": decoder_strategy,
+        "decoder_notes": decoder_notes,
+        "notes": notes,
+    }
+    config_path = output_dir / "config.json"
+    with config_path.open("w") as f:
+        json.dump(report, f, indent=2)
+    print(f"\nWrote config: {config_path}")
+
+
+def update_config_with_kv_decoder(output_dir: Path) -> None:
+    cfg_path = output_dir / "config.json"
+    with cfg_path.open() as f:
+        cfg = json.load(f)
+
+    cfg["files"]["decoder_init"] = "decoder_init.onnx"
+    cfg["files"]["decoder_step"] = "decoder_step.onnx"
+    cfg["decoder_kv_cache"] = {
+        "num_layers": NUM_LAYERS,
+        "num_heads": NUM_HEADS,
+        "head_dim": HEAD_DIM,
+        "decoder_init_inputs": ["decoder_input_ids [1,1] int64", "encoder_hidden_states [1,T,1280] float32"],
+        "decoder_init_outputs": (
+            ["logits [1,1,vocab] float32"]
+            + [f"self_key_{i} [1,8,1,128] float32" for i in range(NUM_LAYERS)]
+            + [f"self_val_{i} [1,8,1,128] float32" for i in range(NUM_LAYERS)]
+            + [f"cross_key_{i} [1,8,T',128] float32" for i in range(NUM_LAYERS)]
+            + [f"cross_val_{i} [1,8,T',128] float32" for i in range(NUM_LAYERS)]
+        ),
+        "decoder_step_inputs": (
+            ["decoder_input_ids [1,1] int64", "positions [1,1] int64"]
+            + [f"self_key_{i} [1,8,past,128] float32" for i in range(NUM_LAYERS)]
+            + [f"self_val_{i} [1,8,past,128] float32" for i in range(NUM_LAYERS)]
+            + [f"cross_key_{i} [1,8,T',128] float32" for i in range(NUM_LAYERS)]
+            + [f"cross_val_{i} [1,8,T',128] float32" for i in range(NUM_LAYERS)]
+        ),
+        "decoder_step_outputs": (
+            ["logits [1,1,vocab] float32"]
+            + [f"new_self_key_{i} [1,8,past+1,128] float32" for i in range(NUM_LAYERS)]
+            + [f"new_self_val_{i} [1,8,past+1,128] float32" for i in range(NUM_LAYERS)]
+        ),
+        "notes": [
+            "Run decoder_init once with the start token and encoder hidden states.",
+            "decoder_init outputs: logits + 8 self_key + 8 self_val + 8 cross_key + 8 cross_val.",
+            "Run decoder_step for each subsequent token; pass self KV from previous step output.",
+            "cross_key/cross_val come from decoder_init and are fixed for the whole utterance.",
+            "decoder_step self KV outputs are already concatenated (past||new) and can be passed directly to the next step.",
+            "positions input to decoder_step = number of tokens decoded so far (1 after init, 2 after step 1, ...).",
+        ],
+    }
+
+    with cfg_path.open("w") as f:
+        json.dump(cfg, f, indent=2)
+    print(f"\nUpdated {cfg_path}")
+
+
+def export_tokenizer_assets(
+    repo_id: str,
+    processor: Any,
+    output_dir: Path,
+) -> None:
+    """
+    Make the exported model directory self-contained for downstream runtimes.
+
+    We always write vocab.json because the C# loader expects an index-ordered array
+    of token strings. We also copy the original tokenizer artifacts from the local
+    Hugging Face snapshot cache for debugging, future compatibility, and parity with
+    the source model layout.
+    """
+    vocab = processor.tokenizer.convert_ids_to_tokens(
+        list(range(processor.tokenizer.vocab_size))
+    )
+    vocab_path = output_dir / "vocab.json"
+    with vocab_path.open("w", encoding="utf-8") as f:
+        json.dump(vocab, f, ensure_ascii=False, indent=2)
+    print(f"Wrote vocab: {vocab_path}")
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        print("WARNING: huggingface_hub unavailable; skipped copying tokenizer artifacts from cache.")
+        return
+
+    snapshot_dir = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            allow_patterns=[
+                "tokenizer.json",
+                "tokenizer.model",
+                "tokenizer_config.json",
+                "special_tokens_map.json",
+            ],
+        )
+    )
+
+    copied_any = False
+    for name in (
+        "tokenizer.json",
+        "tokenizer.model",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+    ):
+        src = snapshot_dir / name
+        if not src.exists():
+            continue
+        shutil.copy2(src, output_dir / name)
+        copied_any = True
+        print(f"Copied tokenizer asset: {name}")
+
+    if not copied_any:
+        print("WARNING: no tokenizer artifacts were found in the Hugging Face snapshot cache.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    args = parse_args()
+    ensure_output_dir(args.output_dir, args.overwrite)
+
+    # ---- Lazy imports -------------------------------------------------------
+    try:
+        import torch
+        import onnx
+        import onnxruntime as ort
+    except ImportError as exc:
+        raise SystemExit(
+            "Missing dependencies. Install with:\n"
+            "  pip install torch transformers accelerate onnx onnxruntime huggingface_hub\n"
+            f"Original error: {exc}"
+        ) from exc
+
+    device = resolve_device(torch, args.device)
+    dtype = resolve_dtype(torch, args.dtype)
+    print(f"Device: {device}  |  dtype: {args.dtype}  |  opset: {args.opset}")
+
+    if args.conventional_decoder and args.dtype != "float32" and not args.skip_decoder:
+        print(
+            "\nSkipping conventional decoder export (dtype != float32; "
+            "decoder.onnx wrapper requires float32 graph I/O)."
+        )
+        args.skip_decoder = True
+
+    # ---- Load model ---------------------------------------------------------
+    model, processor = load_model_and_processor(args.model_repo, device, dtype, torch)
+
+    # ---- Build wrappers -----------------------------------------------------
+    encoder_wrapper = make_encoder_wrapper(torch, model, model_dtype=dtype).to(device)
+    encoder_wrapper.eval()
+    decoder_wrapper = None
+    if args.conventional_decoder and not args.skip_decoder:
+        decoder_wrapper = make_decoder_wrapper(torch, model).to(device)
+        decoder_wrapper.eval()
+
+    # ---- Dummy inputs -------------------------------------------------------
+    dummy_features, dummy_lengths = make_encoder_dummy_inputs(
+        torch, processor, device, dtype, args.dummy_seconds
+    )
+
+    with torch.no_grad():
+        enc_hidden = encoder_wrapper(dummy_features, dummy_lengths)
+
+    # Decoder dummy uses B=1 — take the first item from the B=2 encoder output.
+    decoder_input_ids = None
+    enc_hidden_for_dec = None
+    if args.conventional_decoder and not args.skip_decoder:
+        decoder_input_ids, enc_hidden_for_dec = make_decoder_dummy_inputs(
+            torch, model, enc_hidden[:1], device
+        )
+
+    # ---- Export encoder -----------------------------------------------------
+    encoder_path = args.output_dir / "encoder.onnx"
+    if not args.skip_encoder:
+        export_encoder(torch, encoder_wrapper, dummy_features, dummy_lengths, encoder_path, args.opset)
+        validate_onnx(onnx, encoder_path, "encoder")
+        parity_check_encoder(ort, torch, encoder_wrapper, dummy_features, dummy_lengths, encoder_path)
+    else:
+        print("\nSkipping encoder export (--skip-encoder).")
+
+    # ---- Export mel preprocessor -------------------------------------------
+    mel_path = args.output_dir / "mel.onnx"
+    if not args.skip_mel:
+        mel_wrapper = make_mel_wrapper(torch, processor)
+        mel_wrapper.eval()
+        dummy_wave, dummy_wave_lens = export_mel(
+            torch, mel_wrapper, processor, mel_path, args.opset, args.dummy_seconds
+        )
+        validate_onnx(onnx, mel_path, "mel")
+        parity_check_mel(ort, torch, mel_wrapper, processor, dummy_wave, dummy_wave_lens, mel_path)
+    else:
+        print("\nSkipping mel export (--skip-mel).")
+
+    # ---- Export decoder -----------------------------------------------------
+    if args.conventional_decoder:
+        decoder_path = args.output_dir / "decoder.onnx"
+        if not args.skip_decoder:
+            export_decoder(
+                torch,
+                decoder_wrapper,
+                decoder_input_ids,
+                enc_hidden_for_dec,
+                decoder_path,
+                args.opset,
+            )
+            validate_onnx(onnx, decoder_path, "decoder")
+            parity_check_decoder(
+                ort, torch, decoder_wrapper, decoder_input_ids, enc_hidden_for_dec, decoder_path
+            )
+        else:
+            print("\nSkipping conventional decoder export (--skip-decoder).")
+    else:
+        if not args.skip_decoder:
+            kv_init_wrapper = make_kv_init_wrapper(torch, model, dtype).to(device)
+            kv_step_wrapper = make_kv_step_wrapper(torch, model, dtype).to(device)
+            kv_init_wrapper.eval()
+            kv_step_wrapper.eval()
+
+            export_kv_init(torch, kv_init_wrapper, args.output_dir, args.opset, device)
+            export_kv_step(torch, kv_step_wrapper, args.output_dir, args.opset, device)
+            validate_onnx(onnx, args.output_dir / "decoder_init.onnx", "decoder_init")
+            validate_onnx(onnx, args.output_dir / "decoder_step.onnx", "decoder_step")
+            parity_check_kv(torch, ort, model, args.output_dir, device)
+        else:
+            print("\nSkipping KV-cache decoder export (--skip-decoder).")
+
+    # ---- Config / report ----------------------------------------------------
+    export_tokenizer_assets(args.model_repo, processor, args.output_dir)
+
+    config = extract_config(args.model_repo, model, processor, args.opset, args.dtype)
+    write_export_report(
+        config,
+        args.output_dir,
+        args.conventional_decoder,
+        args.skip_decoder,
+        notes=[
+            "Model requires trust_remote_code=True when loading via transformers.",
+            "mel.onnx: waveforms [B,T] float32 + waveforms_lens [B] int64 → features [B,128,F] + features_lens [B].",
+            "mel.onnx uses DFT conv1d (no STFT op); dither is disabled — add 1e-5*randn in training but not inference.",
+            "encoder.onnx: input_features [B,128,F] float32 → encoder_hidden_states [B,F/8,1280] float32.",
+            "Default decoder export is KV-cache based: decoder_init.onnx + decoder_step.onnx.",
+            "Pass --conventional-decoder to export decoder.onnx instead.",
+            "vocab.json is generated from the tokenizer ID mapping; tokenizer.json/model metadata are copied from the Hugging Face snapshot cache when available.",
+            "The model is gated on HuggingFace; run `huggingface-cli login` before export.",
+        ],
+    )
+
+    if not args.conventional_decoder and not args.skip_decoder:
+        update_config_with_kv_decoder(args.output_dir)
+
+    print(f"\nExport complete.  Models written to: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cohere_export/requirements.txt
+++ b/scripts/cohere_export/requirements.txt
@@ -1,0 +1,18 @@
+# Python 3.11 or 3.12 recommended.
+#
+# The model is gated; run `huggingface-cli login` before export.
+# GPU export requires a CUDA-capable torch build (torch>=2.1 recommended).
+
+torch>=2.1,<3
+transformers>=4.50         # CohereAsrForConditionalGeneration was added in 4.50+
+accelerate>=0.27           # required by from_pretrained(low_cpu_mem_usage=True)
+librosa>=0.10              # required by the model's processing_cohere_asr.py
+sentencepiece>=0.2,<1      # required by the Cohere tokenizer remote code
+onnx>=1.17,<2
+# Install exactly one of these — they conflict if both are present:
+#   CPU only:  pip install onnxruntime>=1.20,<2
+#   CUDA GPU:  pip install onnxruntime-gpu>=1.20,<2
+# onnxruntime-gpu includes the CPU provider as fallback, so it works for
+# both export parity checks (CPU) and smoke test inference (CUDA).
+onnxruntime-gpu>=1.20,<2
+huggingface_hub>=0.30,<1

--- a/src/Vernacula.Avalonia/AudioUtils.cs
+++ b/src/Vernacula.Avalonia/AudioUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using ClosedXML.Excel;
 using Vernacula.Base;
@@ -13,6 +14,12 @@ namespace Vernacula.App;
 
 internal static class AudioUtils
 {
+    private static readonly HashSet<string> CrossPlatformFfmpegAudioExtensions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".aac", ".flac", ".m4a", ".mp3",
+        };
+
     // ── Mel filterbank (computed once) ───────────────────────────────────────
     public static readonly float[,] MelFilterbank = CreateMelFilterbank();
 
@@ -233,9 +240,13 @@ internal static class AudioUtils
         ReadAudio(string path, int streamIndex = -1)
     {
         string ext = Path.GetExtension(path);
+        bool preferFfmpegForCompressedAudio =
+            !OperatingSystem.IsWindows()
+            && CrossPlatformFfmpegAudioExtensions.Contains(ext);
         bool useFFmpeg = streamIndex >= 0
                       || FFmpegDecoder.VideoExtensions.Contains(ext)
-                      || FFmpegDecoder.FfmpegAudioExtensions.Contains(ext);
+                      || FFmpegDecoder.FfmpegAudioExtensions.Contains(ext)
+                      || preferFfmpegForCompressedAudio;
 
         if (useFFmpeg)
             return FFmpegDecoder.DecodeStream(path, streamIndex >= 0 ? streamIndex : 0);

--- a/src/Vernacula.Avalonia/FFmpegDecoder.cs
+++ b/src/Vernacula.Avalonia/FFmpegDecoder.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using FFmpeg.AutoGen;
 using Vernacula.App.Models;
 
@@ -40,16 +42,64 @@ internal static unsafe class FFmpegDecoder
     {
         if (_initialized) return;
 
-        // Modern .NET places native runtime assets in runtimes/{rid}/native/ —
-        // check that subdirectory first, fall back to the root output folder.
-        string runtimesDir = Path.Combine(rootPath, "runtimes", "win-x64", "native");
-        ffmpeg.RootPath = Directory.Exists(runtimesDir) ? runtimesDir : rootPath;
+        // Modern .NET places native runtime assets in runtimes/{rid}/native/.
+        // Probe the current platform first, then fall back to the output root.
+        string? runtimesDir = FindNativeRuntimeDirectory(rootPath);
+        ffmpeg.RootPath = runtimesDir ?? rootPath;
 
         // avformat_network_init() is only needed for network protocols (HTTP/RTMP/…).
         // We use local-file decoding only, so skip the call to avoid loading DLLs
         // eagerly at startup — they will be loaded on demand on first use instead.
 
         _initialized = true;
+    }
+
+    private static string? FindNativeRuntimeDirectory(string rootPath)
+    {
+        foreach (string rid in EnumerateRuntimeIdentifiers())
+        {
+            string candidate = Path.Combine(rootPath, "runtimes", rid, "native");
+            if (Directory.Exists(candidate))
+                return candidate;
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateRuntimeIdentifiers()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Add(string rid)
+        {
+            if (!string.IsNullOrWhiteSpace(rid))
+                seen.Add(rid);
+        }
+
+        Add(RuntimeInformation.RuntimeIdentifier);
+
+        string arch = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            Architecture.Arm => "arm",
+            Architecture.S390x => "s390x",
+            Architecture.LoongArch64 => "loongarch64",
+            _ => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
+        };
+
+        if (OperatingSystem.IsWindows())
+            Add($"win-{arch}");
+        else if (OperatingSystem.IsMacOS())
+            Add($"osx-{arch}");
+        else if (OperatingSystem.IsLinux())
+        {
+            Add($"linux-{arch}");
+            Add($"linux-musl-{arch}");
+        }
+
+        return seen;
     }
 
     // ── Stream probing ────────────────────────────────────────────────────────
@@ -123,6 +173,19 @@ internal static unsafe class FFmpegDecoder
     public static (float[] samples, int sampleRate, int channels)
         DecodeStream(string filePath, int streamIndex)
     {
+        try
+        {
+            return DecodeStreamAutoGen(filePath, streamIndex);
+        }
+        catch (NotSupportedException)
+        {
+            return DecodeStreamViaCli(filePath, streamIndex);
+        }
+    }
+
+    private static (float[] samples, int sampleRate, int channels)
+        DecodeStreamAutoGen(string filePath, int streamIndex)
+    {
         AVFormatContext* fmtCtx = null;
 
         if (ffmpeg.avformat_open_input(&fmtCtx, filePath, null, null) < 0)
@@ -167,6 +230,132 @@ internal static unsafe class FFmpegDecoder
         {
             ffmpeg.avformat_close_input(&fmtCtx);
         }
+    }
+
+    private static (float[] samples, int sampleRate, int channels)
+        DecodeStreamViaCli(string filePath, int streamIndex)
+    {
+        var stream = ProbeAudioStreamsViaCli(filePath)
+            .FirstOrDefault(s => s.StreamIndex == streamIndex);
+
+        if (stream is null)
+        {
+            stream = ProbeAudioStreamsViaCli(filePath).FirstOrDefault()
+                ?? throw new InvalidOperationException("No audio streams found in file.");
+        }
+
+        string mapSpecifier = $"0:{stream.StreamIndex}";
+        var psi = new ProcessStartInfo("ffmpeg")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("-v");
+        psi.ArgumentList.Add("error");
+        psi.ArgumentList.Add("-i");
+        psi.ArgumentList.Add(filePath);
+        psi.ArgumentList.Add("-map");
+        psi.ArgumentList.Add(mapSpecifier);
+        psi.ArgumentList.Add("-f");
+        psi.ArgumentList.Add("f32le");
+        psi.ArgumentList.Add("-acodec");
+        psi.ArgumentList.Add("pcm_f32le");
+        psi.ArgumentList.Add("-");
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start ffmpeg process.");
+
+        using var ms = new MemoryStream();
+        process.StandardOutput.BaseStream.CopyTo(ms);
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"ffmpeg failed to decode audio stream {stream.StreamIndex}: {stderr.Trim()}");
+
+        byte[] raw = ms.ToArray();
+        if (raw.Length % sizeof(float) != 0)
+            throw new InvalidOperationException("Decoded PCM payload had an unexpected size.");
+
+        float[] samples = new float[raw.Length / sizeof(float)];
+        Buffer.BlockCopy(raw, 0, samples, 0, raw.Length);
+        return (samples, stream.SampleRate, stream.Channels);
+    }
+
+    private static List<AudioStreamInfo> ProbeAudioStreamsViaCli(string filePath)
+    {
+        var psi = new ProcessStartInfo("ffprobe")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("-v");
+        psi.ArgumentList.Add("error");
+        psi.ArgumentList.Add("-show_streams");
+        psi.ArgumentList.Add("-select_streams");
+        psi.ArgumentList.Add("a");
+        psi.ArgumentList.Add("-of");
+        psi.ArgumentList.Add("json");
+        psi.ArgumentList.Add(filePath);
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start ffprobe process.");
+
+        string stdout = process.StandardOutput.ReadToEnd();
+        string stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"ffprobe failed to inspect media file: {stderr.Trim()}");
+
+        using JsonDocument doc = JsonDocument.Parse(stdout);
+        if (!doc.RootElement.TryGetProperty("streams", out JsonElement streamsEl)
+            || streamsEl.ValueKind != JsonValueKind.Array)
+            return new List<AudioStreamInfo>();
+
+        var streams = new List<AudioStreamInfo>();
+        foreach (JsonElement streamEl in streamsEl.EnumerateArray())
+        {
+            int index = streamEl.TryGetProperty("index", out JsonElement indexEl)
+                && indexEl.TryGetInt32(out int parsedIndex)
+                ? parsedIndex
+                : -1;
+            string codec = streamEl.TryGetProperty("codec_name", out JsonElement codecEl)
+                ? codecEl.GetString() ?? "unknown"
+                : "unknown";
+            int channels = streamEl.TryGetProperty("channels", out JsonElement channelsEl)
+                && channelsEl.TryGetInt32(out int parsedChannels)
+                ? parsedChannels
+                : 1;
+            int sampleRate = streamEl.TryGetProperty("sample_rate", out JsonElement sampleRateEl)
+                && int.TryParse(sampleRateEl.GetString(), out int parsedRate)
+                ? parsedRate
+                : 0;
+            double duration = streamEl.TryGetProperty("duration", out JsonElement durationEl)
+                && double.TryParse(durationEl.GetString(), out double parsedDuration)
+                ? parsedDuration
+                : 0;
+
+            string? language = null;
+            string? title = null;
+            if (streamEl.TryGetProperty("tags", out JsonElement tagsEl)
+                && tagsEl.ValueKind == JsonValueKind.Object)
+            {
+                if (tagsEl.TryGetProperty("language", out JsonElement langEl))
+                    language = langEl.GetString();
+                if (tagsEl.TryGetProperty("title", out JsonElement titleEl))
+                    title = titleEl.GetString();
+            }
+
+            streams.Add(new AudioStreamInfo(
+                index, codec, language, title, channels, sampleRate, duration));
+        }
+
+        return streams;
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -4,11 +4,14 @@ namespace Vernacula.App.Models;
 
 public enum AppTheme    { Dark, Light }
 public enum PlaybackMode { Single, AutoAdvance, Continuous }
+public enum AsrBackend { Parakeet, Cohere }
 
 public class AppSettings
 {
     public AppTheme           Theme               { get; set; } = AppTheme.Dark;
     public SegmentationMode   Segmentation        { get; set; } = SegmentationMode.SileroVad;
+    public AsrBackend         AsrBackend          { get; set; } = AsrBackend.Parakeet;
+    public string             CohereLanguage      { get; set; } = "";
     public DenoiserMode       Denoiser            { get; set; } = DenoiserMode.None;
     public PlaybackMode       EditorPlaybackMode  { get; set; } = PlaybackMode.Continuous;
     public string             ModelsDir           { get; set; } = "";

--- a/src/Vernacula.Avalonia/Models/JobRecord.cs
+++ b/src/Vernacula.Avalonia/Models/JobRecord.cs
@@ -24,6 +24,7 @@ public class JobRecord : ObservableObject
     public string  ResultsFile               { get; set; } = "";
     public string  AudioFilePath             { get; set; } = "";
     public string  AudioFileSha256Sum        { get; set; } = "";
+    public string  AsrModelName              { get; set; } = "nvidia/parakeet-tdt-0.6b-v3";
     public string  AsrLanguageCode           { get; set; } = "auto";
     public string? AudioFileDatestamp        { get; set; }
     public string? TranscriptionRunDatestamp { get; set; }

--- a/src/Vernacula.Avalonia/Models/JobRecord.cs
+++ b/src/Vernacula.Avalonia/Models/JobRecord.cs
@@ -24,6 +24,7 @@ public class JobRecord : ObservableObject
     public string  ResultsFile               { get; set; } = "";
     public string  AudioFilePath             { get; set; } = "";
     public string  AudioFileSha256Sum        { get; set; } = "";
+    public string  AsrLanguageCode           { get; set; } = "auto";
     public string? AudioFileDatestamp        { get; set; }
     public string? TranscriptionRunDatestamp { get; set; }
     public string  CreatedAt                 { get; set; } = "";

--- a/src/Vernacula.Avalonia/Models/TranscriptEditorWindowState.cs
+++ b/src/Vernacula.Avalonia/Models/TranscriptEditorWindowState.cs
@@ -9,6 +9,8 @@ internal sealed partial class TranscriptEditorWindowState : ObservableObject
 {
     [ObservableProperty] private string _headerTitle = "";
     [ObservableProperty] private string _headerSubtext = "";
+    [ObservableProperty] private string _headerNotice = "";
+    [ObservableProperty] private bool _showHeaderNotice;
     [ObservableProperty] private bool _isLoading;
     [ObservableProperty] private string _playPauseGlyph = "▶";
     [ObservableProperty] private bool _isPlaying;
@@ -39,6 +41,12 @@ internal sealed partial class TranscriptEditorWindowState : ObservableObject
     {
         HeaderTitle = title;
         HeaderSubtext = subtext;
+    }
+
+    public void SetHeaderNotice(string text, bool visible)
+    {
+        HeaderNotice = text;
+        ShowHeaderNotice = visible;
     }
 
     public void SetPlaybackModes(IEnumerable<string> modes, int selectedIndex)

--- a/src/Vernacula.Avalonia/Services/ControlDb.cs
+++ b/src/Vernacula.Avalonia/Services/ControlDb.cs
@@ -41,6 +41,10 @@ internal sealed class ControlDb : IDisposable
         // Migrate: add run_time_seconds if it does not exist yet
         try { Execute("ALTER TABLE jobs ADD COLUMN run_time_seconds INTEGER"); }
         catch (SqliteException) { /* column already present — ignore */ }
+
+        // Migrate: add per-job ASR language snapshot if it does not exist yet
+        try { Execute("ALTER TABLE jobs ADD COLUMN asr_language_code TEXT NOT NULL DEFAULT 'auto'"); }
+        catch (SqliteException) { /* column already present — ignore */ }
     }
 
     /// <summary>
@@ -48,7 +52,8 @@ internal sealed class ControlDb : IDisposable
     /// Returns the job_id.
     /// </summary>
     public int UpsertJob(string title, string resultsFile, string audioPath,
-                         string sha256, string audioDateStamp, string runDateStamp)
+                         string sha256, string audioDateStamp, string runDateStamp,
+                         string asrLanguageCode = "auto")
     {
         using var check = _conn.CreateCommand();
         check.CommandText = "SELECT job_id FROM jobs WHERE results_file = $rf";
@@ -62,11 +67,13 @@ internal sealed class ControlDb : IDisposable
                 UPDATE jobs
                 SET status = 'running',
                     transcription_run_datestamp = $ts,
-                    job_title = $jt
+                    job_title = $jt,
+                    asr_language_code = $lc
                 WHERE job_id = $id
                 """;
             upd.Parameters.AddWithValue("$ts", runDateStamp);
             upd.Parameters.AddWithValue("$jt", title);
+            upd.Parameters.AddWithValue("$lc", asrLanguageCode);
             upd.Parameters.AddWithValue("$id", existingId);
             upd.ExecuteNonQuery();
             return (int)existingId;
@@ -77,8 +84,8 @@ internal sealed class ControlDb : IDisposable
             INSERT INTO jobs
                 (job_title, results_file, transcription_run_datestamp,
                  audio_file_path, audio_file_sha256sum, audio_file_datestamp,
-                 status, created_at)
-            VALUES ($jt, $rf, $ts, $ap, $sh, $ad, 'running', $ca)
+                 status, created_at, asr_language_code)
+            VALUES ($jt, $rf, $ts, $ap, $sh, $ad, 'running', $ca, $lc)
             """;
         ins.Parameters.AddWithValue("$jt", title);
         ins.Parameters.AddWithValue("$rf", resultsFile);
@@ -87,6 +94,7 @@ internal sealed class ControlDb : IDisposable
         ins.Parameters.AddWithValue("$sh", sha256);
         ins.Parameters.AddWithValue("$ad", audioDateStamp);
         ins.Parameters.AddWithValue("$ca", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+        ins.Parameters.AddWithValue("$lc", asrLanguageCode);
         ins.ExecuteNonQuery();
 
         using var lastId = _conn.CreateCommand();
@@ -99,7 +107,8 @@ internal sealed class ControlDb : IDisposable
     /// results_file already exists, returns its existing job_id unchanged.
     /// </summary>
     public int InsertNewJob(string title, string resultsFile, string audioPath,
-                            string sha256, string audioDateStamp, int streamIndex = -1)
+                            string sha256, string audioDateStamp, int streamIndex = -1,
+                            string asrLanguageCode = "auto")
     {
         using var check = _conn.CreateCommand();
         check.CommandText = "SELECT job_id FROM jobs WHERE results_file = $rf";
@@ -111,8 +120,8 @@ internal sealed class ControlDb : IDisposable
             INSERT INTO jobs
                 (job_title, results_file, transcription_run_datestamp,
                  audio_file_path, audio_file_sha256sum, audio_file_datestamp,
-                 status, created_at, stream_index)
-            VALUES ($jt, $rf, NULL, $ap, $sh, $ad, 'queued', $ca, $si)
+                 status, created_at, stream_index, asr_language_code)
+            VALUES ($jt, $rf, NULL, $ap, $sh, $ad, 'queued', $ca, $si, $lc)
             """;
         ins.Parameters.AddWithValue("$jt", title);
         ins.Parameters.AddWithValue("$rf", resultsFile);
@@ -121,6 +130,7 @@ internal sealed class ControlDb : IDisposable
         ins.Parameters.AddWithValue("$ad", audioDateStamp);
         ins.Parameters.AddWithValue("$ca", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
         ins.Parameters.AddWithValue("$si", streamIndex);
+        ins.Parameters.AddWithValue("$lc", asrLanguageCode);
         ins.ExecuteNonQuery();
 
         using var lastId = _conn.CreateCommand();
@@ -208,6 +218,7 @@ internal sealed class ControlDb : IDisposable
             ResultsFile               = r.GetString(r.GetOrdinal("results_file")),
             AudioFilePath             = r.GetString(r.GetOrdinal("audio_file_path")),
             AudioFileSha256Sum        = r.GetString(r.GetOrdinal("audio_file_sha256sum")),
+            AsrLanguageCode           = GetNullable("asr_language_code") ?? "auto",
             AudioFileDatestamp        = GetNullable("audio_file_datestamp"),
             TranscriptionRunDatestamp = GetNullable("transcription_run_datestamp"),
             Status = Enum.Parse<JobStatus>(

--- a/src/Vernacula.Avalonia/Services/ControlDb.cs
+++ b/src/Vernacula.Avalonia/Services/ControlDb.cs
@@ -45,6 +45,10 @@ internal sealed class ControlDb : IDisposable
         // Migrate: add per-job ASR language snapshot if it does not exist yet
         try { Execute("ALTER TABLE jobs ADD COLUMN asr_language_code TEXT NOT NULL DEFAULT 'auto'"); }
         catch (SqliteException) { /* column already present — ignore */ }
+
+        // Migrate: add per-job ASR model snapshot if it does not exist yet
+        try { Execute("ALTER TABLE jobs ADD COLUMN asr_model_name TEXT NOT NULL DEFAULT 'nvidia/parakeet-tdt-0.6b-v3'"); }
+        catch (SqliteException) { /* column already present — ignore */ }
     }
 
     /// <summary>
@@ -53,7 +57,8 @@ internal sealed class ControlDb : IDisposable
     /// </summary>
     public int UpsertJob(string title, string resultsFile, string audioPath,
                          string sha256, string audioDateStamp, string runDateStamp,
-                         string asrLanguageCode = "auto")
+                         string asrLanguageCode = "auto",
+                         string asrModelName = "nvidia/parakeet-tdt-0.6b-v3")
     {
         using var check = _conn.CreateCommand();
         check.CommandText = "SELECT job_id FROM jobs WHERE results_file = $rf";
@@ -68,12 +73,14 @@ internal sealed class ControlDb : IDisposable
                 SET status = 'running',
                     transcription_run_datestamp = $ts,
                     job_title = $jt,
-                    asr_language_code = $lc
+                    asr_language_code = $lc,
+                    asr_model_name = $am
                 WHERE job_id = $id
                 """;
             upd.Parameters.AddWithValue("$ts", runDateStamp);
             upd.Parameters.AddWithValue("$jt", title);
             upd.Parameters.AddWithValue("$lc", asrLanguageCode);
+            upd.Parameters.AddWithValue("$am", asrModelName);
             upd.Parameters.AddWithValue("$id", existingId);
             upd.ExecuteNonQuery();
             return (int)existingId;
@@ -84,8 +91,8 @@ internal sealed class ControlDb : IDisposable
             INSERT INTO jobs
                 (job_title, results_file, transcription_run_datestamp,
                  audio_file_path, audio_file_sha256sum, audio_file_datestamp,
-                 status, created_at, asr_language_code)
-            VALUES ($jt, $rf, $ts, $ap, $sh, $ad, 'running', $ca, $lc)
+                 status, created_at, asr_language_code, asr_model_name)
+            VALUES ($jt, $rf, $ts, $ap, $sh, $ad, 'running', $ca, $lc, $am)
             """;
         ins.Parameters.AddWithValue("$jt", title);
         ins.Parameters.AddWithValue("$rf", resultsFile);
@@ -95,6 +102,7 @@ internal sealed class ControlDb : IDisposable
         ins.Parameters.AddWithValue("$ad", audioDateStamp);
         ins.Parameters.AddWithValue("$ca", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
         ins.Parameters.AddWithValue("$lc", asrLanguageCode);
+        ins.Parameters.AddWithValue("$am", asrModelName);
         ins.ExecuteNonQuery();
 
         using var lastId = _conn.CreateCommand();
@@ -108,20 +116,45 @@ internal sealed class ControlDb : IDisposable
     /// </summary>
     public int InsertNewJob(string title, string resultsFile, string audioPath,
                             string sha256, string audioDateStamp, int streamIndex = -1,
-                            string asrLanguageCode = "auto")
+                            string asrLanguageCode = "auto",
+                            string asrModelName = "nvidia/parakeet-tdt-0.6b-v3")
     {
         using var check = _conn.CreateCommand();
         check.CommandText = "SELECT job_id FROM jobs WHERE results_file = $rf";
         check.Parameters.AddWithValue("$rf", resultsFile);
-        if (check.ExecuteScalar() is long existingId) return (int)existingId;
+        if (check.ExecuteScalar() is long existingId)
+        {
+            using var upd = _conn.CreateCommand();
+            upd.CommandText = """
+                UPDATE jobs
+                SET job_title = $jt,
+                    audio_file_path = $ap,
+                    audio_file_sha256sum = $sh,
+                    audio_file_datestamp = $ad,
+                    stream_index = $si,
+                    asr_language_code = $lc,
+                    asr_model_name = $am
+                WHERE job_id = $id
+                """;
+            upd.Parameters.AddWithValue("$jt", title);
+            upd.Parameters.AddWithValue("$ap", audioPath);
+            upd.Parameters.AddWithValue("$sh", sha256);
+            upd.Parameters.AddWithValue("$ad", audioDateStamp);
+            upd.Parameters.AddWithValue("$si", streamIndex);
+            upd.Parameters.AddWithValue("$lc", asrLanguageCode);
+            upd.Parameters.AddWithValue("$am", asrModelName);
+            upd.Parameters.AddWithValue("$id", existingId);
+            upd.ExecuteNonQuery();
+            return (int)existingId;
+        }
 
         using var ins = _conn.CreateCommand();
         ins.CommandText = """
             INSERT INTO jobs
                 (job_title, results_file, transcription_run_datestamp,
                  audio_file_path, audio_file_sha256sum, audio_file_datestamp,
-                 status, created_at, stream_index, asr_language_code)
-            VALUES ($jt, $rf, NULL, $ap, $sh, $ad, 'queued', $ca, $si, $lc)
+                 status, created_at, stream_index, asr_language_code, asr_model_name)
+            VALUES ($jt, $rf, NULL, $ap, $sh, $ad, 'queued', $ca, $si, $lc, $am)
             """;
         ins.Parameters.AddWithValue("$jt", title);
         ins.Parameters.AddWithValue("$rf", resultsFile);
@@ -131,6 +164,7 @@ internal sealed class ControlDb : IDisposable
         ins.Parameters.AddWithValue("$ca", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
         ins.Parameters.AddWithValue("$si", streamIndex);
         ins.Parameters.AddWithValue("$lc", asrLanguageCode);
+        ins.Parameters.AddWithValue("$am", asrModelName);
         ins.ExecuteNonQuery();
 
         using var lastId = _conn.CreateCommand();
@@ -186,6 +220,24 @@ internal sealed class ControlDb : IDisposable
         return result is DBNull or null ? null : (string)result;
     }
 
+    public string GetJobAsrLanguageCode(int jobId)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT asr_language_code FROM jobs WHERE job_id = $id";
+        cmd.Parameters.AddWithValue("$id", jobId);
+        var result = cmd.ExecuteScalar();
+        return result is DBNull or null or "" ? "auto" : (string)result;
+    }
+
+    public string GetJobAsrModelName(int jobId)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT asr_model_name FROM jobs WHERE job_id = $id";
+        cmd.Parameters.AddWithValue("$id", jobId);
+        var result = cmd.ExecuteScalar();
+        return result is DBNull or null or "" ? "nvidia/parakeet-tdt-0.6b-v3" : (string)result;
+    }
+
     public List<JobRecord> GetJobs()
     {
         var jobs = new List<JobRecord>();
@@ -218,6 +270,7 @@ internal sealed class ControlDb : IDisposable
             ResultsFile               = r.GetString(r.GetOrdinal("results_file")),
             AudioFilePath             = r.GetString(r.GetOrdinal("audio_file_path")),
             AudioFileSha256Sum        = r.GetString(r.GetOrdinal("audio_file_sha256sum")),
+            AsrModelName              = GetNullable("asr_model_name") ?? "nvidia/parakeet-tdt-0.6b-v3",
             AsrLanguageCode           = GetNullable("asr_language_code") ?? "auto",
             AudioFileDatestamp        = GetNullable("audio_file_datestamp"),
             TranscriptionRunDatestamp = GetNullable("transcription_run_datestamp"),

--- a/src/Vernacula.Avalonia/Services/JobQueueService.cs
+++ b/src/Vernacula.Avalonia/Services/JobQueueService.cs
@@ -98,13 +98,14 @@ internal sealed class JobQueueService
 
         string fileDateStamp = File.GetLastWriteTime(audioPath)
             .ToString("yyyy-MM-dd HH:mm:ss");
+        string asrLanguageCode = GetJobAsrLanguageCode();
 
         Console.WriteLine("[Queue] Inserting job into database...");
         int jobId = _controlDb.InsertNewJob(
-            jobTitle, dbPath, audioPath, sha256, fileDateStamp, streamIndex);
+            jobTitle, dbPath, audioPath, sha256, fileDateStamp, streamIndex, asrLanguageCode);
         Console.WriteLine($"[Queue] Job inserted with ID: {jobId}");
 
-        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex));
+        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex, asrLanguageCode));
         JobStatusChanged?.Invoke(jobId, JobStatus.Queued, null, null);
         Console.WriteLine("[Queue] Firing JobStatusChanged (Queued) and TryStartNextAsync");
         _ = TryStartNextAsync();
@@ -116,10 +117,11 @@ internal sealed class JobQueueService
     /// <summary>
     /// Re-adds an existing (failed / cancelled) job back into the run queue.
     /// </summary>
-    public void RequeueJob(int jobId, string dbPath, string audioPath, int streamIndex = -1)
+    public void RequeueJob(int jobId, string dbPath, string audioPath, int streamIndex = -1,
+        string asrLanguageCode = "auto")
     {
         _controlDb.UpdateJobStatus(jobId, JobStatus.Queued);
-        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex));
+        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex, asrLanguageCode));
         JobStatusChanged?.Invoke(jobId, JobStatus.Queued, null, null);
         _ = TryStartNextAsync();
     }
@@ -270,6 +272,7 @@ internal sealed class JobQueueService
                 progress,
                 OnSegmentAdded,
                 OnSegmentText,
+                entry.AsrLanguageCode,
                 cts.Token);
 
             sw.Stop();
@@ -301,5 +304,20 @@ internal sealed class JobQueueService
         }
     }
 
-    private record QueueEntry(int JobId, string AudioPath, string DbPath, int StreamIndex = -1);
+    private string GetJobAsrLanguageCode()
+    {
+        if (_settings.Current.AsrBackend != AsrBackend.Cohere)
+            return "auto";
+
+        return string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
+            ? "auto"
+            : _settings.Current.CohereLanguage;
+    }
+
+    private record QueueEntry(
+        int JobId,
+        string AudioPath,
+        string DbPath,
+        int StreamIndex = -1,
+        string AsrLanguageCode = "auto");
 }

--- a/src/Vernacula.Avalonia/Services/JobQueueService.cs
+++ b/src/Vernacula.Avalonia/Services/JobQueueService.cs
@@ -98,14 +98,15 @@ internal sealed class JobQueueService
 
         string fileDateStamp = File.GetLastWriteTime(audioPath)
             .ToString("yyyy-MM-dd HH:mm:ss");
+        string asrModelName = GetJobAsrModelName();
         string asrLanguageCode = GetJobAsrLanguageCode();
 
         Console.WriteLine("[Queue] Inserting job into database...");
         int jobId = _controlDb.InsertNewJob(
-            jobTitle, dbPath, audioPath, sha256, fileDateStamp, streamIndex, asrLanguageCode);
+            jobTitle, dbPath, audioPath, sha256, fileDateStamp, streamIndex, asrLanguageCode, asrModelName);
         Console.WriteLine($"[Queue] Job inserted with ID: {jobId}");
 
-        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex, asrLanguageCode));
+        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex, asrLanguageCode, asrModelName));
         JobStatusChanged?.Invoke(jobId, JobStatus.Queued, null, null);
         Console.WriteLine("[Queue] Firing JobStatusChanged (Queued) and TryStartNextAsync");
         _ = TryStartNextAsync();
@@ -118,10 +119,10 @@ internal sealed class JobQueueService
     /// Re-adds an existing (failed / cancelled) job back into the run queue.
     /// </summary>
     public void RequeueJob(int jobId, string dbPath, string audioPath, int streamIndex = -1,
-        string asrLanguageCode = "auto")
+        string asrLanguageCode = "auto", string asrModelName = "nvidia/parakeet-tdt-0.6b-v3")
     {
         _controlDb.UpdateJobStatus(jobId, JobStatus.Queued);
-        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex, asrLanguageCode));
+        Enqueue(new QueueEntry(jobId, audioPath, dbPath, streamIndex, asrLanguageCode, asrModelName));
         JobStatusChanged?.Invoke(jobId, JobStatus.Queued, null, null);
         _ = TryStartNextAsync();
     }
@@ -272,6 +273,7 @@ internal sealed class JobQueueService
                 progress,
                 OnSegmentAdded,
                 OnSegmentText,
+                entry.AsrModelName,
                 entry.AsrLanguageCode,
                 cts.Token);
 
@@ -304,6 +306,12 @@ internal sealed class JobQueueService
         }
     }
 
+    private string GetJobAsrModelName() => _settings.Current.AsrBackend switch
+    {
+        AsrBackend.Cohere => "CohereLabs/cohere-transcribe-03-2026",
+        _                 => "nvidia/parakeet-tdt-0.6b-v3",
+    };
+
     private string GetJobAsrLanguageCode()
     {
         if (_settings.Current.AsrBackend != AsrBackend.Cohere)
@@ -319,5 +327,6 @@ internal sealed class JobQueueService
         string AudioPath,
         string DbPath,
         int StreamIndex = -1,
-        string AsrLanguageCode = "auto");
+        string AsrLanguageCode = "auto",
+        string AsrModelName = "nvidia/parakeet-tdt-0.6b-v3");
 }

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -48,18 +48,38 @@ internal class ModelManagerService
             new("config.json", "config.json")
         ];
 
+    private static readonly ModelAsset[] CohereFiles =
+        [
+            new(Path.Combine("cohere_transcribe", CohereTranscribe.MelFile), CohereTranscribe.MelFile),
+            new(Path.Combine("cohere_transcribe", CohereTranscribe.EncoderFile), CohereTranscribe.EncoderFile),
+            new(Path.Combine("cohere_transcribe", $"{CohereTranscribe.EncoderFile}.data"), $"{CohereTranscribe.EncoderFile}.data"),
+            new(Path.Combine("cohere_transcribe", CohereTranscribe.DecoderInitFile), CohereTranscribe.DecoderInitFile),
+            new(Path.Combine("cohere_transcribe", CohereTranscribe.DecoderStepFile), CohereTranscribe.DecoderStepFile),
+            new(Path.Combine("cohere_transcribe", CohereTranscribe.VocabFile), CohereTranscribe.VocabFile),
+            new(Path.Combine("cohere_transcribe", CohereTranscribe.ConfigFile), CohereTranscribe.ConfigFile),
+        ];
+
     private readonly SettingsService _settings;
     private readonly HttpClient _http = new(new HttpClientHandler { AllowAutoRedirect = true });
 
     public ModelManagerService(SettingsService settings) => _settings = settings;
 
-    private static ModelAsset[] CoreFiles() =>
-        [.. CoreDiarizationFiles, .. AsrFilesFp32];
+    private ModelAsset[] RequiredFiles() => _settings.Current.AsrBackend switch
+    {
+        AsrBackend.Cohere   => [.. CoreDiarizationFiles, .. CohereFiles],
+        _                   => [.. CoreDiarizationFiles, .. AsrFilesFp32],
+    };
+
+    private ModelAsset[] DownloadableFiles() => _settings.Current.AsrBackend switch
+    {
+        AsrBackend.Cohere   => [.. CoreDiarizationFiles],
+        _                   => [.. CoreDiarizationFiles, .. AsrFilesFp32],
+    };
 
     public IReadOnlyList<string> GetMissingFiles()
     {
         string dir = _settings.GetModelsDir();
-        return CoreFiles()
+        return RequiredFiles()
             .Where(asset => !File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
             .Select(asset => asset.LocalRelativePath)
             .ToList();
@@ -68,8 +88,17 @@ internal class ModelManagerService
     public IReadOnlyList<string> GetPresentFiles()
     {
         string dir = _settings.GetModelsDir();
-        return CoreFiles()
+        return RequiredFiles()
             .Where(asset => File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
+            .Select(asset => asset.LocalRelativePath)
+            .ToList();
+    }
+
+    public IReadOnlyList<string> GetMissingDownloadableFiles()
+    {
+        string dir = _settings.GetModelsDir();
+        return DownloadableFiles()
+            .Where(asset => !File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
             .Select(asset => asset.LocalRelativePath)
             .ToList();
     }
@@ -124,7 +153,7 @@ internal class ModelManagerService
 
         string dir     = _settings.GetModelsDir();
         var outdated = new List<string>();
-        var toCheck = CoreFiles()
+        var toCheck = DownloadableFiles()
             .Where(asset => manifest.ContainsKey(asset.RemoteRelativePath)
                 && File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
             .ToList();
@@ -283,7 +312,7 @@ internal class ModelManagerService
         string dir = _settings.GetModelsDir();
         Directory.CreateDirectory(dir);
 
-        var missing = CoreFiles()
+        var missing = DownloadableFiles()
             .Where(asset => !File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
             .ToList();
         await DownloadMissingAssetsAsync(dir, missing, CoreRepoBase, progress, ct);

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -12,12 +12,21 @@ namespace Vernacula.App.Services;
 internal class ModelManagerService
 {
     private readonly record struct ModelAsset(string LocalRelativePath, string RemoteRelativePath);
+    private readonly record struct AssetRepo(string RepoBase, string ManifestUrl, ModelAsset[] Assets);
+    private readonly record struct RepoAsset(string RepoBase, string LocalRelativePath, string RemoteRelativePath);
 
     private const string CoreRepoBase =
         "https://huggingface.co/christopherthompson81/sortformer_parakeet_onnx/resolve/main";
+    private const string CoreManifestUrl =
+        "https://huggingface.co/christopherthompson81/sortformer_parakeet_onnx/resolve/main/manifest.json";
 
     private const string DiariZenRepoBase =
         "https://huggingface.co/christopherthompson81/diarizen_onnx/resolve/main";
+
+    private const string CohereRepoBase =
+        "https://huggingface.co/christopherthompson81/cohere-transcribe-03-2026-onnx/resolve/main";
+    private const string CohereManifestUrl =
+        "https://huggingface.co/christopherthompson81/cohere-transcribe-03-2026-onnx/resolve/main/manifest.json";
 
     private static readonly ModelAsset[] CoreDiarizationFiles =
         [
@@ -54,7 +63,9 @@ internal class ModelManagerService
             new(Path.Combine("cohere_transcribe", CohereTranscribe.EncoderFile), CohereTranscribe.EncoderFile),
             new(Path.Combine("cohere_transcribe", $"{CohereTranscribe.EncoderFile}.data"), $"{CohereTranscribe.EncoderFile}.data"),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.DecoderInitFile), CohereTranscribe.DecoderInitFile),
+            new(Path.Combine("cohere_transcribe", $"{CohereTranscribe.DecoderInitFile}.data"), $"{CohereTranscribe.DecoderInitFile}.data"),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.DecoderStepFile), CohereTranscribe.DecoderStepFile),
+            new(Path.Combine("cohere_transcribe", $"{CohereTranscribe.DecoderStepFile}.data"), $"{CohereTranscribe.DecoderStepFile}.data"),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.VocabFile), CohereTranscribe.VocabFile),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.ConfigFile), CohereTranscribe.ConfigFile),
         ];
@@ -64,17 +75,25 @@ internal class ModelManagerService
 
     public ModelManagerService(SettingsService settings) => _settings = settings;
 
-    private ModelAsset[] RequiredFiles() => _settings.Current.AsrBackend switch
+    private AssetRepo[] ActiveRepos() => _settings.Current.AsrBackend switch
     {
-        AsrBackend.Cohere   => [.. CoreDiarizationFiles, .. CohereFiles],
-        _                   => [.. CoreDiarizationFiles, .. AsrFilesFp32],
+        AsrBackend.Cohere =>
+        [
+            new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
+            new AssetRepo(CohereRepoBase, CohereManifestUrl, CohereFiles),
+        ],
+        _ =>
+        [
+            new AssetRepo(CoreRepoBase, CoreManifestUrl, [.. CoreDiarizationFiles, .. AsrFilesFp32]),
+        ],
     };
 
-    private ModelAsset[] DownloadableFiles() => _settings.Current.AsrBackend switch
-    {
-        AsrBackend.Cohere   => [.. CoreDiarizationFiles],
-        _                   => [.. CoreDiarizationFiles, .. AsrFilesFp32],
-    };
+    private ModelAsset[] RequiredFiles() =>
+        [.. ActiveRepos().SelectMany(repo => repo.Assets)];
+
+    private RepoAsset[] DownloadableFiles() =>
+        [.. ActiveRepos().SelectMany(repo => repo.Assets.Select(asset =>
+            new RepoAsset(repo.RepoBase, asset.LocalRelativePath, asset.RemoteRelativePath)))];
 
     public IReadOnlyList<string> GetMissingFiles()
     {
@@ -138,39 +157,50 @@ internal class ModelManagerService
         IProgress<(string fileName, int index, int total)>? progress = null,
         CancellationToken ct = default)
     {
-        string json;
-        try
-        {
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            cts.CancelAfter(TimeSpan.FromSeconds(10));
-            json = await _http.GetStringAsync(Config.ManifestUrl, cts.Token);
-        }
-        catch { return null; }
-
-        Dictionary<string, string> manifest;
-        try   { manifest = ParseManifestHashes(json); }
-        catch { return null; }
-
         string dir     = _settings.GetModelsDir();
         var outdated = new List<string>();
-        var toCheck = DownloadableFiles()
-            .Where(asset => manifest.ContainsKey(asset.RemoteRelativePath)
-                && File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
-            .ToList();
+        var toCheck = new List<(string localRelativePath, string expectedHash)>();
+
+        foreach (var repo in ActiveRepos())
+        {
+            string json;
+            try
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                cts.CancelAfter(TimeSpan.FromSeconds(10));
+                json = await _http.GetStringAsync(repo.ManifestUrl, cts.Token);
+            }
+            catch { return null; }
+
+            Dictionary<string, string> manifest;
+            try   { manifest = ParseManifestHashes(json); }
+            catch { return null; }
+
+            foreach (var asset in repo.Assets)
+            {
+                string path = Path.Combine(dir, asset.LocalRelativePath);
+                if (manifest.TryGetValue(asset.RemoteRelativePath, out var expectedHash) &&
+                    expectedHash is not null &&
+                    File.Exists(path))
+                {
+                    toCheck.Add((asset.LocalRelativePath, expectedHash));
+                }
+            }
+        }
+
         int total = toCheck.Count;
 
         for (int i = 0; i < total; i++)
         {
             ct.ThrowIfCancellationRequested();
             var asset = toCheck[i];
-            string expectedHash = manifest[asset.RemoteRelativePath];
-            progress?.Report((asset.LocalRelativePath, i, total));
+            progress?.Report((asset.localRelativePath, i, total));
 
-            string path       = Path.Combine(dir, asset.LocalRelativePath);
+            string path       = Path.Combine(dir, asset.localRelativePath);
             string actualHash = await Task.Run(() => ComputeMd5(path), ct);
 
-            if (!string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
-                outdated.Add(asset.LocalRelativePath);
+            if (!string.Equals(actualHash, asset.expectedHash, StringComparison.OrdinalIgnoreCase))
+                outdated.Add(asset.localRelativePath);
         }
         return outdated;
     }
@@ -315,7 +345,7 @@ internal class ModelManagerService
         var missing = DownloadableFiles()
             .Where(asset => !File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
             .ToList();
-        await DownloadMissingAssetsAsync(dir, missing, CoreRepoBase, progress, ct);
+        await DownloadMissingAssetsAsync(dir, missing, progress, ct);
     }
 
     public async Task DownloadMissingDiariZenModelsAsync(
@@ -328,18 +358,18 @@ internal class ModelManagerService
 
         var missing = DiariZenFiles
             .Where(asset => !File.Exists(Path.Combine(dir, Path.GetRelativePath("diarizen", asset.LocalRelativePath))))
-            .Select(asset => new ModelAsset(
+            .Select(asset => new RepoAsset(
+                DiariZenRepoBase,
                 Path.GetRelativePath("diarizen", asset.LocalRelativePath),
                 asset.RemoteRelativePath))
             .ToList();
 
-        await DownloadMissingAssetsAsync(dir, missing, DiariZenRepoBase, progress, ct);
+        await DownloadMissingAssetsAsync(dir, missing, progress, ct);
     }
 
     private async Task DownloadMissingAssetsAsync(
         string dir,
-        IReadOnlyList<ModelAsset> missing,
-        string repoBase,
+        IReadOnlyList<RepoAsset> missing,
         IProgress<DownloadProgress> progress,
         CancellationToken ct)
     {
@@ -353,7 +383,7 @@ internal class ModelManagerService
             ct.ThrowIfCancellationRequested();
             try
             {
-                using var req  = new HttpRequestMessage(HttpMethod.Head, $"{repoBase}/{missing[i].RemoteRelativePath}");
+                using var req  = new HttpRequestMessage(HttpMethod.Head, $"{missing[i].RepoBase}/{missing[i].RemoteRelativePath}");
                 using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
                 fileSizes[i] = resp.Content.Headers.ContentLength ?? 0;
             }
@@ -368,7 +398,7 @@ internal class ModelManagerService
             ct.ThrowIfCancellationRequested();
             var asset = missing[i];
             string fileName = asset.LocalRelativePath;
-            string url      = $"{repoBase}/{asset.RemoteRelativePath}";
+            string url      = $"{asset.RepoBase}/{asset.RemoteRelativePath}";
             string destPath = Path.Combine(dir, asset.LocalRelativePath);
             string tmpPath  = destPath + ".download";
             Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -80,6 +80,9 @@ internal class SettingsService
     public string GetDenoiserModelsDir() =>
         Path.Combine(GetModelsDir(), "deepfilternet3");
 
+    public string GetCohereModelsDir() =>
+        Path.Combine(GetModelsDir(), "cohere_transcribe");
+
     public string GetJobsDir()
     {
         string dir = Path.Combine(

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -36,6 +36,7 @@ internal class TranscriptionService
         IProgress<TranscriptionProgress> progress,
         Action<SegmentRow>   onSegmentAdded,
         Action<int, string>  onSegmentText,
+        string               asrModelName,
         string               asrLanguageCode,
         CancellationToken    ct)
     {
@@ -49,7 +50,7 @@ internal class TranscriptionService
                 try
                 {
                     await RunPipelineAsync(audioPath, streamIndex, resultsDbPath,
-                        progress, onSegmentAdded, onSegmentText, asrLanguageCode, ct);
+                        progress, onSegmentAdded, onSegmentText, asrModelName, asrLanguageCode, ct);
                 }
                 catch (Exception ex)
                 {
@@ -67,6 +68,7 @@ internal class TranscriptionService
         IProgress<TranscriptionProgress> progress,
         Action<SegmentRow>  onSegmentAdded,
         Action<int, string> onSegmentText,
+        string              asrModelName,
         string              asrLanguageCode,
         CancellationToken   ct)
     {
@@ -125,14 +127,12 @@ internal class TranscriptionService
         if (!db.CheckMetadata(audioPath))
             db.PopulateMetadata(audioPath);
 
-        string asrModelName = _settings.Current.AsrBackend switch
-        {
-            AsrBackend.Cohere => "CohereLabs/cohere-transcribe-03-2026",
-            _                 => "nvidia/parakeet-tdt-0.6b-v3",
-        };
         db.UpdateMetadata("asr_model", asrModelName);
         db.UpdateMetadata("asr_language_code",
             string.IsNullOrWhiteSpace(asrLanguageCode) ? "auto" : asrLanguageCode);
+
+        bool useCohereAsr = string.Equals(
+            asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
 
         // ── Phase 3: Segmentation (Diarization or VAD) ───────────────────────
         List<(double start, double end, string spkId)> segs;
@@ -191,7 +191,7 @@ internal class TranscriptionService
             // ── Sortformer path (streaming diarization with inline ASR) ──────
             segs = new List<(double, double, string)>();
             var seenSpeakers = new HashSet<string>();
-            bool useInlineParakeetAsr = _settings.Current.AsrBackend == AsrBackend.Parakeet;
+            bool useInlineParakeetAsr = !useCohereAsr;
             ParakeetAsr? parakeet = null;
             if (useInlineParakeetAsr)
             {
@@ -463,7 +463,7 @@ internal class TranscriptionService
             int totalSegs  = segs.Count;
             int completed  = startSeg;
 
-            if (_settings.Current.AsrBackend == AsrBackend.Cohere)
+            if (useCohereAsr)
             {
                 string cohereModelsDir = _settings.GetCohereModelsDir();
                 string? forceLanguage =

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -10,6 +10,7 @@ namespace Vernacula.App.Services;
 internal class TranscriptionService
 {
     private const double DiariZenDiarizationPercentWeight = 40.0;
+    private const string CohereSyntheticTimestampMode = "uniform_segment_frames_v1";
 
     private readonly SettingsService _settings;
 
@@ -122,6 +123,13 @@ internal class TranscriptionService
         if (!db.CheckMetadata(audioPath))
             db.PopulateMetadata(audioPath);
 
+        string asrModelName = _settings.Current.AsrBackend switch
+        {
+            AsrBackend.Cohere => "CohereLabs/cohere-transcribe-03-2026",
+            _                 => "nvidia/parakeet-tdt-0.6b-v3",
+        };
+        db.UpdateMetadata("asr_model", asrModelName);
+
         // ── Phase 3: Segmentation (Diarization or VAD) ───────────────────────
         List<(double start, double end, string spkId)> segs;
         bool inlineAsrDone = false;
@@ -179,10 +187,14 @@ internal class TranscriptionService
             // ── Sortformer path (streaming diarization with inline ASR) ──────
             segs = new List<(double, double, string)>();
             var seenSpeakers = new HashSet<string>();
-
-            var (encoderFile, decoderJointFile) =
-                Config.GetAsrFiles(ModelPrecision.Fp32);
-            using var parakeet = new ParakeetAsr(modelsDir, encoderFile, decoderJointFile);
+            bool useInlineParakeetAsr = _settings.Current.AsrBackend == AsrBackend.Parakeet;
+            ParakeetAsr? parakeet = null;
+            if (useInlineParakeetAsr)
+            {
+                var (encoderFile, decoderJointFile) =
+                    Config.GetAsrFiles(ModelPrecision.Fp32);
+                parakeet = new ParakeetAsr(modelsDir, encoderFile, decoderJointFile);
+            }
 
             using var streamer = new SortformerStreamer(modelsDir);
             float[,,] melSpec = AudioUtils.LogMelSpectrogram(audio);
@@ -256,7 +268,7 @@ internal class TranscriptionService
                     : Task.Run(() => enumerator.MoveNext(), ct);
 
                 // (b) CPU preprocessing for current segments — runs concurrently with (a).
-                if (newSegs.Count > 0)
+                if (useInlineParakeetAsr && parakeet is not null && newSegs.Count > 0)
                 {
                     int batchSize = newSegs.Count;
                     var preprocessTask = Task.Run(() => parakeet.PrepareBatch(newSegs, audio), ct);
@@ -305,7 +317,8 @@ internal class TranscriptionService
             }
 
             db.MarkDiarizationComplete();
-            inlineAsrDone = true;
+            inlineAsrDone = useInlineParakeetAsr;
+            parakeet?.Dispose();
         }
         else if (!db.CheckDiarization() && segmentationMode == SegmentationMode.DiariZen)
         {
@@ -442,48 +455,105 @@ internal class TranscriptionService
 
         if (!asrDone && !inlineAsrDone)
         {
-            var (encoderFile, decoderJointFile) =
-                Config.GetAsrFiles(ModelPrecision.Fp32);
-
-            using var parakeet = new ParakeetAsr(modelsDir, encoderFile, decoderJointFile);
             var segsSubset = segs.GetRange(startSeg, segs.Count - startSeg);
             int totalSegs  = segs.Count;
             int completed  = startSeg;
 
-            foreach (var (segId, text, tokens, timestamps, logprobs) in
-                parakeet.Recognize(segsSubset, audio))
+            if (_settings.Current.AsrBackend == AsrBackend.Cohere)
             {
-                ct.ThrowIfCancellationRequested();
-                int absId = startSeg + segId;
-                completed++;
+                string cohereModelsDir = _settings.GetCohereModelsDir();
+                string? forceLanguage = string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
+                    ? null
+                    : _settings.Current.CohereLanguage;
+                using var cohere = new CohereTranscribe(cohereModelsDir);
 
-                db.UpdateResult(
-                    resultId:   absId + 1,
-                    asrContent: text,
-                    content:    text,
-                    tokens:     JsonSerializer.Serialize(tokens),
-                    timestamps: JsonSerializer.Serialize(timestamps),
-                    logprobs:   JsonSerializer.Serialize(logprobs));
+                foreach (var result in cohere.RecognizeDetailed(
+                    segsSubset, audio, forceLanguage: forceLanguage))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    int absId = startSeg + result.SegmentId;
+                    completed++;
+                    var syntheticTimestamps = BuildSyntheticTokenTimestamps(
+                        segsSubset[result.SegmentId].end - segsSubset[result.SegmentId].start,
+                        result.TextTokens.Count);
 
-                onSegmentText(absId, text);
+                    db.UpdateResult(
+                        resultId:   absId + 1,
+                        asrContent: result.Text,
+                        content:    result.Text,
+                        tokens:     JsonSerializer.Serialize(result.TextTokens),
+                        timestamps: JsonSerializer.Serialize(syntheticTimestamps),
+                        logprobs:   JsonSerializer.Serialize(result.TextLogprobs),
+                        language:   result.Meta.Language,
+                        emotion:    result.Meta.Emotion,
+                        asrMeta:    result.Meta.ToJson(
+                            rawDecoderTokens: result.RawTokens,
+                            storedTextTokens: result.TextTokens,
+                            syntheticTimestamps: true,
+                            timestampMode: CohereSyntheticTimestampMode));
 
-                string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
-                    ["i"]     = completed.ToString(),
-                    ["count"] = totalSegs.ToString() });
-                double? overridePercent = segmentationMode == SegmentationMode.DiariZen
-                    ? ScaleOverallProgress(
-                        DiariZenDiarizationPercentWeight,
-                        100,
-                        totalSegs > 0 ? completed / (double)totalSegs : 1)
-                    : null;
-                progress.Report(new TranscriptionProgress(
-                    TranscriptionPhase.Recognizing,
-                    completed,
-                    totalSegs,
-                    asrText,
-                    absId,
-                    text,
-                    overridePercent));
+                    onSegmentText(absId, result.Text);
+
+                    string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
+                        ["i"]     = completed.ToString(),
+                        ["count"] = totalSegs.ToString() });
+                    double? overridePercent = segmentationMode == SegmentationMode.DiariZen
+                        ? ScaleOverallProgress(
+                            DiariZenDiarizationPercentWeight,
+                            100,
+                            totalSegs > 0 ? completed / (double)totalSegs : 1)
+                        : null;
+                    progress.Report(new TranscriptionProgress(
+                        TranscriptionPhase.Recognizing,
+                        completed,
+                        totalSegs,
+                        asrText,
+                        absId,
+                        result.Text,
+                        overridePercent));
+                }
+            }
+            else
+            {
+                var (encoderFile, decoderJointFile) =
+                    Config.GetAsrFiles(ModelPrecision.Fp32);
+
+                using var parakeet = new ParakeetAsr(modelsDir, encoderFile, decoderJointFile);
+                foreach (var (segId, text, tokens, timestamps, logprobs) in
+                    parakeet.Recognize(segsSubset, audio))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    int absId = startSeg + segId;
+                    completed++;
+
+                    db.UpdateResult(
+                        resultId:   absId + 1,
+                        asrContent: text,
+                        content:    text,
+                        tokens:     JsonSerializer.Serialize(tokens),
+                        timestamps: JsonSerializer.Serialize(timestamps),
+                        logprobs:   JsonSerializer.Serialize(logprobs));
+
+                    onSegmentText(absId, text);
+
+                    string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
+                        ["i"]     = completed.ToString(),
+                        ["count"] = totalSegs.ToString() });
+                    double? overridePercent = segmentationMode == SegmentationMode.DiariZen
+                        ? ScaleOverallProgress(
+                            DiariZenDiarizationPercentWeight,
+                            100,
+                            totalSegs > 0 ? completed / (double)totalSegs : 1)
+                        : null;
+                    progress.Report(new TranscriptionProgress(
+                        TranscriptionPhase.Recognizing,
+                        completed,
+                        totalSegs,
+                        asrText,
+                        absId,
+                        text,
+                        overridePercent));
+                }
             }
         }
 
@@ -557,4 +627,26 @@ internal class TranscriptionService
 
     private static double ScaleOverallProgress(double startPercent, double endPercent, double fraction) =>
         startPercent + (endPercent - startPercent) * Math.Clamp(fraction, 0, 1);
+
+    private static List<int> BuildSyntheticTokenTimestamps(double segmentDurationSeconds, int tokenCount)
+    {
+        if (tokenCount <= 0)
+            return [];
+
+        const double frameSeconds = Config.HopLength * 8.0 / Config.SampleRate;
+        int maxFrame = Math.Max((int)Math.Round(segmentDurationSeconds / frameSeconds), 0);
+        if (tokenCount == 1)
+            return [0];
+
+        var timestamps = new List<int>(tokenCount);
+        for (int i = 0; i < tokenCount; i++)
+        {
+            int frame = (int)Math.Round(i * maxFrame / (double)(tokenCount - 1));
+            if (timestamps.Count > 0 && frame < timestamps[^1])
+                frame = timestamps[^1];
+            timestamps.Add(frame);
+        }
+
+        return timestamps;
+    }
 }

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -36,6 +36,7 @@ internal class TranscriptionService
         IProgress<TranscriptionProgress> progress,
         Action<SegmentRow>   onSegmentAdded,
         Action<int, string>  onSegmentText,
+        string               asrLanguageCode,
         CancellationToken    ct)
     {
         // LongRunning spins up a dedicated OS thread. The async lambda allows
@@ -48,7 +49,7 @@ internal class TranscriptionService
                 try
                 {
                     await RunPipelineAsync(audioPath, streamIndex, resultsDbPath,
-                        progress, onSegmentAdded, onSegmentText, ct);
+                        progress, onSegmentAdded, onSegmentText, asrLanguageCode, ct);
                 }
                 catch (Exception ex)
                 {
@@ -66,6 +67,7 @@ internal class TranscriptionService
         IProgress<TranscriptionProgress> progress,
         Action<SegmentRow>  onSegmentAdded,
         Action<int, string> onSegmentText,
+        string              asrLanguageCode,
         CancellationToken   ct)
     {
         Console.WriteLine($"[Transcription] RunPipelineAsync starting for '{audioPath}'");
@@ -129,6 +131,8 @@ internal class TranscriptionService
             _                 => "nvidia/parakeet-tdt-0.6b-v3",
         };
         db.UpdateMetadata("asr_model", asrModelName);
+        db.UpdateMetadata("asr_language_code",
+            string.IsNullOrWhiteSpace(asrLanguageCode) ? "auto" : asrLanguageCode);
 
         // ── Phase 3: Segmentation (Diarization or VAD) ───────────────────────
         List<(double start, double end, string spkId)> segs;
@@ -462,9 +466,11 @@ internal class TranscriptionService
             if (_settings.Current.AsrBackend == AsrBackend.Cohere)
             {
                 string cohereModelsDir = _settings.GetCohereModelsDir();
-                string? forceLanguage = string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
-                    ? null
-                    : _settings.Current.CohereLanguage;
+                string? forceLanguage =
+                    string.Equals(asrLanguageCode, "auto", StringComparison.OrdinalIgnoreCase) ||
+                    string.IsNullOrWhiteSpace(asrLanguageCode)
+                        ? null
+                        : asrLanguageCode;
                 using var cohere = new CohereTranscribe(cohereModelsDir);
 
                 foreach (var result in cohere.RecognizeDetailed(

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
+using System.Text.Json;
 using Avalonia.Media;
 using Vernacula.Base;
 
@@ -11,16 +13,28 @@ namespace Vernacula.App.Services;
 /// </summary>
 internal class VocabService
 {
-    private readonly Dictionary<int, string> _vocab;
+    private enum VocabKind { Parakeet, Cohere }
 
-    public VocabService(string modelsDir)
+    private readonly Dictionary<int, string> _vocab;
+    private readonly VocabKind _kind;
+
+    public VocabService(string modelsDir, string? asrModel = null)
     {
-        _vocab = LoadVocab(Path.Combine(modelsDir, Config.VocabFile));
+        if (string.Equals(asrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal))
+        {
+            _kind = VocabKind.Cohere;
+            _vocab = LoadCohereVocab(Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile));
+        }
+        else
+        {
+            _kind = VocabKind.Parakeet;
+            _vocab = LoadParakeetVocab(Path.Combine(modelsDir, Config.VocabFile));
+        }
     }
 
     // ── Vocab loading (mirrors Parakeet.GetVocab) ────────────────────────────
 
-    private static Dictionary<int, string> LoadVocab(string vocabPath)
+    private static Dictionary<int, string> LoadParakeetVocab(string vocabPath)
     {
         var vocab = new Dictionary<int, string>();
         if (!File.Exists(vocabPath)) return vocab;
@@ -37,14 +51,29 @@ internal class VocabService
         return vocab;
     }
 
+    private static Dictionary<int, string> LoadCohereVocab(string vocabPath)
+    {
+        var vocab = new Dictionary<int, string>();
+        if (!File.Exists(vocabPath)) return vocab;
+
+        string json = File.ReadAllText(vocabPath);
+        var items = JsonSerializer.Deserialize<string[]>(json);
+        if (items is null) return vocab;
+
+        for (int i = 0; i < items.Length; i++)
+            vocab[i] = items[i];
+        return vocab;
+    }
+
     // ── Token decoding ────────────────────────────────────────────────────────
 
     public string DecodeTokens(IReadOnlyList<int> tokens)
     {
-        var sb = new System.Text.StringBuilder();
-        foreach (var t in tokens)
-            if (_vocab.TryGetValue(t, out var s)) sb.Append(s);
-        return sb.ToString().Trim();
+        return _kind switch
+        {
+            VocabKind.Cohere   => DecodeCohereTokens(tokens),
+            _                  => DecodeParakeetTokens(tokens),
+        };
     }
 
     /// <summary>Returns (text, logprob) pairs for each token.</summary>
@@ -54,12 +83,77 @@ internal class VocabService
         var runs = new List<(string, float)>(tokens.Count);
         for (int i = 0; i < tokens.Count; i++)
         {
-            string text = _vocab.TryGetValue(tokens[i], out var s) ? s : "";
+            string text = DecodeToken(tokens[i]);
             float  lp   = i < logprobs.Count ? logprobs[i] : 0f;
             runs.Add((text, lp));
         }
         return runs;
     }
+
+    private string DecodeParakeetTokens(IReadOnlyList<int> tokens)
+    {
+        var sb = new StringBuilder();
+        foreach (var t in tokens)
+            if (_vocab.TryGetValue(t, out var s)) sb.Append(s);
+        return sb.ToString().Trim();
+    }
+
+    private string DecodeCohereTokens(IReadOnlyList<int> tokens)
+    {
+        var bytes = new List<byte>(tokens.Count * 4);
+        foreach (int token in tokens)
+        {
+            if (!_vocab.TryGetValue(token, out var value)) continue;
+
+            if (value.Length == 6 && value[0] == '<' && value[1] == '0' && value[2] == 'x' && value[5] == '>')
+            {
+                if (TryParseHexByte(value[3], value[4], out byte b))
+                {
+                    bytes.Add(b);
+                    continue;
+                }
+            }
+
+            bytes.AddRange(Encoding.UTF8.GetBytes(value.Replace('\u2581', ' ')));
+        }
+
+        string text = Encoding.UTF8.GetString(bytes.ToArray());
+        return text.Length > 0 && text[0] == ' ' ? text[1..] : text;
+    }
+
+    private string DecodeToken(int token)
+    {
+        if (!_vocab.TryGetValue(token, out var value))
+            return "";
+
+        if (_kind == VocabKind.Parakeet)
+            return value;
+
+        if (value.Length == 6 && value[0] == '<' && value[1] == '0' && value[2] == 'x' && value[5] == '>')
+        {
+            if (TryParseHexByte(value[3], value[4], out byte b))
+                return Encoding.UTF8.GetString([b]);
+        }
+
+        return value.Replace('\u2581', ' ');
+    }
+
+    private static bool TryParseHexByte(char hi, char lo, out byte value)
+    {
+        int h = HexVal(hi);
+        int l = HexVal(lo);
+        if (h < 0 || l < 0) { value = 0; return false; }
+        value = (byte)((h << 4) | l);
+        return true;
+    }
+
+    private static int HexVal(char c) => c switch
+    {
+        >= '0' and <= '9' => c - '0',
+        >= 'a' and <= 'f' => c - 'a' + 10,
+        >= 'A' and <= 'F' => c - 'A' + 10,
+        _ => -1,
+    };
 
     // ── Confidence highlight ──────────────────────────────────────────────────
 

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -80,6 +80,9 @@ internal class VocabService
     public IReadOnlyList<(string text, float logprob)> GetTokenRuns(
         IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
     {
+        if (_kind == VocabKind.Cohere)
+            return GetCohereTokenRuns(tokens, logprobs);
+
         var runs = new List<(string, float)>(tokens.Count);
         for (int i = 0; i < tokens.Count; i++)
         {
@@ -87,6 +90,23 @@ internal class VocabService
             float  lp   = i < logprobs.Count ? logprobs[i] : 0f;
             runs.Add((text, lp));
         }
+        return runs;
+    }
+
+    private IReadOnlyList<(string text, float logprob)> GetCohereTokenRuns(
+        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
+    {
+        var runs = new List<(string, float)>(tokens.Count);
+        Decoder decoder = Encoding.UTF8.GetDecoder();
+        bool stripLeadingSpace = true;
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            string runText = DecodeCohereTokenIncrement(decoder, tokens[i], ref stripLeadingSpace);
+            float lp = i < logprobs.Count ? logprobs[i] : 0f;
+            runs.Add((runText, lp));
+        }
+
         return runs;
     }
 
@@ -136,6 +156,44 @@ internal class VocabService
         }
 
         return value.Replace('\u2581', ' ');
+    }
+
+    private string DecodeCohereTokenIncrement(Decoder decoder, int token, ref bool stripLeadingSpace)
+    {
+        byte[] tokenBytes = GetCohereTokenBytes(token);
+        if (tokenBytes.Length == 0)
+            return "";
+
+        int charCount = decoder.GetCharCount(tokenBytes, 0, tokenBytes.Length, flush: false);
+        if (charCount == 0)
+            return "";
+
+        char[] chars = new char[charCount];
+        decoder.GetChars(tokenBytes, 0, tokenBytes.Length, chars, 0, flush: false);
+        string text = new(chars);
+
+        if (stripLeadingSpace && text.Length > 0)
+        {
+            stripLeadingSpace = false;
+            if (text[0] == ' ')
+                text = text[1..];
+        }
+
+        return text;
+    }
+
+    private byte[] GetCohereTokenBytes(int token)
+    {
+        if (!_vocab.TryGetValue(token, out var value))
+            return [];
+
+        if (value.Length == 6 && value[0] == '<' && value[1] == '0' && value[2] == 'x' && value[5] == '>')
+        {
+            if (TryParseHexByte(value[3], value[4], out byte b))
+                return [b];
+        }
+
+        return Encoding.UTF8.GetBytes(value.Replace('\u2581', ' '));
     }
 
     private static bool TryParseHexByte(char hi, char lo, out byte value)

--- a/src/Vernacula.Avalonia/TranscriptionDb.cs
+++ b/src/Vernacula.Avalonia/TranscriptionDb.cs
@@ -108,6 +108,12 @@ internal sealed class TranscriptionDb : IDisposable
         catch (SqliteException) { /* column already exists */ }
         try { Execute("ALTER TABLE results ADD COLUMN suppressed INTEGER NOT NULL DEFAULT 0"); }
         catch (SqliteException) { /* column already exists */ }
+        try { Execute("ALTER TABLE results ADD COLUMN language TEXT"); }
+        catch (SqliteException) { /* column already exists */ }
+        try { Execute("ALTER TABLE results ADD COLUMN emotion  TEXT"); }
+        catch (SqliteException) { /* column already exists */ }
+        try { Execute("ALTER TABLE results ADD COLUMN asr_meta TEXT"); }
+        catch (SqliteException) { /* column already exists */ }
 
         MigrateToCardLayer();
     }
@@ -204,16 +210,21 @@ internal sealed class TranscriptionDb : IDisposable
         string? content,
         string? tokens,
         string? timestamps,
-        string? logprobs)
+        string? logprobs,
+        string? language = null,
+        string? emotion  = null,
+        string? asrMeta  = null)
     {
         using var cmd = CreateCmd();
         cmd.CommandText = """
             INSERT INTO results
                 (diarization_speaker_id, speaker_id,
                  start_time, end_time, start_time_f, end_time_f,
-                 asr_content, content, tokens, timestamps, logprobs)
+                 asr_content, content, tokens, timestamps, logprobs,
+                 language, emotion, asr_meta)
             VALUES
-                ($dspk, $spk, $st, $et, $stf, $etf, $asr, $con, $tok, $ts, $lp)
+                ($dspk, $spk, $st, $et, $stf, $etf, $asr, $con, $tok, $ts, $lp,
+                 $lang, $emo, $meta)
             """;
         cmd.Parameters.AddWithValue("$dspk", diarizationSpeakerId);
         cmd.Parameters.AddWithValue("$spk",  speakerId);
@@ -221,11 +232,14 @@ internal sealed class TranscriptionDb : IDisposable
         cmd.Parameters.AddWithValue("$et",   endTime);
         cmd.Parameters.AddWithValue("$stf",  startTimeF);
         cmd.Parameters.AddWithValue("$etf",  endTimeF);
-        cmd.Parameters.AddWithValue("$asr",  (object?)asrContent  ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$con",  (object?)content     ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$tok",  (object?)tokens      ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$ts",   (object?)timestamps  ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$lp",   (object?)logprobs    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$asr",  (object?)asrContent ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$con",  (object?)content    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$tok",  (object?)tokens     ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$ts",   (object?)timestamps ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$lp",   (object?)logprobs   ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$lang", (object?)language   ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$emo",  (object?)emotion    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$meta", (object?)asrMeta    ?? DBNull.Value);
         cmd.ExecuteNonQuery();
     }
 
@@ -235,7 +249,10 @@ internal sealed class TranscriptionDb : IDisposable
         string? content,
         string? tokens,
         string? timestamps,
-        string? logprobs)
+        string? logprobs,
+        string? language = null,
+        string? emotion  = null,
+        string? asrMeta  = null)
     {
         using var cmd = CreateCmd();
         cmd.CommandText = """
@@ -244,15 +261,21 @@ internal sealed class TranscriptionDb : IDisposable
                 content     = $con,
                 tokens      = $tok,
                 timestamps  = $ts,
-                logprobs    = $lp
+                logprobs    = $lp,
+                language    = $lang,
+                emotion     = $emo,
+                asr_meta    = $meta
             WHERE result_id = $id
             """;
-        cmd.Parameters.AddWithValue("$asr", (object?)asrContent ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$con", (object?)content    ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$tok", (object?)tokens     ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$ts",  (object?)timestamps ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$lp",  (object?)logprobs   ?? DBNull.Value);
-        cmd.Parameters.AddWithValue("$id",  resultId);
+        cmd.Parameters.AddWithValue("$asr",  (object?)asrContent ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$con",  (object?)content    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$tok",  (object?)tokens     ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$ts",   (object?)timestamps ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$lp",   (object?)logprobs   ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$lang", (object?)language   ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$emo",  (object?)emotion    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$meta", (object?)asrMeta    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$id",   resultId);
         cmd.ExecuteNonQuery();
     }
 
@@ -301,15 +324,20 @@ internal sealed class TranscriptionDb : IDisposable
         string? asrContent,
         string? tokens,
         string? timestamps,
-        string? logprobs)
+        string? logprobs,
+        string? language = null,
+        string? emotion  = null,
+        string? asrMeta  = null)
     {
         using var cmd = CreateCmd();
         cmd.CommandText = """
             INSERT INTO results
                 (diarization_speaker_id, speaker_id, start_time, end_time,
-                 start_time_f, end_time_f, asr_content, content, tokens, timestamps, logprobs)
+                 start_time_f, end_time_f, asr_content, content, tokens, timestamps, logprobs,
+                 language, emotion, asr_meta)
             VALUES
-                ($dspk, $spk, $st, $et, $stf, $etf, $asr, $asr, $tok, $ts, $lp);
+                ($dspk, $spk, $st, $et, $stf, $etf, $asr, $asr, $tok, $ts, $lp,
+                 $lang, $emo, $meta);
             SELECT last_insert_rowid();
             """;
         cmd.Parameters.AddWithValue("$dspk", speakerId);
@@ -322,6 +350,9 @@ internal sealed class TranscriptionDb : IDisposable
         cmd.Parameters.AddWithValue("$tok",  (object?)tokens     ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$ts",   (object?)timestamps ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$lp",   (object?)logprobs   ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$lang", (object?)language   ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$emo",  (object?)emotion    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$meta", (object?)asrMeta    ?? DBNull.Value);
         return Convert.ToInt32(cmd.ExecuteScalar());
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
@@ -71,7 +71,9 @@ internal partial class HomeViewModel : ObservableObject
         if (ModelsReady)
             ModelStatusText = Loc.Instance.T("model_status_ok", new() { ["count"] = _modelMgr.GetPresentFiles().Count.ToString() });
         else if (ModelsWarning)
-            ModelStatusText = _settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen
+            ModelStatusText = _settings.Current.AsrBackend == AsrBackend.Cohere
+                ? $"Cohere Transcribe weights are missing. Place them in {_settings.GetCohereModelsDir()}."
+                : _settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen
                 ? "DiariZen external weights are missing. Open Settings to review the notice and import or download them."
                 : Loc.Instance["settings_model_warning"];
     }

--- a/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
@@ -79,7 +79,8 @@ internal partial class MainViewModel : ObservableObject
         // Home → Requeue (resume a failed / cancelled job)
         Home.RequeueJob = job =>
         {
-            queue.RequeueJob(job.JobId, job.ResultsFile, job.AudioFilePath, job.AudioStreamIndex);
+            queue.RequeueJob(job.JobId, job.ResultsFile, job.AudioFilePath, job.AudioStreamIndex,
+                job.AsrLanguageCode);
             RefreshJobsAndSync();
         };
 

--- a/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
@@ -80,7 +80,7 @@ internal partial class MainViewModel : ObservableObject
         Home.RequeueJob = job =>
         {
             queue.RequeueJob(job.JobId, job.ResultsFile, job.AudioFilePath, job.AudioStreamIndex,
-                job.AsrLanguageCode);
+                job.AsrLanguageCode, job.AsrModelName);
             RefreshJobsAndSync();
         };
 

--- a/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
@@ -225,15 +225,17 @@ internal partial class ProgressViewModel : ObservableObject
         string runStamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
         string fileDateStamp = File.GetLastWriteTime(audioPath)
             .ToString("yyyy-MM-dd HH:mm:ss");
+        string asrModelName = GetJobAsrModelName();
         string asrLanguageCode = GetJobAsrLanguageCode();
 
         int jobId = _controlDb.UpsertJob(
-            jobTitle, dbPath, audioPath, sha256, fileDateStamp, runStamp, asrLanguageCode);
+            jobTitle, dbPath, audioPath, sha256, fileDateStamp, runStamp, asrLanguageCode, asrModelName);
 
         CompletedJobId         = jobId;
         CompletedResultsDbPath = dbPath;
 
-        await RunTranscription(audioPath, dbPath, jobId, asrLanguageCode: asrLanguageCode);
+        await RunTranscription(audioPath, dbPath, jobId, asrModelName: asrModelName,
+            asrLanguageCode: asrLanguageCode);
     }
 
     public async Task LoadJob(int jobId, string dbPath, string audioPath, string audioBaseName)
@@ -266,10 +268,10 @@ internal partial class ProgressViewModel : ObservableObject
         IsIndeterminate = true;
         StatusMessage   = Loc.Instance["progress_resuming"];
         _cts            = new CancellationTokenSource();
-        string asrLanguageCode;
-        using (var resultsDb = new TranscriptionDb(dbPath))
-            asrLanguageCode = resultsDb.GetMetadata("asr_language_code") ?? "auto";
-        await RunTranscription(audioPath, dbPath, jobId, asrLanguageCode: asrLanguageCode);
+        string asrModelName = _controlDb.GetJobAsrModelName(jobId);
+        string asrLanguageCode = _controlDb.GetJobAsrLanguageCode(jobId);
+        await RunTranscription(audioPath, dbPath, jobId, asrModelName: asrModelName,
+            asrLanguageCode: asrLanguageCode);
     }
 
     private async Task RunTranscription(
@@ -277,6 +279,7 @@ internal partial class ProgressViewModel : ObservableObject
         string dbPath,
         int jobId,
         int streamIndex = -1,
+        string asrModelName = "nvidia/parakeet-tdt-0.6b-v3",
         string asrLanguageCode = "auto")
     {
         _activeJobId = jobId;
@@ -313,7 +316,7 @@ internal partial class ProgressViewModel : ObservableObject
 
         _runningTask = _svc.RunAsync(
             audioPath, streamIndex, dbPath, progress, OnSegmentAdded, OnSegmentText,
-            asrLanguageCode, _cts!.Token);
+            asrModelName, asrLanguageCode, _cts!.Token);
 
         try
         {
@@ -340,6 +343,12 @@ internal partial class ProgressViewModel : ObservableObject
             _runningTask = null;
         }
     }
+
+    private string GetJobAsrModelName() => _settings.Current.AsrBackend switch
+    {
+        AsrBackend.Cohere => "CohereLabs/cohere-transcribe-03-2026",
+        _                 => "nvidia/parakeet-tdt-0.6b-v3",
+    };
 
     private string GetJobAsrLanguageCode()
     {

--- a/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
@@ -225,14 +225,15 @@ internal partial class ProgressViewModel : ObservableObject
         string runStamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
         string fileDateStamp = File.GetLastWriteTime(audioPath)
             .ToString("yyyy-MM-dd HH:mm:ss");
+        string asrLanguageCode = GetJobAsrLanguageCode();
 
         int jobId = _controlDb.UpsertJob(
-            jobTitle, dbPath, audioPath, sha256, fileDateStamp, runStamp);
+            jobTitle, dbPath, audioPath, sha256, fileDateStamp, runStamp, asrLanguageCode);
 
         CompletedJobId         = jobId;
         CompletedResultsDbPath = dbPath;
 
-        await RunTranscription(audioPath, dbPath, jobId);
+        await RunTranscription(audioPath, dbPath, jobId, asrLanguageCode: asrLanguageCode);
     }
 
     public async Task LoadJob(int jobId, string dbPath, string audioPath, string audioBaseName)
@@ -265,10 +266,18 @@ internal partial class ProgressViewModel : ObservableObject
         IsIndeterminate = true;
         StatusMessage   = Loc.Instance["progress_resuming"];
         _cts            = new CancellationTokenSource();
-        await RunTranscription(audioPath, dbPath, jobId);
+        string asrLanguageCode;
+        using (var resultsDb = new TranscriptionDb(dbPath))
+            asrLanguageCode = resultsDb.GetMetadata("asr_language_code") ?? "auto";
+        await RunTranscription(audioPath, dbPath, jobId, asrLanguageCode: asrLanguageCode);
     }
 
-    private async Task RunTranscription(string audioPath, string dbPath, int jobId, int streamIndex = -1)
+    private async Task RunTranscription(
+        string audioPath,
+        string dbPath,
+        int jobId,
+        int streamIndex = -1,
+        string asrLanguageCode = "auto")
     {
         _activeJobId = jobId;
         _controlDb.UpdateJobStatus(jobId, JobStatus.Running);
@@ -303,7 +312,8 @@ internal partial class ProgressViewModel : ObservableObject
         }
 
         _runningTask = _svc.RunAsync(
-            audioPath, streamIndex, dbPath, progress, OnSegmentAdded, OnSegmentText, _cts!.Token);
+            audioPath, streamIndex, dbPath, progress, OnSegmentAdded, OnSegmentText,
+            asrLanguageCode, _cts!.Token);
 
         try
         {
@@ -329,6 +339,16 @@ internal partial class ProgressViewModel : ObservableObject
             _activeJobId = null;
             _runningTask = null;
         }
+    }
+
+    private string GetJobAsrLanguageCode()
+    {
+        if (_settings.Current.AsrBackend != AsrBackend.Cohere)
+            return "auto";
+
+        return string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
+            ? "auto"
+            : _settings.Current.CohereLanguage;
     }
 
     // ── Shared helpers ────────────────────────────────────────────────────────

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -29,6 +29,14 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere))]
+    private AsrBackend _selectedAsrBackend;
+
+    [ObservableProperty]
+    private CohereLanguageOption? _selectedCohereLanguage;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowCohereLanguagePicker))]
     [NotifyPropertyChangedFor(nameof(IsDenoiserNone), nameof(IsDenoiserDfn3))]
     private DenoiserMode _selectedDenoiser;
 
@@ -53,6 +61,9 @@ internal partial class SettingsViewModel : ObservableObject
     public bool IsSileroVad         => SelectedSegmentation == SegmentationMode.SileroVad;
     public bool IsSortformer        => SelectedSegmentation == SegmentationMode.Sortformer;
     public bool IsDiariZen          => SelectedSegmentation == SegmentationMode.DiariZen;
+    public bool IsAsrParakeet       => SelectedAsrBackend == AsrBackend.Parakeet;
+    public bool IsAsrCohere         => SelectedAsrBackend == AsrBackend.Cohere;
+    public bool ShowCohereLanguagePicker => SelectedAsrBackend == AsrBackend.Cohere;
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
     public bool ShowDiariZenInSegmentation => HasAcceptedDiariZenNotice;
@@ -63,6 +74,26 @@ internal partial class SettingsViewModel : ObservableObject
     public string GatedModelsStatusText => HasUnlockedGatedModels
         ? "Unlocked gated models: DiariZen"
         : "Some optional models require accepting their own license terms before they appear in settings.";
+
+    public record CohereLanguageOption(string Code, string DisplayName);
+    public static readonly IReadOnlyList<CohereLanguageOption> CohereLanguages =
+    [
+        new("",   "Auto-detect"),
+        new("ar", "Arabic"),
+        new("de", "German"),
+        new("el", "Greek"),
+        new("en", "English"),
+        new("es", "Spanish"),
+        new("fr", "French"),
+        new("it", "Italian"),
+        new("ja", "Japanese"),
+        new("ko", "Korean"),
+        new("nl", "Dutch"),
+        new("pl", "Polish"),
+        new("pt", "Portuguese"),
+        new("vi", "Vietnamese"),
+        new("zh", "Chinese"),
+    ];
 
     // ── Hardware check state ─────────────────────────────────────────────────
 
@@ -115,6 +146,9 @@ internal partial class SettingsViewModel : ObservableObject
         _selectedSegmentation         = svc.Current.Segmentation == SegmentationMode.DiariZen && !svc.IsGatedModelAccepted(DiariZenGatedModelId)
             ? SegmentationMode.Sortformer
             : svc.Current.Segmentation;
+        _selectedAsrBackend           = svc.Current.AsrBackend;
+        _selectedCohereLanguage       = CohereLanguages.FirstOrDefault(l => l.Code == svc.Current.CohereLanguage)
+                                        ?? CohereLanguages[0];
         _selectedDenoiser             = svc.Current.Denoiser;
         _selectedEditorPlaybackMode   = svc.Current.EditorPlaybackMode;
         _selectedLanguage             = svc.Current.Language;
@@ -159,6 +193,21 @@ internal partial class SettingsViewModel : ObservableObject
         _svc.Current.Segmentation = value;
         _svc.Save();
         OnSegmentationChanged?.Invoke();
+    }
+
+    partial void OnSelectedAsrBackendChanged(AsrBackend value)
+    {
+        _svc.Current.AsrBackend = value;
+        _svc.Save();
+        OnPropertyChanged(nameof(ShowCohereLanguagePicker));
+        OnSegmentationChanged?.Invoke();
+        _ = CheckModelsAsync();
+    }
+
+    partial void OnSelectedCohereLanguageChanged(CohereLanguageOption? value)
+    {
+        _svc.Current.CohereLanguage = value?.Code ?? "";
+        _svc.Save();
     }
 
     partial void OnSelectedDenoiserChanged(DenoiserMode value)
@@ -207,6 +256,7 @@ internal partial class SettingsViewModel : ObservableObject
 
     [RelayCommand] private void SetTheme(string n)              { if (Enum.TryParse<AppTheme>(n,         out var t)) SelectedTheme              = t; }
     [RelayCommand] private void SetSegmentation(string n)       { if (Enum.TryParse<SegmentationMode>(n, out var s)) SelectedSegmentation       = s; }
+    [RelayCommand] private void SetAsrBackend(string n)         { if (Enum.TryParse<AsrBackend>(n,      out var a)) SelectedAsrBackend         = a; }
     [RelayCommand] private void SetDenoiser(string n)           { if (Enum.TryParse<DenoiserMode>(n,     out var d)) SelectedDenoiser           = d; }
     [RelayCommand] private void SetEditorPlaybackMode(string n) { if (Enum.TryParse<PlaybackMode>(n,     out var m)) SelectedEditorPlaybackMode = m; }
     [RelayCommand] private void SetLanguage(string l)           => SelectedLanguage = l;
@@ -292,6 +342,19 @@ internal partial class SettingsViewModel : ObservableObject
 
     private void ApplyModelStatusText()
     {
+        if (_lastMissing.Count == 0)
+        {
+            ModelStatusText = Loc.Instance.T("model_status_ok", new() { ["count"] = _lastPresent.Count.ToString() });
+            return;
+        }
+
+        if (SelectedAsrBackend == AsrBackend.Cohere)
+        {
+            ModelStatusText = $"Missing {_lastMissing.Count} required model file(s): {string.Join(", ", _lastMissing)}. " +
+                              $"Place Cohere weights under {_svc.GetCohereModelsDir()}.";
+            return;
+        }
+
         ModelStatusText = _lastMissing.Count == 0
             ? Loc.Instance.T("model_status_ok",      new() { ["count"] = _lastPresent.Count.ToString() })
             : Loc.Instance.T("model_status_missing",  new() { ["count"] = _lastMissing.Count.ToString(),
@@ -322,7 +385,7 @@ internal partial class SettingsViewModel : ObservableObject
             missing         = _modelMgr.GetMissingFiles();
             present         = _modelMgr.GetPresentFiles();
             ModelsReady     = missing.Count == 0;
-            DownloadVisible = missing.Count > 0;
+            DownloadVisible = _modelMgr.GetMissingDownloadableFiles().Count > 0;
         });
 
         _lastMissing    = missing;

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1025,7 +1025,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             string encoderFile,
             string decoderJointFile,
             string? cohereModelsDir = null,
-            string? cohereLanguage = null)
+            string? cohereLanguageCode = null)
     {
         if (index < 0 || index >= Segments.Count || _dbPath is null || _fullAudio is null)
             return null;
@@ -1061,8 +1061,14 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             if (string.IsNullOrWhiteSpace(cohereModelsDir))
                 return null;
 
+            string? forceLanguage =
+                string.Equals(cohereLanguageCode, "auto", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(cohereLanguageCode)
+                    ? null
+                    : cohereLanguageCode;
+
             using var cohere = new CohereTranscribe(cohereModelsDir);
-            foreach (var result in cohere.RecognizeDetailed(asrSeg, mono16k, forceLanguage: cohereLanguage))
+            foreach (var result in cohere.RecognizeDetailed(asrSeg, mono16k, forceLanguage: forceLanguage))
             {
                 text = result.Text;
                 tokens = result.TextTokens.ToList();

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1018,7 +1018,14 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     /// Returns (newResultId, asrContent, tokens, timestamps, logprobs) on success, or null.
     /// </summary>
     public (int newResultId, string asrContent, List<int> tokens, List<int> timestamps, List<float> logprobs)?
-        PerformRedoAsr(int index, string modelsDir, string encoderFile, string decoderJointFile)
+        PerformRedoAsr(
+            int index,
+            string asrModel,
+            string parakeetModelsDir,
+            string encoderFile,
+            string decoderJointFile,
+            string? cohereModelsDir = null,
+            string? cohereLanguage = null)
     {
         if (index < 0 || index >= Segments.Count || _dbPath is null || _fullAudio is null)
             return null;
@@ -1036,8 +1043,6 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         Array.Copy(_fullAudio, startSample, slice, 0, slice.Length);
         float[] mono16k = AudioUtils.AudioTo16000Mono(slice, _audioSampleRate, _audioChannels);
 
-        // Run ASR — the slice starts at t=0, so pass a 0-based time range
-        using var parakeet = new ParakeetAsr(modelsDir, encoderFile, decoderJointFile);
         var asrSeg = new List<(double start, double end, string spk)>
         {
             (0.0, seg.PlayEnd - seg.PlayStart, $"speaker_{seg.SpeakerId - 1}")
@@ -1047,9 +1052,39 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         List<int> tokens = [];
         List<int> timestamps = [];
         List<float> logprobs = [];
-        foreach (var (_, t, tk, ts, lp) in parakeet.Recognize(asrSeg, mono16k))
+        string? language = null;
+        string? emotion = null;
+        string? asrMeta = null;
+
+        if (string.Equals(asrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal))
         {
-            text = t; tokens = tk; timestamps = ts; logprobs = lp;
+            if (string.IsNullOrWhiteSpace(cohereModelsDir))
+                return null;
+
+            using var cohere = new CohereTranscribe(cohereModelsDir);
+            foreach (var result in cohere.RecognizeDetailed(asrSeg, mono16k, forceLanguage: cohereLanguage))
+            {
+                text = result.Text;
+                tokens = result.TextTokens.ToList();
+                timestamps = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, result.TextTokens.Count);
+                logprobs = result.TextLogprobs.ToList();
+                language = result.Meta.Language;
+                emotion = result.Meta.Emotion;
+                asrMeta = result.Meta.ToJson(
+                    rawDecoderTokens: result.RawTokens,
+                    storedTextTokens: result.TextTokens,
+                    syntheticTimestamps: true,
+                    timestampMode: CohereSyntheticTimestampMode);
+            }
+        }
+        else
+        {
+            // Run ASR — the slice starts at t=0, so pass a 0-based time range
+            using var parakeet = new ParakeetAsr(parakeetModelsDir, encoderFile, decoderJointFile);
+            foreach (var (_, t, tk, ts, lp) in parakeet.Recognize(asrSeg, mono16k))
+            {
+                text = t; tokens = tk; timestamps = ts; logprobs = lp;
+            }
         }
 
         // Persist: insert new result, swap card sources, clean up orphaned old results
@@ -1062,7 +1097,10 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
                 asrContent: text,
                 tokens:     JsonSerializer.Serialize(tokens),
                 timestamps: JsonSerializer.Serialize(timestamps),
-                logprobs:   JsonSerializer.Serialize(logprobs));
+                logprobs:   JsonSerializer.Serialize(logprobs),
+                language:   language,
+                emotion:    emotion,
+                asrMeta:    asrMeta);
 
             db.DeleteCardSources(seg.CardId);
             db.AddCardSource(seg.CardId, newResultId, 0, null, 0, 0);
@@ -1071,6 +1109,31 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         }
 
         return (newResultId, text, tokens, timestamps, logprobs);
+    }
+
+    private const string CohereSyntheticTimestampMode = "uniform_segment_frames_v1";
+
+    private static List<int> BuildSyntheticTokenTimestamps(double segmentDurationSeconds, int tokenCount)
+    {
+        if (tokenCount <= 0)
+            return [];
+
+        const double frameSeconds = Config.HopLength * 8.0 / Config.SampleRate;
+        int maxFrame = Math.Max((int)Math.Round(segmentDurationSeconds / frameSeconds), 0);
+        if (tokenCount == 1)
+            return [0];
+
+        var timestamps = new List<int>(tokenCount);
+        for (int i = 0; i < tokenCount; i++)
+        {
+            double fraction = i / (double)(tokenCount - 1);
+            int frame = (int)Math.Round(fraction * maxFrame);
+            if (timestamps.Count > 0 && frame < timestamps[^1])
+                frame = timestamps[^1];
+            timestamps.Add(frame);
+        }
+
+        return timestamps;
     }
 
     /// <summary>

--- a/src/Vernacula.Avalonia/Views/Dialogs/SplitSegmentDialog.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/Dialogs/SplitSegmentDialog.axaml.cs
@@ -55,7 +55,8 @@ public partial class SplitSegmentDialog : Window
         for (int i = 0; i < _tokenTexts.Count; i++)
         {
             int    capturedIndex = i;
-            string display       = _tokenTexts[i].Replace(" ", "·");
+            bool   hasVisibleText = _tokenTexts[i].Length > 0;
+            string display       = hasVisibleText ? _tokenTexts[i].Replace(" ", "·") : "[]";
 
             var btn = new Button
             {
@@ -67,7 +68,7 @@ public partial class SplitSegmentDialog : Window
             btn.SetValue(ToolTip.TipProperty, $"Token {i}: \"{_tokenTexts[i]}\"  — click to split before this token");
 
             // Token 0 cannot be the start of the second half (would leave empty first half)
-            if (i == 0)
+            if (i == 0 || !hasVisibleText)
             {
                 btn.IsEnabled = false;
                 btn.Opacity   = 0.4;

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -385,6 +385,78 @@
                     </StackPanel>
                 </Border>
 
+                <!-- ─── Speech Recognition ─────────────────────────────────── -->
+                <TextBlock Text="Speech Recognition"
+                           Classes="section-heading" />
+
+                <Border Background="{DynamicResource SurfaceBrush}"
+                        CornerRadius="8" Padding="16">
+                    <StackPanel>
+
+                        <RadioButton GroupName="AsrBackend"
+                                     IsChecked="{Binding IsAsrParakeet, Mode=OneWay}"
+                                     Command="{Binding SetAsrBackendCommand}"
+                                     CommandParameter="Parakeet"
+                                     Foreground="{DynamicResource TextBrush}"
+                                     Margin="0,0,0,4">
+                            <StackPanel>
+                                <TextBlock Text="Parakeet"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextBrush}" />
+                                <TextBlock Text="Existing ONNX Parakeet backend. Best integrated option for now."
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+
+                        <RadioButton GroupName="AsrBackend"
+                                     IsChecked="{Binding IsAsrCohere, Mode=OneWay}"
+                                     Command="{Binding SetAsrBackendCommand}"
+                                     CommandParameter="Cohere"
+                                     Foreground="{DynamicResource TextBrush}">
+                            <StackPanel>
+                                <TextBlock Text="Cohere Transcribe"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextBrush}" />
+                                <TextBlock Text="Requires local Cohere weights in the cohere_transcribe models folder."
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <StackPanel Margin="24,10,0,0"
+                                    IsVisible="{Binding ShowCohereLanguagePicker}">
+                            <TextBlock Text="Forced Language"
+                                       Foreground="{DynamicResource TextBrush}"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,0,6" />
+                            <TextBlock Text="Optional. Use this when auto language detection is unstable."
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <ComboBox ItemsSource="{x:Static vm:SettingsViewModel.CohereLanguages}"
+                                      SelectedItem="{Binding SelectedCohereLanguage}"
+                                      Background="{DynamicResource OverlayBrush}"
+                                      Foreground="{DynamicResource TextBrush}"
+                                      BorderBrush="{DynamicResource OverlayBrush}"
+                                      HorizontalAlignment="Left"
+                                      MinWidth="220">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+
+                    </StackPanel>
+                </Border>
+
                 <!-- ─── Segmentation ────────────────────────────────────────── -->
                 <TextBlock x:Name="SegmentationSectionHeader"
                            Text="{Binding Source={x:Static local:Loc.Instance}, Path=[settings_section_segmentation]}"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
@@ -183,21 +183,35 @@
             <Border DockPanel.Dock="Top"
                     Background="{DynamicResource SurfaceBrush}"
                     Padding="16,10">
-                <DockPanel>
-                    <TextBlock x:Name="HeaderSubtext"
-                               Text="{Binding HeaderSubtext}"
-                               DockPanel.Dock="Right"
-                               Foreground="{DynamicResource SubtextBrush}"
-                               VerticalAlignment="Center"
-                               Margin="12,0,0,0" />
-                    <TextBlock x:Name="HeaderTitle"
-                               Text="{Binding HeaderTitle}"
-                               Foreground="{DynamicResource TextBrush}"
-                               FontSize="18"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center"
-                               TextTrimming="CharacterEllipsis" />
-                </DockPanel>
+                <StackPanel Spacing="8">
+                    <DockPanel>
+                        <TextBlock x:Name="HeaderSubtext"
+                                   Text="{Binding HeaderSubtext}"
+                                   DockPanel.Dock="Right"
+                                   Foreground="{DynamicResource SubtextBrush}"
+                                   VerticalAlignment="Center"
+                                   Margin="12,0,0,0" />
+                        <TextBlock x:Name="HeaderTitle"
+                                   Text="{Binding HeaderTitle}"
+                                   Foreground="{DynamicResource TextBrush}"
+                                   FontSize="18"
+                                   FontWeight="SemiBold"
+                                   VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis" />
+                    </DockPanel>
+
+                    <Border Background="{DynamicResource OverlayBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"
+                            BorderThickness="1"
+                            CornerRadius="999"
+                            Padding="10,4"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding ShowHeaderNotice, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding HeaderNotice}"
+                                   Foreground="{DynamicResource TextBrush}"
+                                   FontSize="11" />
+                    </Border>
+                </StackPanel>
             </Border>
 
             <Border x:Name="PlaybackBar"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -106,8 +106,11 @@ public partial class TranscriptEditorWindow : Window
             _asrModelsAvailable =
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.MelFile)) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.EncoderFile)) &&
+                File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.EncoderFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.DecoderInitFile)) &&
+                File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.DecoderInitFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.DecoderStepFile)) &&
+                File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.DecoderStepFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.VocabFile));
         }
         else

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -46,6 +46,7 @@ public partial class TranscriptEditorWindow : Window
     private readonly string _dbPath = "";
     private readonly string _audioBaseName = "";
     private readonly bool _asrModelsAvailable;
+    private readonly bool _showApproximateTimingNotice;
     private bool _isUpdatingUi;
     private bool _isLoading;
     private bool _suppressSegmentCollectionChanged;
@@ -79,10 +80,20 @@ public partial class TranscriptEditorWindow : Window
         _vm.PlayCommand.CanExecuteChanged += OnPlayCommandCanExecuteChanged;
 
         string modelsDir = App.Current.Settings.GetModelsDir();
-        string vocabPath = Path.Combine(modelsDir, Config.VocabFile);
+        string? asrModel;
+        using (var db = new TranscriptionDb(dbPath))
+            asrModel = db.GetMetadata("asr_model");
+        _showApproximateTimingNotice = string.Equals(
+            asrModel,
+            "CohereLabs/cohere-transcribe-03-2026",
+            StringComparison.Ordinal);
+
+        string vocabPath = string.Equals(asrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal)
+            ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)
+            : Path.Combine(modelsDir, Config.VocabFile);
         if (File.Exists(vocabPath))
         {
-            _vocab = new VocabService(modelsDir);
+            _vocab = new VocabService(modelsDir, asrModel);
         }
 
         var (encoderFile, _) = Config.GetAsrFiles(ModelPrecision.Fp32);
@@ -481,6 +492,9 @@ public partial class TranscriptEditorWindow : Window
     private void RefreshHeader()
     {
         _state.SetHeader(_audioBaseName, $"{_vm.Segments.Count} {Loc.Instance["results_segments_label"]}");
+        _state.SetHeaderNotice(
+            "Cohere Transcribe: no word-level timing; token sync is approximate.",
+            _showApproximateTimingNotice);
     }
 
     private void RefreshPlaybackModeCombo()

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -45,6 +45,7 @@ public partial class TranscriptEditorWindow : Window
     private readonly VocabService? _vocab;
     private readonly string _dbPath = "";
     private readonly string _audioBaseName = "";
+    private readonly string _jobAsrModel = "nvidia/parakeet-tdt-0.6b-v3";
     private readonly bool _asrModelsAvailable;
     private readonly bool _showApproximateTimingNotice;
     private bool _isUpdatingUi;
@@ -83,21 +84,37 @@ public partial class TranscriptEditorWindow : Window
         string? asrModel;
         using (var db = new TranscriptionDb(dbPath))
             asrModel = db.GetMetadata("asr_model");
+        _jobAsrModel = string.IsNullOrWhiteSpace(asrModel)
+            ? "nvidia/parakeet-tdt-0.6b-v3"
+            : asrModel;
         _showApproximateTimingNotice = string.Equals(
-            asrModel,
+            _jobAsrModel,
             "CohereLabs/cohere-transcribe-03-2026",
             StringComparison.Ordinal);
 
-        string vocabPath = string.Equals(asrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal)
+        string vocabPath = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal)
             ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)
             : Path.Combine(modelsDir, Config.VocabFile);
         if (File.Exists(vocabPath))
         {
-            _vocab = new VocabService(modelsDir, asrModel);
+            _vocab = new VocabService(modelsDir, _jobAsrModel);
         }
 
-        var (encoderFile, _) = Config.GetAsrFiles(ModelPrecision.Fp32);
-        _asrModelsAvailable = File.Exists(Path.Combine(modelsDir, encoderFile));
+        if (string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal))
+        {
+            string cohereDir = App.Current.Settings.GetCohereModelsDir();
+            _asrModelsAvailable =
+                File.Exists(Path.Combine(cohereDir, CohereTranscribe.MelFile)) &&
+                File.Exists(Path.Combine(cohereDir, CohereTranscribe.EncoderFile)) &&
+                File.Exists(Path.Combine(cohereDir, CohereTranscribe.DecoderInitFile)) &&
+                File.Exists(Path.Combine(cohereDir, CohereTranscribe.DecoderStepFile)) &&
+                File.Exists(Path.Combine(cohereDir, CohereTranscribe.VocabFile));
+        }
+        else
+        {
+            var (encoderFile, _) = Config.GetAsrFiles(ModelPrecision.Fp32);
+            _asrModelsAvailable = File.Exists(Path.Combine(modelsDir, encoderFile));
+        }
 
         Loaded += OnLoaded;
         Closed += OnClosed;
@@ -1215,9 +1232,20 @@ public partial class TranscriptEditorWindow : Window
         try
         {
             string modelsDir = App.Current.Settings.GetModelsDir();
+            string cohereModelsDir = App.Current.Settings.GetCohereModelsDir();
+            string? cohereLanguage = string.IsNullOrWhiteSpace(App.Current.Settings.Current.CohereLanguage)
+                ? null
+                : App.Current.Settings.Current.CohereLanguage;
             var (encoderFile, decoderJointFile) = Config.GetAsrFiles(ModelPrecision.Fp32);
 
-            var result = await Task.Run(() => _vm.PerformRedoAsr(card.Index, modelsDir, encoderFile, decoderJointFile));
+            var result = await Task.Run(() => _vm.PerformRedoAsr(
+                card.Index,
+                _jobAsrModel,
+                modelsDir,
+                encoderFile,
+                decoderJointFile,
+                cohereModelsDir,
+                cohereLanguage));
             if (result is null)
             {
                 SetCardStatus(card, "Redo ASR did not produce a result.");

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -119,7 +119,8 @@ public partial class TranscriptEditorWindow : Window
                 File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.DecoderInitFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.DecoderStepFile)) &&
                 File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.DecoderStepFile}.data")) &&
-                File.Exists(Path.Combine(cohereDir, CohereTranscribe.VocabFile));
+                File.Exists(Path.Combine(cohereDir, CohereTranscribe.VocabFile)) &&
+                File.Exists(Path.Combine(cohereDir, CohereTranscribe.ConfigFile));
         }
         else
         {
@@ -1188,7 +1189,7 @@ public partial class TranscriptEditorWindow : Window
 
         IReadOnlyList<string> tokenTexts = _vocab != null
             ? _vocab.GetTokenRuns(seg.Tokens, seg.Logprobs)
-                .Select(r => string.IsNullOrWhiteSpace(r.text) ? "[]" : r.text)
+                .Select(r => r.text)
                 .ToList()
             : seg.Tokens.Select(t => $"[{t}]").ToList();
 

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -46,6 +46,7 @@ public partial class TranscriptEditorWindow : Window
     private readonly string _dbPath = "";
     private readonly string _audioBaseName = "";
     private readonly string _jobAsrModel = "nvidia/parakeet-tdt-0.6b-v3";
+    private readonly string _jobAsrLanguageCode = "auto";
     private readonly bool _asrModelsAvailable;
     private readonly bool _showApproximateTimingNotice;
     private bool _isUpdatingUi;
@@ -82,11 +83,18 @@ public partial class TranscriptEditorWindow : Window
 
         string modelsDir = App.Current.Settings.GetModelsDir();
         string? asrModel;
+        string? asrLanguageCode;
         using (var db = new TranscriptionDb(dbPath))
+        {
             asrModel = db.GetMetadata("asr_model");
+            asrLanguageCode = db.GetMetadata("asr_language_code");
+        }
         _jobAsrModel = string.IsNullOrWhiteSpace(asrModel)
             ? "nvidia/parakeet-tdt-0.6b-v3"
             : asrModel;
+        _jobAsrLanguageCode = string.IsNullOrWhiteSpace(asrLanguageCode)
+            ? "auto"
+            : asrLanguageCode;
         _showApproximateTimingNotice = string.Equals(
             _jobAsrModel,
             "CohereLabs/cohere-transcribe-03-2026",
@@ -1236,9 +1244,6 @@ public partial class TranscriptEditorWindow : Window
         {
             string modelsDir = App.Current.Settings.GetModelsDir();
             string cohereModelsDir = App.Current.Settings.GetCohereModelsDir();
-            string? cohereLanguage = string.IsNullOrWhiteSpace(App.Current.Settings.Current.CohereLanguage)
-                ? null
-                : App.Current.Settings.Current.CohereLanguage;
             var (encoderFile, decoderJointFile) = Config.GetAsrFiles(ModelPrecision.Fp32);
 
             var result = await Task.Run(() => _vm.PerformRedoAsr(
@@ -1248,7 +1253,7 @@ public partial class TranscriptEditorWindow : Window
                 encoderFile,
                 decoderJointFile,
                 cohereModelsDir,
-                cohereLanguage));
+                _jobAsrLanguageCode));
             if (result is null)
             {
                 SetCardStatus(card, "Redo ASR did not produce a result.");

--- a/src/Vernacula.Base/CohereTranscribe.cs
+++ b/src/Vernacula.Base/CohereTranscribe.cs
@@ -72,11 +72,15 @@ public sealed class CohereTranscribe : IDisposable
     // segments of similar length land in the same batch, minimising the "straggler"
     // waste where shorter segments keep stepping after they have emitted EOS.
 
-    // Hard upper limit on segments per batch.
-    // B=128 crashes on RTX 3090 (24 GB): decoder_init intermediate activations
-    // scale as B × encTMax and exhaust VRAM after model weights consume ~12 GB.
-    // B=8 is confirmed safe; B=32 keeps four-session ONNX model weights + BFC
-    // arena overhead within budget while giving 4× better GPU utilisation vs B=8.
+    // Hard upper limit on segments per batch.  The VRAM constraint (EstimateKvBytes vs
+    // _vramBudgetForKvBytes) is the primary limiter; this cap handles pathological cases
+    // (thousands of very short segments) or CPU-only builds where VRAM estimation falls
+    // back to 3 GB.
+    //
+    // encoder.onnx accepts input_lengths [B] int64 so the Conformer's self-attention masks
+    // padded positions per item — segments of different lengths can be freely batched.
+    // decoder_init intermediate activations scale as B × encTMax; peak VRAM is estimated
+    // conservatively and the budget check prevents OOM.
     private const int MaxBatchSize = 32;
 
     // VRAM budget for KV-cache tensors AND intermediate activations during the
@@ -213,37 +217,43 @@ public sealed class CohereTranscribe : IDisposable
     }
 
     /// <summary>
-    /// Encoder batch: mel features [B, 128, F_max] → encoder_hidden_states [B, T_enc_max, 1280].
-    /// Segments shorter than F_max are zero-padded on the right.
-    /// Returns the full padded batch tensor and T_enc_max (the decoder uses all T_enc_max
-    /// cross-attention positions; near-zero outputs from padding receive negligible attention).
+    /// Batched encoder: mel features [B, 128, F_max] + lengths [B] → encoder_hidden_states [B, T_enc_max, 1280].
+    ///
+    /// The encoder.onnx graph accepts an <c>input_lengths</c> tensor (int64 [B]) giving the
+    /// actual mel-frame count for each batch item.  The Conformer's self-attention uses this
+    /// to build a padding mask, so zero-padded positions beyond each segment's true length are
+    /// masked out and cannot contaminate the attention of valid positions.  This means segments
+    /// of different lengths can be safely batched without hallucinations or repetition loops.
     /// </summary>
     private (float[] batchHidden, int T_enc_max) RunEncoderBatch(
         IReadOnlyList<(float[] features, int nMels, int F)> melResults)
     {
         int B     = melResults.Count;
-        int nMels = melResults[0].nMels;
+        int nMels = melResults[0].Item2;
         int F_max = 0;
         foreach (var (_, _, F) in melResults) if (F > F_max) F_max = F;
 
-        // Build [B, 128, F_max] — zero-initialised, fill each segment's valid frames.
+        // Build [B, 128, F_max] — zero-initialised so padded positions are silent.
         var batchData = new float[B * nMels * F_max];
+        var lengths   = new long[B];
         for (int b = 0; b < B; b++)
         {
             var (features, _, F) = melResults[b];
             for (int m = 0; m < nMels; m++)
                 Array.Copy(features, m * F, batchData, (b * nMels + m) * F_max, F);
+            lengths[b] = F;   // actual mel frames; encoder uses this for the padding mask
         }
 
-        var batchT = new DenseTensor<float>(batchData, new[] { B, nMels, F_max });
+        var batchT   = new DenseTensor<float>(batchData, new[] { B, nMels, F_max });
+        var lengthsT = new DenseTensor<long>(lengths, new[] { B });
         using var encResults = _encoder.Run(
         [
             NamedOnnxValue.CreateFromTensor("input_features", batchT),
+            NamedOnnxValue.CreateFromTensor("input_lengths",  lengthsT),
         ]);
 
         var hidT      = encResults.First(r => r.Name == "encoder_hidden_states").AsTensor<float>();
         int T_enc_max = hidT.Dimensions[1];
-        // Row-major [B, T_enc_max, dMod] — bulk copy via DenseTensor buffer.
         var batchHidden = ExtractTensorFlatDirect(hidT);
         return (batchHidden, T_enc_max);
     }
@@ -274,12 +284,20 @@ public sealed class CohereTranscribe : IDisposable
         const int encDim = 1280;
 
         // ── Build decoder_init input ──────────────────────────────────────────
-        // With a forced language we send the full context block as a prefix so
-        // decoder_init computes KV for all context positions in one forward pass.
-        // Without forced language we send BOS only and step through the context
-        // block token-by-token in the step loop (existing behaviour).
-        bool usePrefill   = forcedLangTokenId >= 0;
-        int  contextLen   = usePrefill ? 10 : 1;   // number of tokens in the prefix
+        // Always send BOS only and let the model generate the context block
+        // token-by-token in the step loop.  ForceLang intercepts any language
+        // token the model emits (IDs 22–204) and substitutes the forced language;
+        // all other context tokens (emotion, ITN flag, etc.) are left to the model
+        // so it can choose appropriate values for each segment's content.
+        //
+        // NOTE: The full 10-token prefill was tried but caused the model to
+        // produce Chinese annotations ([笑], 嗯) for short non-speech segments
+        // (laughter, filled pauses) because hard-coding noitn + nodiarize etc.
+        // over-constrains the decoding for ambiguous audio.  Auto-generating the
+        // context block with only the language forced gives significantly better
+        // results for those segments.
+        bool usePrefill   = false;
+        int  contextLen   = 1;   // always BOS only for decoder_init
 
         var initTokens = new long[B * contextLen];
         for (int b = 0; b < B; b++)
@@ -613,9 +631,13 @@ public sealed class CohereTranscribe : IDisposable
             // ── Build a variable-size batch bounded by VRAM and MaxBatchSize ──────
             // Grow the batch one segment at a time, stopping when the estimated peak
             // KV-cache size would exceed VramBudgetForKvBytes or MaxBatchSize is hit.
-            // Uses the *worst-case* (longest) segment in the batch for both enc and dec
-            // estimates, which is always the last segment added (since we sort ascending).
-            int batchSize   = 0;
+            // Segments are sorted ascending by duration so the worst-case (longest)
+            // segment drives the KV estimate.
+            // Note: there is no encoder-frame ratio limit because the encoder is now
+            // run per-segment (B=1 each), so Conformer self-attention contamination
+            // from batch padding is no longer an issue.  Padded positions in the
+            // stacked decoder input are zero, contributing zero to cross-attention output.
+            int batchSize    = 0;
             int maxEncFrames = 0;
             int maxDecSteps  = 0;
 

--- a/src/Vernacula.Base/CohereTranscribe.cs
+++ b/src/Vernacula.Base/CohereTranscribe.cs
@@ -1,0 +1,534 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Models;
+
+namespace Vernacula.Base;
+
+/// <summary>
+/// Cohere Transcribe 03-2026 — encoder-decoder ASR with KV-cache greedy decoder.
+///
+/// Uses four ONNX models in the model directory:
+///   mel.onnx          waveforms [1,T] → features [1,128,F]
+///   encoder.onnx      features [1,128,F] → encoder_hidden_states [1,T',1280]
+///   decoder_init.onnx BOS token + enc_hidden → logits + 32 KV tensors
+///   decoder_step.onnx single token + past self-KV + fixed cross-KV → next logit + updated self-KV
+///
+/// Vocab is loaded from vocab.json (array of 16384 token strings indexed by ID).
+/// </summary>
+public sealed class CohereTranscribe : IDisposable
+{
+    private const int NumLayers = 8;
+    private const int NumHeads  = 8;
+    private const int HeadDim   = 128;
+
+    public const string MelFile         = "mel.onnx";
+    public const string EncoderFile     = "encoder.onnx";
+    public const string DecoderInitFile = "decoder_init.onnx";
+    public const string DecoderStepFile = "decoder_step.onnx";
+    public const string VocabFile       = "vocab.json";
+    public const string ConfigFile      = "config.json";
+
+    private readonly InferenceSession _mel;
+    private readonly InferenceSession _encoder;
+    private readonly InferenceSession _decoderInit;
+    private readonly InferenceSession _decoderStep;
+
+    private readonly string[] _vocab;      // index → token string
+    private readonly int _bosTokenId;      // decoder_start_token_id (13764)
+    private readonly int _eosTokenId;      // eos_token_id (3)
+    private readonly int _padTokenId;      // pad_token_id (2)
+    private readonly int _startTokenId;    // bos_token_id (4)
+
+    // Byte-fallback tokens occupy indices 255..510 (0x00..0xFF).
+    private const int ByteFallbackOffset = 255;
+
+    // Language token ID range in the vocab.
+    private const int LangIdMin = 22;
+    private const int LangIdMax = 204;
+
+    // The Cohere conformer encoder specializes batch=1 internally — encoder
+    // batching is not supported by this model architecture.
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    public CohereTranscribe(string modelPath, ExecutionProvider ep = ExecutionProvider.Auto)
+    {
+        var cpuOpts = new SessionOptions();
+        _mel = new InferenceSession(Path.Combine(modelPath, MelFile), cpuOpts);
+
+        var gpuOpts = MakeSessionOptions(ep);
+        _encoder      = new InferenceSession(Path.Combine(modelPath, EncoderFile),     gpuOpts);
+        _decoderInit  = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), gpuOpts);
+        _decoderStep  = new InferenceSession(Path.Combine(modelPath, DecoderStepFile), gpuOpts);
+
+        // Load vocab
+        string vocabJson = File.ReadAllText(Path.Combine(modelPath, VocabFile));
+        _vocab = JsonSerializer.Deserialize<string[]>(vocabJson)
+            ?? throw new InvalidDataException("Failed to deserialize vocab.json");
+
+        // Load token IDs from config
+        string cfgJson = File.ReadAllText(Path.Combine(modelPath, ConfigFile));
+        using var doc  = JsonDocument.Parse(cfgJson);
+        var root       = doc.RootElement;
+        _bosTokenId    = root.GetProperty("decoder_start_token_id").GetInt32();
+        _eosTokenId    = root.GetProperty("eos_token_id").GetInt32();
+        _padTokenId    = root.GetProperty("pad_token_id").GetInt32();
+        _startTokenId  = root.GetProperty("bos_token_id").GetInt32();
+    }
+
+    private static SessionOptions MakeSessionOptions(ExecutionProvider ep)
+    {
+        var opts = new SessionOptions();
+        switch (ep)
+        {
+            case ExecutionProvider.Auto:
+                if (HardwareInfo.CanProbeCudaExecutionProvider())
+                {
+                    try { opts.AppendExecutionProvider_CUDA(0); } catch { }
+                }
+                try { opts.AppendExecutionProvider_DML(0); } catch { }
+                break;
+            case ExecutionProvider.Cuda:
+                try { opts.AppendExecutionProvider_CUDA(0); }
+                catch (EntryPointNotFoundException)
+                { throw new InvalidOperationException("CUDA EP not available in current OnnxRuntime build."); }
+                break;
+            case ExecutionProvider.DirectML:
+                try { opts.AppendExecutionProvider_DML(0); }
+                catch (EntryPointNotFoundException)
+                { throw new InvalidOperationException("DirectML EP not available."); }
+                break;
+            case ExecutionProvider.Cpu:
+                break;
+        }
+        return opts;
+    }
+
+    // ── Language token lookup ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the vocab token ID for an ISO 639-1 language code (e.g. "en", "fr"),
+    /// or -1 if the language is not in the vocab.
+    /// </summary>
+    public int LookupLanguageTokenId(string isoCode)
+    {
+        string tag = $"<|{isoCode.ToLowerInvariant()}|>";
+        for (int i = LangIdMin; i <= LangIdMax; i++)
+            if (i < _vocab.Length && _vocab[i] == tag)
+                return i;
+        return -1;
+    }
+
+    // ── Inference pipeline ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Mel preprocessing for a single waveform: waveforms [1,T] → features [1,128,F].
+    /// Returns the flat mel features and the valid frame count.
+    /// </summary>
+    private (float[] features, int nMels, int F) RunMel(float[] waveform)
+    {
+        int T = waveform.Length;
+        var waveT = new DenseTensor<float>(waveform, new[] { 1, T });
+        var waveL = new DenseTensor<long>(new long[] { T }, new[] { 1 });
+
+        using var results = _mel.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("waveforms",      waveT),
+            NamedOnnxValue.CreateFromTensor("waveforms_lens", waveL),
+        ]);
+
+        var featT = results.First(r => r.Name == "features").AsTensor<float>();
+        int nMels = featT.Dimensions[1];
+        int F     = featT.Dimensions[2];
+
+        var features = new float[nMels * F];
+        for (int m = 0; m < nMels; m++)
+            for (int f = 0; f < F; f++)
+                features[m * F + f] = featT[0, m, f];
+
+        return (features, nMels, F);
+    }
+
+    /// <summary>
+    /// Encoder: mel features [1, 128, F] → encoder_hidden_states [1, T', 1280].
+    /// Returns the hidden states flat [T', dModel] and T'.
+    /// </summary>
+    private (float[] hidden, int T_enc) RunEncoder(float[] features, int nMels, int F)
+    {
+        var featT = new DenseTensor<float>(features, new[] { 1, nMels, F });
+
+        using var results = _encoder.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("input_features", featT),
+        ]);
+
+        var hidT  = results.First(r => r.Name == "encoder_hidden_states").AsTensor<float>();
+        int T_enc = hidT.Dimensions[1];
+        int dMod  = hidT.Dimensions[2];
+
+        var hidden = new float[T_enc * dMod];
+        for (int t = 0; t < T_enc; t++)
+            for (int d = 0; d < dMod; d++)
+                hidden[t * dMod + d] = hidT[0, t, d];
+
+        return (hidden, T_enc);
+    }
+
+    /// <summary>
+    /// Greedy KV-cache decoder.
+    /// Returns the full token list including decoder_start token.
+    /// When <paramref name="forcedLangTokenId"/> is ≥ 0, any context-block token in the
+    /// language ID range (22–204) is replaced with the forced language token ID so that
+    /// all subsequent decoding is conditioned on the specified language.
+    /// </summary>
+    private List<int> GreedyDecode(float[] encoderHidden, int encT,
+                                   int maxTokens = 256, int forcedLangTokenId = -1)
+    {
+        const int dModel = 1280;
+        var encT_tensor = new DenseTensor<float>(encoderHidden, new[] { 1, encT, dModel });
+        var bosT        = new DenseTensor<long>(new long[] { _bosTokenId }, new[] { 1, 1 });
+
+        // ── Decoder init ─────────────────────────────────────────────────────
+        float[] logits;
+        float[][] selfKey  = new float[NumLayers][];
+        float[][] selfVal  = new float[NumLayers][];
+        float[][] crossKey = new float[NumLayers][];
+        float[][] crossVal = new float[NumLayers][];
+
+        using (var initResults = _decoderInit.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("decoder_input_ids",    bosT),
+            NamedOnnxValue.CreateFromTensor("encoder_hidden_states", encT_tensor),
+        ]))
+        {
+            // Outputs: logits, sk0..7, sv0..7, ck0..7, cv0..7
+            logits = ExtractLogits(initResults, "logits");
+
+            for (int i = 0; i < NumLayers; i++)
+            {
+                selfKey[i]  = ExtractTensorFlat(initResults, $"self_key_{i}");
+                selfVal[i]  = ExtractTensorFlat(initResults, $"self_val_{i}");
+                crossKey[i] = ExtractTensorFlat(initResults, $"cross_key_{i}");
+                crossVal[i] = ExtractTensorFlat(initResults, $"cross_val_{i}");
+            }
+        }
+
+        int firstToken = ForceLang(ArgMax(logits), forcedLangTokenId);
+        var tokens     = new List<int>(maxTokens + 2) { _bosTokenId, firstToken };
+        if (firstToken == _eosTokenId)
+            return tokens;
+
+        int tPast = 1;  // number of tokens in self-KV (= 1 after init)
+
+        // ── Step loop ────────────────────────────────────────────────────────
+        for (int step = 1; step < maxTokens; step++)
+        {
+            int lastToken = tokens[tokens.Count - 1];
+            var inputs = BuildStepInputs(lastToken, step, tPast, encT,
+                                         selfKey, selfVal, crossKey, crossVal);
+
+            using var stepResults = _decoderStep.Run(inputs);
+
+            logits = ExtractLogits(stepResults, "logits");
+            tPast++;
+
+            for (int i = 0; i < NumLayers; i++)
+            {
+                selfKey[i] = ExtractTensorFlat(stepResults, $"new_self_key_{i}");
+                selfVal[i] = ExtractTensorFlat(stepResults, $"new_self_val_{i}");
+            }
+
+            int nextToken = ForceLang(ArgMax(logits), forcedLangTokenId);
+            tokens.Add(nextToken);
+            if (nextToken == _eosTokenId)
+                break;
+        }
+
+        return tokens;
+    }
+
+    // If the decoded token is a language tag and we have a forced language, substitute it.
+    private static int ForceLang(int token, int forcedLangTokenId) =>
+        forcedLangTokenId >= 0 && token >= LangIdMin && token <= LangIdMax
+            ? forcedLangTokenId
+            : token;
+
+    private List<NamedOnnxValue> BuildStepInputs(
+        int lastToken, int position, int tPast, int encT,
+        float[][] selfKey, float[][] selfVal,
+        float[][] crossKey, float[][] crossVal)
+    {
+        var inputs = new List<NamedOnnxValue>(2 + NumLayers * 4);
+
+        inputs.Add(NamedOnnxValue.CreateFromTensor("decoder_input_ids",
+            new DenseTensor<long>(new long[] { lastToken }, new[] { 1, 1 })));
+        inputs.Add(NamedOnnxValue.CreateFromTensor("positions",
+            new DenseTensor<long>(new long[] { position }, new[] { 1, 1 })));
+
+        for (int i = 0; i < NumLayers; i++)
+        {
+            inputs.Add(NamedOnnxValue.CreateFromTensor($"self_key_{i}",
+                new DenseTensor<float>(selfKey[i], new[] { 1, NumHeads, tPast, HeadDim })));
+            inputs.Add(NamedOnnxValue.CreateFromTensor($"self_val_{i}",
+                new DenseTensor<float>(selfVal[i], new[] { 1, NumHeads, tPast, HeadDim })));
+        }
+        for (int i = 0; i < NumLayers; i++)
+        {
+            inputs.Add(NamedOnnxValue.CreateFromTensor($"cross_key_{i}",
+                new DenseTensor<float>(crossKey[i], new[] { 1, NumHeads, encT, HeadDim })));
+            inputs.Add(NamedOnnxValue.CreateFromTensor($"cross_val_{i}",
+                new DenseTensor<float>(crossVal[i], new[] { 1, NumHeads, encT, HeadDim })));
+        }
+
+        return inputs;
+    }
+
+    // ── Token decoding ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Decodes a list of token IDs to a UTF-8 string using the BPE vocab.
+    ///
+    /// Skips special tokens, handles byte-fallback tokens (&lt;0xNN&gt;),
+    /// and converts the SentencePiece word-boundary marker '▁' to space.
+    /// </summary>
+    public string DecodeTokens(IReadOnlyList<int> tokens)
+    {
+        var bytes = new List<byte>(tokens.Count * 4);
+
+        foreach (int id in tokens)
+        {
+            if (id < 0 || id >= _vocab.Length) continue;
+            // IDs 0..254 are all special/control tokens (language tags, emotion, etc.) — skip.
+            // ID ByteFallbackOffset (13764) is decoder_start — skip.
+            if (id < ByteFallbackOffset || id == _bosTokenId) continue;
+
+            string token = _vocab[id];
+
+            // Byte-fallback: <0xNN> → single byte 0xNN
+            if (token.Length == 6 && token[0] == '<' && token[1] == '0' && token[2] == 'x'
+                && token[5] == '>')
+            {
+                if (TryParseHexByte(token[3], token[4], out byte b))
+                {
+                    bytes.Add(b);
+                    continue;
+                }
+            }
+
+            // Normal BPE token: replace ▁ (U+2581) with space, then UTF-8 encode
+            string expanded = token.Replace('\u2581', ' ');
+            byte[] tokenBytes = Encoding.UTF8.GetBytes(expanded);
+            bytes.AddRange(tokenBytes);
+        }
+
+        string text = Encoding.UTF8.GetString(bytes.ToArray());
+
+        // Strip up to one leading space (mirrors HF tokenizer's Strip decoder)
+        if (text.Length > 0 && text[0] == ' ')
+            text = text[1..];
+
+        return text;
+    }
+
+    private static bool TryParseHexByte(char hi, char lo, out byte value)
+    {
+        int h = HexVal(hi);
+        int l = HexVal(lo);
+        if (h < 0 || l < 0) { value = 0; return false; }
+        value = (byte)((h << 4) | l);
+        return true;
+    }
+
+    private static int HexVal(char c) => c switch
+    {
+        >= '0' and <= '9' => c - '0',
+        >= 'a' and <= 'f' => c - 'a' + 10,
+        >= 'A' and <= 'F' => c - 'A' + 10,
+        _ => -1,
+    };
+
+    // ── Context-block parsing ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Extracts structured metadata from the context tokens the model prepends
+    /// before the text (IDs 0–254: language tags, emotion, formatting flags).
+    /// </summary>
+    private CohereSegmentMeta ParseContextBlock(IReadOnlyList<int> tokens)
+    {
+        string? language   = null;
+        string? emotion    = null;
+        bool?   pnc        = null;
+        bool?   itn        = null;
+        bool?   timestamps = null;
+        bool?   diarize    = null;
+
+        foreach (int id in tokens)
+        {
+            if (id <= 0 || id >= ByteFallbackOffset) continue;  // skip BOS, text, byte-fallback
+
+            switch (id)
+            {
+                case  5: pnc        = true;        break;
+                case  6: pnc        = false;       break;
+                case  8: itn        = true;        break;
+                case  9: itn        = false;       break;
+                case 10: timestamps = true;        break;
+                case 11: timestamps = false;       break;
+                case 12: diarize    = true;        break;
+                case 13: diarize    = false;       break;
+                case 16: emotion    = "undefined"; break;
+                case 17: emotion    = "neutral";   break;
+                case 18: emotion    = "happy";     break;
+                case 19: emotion    = "sad";       break;
+                case 20: emotion    = "angry";     break;
+                case 21: language ??= "unknown";   break;
+                default:
+                    // Language tokens 22–204: vocab string is "<|xx|>" → extract "xx"
+                    if (id >= 22 && id <= 204 && language is null)
+                    {
+                        string tok = _vocab[id];
+                        if (tok.Length > 4 && tok.StartsWith("<|") && tok.EndsWith("|>"))
+                            language = tok[2..^2];
+                    }
+                    break;
+            }
+        }
+
+        return new CohereSegmentMeta(language, emotion, pnc, itn, timestamps, diarize);
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Transcribes each segment from <paramref name="segs"/> and yields
+    /// <c>(segId, text, meta)</c> in order as each segment completes.
+    /// </summary>
+    /// <param name="forceLanguage">
+    /// Optional ISO 639-1 language code (e.g. "en").  When set, any language token
+    /// the model would emit during context-block decoding is replaced with this
+    /// language's token, conditioning the rest of the decode on the specified language.
+    /// </param>
+    public IEnumerable<(int segId, string text, CohereSegmentMeta meta)> Recognize(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio,
+        int maxNewTokens = 256,
+        string? forceLanguage = null)
+    {
+        int forcedLangTokenId = -1;
+        if (forceLanguage is not null)
+        {
+            forcedLangTokenId = LookupLanguageTokenId(forceLanguage);
+            if (forcedLangTokenId < 0)
+                throw new ArgumentException(
+                    $"Language '{forceLanguage}' not found in Cohere vocab. " +
+                    "Use an ISO 639-1 code such as 'en', 'fr', 'de'.");
+        }
+
+        for (int i = 0; i < segs.Count; i++)
+        {
+            var (start, end, _) = segs[i];
+            float[] waveform = ExtractSegment(audio, start, end);
+
+            if (waveform.Length < Config.SampleRate / 10)  // < 100 ms
+            {
+                yield return (i, string.Empty, CohereSegmentMeta.Empty);
+                continue;
+            }
+
+            var (features, nMels, F) = RunMel(waveform);
+            var (encHidden, encT)    = RunEncoder(features, nMels, F);
+            var tokens               = GreedyDecode(encHidden, encT, maxNewTokens, forcedLangTokenId);
+            var meta                 = ParseContextBlock(tokens);
+            string text              = DecodeTokens(tokens);
+
+            yield return (i, text, meta);
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static float[] ExtractSegment(float[] audio, double start, double end)
+    {
+        int s = Math.Max((int)(start * Config.SampleRate), 0);
+        int e = Math.Min((int)(end   * Config.SampleRate), audio.Length);
+        int len = Math.Max(e - s, 0);
+        var seg = new float[len];
+        if (len > 0) Array.Copy(audio, s, seg, 0, len);
+        return seg;
+    }
+
+    private static float[] ExtractLogits(
+        IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results,
+        string name)
+    {
+        var tensor = results.First(r => r.Name == name).AsTensor<float>();
+        // shape [1, 1, vocab_size] — return the last (only) position
+        int vocabSize = tensor.Dimensions[2];
+        var logits = new float[vocabSize];
+        for (int v = 0; v < vocabSize; v++)
+            logits[v] = tensor[0, 0, v];
+        return logits;
+    }
+
+    private static float[] ExtractTensorFlat(
+        IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results,
+        string name)
+    {
+        var tensor = results.First(r => r.Name == name).AsTensor<float>();
+        int total = 1;
+        for (int d = 0; d < tensor.Rank; d++)
+            total *= tensor.Dimensions[d];
+        var flat = new float[total];
+        for (int i = 0; i < total; i++)
+            flat[i] = tensor.GetValue(i);
+        return flat;
+    }
+
+    private static int ArgMax(float[] arr)
+    {
+        int idx = 0;
+        float max = float.NegativeInfinity;
+        for (int i = 0; i < arr.Length; i++)
+            if (arr[i] > max) { max = arr[i]; idx = i; }
+        return idx;
+    }
+
+    // ── IDisposable ───────────────────────────────────────────────────────────
+
+    public void Dispose()
+    {
+        _mel.Dispose();
+        _encoder.Dispose();
+        _decoderInit.Dispose();
+        _decoderStep.Dispose();
+    }
+}
+
+/// <summary>
+/// Structured metadata extracted from the Cohere Transcribe context-token block.
+/// All fields are nullable — null means the model did not emit a token for that category.
+/// </summary>
+public sealed record CohereSegmentMeta(
+    string? Language,    // ISO 639-1 code e.g. "en", "fr"; "unknown" if <|unklang|>; null if absent
+    string? Emotion,     // "neutral" | "happy" | "sad" | "angry" | "undefined" | null
+    bool?   Pnc,         // punctuation and capitalisation applied (true) or suppressed (false)
+    bool?   Itn,         // inverse text normalisation applied (true) or suppressed (false)
+    bool?   Timestamps,  // word-level timestamps in output
+    bool?   Diarize      // model's own speaker-change tracking active
+)
+{
+    public static readonly CohereSegmentMeta Empty = new(null, null, null, null, null, null);
+
+    /// <summary>Serialises all fields to a compact JSON string for the asr_meta DB column.</summary>
+    public string ToJson() => JsonSerializer.Serialize(new
+    {
+        language   = Language,
+        emotion    = Emotion,
+        pnc        = Pnc,
+        itn        = Itn,
+        timestamps = Timestamps,
+        diarize    = Diarize,
+    });
+}

--- a/src/Vernacula.Base/CohereTranscribe.cs
+++ b/src/Vernacula.Base/CohereTranscribe.cs
@@ -459,7 +459,8 @@ public sealed class CohereTranscribe : IDisposable
             for (int b = 0; b < B; b++)
             {
                 if (finished[b]) { nextTok[b] = _eosTokenId; continue; }
-                int tok = ForceLang(ArgMaxSpan(logitsSpan.Slice(b * vocabSize, vocabSize)), forcedLangTokenId);
+                var stepLogits = logitsSpan.Slice(b * vocabSize, vocabSize);
+                int tok = ForceLang(ArgMaxSpan(stepLogits), forcedLangTokenId);
                 nextTok[b] = tok;
                 tokens[b].Add(tok);
                 if (tok == _eosTokenId) { finished[b] = true; finishedCount++; }

--- a/src/Vernacula.Base/CohereTranscribe.cs
+++ b/src/Vernacula.Base/CohereTranscribe.cs
@@ -11,9 +11,12 @@ namespace Vernacula.Base;
 ///
 /// Uses four ONNX models in the model directory:
 ///   mel.onnx          waveforms [1,T] → features [1,128,F]
-///   encoder.onnx      features [1,128,F] → encoder_hidden_states [1,T',1280]
-///   decoder_init.onnx BOS token + enc_hidden → logits + 32 KV tensors
-///   decoder_step.onnx single token + past self-KV + fixed cross-KV → next logit + updated self-KV
+///   encoder.onnx      features [B,128,F] → encoder_hidden_states [B,T',1280]
+///   decoder_init.onnx BOS [B,1] + enc_hidden [B,T',1280] → logits [B,1,V] + 32 KV tensors
+///   decoder_step.onnx tokens [B,1] + past self-KV [B,H,t,d] + fixed cross-KV → logits + updated self-KV
+///
+/// All four models are batch-dynamic.  Mel runs B=1 serially (per-segment);
+/// encoder and decoder run over the full segment batch together.
 ///
 /// Vocab is loaded from vocab.json (array of 16384 token strings indexed by ID).
 /// </summary>
@@ -48,8 +51,66 @@ public sealed class CohereTranscribe : IDisposable
     private const int LangIdMin = 22;
     private const int LangIdMax = 204;
 
-    // The Cohere conformer encoder specializes batch=1 internally — encoder
-    // batching is not supported by this model architecture.
+    // Fixed context-block token IDs (from vocab.json).
+    // When a language is forced the entire context block is known upfront;
+    // decoder_init is called once with a 10-token prefix instead of stepping
+    // through the context block one token at a time (saves 9 decoder_step calls).
+    private const int TokStartOfContext    = 7;   // <|startofcontext|>
+    private const int TokStartOfTranscript = 4;   // <|startoftranscript|>
+    private const int TokEmoNeutral        = 17;  // <|emo:neutral|>
+    private const int TokPncOn             = 5;   // <|pnc|>
+    private const int TokNoItn             = 9;   // <|noitn|>
+    private const int TokNoTimestamp       = 11;  // <|notimestamp|>
+    private const int TokNoDiarize         = 13;  // <|nodiarize|>
+
+    // ── Batch sizing ─────────────────────────────────────────────────────────
+    // Both encoder.onnx and decoder_init/step.onnx are fully batch-dynamic.
+    // Batch size is determined dynamically per-batch from the VRAM budget and the
+    // estimated peak KV-cache size of the longest segment in that batch.
+    //
+    // Segments are sorted by ascending audio duration before batching so that
+    // segments of similar length land in the same batch, minimising the "straggler"
+    // waste where shorter segments keep stepping after they have emitted EOS.
+
+    // Hard upper limit on segments per batch.
+    // B=128 crashes on RTX 3090 (24 GB): decoder_init intermediate activations
+    // scale as B × encTMax and exhaust VRAM after model weights consume ~12 GB.
+    // B=8 is confirmed safe; B=32 keeps four-session ONNX model weights + BFC
+    // arena overhead within budget while giving 4× better GPU utilisation vs B=8.
+    private const int MaxBatchSize = 32;
+
+    // VRAM budget for KV-cache tensors AND intermediate activations during the
+    // decoder_init forward pass.  Computed at construction time: free GPU VRAM
+    // (measured after all four ONNX sessions are loaded) minus a 2 GB safety
+    // buffer for CUDA runtime overhead and activation peaks.
+    // Falls back to 3 GB if the CUDA query is unavailable (CPU-only builds).
+    private const long VramSafetyBufferBytes = 2_000_000_000L;
+    private const long VramBudgetFallbackBytes = 3_000_000_000L;
+    private readonly long _vramBudgetForKvBytes;
+
+    // Rough token rate used to estimate the maximum decode depth from audio duration.
+    // ~8 text tokens/s + context-block overhead; capped by maxNewTokens.
+    private const float TokensPerAudioSecond = 10f;
+
+    // Mel spectrogram frame rate and encoder temporal downsampling factor.
+    private const float MelFramesPerSec  = 100f;
+    private const float EncoderDownsample = 8f;
+
+    private static int EstimateEncFrames(double durSec)
+        => Math.Max(1, (int)Math.Ceiling(durSec * MelFramesPerSec / EncoderDownsample));
+
+    private static int EstimateDecSteps(double durSec, int maxNewTokens)
+        => Math.Min(maxNewTokens, (int)Math.Ceiling(durSec * TokensPerAudioSecond) + 16);
+
+    // Peak VRAM for KV tensors at the end of a batch decode.
+    //   Self-KV:  B × NumLayers × 2 × NumHeads × maxDecSteps × HeadDim × 4 bytes
+    //   Cross-KV: B × NumLayers × 2 × NumHeads × maxEncFrames × HeadDim × 4 bytes
+    private static long EstimateKvBytes(int batchSize, int maxEncFrames, int maxDecSteps)
+    {
+        const long bytesPerFloat = 4L;
+        return (long)batchSize * NumLayers * 2 * NumHeads * HeadDim * bytesPerFloat
+               * (maxDecSteps + maxEncFrames);
+    }
 
     // ── Construction ─────────────────────────────────────────────────────────
 
@@ -59,9 +120,9 @@ public sealed class CohereTranscribe : IDisposable
         _mel = new InferenceSession(Path.Combine(modelPath, MelFile), cpuOpts);
 
         var gpuOpts = MakeSessionOptions(ep);
-        _encoder      = new InferenceSession(Path.Combine(modelPath, EncoderFile),     gpuOpts);
-        _decoderInit  = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), gpuOpts);
-        _decoderStep  = new InferenceSession(Path.Combine(modelPath, DecoderStepFile), gpuOpts);
+        _encoder     = new InferenceSession(Path.Combine(modelPath, EncoderFile),     gpuOpts);
+        _decoderInit = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), gpuOpts);
+        _decoderStep = new InferenceSession(Path.Combine(modelPath, DecoderStepFile), gpuOpts);
 
         // Load vocab
         string vocabJson = File.ReadAllText(Path.Combine(modelPath, VocabFile));
@@ -76,6 +137,10 @@ public sealed class CohereTranscribe : IDisposable
         _eosTokenId    = root.GetProperty("eos_token_id").GetInt32();
         _padTokenId    = root.GetProperty("pad_token_id").GetInt32();
         _startTokenId  = root.GetProperty("bos_token_id").GetInt32();
+
+        // Query free VRAM now that all four sessions are loaded so model weights
+        // are already resident on the device.
+        _vramBudgetForKvBytes = QueryVramBudget();
     }
 
     private static SessionOptions MakeSessionOptions(ExecutionProvider ep)
@@ -125,7 +190,7 @@ public sealed class CohereTranscribe : IDisposable
 
     /// <summary>
     /// Mel preprocessing for a single waveform: waveforms [1,T] → features [1,128,F].
-    /// Returns the flat mel features and the valid frame count.
+    /// mel.onnx is B=1 only; callers run this per segment.
     /// </summary>
     private (float[] features, int nMels, int F) RunMel(float[] waveform)
     {
@@ -142,110 +207,249 @@ public sealed class CohereTranscribe : IDisposable
         var featT = results.First(r => r.Name == "features").AsTensor<float>();
         int nMels = featT.Dimensions[1];
         int F     = featT.Dimensions[2];
-
-        var features = new float[nMels * F];
-        for (int m = 0; m < nMels; m++)
-            for (int f = 0; f < F; f++)
-                features[m * F + f] = featT[0, m, f];
-
+        // Batch=1, so the flat layout is already [nMels, F]; bulk copy.
+        var features = ExtractTensorFlatDirect(featT);
         return (features, nMels, F);
     }
 
     /// <summary>
-    /// Encoder: mel features [1, 128, F] → encoder_hidden_states [1, T', 1280].
-    /// Returns the hidden states flat [T', dModel] and T'.
+    /// Encoder batch: mel features [B, 128, F_max] → encoder_hidden_states [B, T_enc_max, 1280].
+    /// Segments shorter than F_max are zero-padded on the right.
+    /// Returns the full padded batch tensor and T_enc_max (the decoder uses all T_enc_max
+    /// cross-attention positions; near-zero outputs from padding receive negligible attention).
     /// </summary>
-    private (float[] hidden, int T_enc) RunEncoder(float[] features, int nMels, int F)
+    private (float[] batchHidden, int T_enc_max) RunEncoderBatch(
+        IReadOnlyList<(float[] features, int nMels, int F)> melResults)
     {
-        var featT = new DenseTensor<float>(features, new[] { 1, nMels, F });
+        int B     = melResults.Count;
+        int nMels = melResults[0].nMels;
+        int F_max = 0;
+        foreach (var (_, _, F) in melResults) if (F > F_max) F_max = F;
 
-        using var results = _encoder.Run(
+        // Build [B, 128, F_max] — zero-initialised, fill each segment's valid frames.
+        var batchData = new float[B * nMels * F_max];
+        for (int b = 0; b < B; b++)
+        {
+            var (features, _, F) = melResults[b];
+            for (int m = 0; m < nMels; m++)
+                Array.Copy(features, m * F, batchData, (b * nMels + m) * F_max, F);
+        }
+
+        var batchT = new DenseTensor<float>(batchData, new[] { B, nMels, F_max });
+        using var encResults = _encoder.Run(
         [
-            NamedOnnxValue.CreateFromTensor("input_features", featT),
+            NamedOnnxValue.CreateFromTensor("input_features", batchT),
         ]);
 
-        var hidT  = results.First(r => r.Name == "encoder_hidden_states").AsTensor<float>();
-        int T_enc = hidT.Dimensions[1];
-        int dMod  = hidT.Dimensions[2];
-
-        var hidden = new float[T_enc * dMod];
-        for (int t = 0; t < T_enc; t++)
-            for (int d = 0; d < dMod; d++)
-                hidden[t * dMod + d] = hidT[0, t, d];
-
-        return (hidden, T_enc);
+        var hidT      = encResults.First(r => r.Name == "encoder_hidden_states").AsTensor<float>();
+        int T_enc_max = hidT.Dimensions[1];
+        // Row-major [B, T_enc_max, dMod] — bulk copy via DenseTensor buffer.
+        var batchHidden = ExtractTensorFlatDirect(hidT);
+        return (batchHidden, T_enc_max);
     }
 
     /// <summary>
-    /// Greedy KV-cache decoder.
-    /// Returns the full token list including decoder_start token.
-    /// When <paramref name="forcedLangTokenId"/> is ≥ 0, any context-block token in the
-    /// language ID range (22–204) is replaced with the forced language token ID so that
-    /// all subsequent decoding is conditioned on the specified language.
+    /// Batched KV-cache greedy decoder with ORT IOBinding.
+    ///
+    /// Key optimisations vs the previous implementation:
+    ///
+    /// 1. IOBinding — cross-KV tensors ([B, H, encTMax, d]) are returned by
+    ///    decoder_init directly into CUDA device memory and bound once to the
+    ///    decoder_step session.  They never cross the PCIe bus.  Self-KV tensors
+    ///    are similarly kept on the GPU between steps (step-output OrtValues bound
+    ///    directly as next-step inputs).
+    ///
+    /// 2. Context-block prefill — when a language is forced, the full 10-token
+    ///    context prefix [BOS, startofcontext, startoftranscript, emo:neutral,
+    ///    lang, lang, pnc, noitn, notimestamp, nodiarize] is fed to decoder_init
+    ///    in one call, collapsing 9 serial decoder_step calls into zero.
+    ///    Without forced language the prefix is just BOS (existing behaviour).
+    ///
+    /// Returns one token list per segment (includes BOS and all context tokens).
     /// </summary>
-    private List<int> GreedyDecode(float[] encoderHidden, int encT,
-                                   int maxTokens = 256, int forcedLangTokenId = -1)
+    private List<int>[] GreedyDecodeBatch(
+        float[] encoderHiddenBatch, int B, int encTMax,
+        int maxTokens = 256, int forcedLangTokenId = -1)
     {
-        const int dModel = 1280;
-        var encT_tensor = new DenseTensor<float>(encoderHidden, new[] { 1, encT, dModel });
-        var bosT        = new DenseTensor<long>(new long[] { _bosTokenId }, new[] { 1, 1 });
+        const int encDim = 1280;
 
-        // ── Decoder init ─────────────────────────────────────────────────────
-        float[] logits;
-        float[][] selfKey  = new float[NumLayers][];
-        float[][] selfVal  = new float[NumLayers][];
-        float[][] crossKey = new float[NumLayers][];
-        float[][] crossVal = new float[NumLayers][];
+        // ── Build decoder_init input ──────────────────────────────────────────
+        // With a forced language we send the full context block as a prefix so
+        // decoder_init computes KV for all context positions in one forward pass.
+        // Without forced language we send BOS only and step through the context
+        // block token-by-token in the step loop (existing behaviour).
+        bool usePrefill   = forcedLangTokenId >= 0;
+        int  contextLen   = usePrefill ? 10 : 1;   // number of tokens in the prefix
 
-        using (var initResults = _decoderInit.Run(
-        [
-            NamedOnnxValue.CreateFromTensor("decoder_input_ids",    bosT),
-            NamedOnnxValue.CreateFromTensor("encoder_hidden_states", encT_tensor),
-        ]))
+        var initTokens = new long[B * contextLen];
+        for (int b = 0; b < B; b++)
         {
-            // Outputs: logits, sk0..7, sv0..7, ck0..7, cv0..7
-            logits = ExtractLogits(initResults, "logits");
-
-            for (int i = 0; i < NumLayers; i++)
+            int o = b * contextLen;
+            initTokens[o] = _bosTokenId;
+            if (usePrefill)
             {
-                selfKey[i]  = ExtractTensorFlat(initResults, $"self_key_{i}");
-                selfVal[i]  = ExtractTensorFlat(initResults, $"self_val_{i}");
-                crossKey[i] = ExtractTensorFlat(initResults, $"cross_key_{i}");
-                crossVal[i] = ExtractTensorFlat(initResults, $"cross_val_{i}");
+                initTokens[o + 1] = TokStartOfContext;
+                initTokens[o + 2] = TokStartOfTranscript;
+                initTokens[o + 3] = TokEmoNeutral;
+                initTokens[o + 4] = forcedLangTokenId;
+                initTokens[o + 5] = forcedLangTokenId;
+                initTokens[o + 6] = TokPncOn;
+                initTokens[o + 7] = TokNoItn;
+                initTokens[o + 8] = TokNoTimestamp;
+                initTokens[o + 9] = TokNoDiarize;
             }
         }
 
-        int firstToken = ForceLang(ArgMax(logits), forcedLangTokenId);
-        var tokens     = new List<int>(maxTokens + 2) { _bosTokenId, firstToken };
-        if (firstToken == _eosTokenId)
-            return tokens;
+        // ── Memory infos ─────────────────────────────────────────────────────
+        using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var cpuMemInfo  = new OrtMemoryInfo("Cpu",  OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var runOpts     = new RunOptions();
 
-        int tPast = 1;  // number of tokens in self-KV (= 1 after init)
+        // ── decoder_init with IOBinding ───────────────────────────────────────
+        // OrtIoBinding.GetOutputValues() returns tensors in BINDING ORDER (the order
+        // BindOutputToDevice was called), not model output order.  Bind in four grouped
+        // passes so the indices the step loop reads match the actual positions:
+        //   [0]       logits
+        //   [1..8]    self_key_0..7
+        //   [9..16]   self_val_0..7
+        //   [17..24]  cross_key_0..7
+        //   [25..32]  cross_val_0..7
+        using var initTokValue = OrtValue.CreateTensorValueFromMemory(
+            initTokens, new long[] { B, contextLen });
+        using var encHidValue  = OrtValue.CreateTensorValueFromMemory(
+            encoderHiddenBatch, new long[] { B, encTMax, encDim });
 
-        // ── Step loop ────────────────────────────────────────────────────────
-        for (int step = 1; step < maxTokens; step++)
+        using var initBinding = _decoderInit.CreateIoBinding();
+        initBinding.BindInput("decoder_input_ids",     initTokValue);
+        initBinding.BindInput("encoder_hidden_states", encHidValue);
+        initBinding.BindOutputToDevice("logits", cpuMemInfo);   // logits read on CPU
+        for (int i = 0; i < NumLayers; i++) initBinding.BindOutputToDevice($"self_key_{i}",  cudaMemInfo);
+        for (int i = 0; i < NumLayers; i++) initBinding.BindOutputToDevice($"self_val_{i}",  cudaMemInfo);
+        for (int i = 0; i < NumLayers; i++) initBinding.BindOutputToDevice($"cross_key_{i}", cudaMemInfo);
+        for (int i = 0; i < NumLayers; i++) initBinding.BindOutputToDevice($"cross_val_{i}", cudaMemInfo);
+        _decoderInit.RunWithBinding(runOpts, initBinding);
+
+        // Keep initOutputs alive for the full decode loop — cross-KV is bound
+        // from it for every step.  Disposed after the loop.
+        var initOutputs = initBinding.GetOutputValues();
+
+        // ── Read first tokens from init logits ────────────────────────────────
+        // Shape: [B, contextLen, vocabSize]; last position = index contextLen-1.
+        int vocabSize;
+        int[] firstTokens;
         {
-            int lastToken = tokens[tokens.Count - 1];
-            var inputs = BuildStepInputs(lastToken, step, tPast, encT,
-                                         selfKey, selfVal, crossKey, crossVal);
+            var shape     = initOutputs[0].GetTensorTypeAndShape().Shape;
+            vocabSize     = (int)shape[2];
+            var logitsSpan = initOutputs[0].GetTensorDataAsSpan<float>();
+            firstTokens   = new int[B];
+            int lastPos   = contextLen - 1;
+            for (int b = 0; b < B; b++)
+            {
+                var slice   = logitsSpan.Slice((b * contextLen + lastPos) * vocabSize, vocabSize);
+                firstTokens[b] = ForceLang(ArgMaxSpan(slice), forcedLangTokenId);
+            }
+        }
 
-            using var stepResults = _decoderStep.Run(inputs);
+        // ── Initialise per-segment token lists ───────────────────────────────
+        var tokens        = new List<int>[B];
+        var finished      = new bool[B];
+        var nextTok       = new long[B];
+        int finishedCount = 0;
 
-            logits = ExtractLogits(stepResults, "logits");
+        for (int b = 0; b < B; b++)
+        {
+            tokens[b] = new List<int>(maxTokens + contextLen + 1);
+            tokens[b].Add(_bosTokenId);
+            if (usePrefill)
+            {
+                tokens[b].Add(TokStartOfContext);
+                tokens[b].Add(TokStartOfTranscript);
+                tokens[b].Add(TokEmoNeutral);
+                tokens[b].Add(forcedLangTokenId);
+                tokens[b].Add(forcedLangTokenId);
+                tokens[b].Add(TokPncOn);
+                tokens[b].Add(TokNoItn);
+                tokens[b].Add(TokNoTimestamp);
+                tokens[b].Add(TokNoDiarize);
+            }
+            tokens[b].Add(firstTokens[b]);
+            nextTok[b] = firstTokens[b];
+            if (firstTokens[b] == _eosTokenId) { finished[b] = true; finishedCount++; }
+        }
+
+        int tPast = contextLen;
+
+        // ── Step loop ─────────────────────────────────────────────────────────
+        // decoder_step output layout (17 tensors, binding order = grouped):
+        //   [0]       logits              float32 CPU
+        //   [1..8]    new_self_key_0..7   float16 CUDA  (grow by 1 each step)
+        //   [9..16]   new_self_val_0..7   float16 CUDA
+        //
+        // A FRESH OrtIoBinding is created each step.  ORT caches the CUDA buffer
+        // allocated by BindOutputToDevice and reuses it on subsequent RunWithBinding
+        // calls; when the Concat output grows by one token the cached shape mismatches
+        // and ORT throws.  Creating a fresh binding each step forces a new allocation
+        // at the correct shape without any caching from the previous step.
+        //
+        // prevStepOutputs keeps the previous step's self-KV OrtValues alive while
+        // they are bound as inputs for the current step.  They are disposed only
+        // after the current step has run and the new self-KV are in hand.
+        IDisposableReadOnlyCollection<OrtValue>? prevStepOutputs = null;
+
+        for (int step = 1; step < maxTokens && finishedCount < B; step++)
+        {
+            var stepToks = new long[B];
+            var stepPos  = new long[B];
+            for (int b = 0; b < B; b++)
+                stepToks[b] = finished[b] ? _eosTokenId : nextTok[b];
+            Array.Fill(stepPos, (long)tPast);
+
+            using var tokVal = OrtValue.CreateTensorValueFromMemory(stepToks, new long[] { B, 1 });
+            using var posVal = OrtValue.CreateTensorValueFromMemory(stepPos,  new long[] { B, 1 });
+
+            // Fresh binding each step — avoids buffer-reuse shape failures on self-KV.
+            // Outputs bound in two grouped passes so GetOutputValues() returns them in the
+            // expected grouped order: [1..8]=new_sk0..7, [9..16]=new_sv0..7.
+            using var stepBinding = _decoderStep.CreateIoBinding();
+            stepBinding.BindOutputToDevice("logits", cpuMemInfo);
+            for (int i = 0; i < NumLayers; i++) stepBinding.BindOutputToDevice($"new_self_key_{i}", cudaMemInfo);
+            for (int i = 0; i < NumLayers; i++) stepBinding.BindOutputToDevice($"new_self_val_{i}", cudaMemInfo);
+            stepBinding.BindInput("decoder_input_ids", tokVal);
+            stepBinding.BindInput("positions",         posVal);
+            for (int i = 0; i < NumLayers; i++)
+            {
+                stepBinding.BindInput($"cross_key_{i}", initOutputs[17 + i]);
+                stepBinding.BindInput($"cross_val_{i}", initOutputs[25 + i]);
+                // self-KV: from init on step 1, from previous step's outputs thereafter.
+                var skSrc = prevStepOutputs is null ? initOutputs[1 + i]             : prevStepOutputs[1 + i];
+                var svSrc = prevStepOutputs is null ? initOutputs[9 + i]             : prevStepOutputs[1 + NumLayers + i];
+                stepBinding.BindInput($"self_key_{i}", skSrc);
+                stepBinding.BindInput($"self_val_{i}", svSrc);
+            }
+
+            _decoderStep.RunWithBinding(runOpts, stepBinding);
+            var curOutputs = stepBinding.GetOutputValues();
             tPast++;
 
-            for (int i = 0; i < NumLayers; i++)
-            {
-                selfKey[i] = ExtractTensorFlat(stepResults, $"new_self_key_{i}");
-                selfVal[i] = ExtractTensorFlat(stepResults, $"new_self_val_{i}");
-            }
+            // Logits are CPU-resident; read argmax without copying.
+            var logitsSpan = curOutputs[0].GetTensorDataAsSpan<float>();
 
-            int nextToken = ForceLang(ArgMax(logits), forcedLangTokenId);
-            tokens.Add(nextToken);
-            if (nextToken == _eosTokenId)
-                break;
+            // Dispose previous self-KV — no longer needed as inputs (new ones are in curOutputs).
+            prevStepOutputs?.Dispose();
+            prevStepOutputs = curOutputs;
+
+            for (int b = 0; b < B; b++)
+            {
+                if (finished[b]) { nextTok[b] = _eosTokenId; continue; }
+                int tok = ForceLang(ArgMaxSpan(logitsSpan.Slice(b * vocabSize, vocabSize)), forcedLangTokenId);
+                nextTok[b] = tok;
+                tokens[b].Add(tok);
+                if (tok == _eosTokenId) { finished[b] = true; finishedCount++; }
+            }
         }
 
+        prevStepOutputs?.Dispose();
+        initOutputs.Dispose();
         return tokens;
     }
 
@@ -254,36 +458,6 @@ public sealed class CohereTranscribe : IDisposable
         forcedLangTokenId >= 0 && token >= LangIdMin && token <= LangIdMax
             ? forcedLangTokenId
             : token;
-
-    private List<NamedOnnxValue> BuildStepInputs(
-        int lastToken, int position, int tPast, int encT,
-        float[][] selfKey, float[][] selfVal,
-        float[][] crossKey, float[][] crossVal)
-    {
-        var inputs = new List<NamedOnnxValue>(2 + NumLayers * 4);
-
-        inputs.Add(NamedOnnxValue.CreateFromTensor("decoder_input_ids",
-            new DenseTensor<long>(new long[] { lastToken }, new[] { 1, 1 })));
-        inputs.Add(NamedOnnxValue.CreateFromTensor("positions",
-            new DenseTensor<long>(new long[] { position }, new[] { 1, 1 })));
-
-        for (int i = 0; i < NumLayers; i++)
-        {
-            inputs.Add(NamedOnnxValue.CreateFromTensor($"self_key_{i}",
-                new DenseTensor<float>(selfKey[i], new[] { 1, NumHeads, tPast, HeadDim })));
-            inputs.Add(NamedOnnxValue.CreateFromTensor($"self_val_{i}",
-                new DenseTensor<float>(selfVal[i], new[] { 1, NumHeads, tPast, HeadDim })));
-        }
-        for (int i = 0; i < NumLayers; i++)
-        {
-            inputs.Add(NamedOnnxValue.CreateFromTensor($"cross_key_{i}",
-                new DenseTensor<float>(crossKey[i], new[] { 1, NumHeads, encT, HeadDim })));
-            inputs.Add(NamedOnnxValue.CreateFromTensor($"cross_val_{i}",
-                new DenseTensor<float>(crossVal[i], new[] { 1, NumHeads, encT, HeadDim })));
-        }
-
-        return inputs;
-    }
 
     // ── Token decoding ───────────────────────────────────────────────────────
 
@@ -426,24 +600,98 @@ public sealed class CohereTranscribe : IDisposable
                     "Use an ISO 639-1 code such as 'en', 'fr', 'de'.");
         }
 
-        for (int i = 0; i < segs.Count; i++)
-        {
-            var (start, end, _) = segs[i];
-            float[] waveform = ExtractSegment(audio, start, end);
+        // Sort segment indices by ascending audio duration so that similar-length
+        // segments land in the same batch, minimising straggler waste (shorter segments
+        // that have emitted EOS still step until the longest segment finishes).
+        int[] order = Enumerable.Range(0, segs.Count)
+            .OrderBy(i => segs[i].end - segs[i].start)
+            .ToArray();
 
-            if (waveform.Length < Config.SampleRate / 10)  // < 100 ms
+        int pos = 0;
+        while (pos < order.Length)
+        {
+            // ── Build a variable-size batch bounded by VRAM and MaxBatchSize ──────
+            // Grow the batch one segment at a time, stopping when the estimated peak
+            // KV-cache size would exceed VramBudgetForKvBytes or MaxBatchSize is hit.
+            // Uses the *worst-case* (longest) segment in the batch for both enc and dec
+            // estimates, which is always the last segment added (since we sort ascending).
+            int batchSize   = 0;
+            int maxEncFrames = 0;
+            int maxDecSteps  = 0;
+
+            while (pos + batchSize < order.Length && batchSize < MaxBatchSize)
             {
-                yield return (i, string.Empty, CohereSegmentMeta.Empty);
-                continue;
+                int candidateIdx    = order[pos + batchSize];
+                var (cs, ce, _)     = segs[candidateIdx];
+                double candDur      = ce - cs;
+                int candEncFrames   = EstimateEncFrames(candDur);
+                int candDecSteps    = EstimateDecSteps(candDur, maxNewTokens);
+
+                // Worst-case across all segments in the prospective batch.
+                int newMaxEnc = Math.Max(maxEncFrames, candEncFrames);
+                int newMaxDec = Math.Max(maxDecSteps,  candDecSteps);
+
+                long kvBytes = EstimateKvBytes(batchSize + 1, newMaxEnc, newMaxDec);
+                if (batchSize > 0 && kvBytes > _vramBudgetForKvBytes)
+                    break;  // adding this segment would exceed the VRAM budget
+
+                maxEncFrames = newMaxEnc;
+                maxDecSteps  = newMaxDec;
+                batchSize++;
             }
 
-            var (features, nMels, F) = RunMel(waveform);
-            var (encHidden, encT)    = RunEncoder(features, nMels, F);
-            var tokens               = GreedyDecode(encHidden, encT, maxNewTokens, forcedLangTokenId);
-            var meta                 = ParseContextBlock(tokens);
-            string text              = DecodeTokens(tokens);
+            // ── Extract waveforms; flag segments too short to encode ──────────────
+            var waveforms = new float[batchSize][];
+            var skipped   = new bool[batchSize];
+            var segIds    = new int[batchSize];
 
-            yield return (i, text, meta);
+            for (int b = 0; b < batchSize; b++)
+            {
+                segIds[b] = order[pos + b];
+                var (start, end, _) = segs[segIds[b]];
+                waveforms[b] = ExtractSegment(audio, start, end);
+                skipped[b]   = waveforms[b].Length < Config.SampleRate / 10;
+            }
+
+            // ── Mel (serial, B=1 only) ────────────────────────────────────────────
+            var melResults = new (float[] features, int nMels, int F)[batchSize];
+            for (int b = 0; b < batchSize; b++)
+                if (!skipped[b])
+                    melResults[b] = RunMel(waveforms[b]);
+
+            // ── Encoder + batched decoder ────────────────────────────────────────
+            // Only pass valid (non-skipped) segments to the encoder.
+            var validMel    = new List<(float[], int, int)>(batchSize);
+            var validBSlots = new List<int>(batchSize);  // b-indices of valid segments
+            for (int b = 0; b < batchSize; b++)
+                if (!skipped[b]) { validMel.Add(melResults[b]); validBSlots.Add(b); }
+
+            List<int>[] batchTokens = [];
+            if (validMel.Count > 0)
+            {
+                var (batchHidden, T_enc_max) = RunEncoderBatch(validMel);
+                batchTokens = GreedyDecodeBatch(
+                    batchHidden, validMel.Count, T_enc_max, maxNewTokens, forcedLangTokenId);
+            }
+
+            // ── Yield results ────────────────────────────────────────────────────
+            int encIdx = 0;
+            for (int b = 0; b < batchSize; b++)
+            {
+                int segId = segIds[b];
+                if (skipped[b])
+                {
+                    yield return (segId, string.Empty, CohereSegmentMeta.Empty);
+                    continue;
+                }
+
+                var tokens = batchTokens[encIdx++];
+                var meta   = ParseContextBlock(tokens);
+                string text = DecodeTokens(tokens);
+                yield return (segId, text, meta);
+            }
+
+            pos += batchSize;
         }
     }
 
@@ -459,40 +707,55 @@ public sealed class CohereTranscribe : IDisposable
         return seg;
     }
 
-    private static float[] ExtractLogits(
-        IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results,
-        string name)
+    // Bulk-copy a Tensor<float> to a flat float[] via DenseTensor buffer when available.
+    private static float[] ExtractTensorFlatDirect(Tensor<float> tensor)
     {
-        var tensor = results.First(r => r.Name == name).AsTensor<float>();
-        // shape [1, 1, vocab_size] — return the last (only) position
-        int vocabSize = tensor.Dimensions[2];
-        var logits = new float[vocabSize];
-        for (int v = 0; v < vocabSize; v++)
-            logits[v] = tensor[0, 0, v];
-        return logits;
-    }
-
-    private static float[] ExtractTensorFlat(
-        IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results,
-        string name)
-    {
-        var tensor = results.First(r => r.Name == name).AsTensor<float>();
         int total = 1;
-        for (int d = 0; d < tensor.Rank; d++)
-            total *= tensor.Dimensions[d];
+        for (int d = 0; d < tensor.Rank; d++) total *= tensor.Dimensions[d];
         var flat = new float[total];
-        for (int i = 0; i < total; i++)
-            flat[i] = tensor.GetValue(i);
+        if (tensor is DenseTensor<float> dense)
+            dense.Buffer.Span.CopyTo(flat);
+        else
+            for (int i = 0; i < total; i++) flat[i] = tensor.GetValue(i);
         return flat;
     }
 
-    private static int ArgMax(float[] arr)
+    private static int ArgMaxSpan(ReadOnlySpan<float> span)
     {
         int idx = 0;
         float max = float.NegativeInfinity;
-        for (int i = 0; i < arr.Length; i++)
-            if (arr[i] > max) { max = arr[i]; idx = i; }
+        for (int i = 0; i < span.Length; i++)
+            if (span[i] > max) { max = span[i]; idx = i; }
         return idx;
+    }
+
+    // ── CUDA VRAM query ───────────────────────────────────────────────────────
+
+    // cudaMemGetInfo returns free and total device memory in bytes.
+    // The DllImport name resolves to libcudart.so on Linux / cudart.dll on Windows.
+    [System.Runtime.InteropServices.DllImport("cudart",
+        EntryPoint            = "cudaMemGetInfo",
+        ExactSpelling         = true,
+        CallingConvention     = System.Runtime.InteropServices.CallingConvention.Cdecl)]
+    private static extern int CudaMemGetInfo(out ulong free, out ulong total);
+
+    /// <summary>
+    /// Queries GPU free memory after all ONNX sessions are loaded and subtracts
+    /// <see cref="VramSafetyBufferBytes"/> as headroom for activations and CUDA
+    /// runtime overhead.  Returns <see cref="VramBudgetFallbackBytes"/> if the
+    /// CUDA runtime is not available (CPU-only builds or non-CUDA EPs).
+    /// </summary>
+    private static long QueryVramBudget()
+    {
+        try
+        {
+            int rc = CudaMemGetInfo(out ulong free, out _);
+            if (rc == 0 && free > VramSafetyBufferBytes)
+                return (long)(free - VramSafetyBufferBytes);
+        }
+        catch (DllNotFoundException) { }
+        catch (EntryPointNotFoundException) { }
+        return VramBudgetFallbackBytes;
     }
 
     // ── IDisposable ───────────────────────────────────────────────────────────

--- a/src/Vernacula.Base/CohereTranscribe.cs
+++ b/src/Vernacula.Base/CohereTranscribe.cs
@@ -967,7 +967,7 @@ public sealed class CohereTranscribe : IDisposable
         return work;
     }
 
-    private static CohereRecognitionResult CombineChunkParts(
+    private CohereRecognitionResult CombineChunkParts(
         int segmentId,
         List<ChunkDecodePart> parts)
     {
@@ -976,7 +976,6 @@ public sealed class CohereTranscribe : IDisposable
         var rawTokens = new List<int>();
         var textTokens = new List<int>();
         var textLogprobs = new List<float>();
-        var textBuilder = new StringBuilder();
 
         string? language = null;
         string? emotion = null;
@@ -987,13 +986,6 @@ public sealed class CohereTranscribe : IDisposable
 
         foreach (var part in parts)
         {
-            if (!string.IsNullOrWhiteSpace(part.Text))
-            {
-                if (textBuilder.Length > 0)
-                    textBuilder.Append(' ');
-                textBuilder.Append(part.Text.Trim());
-            }
-
             rawTokens.AddRange(part.RawTokens);
             textTokens.AddRange(part.TextTokens);
             textLogprobs.AddRange(part.TextLogprobs);
@@ -1006,9 +998,11 @@ public sealed class CohereTranscribe : IDisposable
             diarize ??= part.Meta.Diarize;
         }
 
+        string text = DecodeTokens(textTokens);
+
         return new CohereRecognitionResult(
             segmentId,
-            textBuilder.ToString(),
+            text,
             rawTokens,
             textTokens,
             textLogprobs,

--- a/src/Vernacula.Base/CohereTranscribe.cs
+++ b/src/Vernacula.Base/CohereTranscribe.cs
@@ -22,6 +22,7 @@ namespace Vernacula.Base;
 /// </summary>
 public sealed class CohereTranscribe : IDisposable
 {
+    private const int EncDim = 1280;
     private const int NumLayers = 8;
     private const int NumHeads  = 8;
     private const int HeadDim   = 128;
@@ -99,9 +100,13 @@ public sealed class CohereTranscribe : IDisposable
     // Mel spectrogram frame rate and encoder temporal downsampling factor.
     private const float MelFramesPerSec  = 100f;
     private const float EncoderDownsample = 8f;
+    private const double MaxAsrSegmentSeconds = 30.0;
 
     private static int EstimateEncFrames(double durSec)
         => Math.Max(1, (int)Math.Ceiling(durSec * MelFramesPerSec / EncoderDownsample));
+
+    private static int EstimateMelFrames(double durSec)
+        => Math.Max(1, (int)Math.Ceiling(durSec * MelFramesPerSec));
 
     private static int EstimateDecSteps(double durSec, int maxNewTokens)
         => Math.Min(maxNewTokens, (int)Math.Ceiling(durSec * TokensPerAudioSecond) + 16);
@@ -114,6 +119,18 @@ public sealed class CohereTranscribe : IDisposable
         const long bytesPerFloat = 4L;
         return (long)batchSize * NumLayers * 2 * NumHeads * HeadDim * bytesPerFloat
                * (maxDecSteps + maxEncFrames);
+    }
+
+    // Peak output allocation of the first encoder conv:
+    //   [B, 256, outT, outF] float32, where outT=(T+1)/2 and outF=(128+1)/2=64.
+    // This is the exact site of the observed OOM in long DiariZen + Cohere runs.
+    private static long EstimateEncoderConvBytes(int batchSize, int maxMelFrames)
+    {
+        const long convChannels = 256L;
+        const long bytesPerFloat = 4L;
+        long outT = (maxMelFrames + 1L) / 2L;
+        const long outF = 64L;
+        return batchSize * convChannels * outT * outF * bytesPerFloat;
     }
 
     // ── Construction ─────────────────────────────────────────────────────────
@@ -246,16 +263,36 @@ public sealed class CohereTranscribe : IDisposable
 
         var batchT   = new DenseTensor<float>(batchData, new[] { B, nMels, F_max });
         var lengthsT = new DenseTensor<long>(lengths, new[] { B });
-        using var encResults = _encoder.Run(
-        [
-            NamedOnnxValue.CreateFromTensor("input_features", batchT),
-            NamedOnnxValue.CreateFromTensor("input_lengths",  lengthsT),
-        ]);
+        try
+        {
+            using var encResults = _encoder.Run(
+            [
+                NamedOnnxValue.CreateFromTensor("input_features", batchT),
+                NamedOnnxValue.CreateFromTensor("input_lengths",  lengthsT),
+            ]);
 
-        var hidT      = encResults.First(r => r.Name == "encoder_hidden_states").AsTensor<float>();
-        int T_enc_max = hidT.Dimensions[1];
-        var batchHidden = ExtractTensorFlatDirect(hidT);
-        return (batchHidden, T_enc_max);
+            var hidT = encResults.First(r => r.Name == "encoder_hidden_states").AsTensor<float>();
+            int T_enc_max = hidT.Dimensions[1];
+            var batchHidden = ExtractTensorFlatDirect(hidT);
+            return (batchHidden, T_enc_max);
+        }
+        catch (OnnxRuntimeException ex) when (IsLikelyOutOfMemory(ex) && B > 1)
+        {
+            int leftCount = B / 2;
+            var left = new (float[] features, int nMels, int F)[leftCount];
+            var right = new (float[] features, int nMels, int F)[B - leftCount];
+            for (int i = 0; i < leftCount; i++) left[i] = melResults[i];
+            for (int i = leftCount; i < B; i++) right[i - leftCount] = melResults[i];
+
+            var (leftHidden, leftT) = RunEncoderBatch(left);
+            var (rightHidden, rightT) = RunEncoderBatch(right);
+            int mergedT = Math.Max(leftT, rightT);
+            var merged = new float[B * mergedT * EncDim];
+
+            CopyEncoderBatchWithPadding(leftHidden, leftCount, leftT, merged, mergedT, 0);
+            CopyEncoderBatchWithPadding(rightHidden, B - leftCount, rightT, merged, mergedT, leftCount);
+            return (merged, mergedT);
+        }
     }
 
     /// <summary>
@@ -678,11 +715,20 @@ public sealed class CohereTranscribe : IDisposable
                     "Use an ISO 639-1 code such as 'en', 'fr', 'de'.");
         }
 
-        // Sort segment indices by ascending audio duration so that similar-length
+        var workItems = BuildWorkItems(segs);
+        var remainingChunks = new int[segs.Count];
+        var chunkParts = new List<ChunkDecodePart>?[segs.Count];
+        foreach (var work in workItems)
+        {
+            remainingChunks[work.OriginalSegmentId]++;
+            chunkParts[work.OriginalSegmentId] ??= [];
+        }
+
+        // Sort work-item indices by ascending audio duration so that similar-length
         // segments land in the same batch, minimising straggler waste (shorter segments
         // that have emitted EOS still step until the longest segment finishes).
-        int[] order = Enumerable.Range(0, segs.Count)
-            .OrderBy(i => segs[i].end - segs[i].start)
+        int[] order = Enumerable.Range(0, workItems.Count)
+            .OrderBy(i => workItems[i].end - workItems[i].start)
             .ToArray();
 
         int pos = 0;
@@ -700,25 +746,31 @@ public sealed class CohereTranscribe : IDisposable
             int batchSize    = 0;
             int maxEncFrames = 0;
             int maxDecSteps  = 0;
+            int maxMelFrames = 0;
 
             while (pos + batchSize < order.Length && batchSize < MaxBatchSize)
             {
                 int candidateIdx    = order[pos + batchSize];
-                var (cs, ce, _)     = segs[candidateIdx];
+                var (_, _, cs, ce, _) = workItems[candidateIdx];
                 double candDur      = ce - cs;
                 int candEncFrames   = EstimateEncFrames(candDur);
+                int candMelFrames   = EstimateMelFrames(candDur);
                 int candDecSteps    = EstimateDecSteps(candDur, maxNewTokens);
 
                 // Worst-case across all segments in the prospective batch.
                 int newMaxEnc = Math.Max(maxEncFrames, candEncFrames);
                 int newMaxDec = Math.Max(maxDecSteps,  candDecSteps);
+                int newMaxMel = Math.Max(maxMelFrames, candMelFrames);
 
                 long kvBytes = EstimateKvBytes(batchSize + 1, newMaxEnc, newMaxDec);
-                if (batchSize > 0 && kvBytes > _vramBudgetForKvBytes)
+                long encBytes = EstimateEncoderConvBytes(batchSize + 1, newMaxMel);
+                long peakBytes = Math.Max(kvBytes, encBytes);
+                if (batchSize > 0 && peakBytes > _vramBudgetForKvBytes)
                     break;  // adding this segment would exceed the VRAM budget
 
                 maxEncFrames = newMaxEnc;
                 maxDecSteps  = newMaxDec;
+                maxMelFrames = newMaxMel;
                 batchSize++;
             }
 
@@ -730,7 +782,7 @@ public sealed class CohereTranscribe : IDisposable
             for (int b = 0; b < batchSize; b++)
             {
                 segIds[b] = order[pos + b];
-                var (start, end, _) = segs[segIds[b]];
+                var (_, _, start, end, _) = workItems[segIds[b]];
                 waveforms[b] = ExtractSegment(audio, start, end);
                 skipped[b]   = waveforms[b].Length < Config.SampleRate / 10;
             }
@@ -763,16 +815,20 @@ public sealed class CohereTranscribe : IDisposable
             int encIdx = 0;
             for (int b = 0; b < batchSize; b++)
             {
-                int segId = segIds[b];
+                int workId = segIds[b];
+                var work = workItems[workId];
                 if (skipped[b])
                 {
-                    yield return new CohereRecognitionResult(
-                        segId,
+                    chunkParts[work.OriginalSegmentId]!.Add(new ChunkDecodePart(
+                        work.ChunkIndex,
                         string.Empty,
                         [],
                         [],
                         [],
-                        CohereSegmentMeta.Empty);
+                        CohereSegmentMeta.Empty));
+                    remainingChunks[work.OriginalSegmentId]--;
+                    if (remainingChunks[work.OriginalSegmentId] == 0)
+                        yield return CombineChunkParts(work.OriginalSegmentId, chunkParts[work.OriginalSegmentId]!);
                     continue;
                 }
 
@@ -781,13 +837,16 @@ public sealed class CohereTranscribe : IDisposable
                 var meta   = ParseContextBlock(tokens);
                 string text = DecodeTokens(tokens);
                 var (textTokens, textTokenLogprobs) = ExtractTextTokenData(tokens, tokenLogprobs);
-                yield return new CohereRecognitionResult(
-                    segId,
+                chunkParts[work.OriginalSegmentId]!.Add(new ChunkDecodePart(
+                    work.ChunkIndex,
                     text,
                     tokens,
                     textTokens,
                     textTokenLogprobs,
-                    meta);
+                    meta));
+                remainingChunks[work.OriginalSegmentId]--;
+                if (remainingChunks[work.OriginalSegmentId] == 0)
+                    yield return CombineChunkParts(work.OriginalSegmentId, chunkParts[work.OriginalSegmentId]!);
             }
 
             pos += batchSize;
@@ -828,6 +887,31 @@ public sealed class CohereTranscribe : IDisposable
         return idx;
     }
 
+    private static void CopyEncoderBatchWithPadding(
+        float[] source,
+        int sourceBatch,
+        int sourceT,
+        float[] destination,
+        int destT,
+        int destBatchOffset)
+    {
+        for (int b = 0; b < sourceBatch; b++)
+        {
+            int srcOffset = b * sourceT * EncDim;
+            int dstOffset = (destBatchOffset + b) * destT * EncDim;
+            Array.Copy(source, srcOffset, destination, dstOffset, sourceT * EncDim);
+        }
+    }
+
+    private static bool IsLikelyOutOfMemory(OnnxRuntimeException ex)
+    {
+        string message = ex.Message ?? string.Empty;
+        return message.Contains("out of memory", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("failed to allocate memory", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("cuda out of memory", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("bfc_arena", StringComparison.OrdinalIgnoreCase);
+    }
+
     // ── CUDA VRAM query ───────────────────────────────────────────────────────
 
     // cudaMemGetInfo returns free and total device memory in bytes.
@@ -855,6 +939,80 @@ public sealed class CohereTranscribe : IDisposable
         catch (DllNotFoundException) { }
         catch (EntryPointNotFoundException) { }
         return VramBudgetFallbackBytes;
+    }
+
+    private static List<SegmentWorkItem> BuildWorkItems(
+        IReadOnlyList<(double start, double end, string spk)> segs)
+    {
+        var work = new List<SegmentWorkItem>(segs.Count);
+        for (int segId = 0; segId < segs.Count; segId++)
+        {
+            var (start, end, spk) = segs[segId];
+            double duration = Math.Max(0, end - start);
+            if (duration <= MaxAsrSegmentSeconds)
+            {
+                work.Add(new SegmentWorkItem(segId, 0, start, end, spk));
+                continue;
+            }
+
+            int chunkCount = Math.Max(1, (int)Math.Ceiling(duration / MaxAsrSegmentSeconds));
+            for (int chunkIndex = 0; chunkIndex < chunkCount; chunkIndex++)
+            {
+                double chunkStart = start + chunkIndex * MaxAsrSegmentSeconds;
+                double chunkEnd = Math.Min(end, chunkStart + MaxAsrSegmentSeconds);
+                work.Add(new SegmentWorkItem(segId, chunkIndex, chunkStart, chunkEnd, spk));
+            }
+        }
+
+        return work;
+    }
+
+    private static CohereRecognitionResult CombineChunkParts(
+        int segmentId,
+        List<ChunkDecodePart> parts)
+    {
+        parts.Sort((a, b) => a.ChunkIndex.CompareTo(b.ChunkIndex));
+
+        var rawTokens = new List<int>();
+        var textTokens = new List<int>();
+        var textLogprobs = new List<float>();
+        var textBuilder = new StringBuilder();
+
+        string? language = null;
+        string? emotion = null;
+        bool? pnc = null;
+        bool? itn = null;
+        bool? timestamps = null;
+        bool? diarize = null;
+
+        foreach (var part in parts)
+        {
+            if (!string.IsNullOrWhiteSpace(part.Text))
+            {
+                if (textBuilder.Length > 0)
+                    textBuilder.Append(' ');
+                textBuilder.Append(part.Text.Trim());
+            }
+
+            rawTokens.AddRange(part.RawTokens);
+            textTokens.AddRange(part.TextTokens);
+            textLogprobs.AddRange(part.TextLogprobs);
+
+            language ??= part.Meta.Language;
+            emotion ??= part.Meta.Emotion;
+            pnc ??= part.Meta.Pnc;
+            itn ??= part.Meta.Itn;
+            timestamps ??= part.Meta.Timestamps;
+            diarize ??= part.Meta.Diarize;
+        }
+
+        return new CohereRecognitionResult(
+            segmentId,
+            textBuilder.ToString(),
+            rawTokens,
+            textTokens,
+            textLogprobs,
+            new CohereSegmentMeta(language, emotion, pnc, itn, timestamps, diarize));
     }
 
     // ── IDisposable ───────────────────────────────────────────────────────────
@@ -905,6 +1063,21 @@ public sealed record CohereSegmentMeta(
 
 public sealed record CohereRecognitionResult(
     int SegmentId,
+    string Text,
+    IReadOnlyList<int> RawTokens,
+    IReadOnlyList<int> TextTokens,
+    IReadOnlyList<float> TextLogprobs,
+    CohereSegmentMeta Meta);
+
+internal sealed record SegmentWorkItem(
+    int OriginalSegmentId,
+    int ChunkIndex,
+    double start,
+    double end,
+    string spk);
+
+internal sealed record ChunkDecodePart(
+    int ChunkIndex,
     string Text,
     IReadOnlyList<int> RawTokens,
     IReadOnlyList<int> TextTokens,

--- a/src/Vernacula.Base/CohereTranscribe.cs
+++ b/src/Vernacula.Base/CohereTranscribe.cs
@@ -277,7 +277,7 @@ public sealed class CohereTranscribe : IDisposable
     ///
     /// Returns one token list per segment (includes BOS and all context tokens).
     /// </summary>
-    private List<int>[] GreedyDecodeBatch(
+    private (List<int>[] tokens, List<float>[] tokenLogprobs) GreedyDecodeBatch(
         float[] encoderHiddenBatch, int B, int encTMax,
         int maxTokens = 256, int forcedLangTokenId = -1)
     {
@@ -355,21 +355,25 @@ public sealed class CohereTranscribe : IDisposable
         // Shape: [B, contextLen, vocabSize]; last position = index contextLen-1.
         int vocabSize;
         int[] firstTokens;
+        float[] firstLogprobs;
         {
             var shape     = initOutputs[0].GetTensorTypeAndShape().Shape;
             vocabSize     = (int)shape[2];
             var logitsSpan = initOutputs[0].GetTensorDataAsSpan<float>();
             firstTokens   = new int[B];
+            firstLogprobs = new float[B];
             int lastPos   = contextLen - 1;
             for (int b = 0; b < B; b++)
             {
                 var slice   = logitsSpan.Slice((b * contextLen + lastPos) * vocabSize, vocabSize);
                 firstTokens[b] = ForceLang(ArgMaxSpan(slice), forcedLangTokenId);
+                firstLogprobs[b] = SelectedLogProb(slice, firstTokens[b]);
             }
         }
 
         // ── Initialise per-segment token lists ───────────────────────────────
         var tokens        = new List<int>[B];
+        var tokenLogprobs = new List<float>[B];
         var finished      = new bool[B];
         var nextTok       = new long[B];
         int finishedCount = 0;
@@ -377,20 +381,32 @@ public sealed class CohereTranscribe : IDisposable
         for (int b = 0; b < B; b++)
         {
             tokens[b] = new List<int>(maxTokens + contextLen + 1);
+            tokenLogprobs[b] = new List<float>(maxTokens + contextLen + 1);
             tokens[b].Add(_bosTokenId);
+            tokenLogprobs[b].Add(0f);
             if (usePrefill)
             {
                 tokens[b].Add(TokStartOfContext);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(TokStartOfTranscript);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(TokEmoNeutral);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(forcedLangTokenId);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(forcedLangTokenId);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(TokPncOn);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(TokNoItn);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(TokNoTimestamp);
+                tokenLogprobs[b].Add(0f);
                 tokens[b].Add(TokNoDiarize);
+                tokenLogprobs[b].Add(0f);
             }
             tokens[b].Add(firstTokens[b]);
+            tokenLogprobs[b].Add(firstLogprobs[b]);
             nextTok[b] = firstTokens[b];
             if (firstTokens[b] == _eosTokenId) { finished[b] = true; finishedCount++; }
         }
@@ -463,13 +479,14 @@ public sealed class CohereTranscribe : IDisposable
                 int tok = ForceLang(ArgMaxSpan(stepLogits), forcedLangTokenId);
                 nextTok[b] = tok;
                 tokens[b].Add(tok);
+                tokenLogprobs[b].Add(SelectedLogProb(stepLogits, tok));
                 if (tok == _eosTokenId) { finished[b] = true; finishedCount++; }
             }
         }
 
         prevStepOutputs?.Dispose();
         initOutputs.Dispose();
-        return tokens;
+        return (tokens, tokenLogprobs);
     }
 
     // If the decoded token is a language tag and we have a forced language, substitute it.
@@ -477,6 +494,38 @@ public sealed class CohereTranscribe : IDisposable
         forcedLangTokenId >= 0 && token >= LangIdMin && token <= LangIdMax
             ? forcedLangTokenId
             : token;
+
+    private static float SelectedLogProb(ReadOnlySpan<float> logits, int token)
+    {
+        float max = float.NegativeInfinity;
+        for (int i = 0; i < logits.Length; i++)
+            if (logits[i] > max) max = logits[i];
+
+        double sumExp = 0.0;
+        for (int i = 0; i < logits.Length; i++)
+            sumExp += Math.Exp(logits[i] - max);
+
+        return (float)(logits[token] - (Math.Log(sumExp) + max));
+    }
+
+    private static (List<int> textTokens, List<float> textLogprobs) ExtractTextTokenData(
+        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
+    {
+        var textTokens = new List<int>(tokens.Count);
+        var textLogprobs = new List<float>(tokens.Count);
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            int token = tokens[i];
+            if (token < ByteFallbackOffset) continue;
+            if (token == 0) continue;
+
+            textTokens.Add(token);
+            textLogprobs.Add(i < logprobs.Count ? logprobs[i] : 0f);
+        }
+
+        return (textTokens, textLogprobs);
+    }
 
     // ── Token decoding ───────────────────────────────────────────────────────
 
@@ -609,6 +658,16 @@ public sealed class CohereTranscribe : IDisposable
         int maxNewTokens = 256,
         string? forceLanguage = null)
     {
+        foreach (var result in RecognizeDetailed(segs, audio, maxNewTokens, forceLanguage))
+            yield return (result.SegmentId, result.Text, result.Meta);
+    }
+
+    public IEnumerable<CohereRecognitionResult> RecognizeDetailed(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio,
+        int maxNewTokens = 256,
+        string? forceLanguage = null)
+    {
         int forcedLangTokenId = -1;
         if (forceLanguage is not null)
         {
@@ -690,11 +749,14 @@ public sealed class CohereTranscribe : IDisposable
                 if (!skipped[b]) { validMel.Add(melResults[b]); validBSlots.Add(b); }
 
             List<int>[] batchTokens = [];
+            List<float>[] batchTokenLogprobs = [];
             if (validMel.Count > 0)
             {
                 var (batchHidden, T_enc_max) = RunEncoderBatch(validMel);
-                batchTokens = GreedyDecodeBatch(
+                var decoded = GreedyDecodeBatch(
                     batchHidden, validMel.Count, T_enc_max, maxNewTokens, forcedLangTokenId);
+                batchTokens = decoded.tokens;
+                batchTokenLogprobs = decoded.tokenLogprobs;
             }
 
             // ── Yield results ────────────────────────────────────────────────────
@@ -704,14 +766,28 @@ public sealed class CohereTranscribe : IDisposable
                 int segId = segIds[b];
                 if (skipped[b])
                 {
-                    yield return (segId, string.Empty, CohereSegmentMeta.Empty);
+                    yield return new CohereRecognitionResult(
+                        segId,
+                        string.Empty,
+                        [],
+                        [],
+                        [],
+                        CohereSegmentMeta.Empty);
                     continue;
                 }
 
                 var tokens = batchTokens[encIdx++];
+                var tokenLogprobs = batchTokenLogprobs[encIdx - 1];
                 var meta   = ParseContextBlock(tokens);
                 string text = DecodeTokens(tokens);
-                yield return (segId, text, meta);
+                var (textTokens, textTokenLogprobs) = ExtractTextTokenData(tokens, tokenLogprobs);
+                yield return new CohereRecognitionResult(
+                    segId,
+                    text,
+                    tokens,
+                    textTokens,
+                    textTokenLogprobs,
+                    meta);
             }
 
             pos += batchSize;
@@ -808,7 +884,11 @@ public sealed record CohereSegmentMeta(
     public static readonly CohereSegmentMeta Empty = new(null, null, null, null, null, null);
 
     /// <summary>Serialises all fields to a compact JSON string for the asr_meta DB column.</summary>
-    public string ToJson() => JsonSerializer.Serialize(new
+    public string ToJson(
+        IReadOnlyList<int>? rawDecoderTokens = null,
+        IReadOnlyList<int>? storedTextTokens = null,
+        bool? syntheticTimestamps = null,
+        string? timestampMode = null) => JsonSerializer.Serialize(new
     {
         language   = Language,
         emotion    = Emotion,
@@ -816,5 +896,17 @@ public sealed record CohereSegmentMeta(
         itn        = Itn,
         timestamps = Timestamps,
         diarize    = Diarize,
+        raw_decoder_tokens = rawDecoderTokens,
+        stored_text_tokens = storedTextTokens,
+        synthetic_timestamps = syntheticTimestamps,
+        timestamp_mode = timestampMode,
     });
 }
+
+public sealed record CohereRecognitionResult(
+    int SegmentId,
+    string Text,
+    IReadOnlyList<int> RawTokens,
+    IReadOnlyList<int> TextTokens,
+    IReadOnlyList<float> TextLogprobs,
+    CohereSegmentMeta Meta);

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
+using Microsoft.ML.OnnxRuntime;
 using Vernacula.Base;
 using Vernacula.Base.Models;
 using ParakeetAsr = Vernacula.Base.Parakeet;
@@ -120,7 +121,21 @@ if (outputPath is null)
 // ── Ctrl+C cancellation ───────────────────────────────────────────────────────
 
 using var cts = new CancellationTokenSource();
-Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+int cancelPressCount = 0;
+Console.CancelKeyPress += (_, e) =>
+{
+    int press = Interlocked.Increment(ref cancelPressCount);
+    if (press == 1)
+    {
+        e.Cancel = true;
+        Console.Error.WriteLine("\nCancellation requested. Press Ctrl+C again to force exit.");
+        cts.Cancel();
+        return;
+    }
+
+    Console.Error.WriteLine("\nForce exiting...");
+    Environment.Exit(130);
+};
 
 try
 {
@@ -283,7 +298,7 @@ try
         int completed = 0;
 
         Console.WriteLine($"Transcribing {totalSegs} segment(s) (Cohere)...");
-        foreach (var (segId, text, _) in cohere.Recognize(segs, audio,
+        foreach (var (segId, text, meta) in cohere.Recognize(segs, audio,
                      forceLanguage: cohereLanguage))
         {
             cts.Token.ThrowIfCancellationRequested();
@@ -356,6 +371,13 @@ catch (OperationCanceledException)
     Console.Error.WriteLine("\nCancelled.");
     return 130;
 }
+catch (OnnxRuntimeException ex) when (IsLikelyOutOfMemory(ex))
+{
+    Console.Error.WriteLine("\nONNX Runtime ran out of memory while loading or running the model.");
+    Console.Error.WriteLine("Free GPU memory and try again, or rerun with a smaller workload / CPU build.");
+    Console.Error.WriteLine(ex.Message);
+    return 1;
+}
 
 return 0;
 
@@ -406,7 +428,7 @@ static string BuildSrt(List<(double start, double end, string spkId, string text
     {
         sb.AppendLine(idx.ToString());
         sb.AppendLine($"{SrtTime(start)} --> {SrtTime(end)}");
-        sb.AppendLine($"[{spkId}] {text}");
+        sb.AppendLine($"[{spkId}] {text}".Trim());
         sb.AppendLine();
         idx++;
     }
@@ -420,6 +442,15 @@ static string SrtTime(double seconds)
 {
     var ts = TimeSpan.FromSeconds(seconds);
     return $"{ts.Hours:D2}:{ts.Minutes:D2}:{ts.Seconds:D2},{ts.Milliseconds:D3}";
+}
+
+static bool IsLikelyOutOfMemory(OnnxRuntimeException ex)
+{
+    string message = ex.Message;
+    return message.Contains("out of memory", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("failed to allocate memory", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("cuda out of memory", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("bfcarena", StringComparison.OrdinalIgnoreCase);
 }
 
 static void PrintUsage()

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -18,6 +18,9 @@ bool    showBenchmark   = false;
 bool    skipAsr         = false;
 string  denoiser        = "none";       // none, dfn3
 string? denoiserModels  = null;         // defaults to <modelDir>/deepfilternet3
+string  asrBackend      = "parakeet";   // parakeet or cohere
+string? cohereModelDir  = null;         // defaults to <modelDir>/cohere_transcribe
+string? cohereLanguage  = null;         // ISO 639-1 forced language (e.g. "en")
 ModelPrecision precision = ModelPrecision.Fp32;
 
 for (int i = 0; i < args.Length; i++)
@@ -50,6 +53,16 @@ for (int i = 0; i < args.Length; i++)
             }
             break;
         case "--denoiser-models": denoiserModels = args[++i]; break;
+        case "--asr":
+            asrBackend = args[++i].ToLowerInvariant();
+            if (asrBackend is not ("parakeet" or "cohere"))
+            {
+                Console.Error.WriteLine($"Unknown ASR backend: {asrBackend}. Choose: parakeet, cohere.");
+                return 1;
+            }
+            break;
+        case "--cohere-model":    cohereModelDir = args[++i]; break;
+        case "--language":        cohereLanguage = args[++i]; break;
         case "--precision":
             precision = args[++i].ToLowerInvariant() switch {
                 "int8" => ModelPrecision.Int8,
@@ -250,6 +263,39 @@ try
         results.AddRange(segs.Select(s => (s.start, s.end, s.spkId, string.Empty)));
         swAsr.Stop();
     }
+    else if (asrBackend == "cohere")
+    {
+        string cohereDir = cohereModelDir
+            ?? (Directory.Exists(Path.Combine(modelDir, "cohere_transcribe"))
+                ? Path.Combine(modelDir, "cohere_transcribe")
+                : modelDir);
+
+        if (!File.Exists(Path.Combine(cohereDir, CohereTranscribe.MelFile)))
+        {
+            Console.Error.WriteLine($"\nError: Cohere model not found in: {cohereDir}");
+            Console.Error.WriteLine($"Expected {CohereTranscribe.MelFile} and related files there.");
+            Console.Error.WriteLine("Use --cohere-model <dir> to specify the directory explicitly.");
+            return 1;
+        }
+
+        using var cohere = new CohereTranscribe(cohereDir);
+        int totalSegs = segs.Count;
+        int completed = 0;
+
+        Console.WriteLine($"Transcribing {totalSegs} segment(s) (Cohere)...");
+        foreach (var (segId, text, _) in cohere.Recognize(segs, audio,
+                     forceLanguage: cohereLanguage))
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            completed++;
+            var (start, end, spkId) = segs[segId];
+            results.Add((start, end, spkId, text));
+            Console.Write($"\r  {completed}/{totalSegs}");
+        }
+
+        Console.WriteLine();
+        swAsr.Stop();
+    }
     else
     {
         var (encoderFile, decoderJointFile) = Config.GetAsrFiles(precision);
@@ -387,9 +433,12 @@ static void PrintUsage()
     Console.WriteLine("  --diarization <backend>            Diarization backend: sortformer, diarizen, vad");
     Console.WriteLine("                                     (default: sortformer)");
     Console.WriteLine("  --vad                              Use VAD instead of diarization (deprecated)");
+    Console.WriteLine("  --asr <parakeet|cohere>            ASR backend (default: parakeet)");
+    Console.WriteLine("  --cohere-model <dir>               Path to Cohere Transcribe model dir (default: <model>/cohere_transcribe)");
+    Console.WriteLine("  --language <code>                  Force language for Cohere ASR (ISO 639-1, e.g. en, fr, de)");
     Console.WriteLine("  --denoiser <none|dfn3>             Pre-processing denoiser (default: none)");
     Console.WriteLine("  --denoiser-models <dir>            Path to denoiser ONNX models (default: <model>/deepfilternet3)");
-    Console.WriteLine("  --precision <fp32|int8>            Model precision (default: fp32)");
+    Console.WriteLine("  --precision <fp32|int8>            Model precision (default: fp32, parakeet only)");
     Console.WriteLine("  --skip-asr                         Export diarization/VAD segments without transcription");
     Console.WriteLine("  --benchmark                        Print timing / RTF after transcription");
     Console.WriteLine("  -h, --help                         Show this help");


### PR DESCRIPTION
## Summary
- add Cohere Transcribe 03-2026 ONNX inference support and KV-cache decoding in `Vernacula.Base`
- integrate Cohere as an ASR backend in Avalonia, including settings, transcript editor support, and model-aware redo ASR
- add Cohere export tooling under `scripts/cohere_export` with KV-cache export as the default path
- harden the Cohere path with cleaner OOM handling, long-segment chunking, and encoder batch fallback on GPU OOM
- improve Avalonia audio format handling for non-WAV inputs used in testing

## What changed
- Added `CohereTranscribe` ONNX runtime pipeline in `src/Vernacula.Base/CohereTranscribe.cs`
- Added Cohere backend selection and forced-language setting in Avalonia settings UI
- Persisted Cohere tokens, synthetic timestamps, logprobs, and ASR metadata to the results DB
- Made transcript editor token decoding backend-aware and added a Cohere approximate-sync notice
- Made transcript editor redo ASR use the job's persisted ASR model instead of always redoing with Parakeet
- Added Cohere export scripts and README in `scripts/cohere_export`
- Switched the main Cohere exporter to default to `decoder_init.onnx` + `decoder_step.onnx`
- Added `--revision` support to pin Hugging Face remote code during export
- Improved cleanup of stray ONNX export `*Constant*` files
- Added cleaner CLI handling for likely ONNX/CUDA OOM cases and more reliable Ctrl+C escape behavior
- Improved Avalonia audio decoding support for non-WAV inputs

## Validation
- `dotnet build src/Vernacula.Base/Vernacula.Base.csproj`
- `dotnet build src/Vernacula.Avalonia/Vernacula.Avalonia.csproj`
- `dotnet build src/Vernacula.CLI/Vernacula.CLI.csproj`
- `python3 -m py_compile scripts/cohere_export/export_cohere_transcribe_to_onnx.py`

## Notes
- Cohere timestamps persisted to the DB are synthetic, not model-native word timings.
- Two exporter follow-ups are intentionally tracked separately:
  - migrate off the legacy TorchScript ONNX exporter
  - investigate the ONNX constant-folding `Slice` warnings
