### PR TITLE
Add VibeVoice-ASR integration and editor persistence fixes

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -93,3 +93,13 @@ Exports `CohereLabs/cohere-transcribe-03-2026` to the ONNX package used by Verna
 
 - `export_cohere_transcribe_to_onnx.py` — exports the base Cohere encoder, mel frontend, config, tokenizer assets, and by default the KV-cache decoder pair
 - `requirements.txt` — export dependencies
+
+---
+
+## vibevoice_export/
+
+Exports `microsoft/VibeVoice-ASR-HF` to the ONNX package used by Vernacula. See [vibevoice_export/README.md](vibevoice_export/README.md) for full documentation.
+
+- `export_vibevoice_asr_to_onnx.py` — exports the VibeVoice audio encoder, decoder graph(s), configs, and export report
+- `test_static_kv_parity.py` — compares `decoder_single_static.onnx` against `decoder_single.onnx`
+- `requirements.txt` — export dependencies

--- a/scripts/vibevoice_export/README.md
+++ b/scripts/vibevoice_export/README.md
@@ -1,0 +1,100 @@
+# VibeVoice-ASR Export
+
+Exports `microsoft/VibeVoice-ASR-HF` into the ONNX package consumed by Vernacula.
+
+This public folder keeps only the core export flow plus the static-vs-dynamic parity check. Investigation, benchmarking, and smoke-test scripts stay in the root `scripts/vibevoice_export` area.
+
+## Files
+
+- `export_vibevoice_asr_to_onnx.py` - exports `audio_encoder.onnx`, decoder graph(s), config files, and `export-report.json`
+- `test_static_kv_parity.py` - compares `decoder_single_static.onnx` token output against `decoder_single.onnx`
+- `_common.py` - shared helpers used by the export and parity scripts
+- `requirements.txt` - Python dependencies for this workflow
+
+## Environment
+
+Use Python `3.11` or `3.12`.
+
+VibeVoice-ASR currently depends on a newer Transformers build than the stable release used elsewhere in this repo:
+
+```bash
+python3 -m venv .venv-vibe-export
+source .venv-vibe-export/bin/activate
+pip install -r public/scripts/vibevoice_export/requirements.txt
+```
+
+If the model or processor is gated for your account, log in first:
+
+```bash
+huggingface-cli login
+```
+
+## Main Export
+
+Export the default recommended package with the unified decoder graph:
+
+```bash
+python public/scripts/vibevoice_export/export_vibevoice_asr_to_onnx.py \
+  --output-dir ./models/vibevoice_asr \
+  --opset 18 \
+  --dtype float16 \
+  --deterministic-audio
+```
+
+Useful options:
+
+- `--device cuda` to export on GPU
+- `--revision <commit-or-tag>` to pin the exact model snapshot
+- `--decoder-exporter auto|legacy|torch-export` to choose the decoder exporter path
+- `--decoder-graph-mode split|single|both|static-single` to choose which decoder graphs to emit
+- `--f32-kv-cache` to export the decoder with float32 KV cache
+- `--f32-lm-head` to export the decoder with a float32 LM head projection
+- `--skip-audio-encoder`, `--skip-prefill`, or `--skip-step` to rerun just part of the export
+- `--overwrite` to replace an existing export
+
+Default outputs:
+
+- `audio_encoder.onnx`
+- `decoder_single.onnx`
+- `config.json`
+- `generation_config.json`
+- `processor_config.json`
+- `export-report.json`
+
+If you want both the unified decoder and the split decoder pair:
+
+```bash
+python public/scripts/vibevoice_export/export_vibevoice_asr_to_onnx.py \
+  --output-dir ./models/vibevoice_asr_both \
+  --opset 18 \
+  --dtype float16 \
+  --decoder-graph-mode both \
+  --deterministic-audio
+```
+
+That additionally emits:
+
+- `decoder_prefill.onnx`
+- `decoder_step.onnx`
+
+## Static KV Parity Check
+
+If you export both the dynamic and static single-decoder variants, compare them with:
+
+```bash
+python public/scripts/vibevoice_export/test_static_kv_parity.py \
+  --static-dir ./models/vibevoice_asr_static \
+  --dynamic-dir ./models/vibevoice_asr_dynamic \
+  --audio ./sample.wav \
+  --max-tokens 256
+```
+
+The script runs the audio encoder, then compares generated token IDs from:
+
+- `decoder_single_static.onnx`
+- `decoder_single.onnx`
+
+## Notes
+
+- The regular single-decoder export is the default and the path Vernacula.Avalonia currently expects.
+- Static-KV export remains supported for parity and experimentation, but it is optional.

--- a/scripts/vibevoice_export/_common.py
+++ b/scripts/vibevoice_export/_common.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+try:
+    import ml_dtypes
+except ImportError:  # pragma: no cover - optional dependency until BF16 ORT path is used
+    ml_dtypes = None
+
+
+def fail(message: str) -> "NoReturn":
+    raise SystemExit(message)
+
+
+def ensure_repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def resolve_device(torch: Any, requested: str) -> str:
+    if requested == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if requested == "cuda" and not torch.cuda.is_available():
+        fail("CUDA was requested but torch.cuda.is_available() is False.")
+    return requested
+
+
+def resolve_dtype(torch: Any, name: str) -> Any:
+    mapping = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    return mapping[name]
+
+
+def torch_dtype_name(dtype: Any) -> str:
+    for name in ("bfloat16", "float32", "float16"):
+        if str(dtype).endswith(name):
+            return name
+    return str(dtype)
+
+
+def ensure_output_dir(path: Path, overwrite: bool, export_files: list[str]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if overwrite:
+        return
+    collisions = [name for name in export_files if (path / name).exists()]
+    if collisions:
+        fail(
+            "Output directory already contains VibeVoice export targets. "
+            "Re-run with --overwrite to replace them.\n"
+            f"Existing files: {', '.join(collisions)}"
+        )
+
+
+def json_dump(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def load_model_and_processor(
+    repo_id: str,
+    revision: str | None,
+    device: str,
+    dtype: Any,
+    torch: Any,
+) -> tuple[Any, Any]:
+    from transformers import AutoProcessor, VibeVoiceAsrForConditionalGeneration
+
+    revision_suffix = f" @ {revision}" if revision else ""
+    print(f"Loading processor from {repo_id}{revision_suffix} ...")
+    processor = AutoProcessor.from_pretrained(repo_id, revision=revision, trust_remote_code=True)
+
+    print(f"Loading model from {repo_id}{revision_suffix} onto {device} as {torch_dtype_name(dtype)} ...")
+    model = VibeVoiceAsrForConditionalGeneration.from_pretrained(
+        repo_id,
+        revision=revision,
+        trust_remote_code=True,
+        torch_dtype=dtype,
+        low_cpu_mem_usage=True,
+    )
+    model.to(device)
+    model.eval()
+
+    param_count = sum(p.numel() for p in model.parameters())
+    print(f"  Loaded {param_count:,} parameters ({param_count / 1e9:.2f}B)")
+    return model, processor
+
+
+def estimate_decoder_memory_gib(config: dict[str, Any]) -> dict[str, float]:
+    text = config["text_config"]
+    layers = int(text["num_hidden_layers"])
+    hidden = int(text["hidden_size"])
+    heads = int(text["num_attention_heads"])
+    kv_heads = int(text["num_key_value_heads"])
+    head_dim = hidden // heads
+    intermediate = int(text["intermediate_size"])
+    vocab = int(text["vocab_size"])
+
+    embed = vocab * hidden
+    attn_per_layer = hidden * hidden + hidden * (kv_heads * head_dim) * 2 + hidden * hidden
+    mlp_per_layer = hidden * intermediate * 3
+    norm_per_layer = hidden * 2
+    total_params = embed + layers * (attn_per_layer + mlp_per_layer + norm_per_layer) + embed
+
+    def gib(param_bytes: float) -> float:
+        return float(param_bytes / (1024 ** 3))
+
+    per_token_bf16 = 2 * layers * kv_heads * head_dim * 2
+
+    return {
+        "decoder_weight_gib_fp16_estimate": gib(total_params * 2),
+        "decoder_weight_gib_int8_estimate": gib(total_params),
+        "kv_cache_gib_16k_fp16_estimate": gib(per_token_bf16 * 16384),
+        "kv_cache_gib_32k_fp16_estimate": gib(per_token_bf16 * 32768),
+        "kv_cache_gib_64k_fp16_estimate": gib(per_token_bf16 * 65536),
+    }
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_export_report(model_dir: Path) -> dict[str, Any]:
+    report_path = model_dir / "export-report.json"
+    if not report_path.exists():
+        fail(f"Missing export-report.json in {model_dir}")
+    return load_json(report_path)
+
+
+def onnx_elem_type_to_numpy(elem_type: Any) -> Any:
+    if isinstance(elem_type, str):
+        text = elem_type.lower()
+        if "bfloat16" in text:
+            if ml_dtypes is None:
+                fail("bfloat16 ONNX feeds require `ml_dtypes`. Install the export requirements and try again.")
+            return ml_dtypes.bfloat16
+        if "float16" in text:
+            return np.float16
+        if "float" in text:
+            return np.float32
+        if "int64" in text:
+            return np.int64
+        if "bool" in text:
+            return np.bool_
+        fail(f"Unsupported ONNX Runtime type string '{elem_type}' in current tooling.")
+
+    mapping = {
+        1: np.float32,
+        7: np.int64,
+        9: np.bool_,
+        10: np.float16,
+    }
+    if elem_type == 16:
+        if ml_dtypes is None:
+            fail("bfloat16 ONNX feeds require `ml_dtypes`. Install the export requirements and try again.")
+        return ml_dtypes.bfloat16
+    if elem_type not in mapping:
+        fail(f"Unsupported ONNX elem_type {elem_type} in current tooling.")
+    return mapping[elem_type]
+
+
+def onnx_elem_type_name(elem_type: Any) -> str:
+    if isinstance(elem_type, str):
+        return elem_type.lower()
+
+    mapping = {
+        1: "float32",
+        7: "int64",
+        9: "bool",
+        10: "float16",
+        16: "bfloat16",
+    }
+    return mapping.get(elem_type, f"elem_type_{elem_type}")
+
+
+def save_export_report(
+    path: Path,
+    *,
+    repo_id: str,
+    revision: str | None,
+    device: str,
+    dtype: str,
+    opset: int,
+    acoustic_tokenizer_chunk_size: int,
+    deterministic_audio: bool,
+    model_config: dict[str, Any],
+    extra: dict[str, Any] | None = None,
+) -> None:
+    payload = {
+        "repo_id": repo_id,
+        "revision": revision,
+        "device": device,
+        "dtype": dtype,
+        "opset": opset,
+        "deterministic_audio": deterministic_audio,
+        "acoustic_tokenizer_chunk_size": acoustic_tokenizer_chunk_size,
+        "memory_estimates": estimate_decoder_memory_gib(model_config),
+        "text_config": model_config["text_config"],
+        "audio_config": {
+            "acoustic_tokenizer_encoder_config": model_config["acoustic_tokenizer_encoder_config"],
+            "semantic_tokenizer_encoder_config": model_config["semantic_tokenizer_encoder_config"],
+            "audio_token_id": model_config["audio_token_id"],
+            "audio_bos_token_id": model_config["audio_bos_token_id"],
+            "audio_eos_token_id": model_config["audio_eos_token_id"],
+            "acoustic_tokenizer_chunk_size": model_config["acoustic_tokenizer_chunk_size"],
+        },
+    }
+    if extra:
+        payload.update(extra)
+    json_dump(path, payload)
+
+
+def flatten_past_key_values(past_key_values: Any) -> list[Any]:
+    flat: list[Any] = []
+    for layer in past_key_values:
+        if len(layer) < 2:
+            fail("Unexpected past_key_values layer shape; expected key/value pair.")
+        flat.append(layer[0])
+        flat.append(layer[1])
+    return flat
+
+
+def unflatten_past_key_values(values: list[Any]) -> tuple[tuple[Any, Any], ...]:
+    if len(values) % 2 != 0:
+        fail(f"Expected an even number of KV tensors, got {len(values)}.")
+    return tuple((values[i], values[i + 1]) for i in range(0, len(values), 2))
+
+
+def kv_input_names(num_layers: int) -> list[str]:
+    names: list[str] = []
+    for idx in range(num_layers):
+        names.append(f"past_key_{idx}")
+        names.append(f"past_value_{idx}")
+    return names
+
+
+def kv_output_names(num_layers: int) -> list[str]:
+    names: list[str] = []
+    for idx in range(num_layers):
+        names.append(f"present_key_{idx}")
+        names.append(f"present_value_{idx}")
+    return names
+
+
+def load_audio_mono_24k(audio_path: Path, target_sr: int = 24000) -> tuple[np.ndarray, int]:
+    import librosa
+    import soundfile as sf
+
+    waveform, sr = sf.read(str(audio_path), always_2d=False)
+    if waveform.ndim == 2:
+        waveform = waveform.mean(axis=1)
+    waveform = waveform.astype(np.float32, copy=False)
+    if sr != target_sr:
+        waveform = librosa.resample(waveform, orig_sr=sr, target_sr=target_sr).astype(np.float32, copy=False)
+        sr = target_sr
+    return waveform, sr
+
+
+def truncate_audio_seconds(waveform: np.ndarray, sr: int, seconds: float | None) -> np.ndarray:
+    if seconds is None:
+        return waveform
+    samples = max(1, int(round(seconds * sr)))
+    return waveform[:samples]
+
+
+def derive_legacy_audio_export_samples(
+    *,
+    export_report: dict[str, Any],
+    sample_rate: int,
+) -> int | None:
+    exact = export_report.get("audio_export_input_samples")
+    if exact:
+        return int(exact)
+
+    chunk_size = export_report.get("acoustic_tokenizer_chunk_size")
+    dummy_audio_seconds = export_report.get("dummy_audio_seconds")
+    if not chunk_size or not dummy_audio_seconds:
+        return None
+
+    chunk_size = int(chunk_size)
+    requested = int(round(float(dummy_audio_seconds) * sample_rate))
+    if requested <= 0:
+        return None
+    return ((requested + chunk_size - 1) // chunk_size) * chunk_size
+
+
+def pad_or_trim_waveform(waveform: np.ndarray, target_samples: int) -> np.ndarray:
+    if waveform.shape[0] == target_samples:
+        return waveform.astype(np.float32, copy=False)
+    if waveform.shape[0] > target_samples:
+        return waveform[:target_samples].astype(np.float32, copy=False)
+    padded = np.zeros((target_samples,), dtype=np.float32)
+    padded[: waveform.shape[0]] = waveform.astype(np.float32, copy=False)
+    return padded
+
+
+def choose_onnx_providers(runtime: str) -> list[str]:
+    runtime = runtime.lower()
+    if runtime == "cpu":
+        return ["CPUExecutionProvider"]
+    if runtime == "cuda":
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if runtime == "tensorrt":
+        return ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]
+    fail(f"Unsupported runtime '{runtime}'.")
+
+
+def read_ort_available_providers() -> list[str]:
+    import onnxruntime as ort
+
+    return list(ort.get_available_providers())
+
+
+def nvidia_smi_query() -> dict[str, str] | None:
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,driver_version,memory.total,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+    if not out:
+        return None
+
+    first = out.splitlines()[0]
+    name, driver_version, memory_total, memory_used = [part.strip() for part in first.split(",")]
+    return {
+        "name": name,
+        "driver_version": driver_version,
+        "memory_total_mib": memory_total,
+        "memory_used_mib": memory_used,
+    }
+
+
+@dataclass
+class TimerResult:
+    wall_seconds: float
+    iterations: int
+
+
+class Timer:
+    def __init__(self) -> None:
+        self._start = 0.0
+
+    def __enter__(self) -> "Timer":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    @property
+    def elapsed(self) -> float:
+        return time.perf_counter() - self._start
+
+
+def add_local_script_path() -> None:
+    script_dir = Path(__file__).resolve().parent
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))

--- a/scripts/vibevoice_export/export_vibevoice_asr_to_onnx.py
+++ b/scripts/vibevoice_export/export_vibevoice_asr_to_onnx.py
@@ -1,0 +1,1372 @@
+#!/usr/bin/env python3
+"""
+Export microsoft/VibeVoice-ASR-HF into ONNX graphs:
+
+  audio_encoder.onnx
+      input_values [1, num_samples] float
+      padding_mask [1, num_samples] bool
+      -> audio_embeddings [num_audio_tokens, hidden]
+
+  decoder_prefill.onnx
+      input_ids [1, prompt_len] int64
+      attention_mask [1, prompt_len] int64
+      audio_embeddings [num_audio_tokens, hidden] float
+      -> logits [1, prompt_len, vocab]
+      -> present_key_*/present_value_*
+
+  decoder_step.onnx
+      input_ids [1, 1] int64
+      attention_mask [1, total_len] int64
+      past_key_*/past_value_*
+      -> logits [1, 1, vocab]
+      -> present_key_*/present_value_*
+
+  decoder_single.onnx
+      prefix_input_ids [1, prefix_len] int64
+      audio_embeddings [num_audio_tokens, hidden] float
+      suffix_input_ids [1, suffix_len] int64
+      past_key_0 .. past_key_27   [1, kv_heads, cache_len, head_dim]
+      past_value_0 .. past_value_27 [1, kv_heads, cache_len, head_dim]
+      -> logits [1, seq_len, vocab]
+      -> present_key_0..27, present_value_0..27 [1, kv_heads, total_len, head_dim]
+
+The initial export target is batch size 1 with dynamic prompt, audio-token, and cache lengths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import gc
+import sys
+from pathlib import Path
+from typing import Any
+
+import onnx
+from onnx.external_data_helper import load_external_data_for_model
+import numpy as np
+import torch
+from transformers.cache_utils import DynamicCache
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from _common import (
+    ensure_output_dir,
+    flatten_past_key_values,
+    kv_input_names,
+    kv_output_names,
+    load_model_and_processor,
+    resolve_device,
+    resolve_dtype,
+    save_export_report,
+    torch_dtype_name,
+)
+
+
+EXPORT_FILES = [
+    "audio_encoder.onnx",
+    "decoder_prefill.onnx",
+    "decoder_step.onnx",
+    "decoder_single.onnx",
+    "decoder_single_static.onnx",
+    "config.json",
+    "generation_config.json",
+    "processor_config.json",
+    "export-report.json",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export VibeVoice-ASR-HF to ONNX graphs.")
+    parser.add_argument("--model-repo", default="microsoft/VibeVoice-ASR-HF")
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--opset", type=int, default=18)
+    parser.add_argument("--device", choices=("auto", "cpu", "cuda"), default="auto")
+    parser.add_argument("--dtype", choices=("float32", "float16", "bfloat16"), default="float16")
+    parser.add_argument(
+        "--decoder-exporter",
+        choices=("auto", "legacy", "torch-export"),
+        default="auto",
+        help="Decoder export backend. 'auto' keeps the audio export on the legacy path and prefers torch.export for decoder graphs.",
+    )
+    parser.add_argument(
+        "--audio-exporter",
+        choices=("auto", "legacy", "torch-export"),
+        default="auto",
+        help="Audio export backend. 'auto' keeps the current legacy path unless a specific backend is requested.",
+    )
+    parser.add_argument(
+        "--torch-export-debug-artifacts",
+        action="store_true",
+        help="When using --decoder-exporter torch-export, emit the exporter report and exported-program artifacts.",
+    )
+    parser.add_argument("--dummy-audio-seconds", type=float, default=15.0)
+    parser.add_argument("--dummy-prompt", default="Transcribe the meeting audio with speaker labels when available.")
+    parser.add_argument("--acoustic-tokenizer-chunk-size", type=int, default=None)
+    parser.add_argument(
+        "--deterministic-audio",
+        action="store_true",
+        help="Disable stochastic acoustic-latent noise in the exported audio path.",
+    )
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--skip-audio-encoder", action="store_true")
+    parser.add_argument("--skip-prefill", action="store_true")
+    parser.add_argument("--skip-step", action="store_true")
+    parser.add_argument(
+        "--decoder-graph-mode",
+        choices=("split", "single", "both", "static-single"),
+        default="single",
+        help=(
+            "Which decoder graph set to export: "
+            "'split' exports decoder_prefill.onnx + decoder_step.onnx, "
+            "'single' exports only decoder_single.onnx (dynamic KV cache, default), "
+            "'both' exports all decoder graphs, "
+            "'static-single' exports only decoder_single_static.onnx (pre-allocated KV buffers, "
+            "eliminates O(n) Concat per step via ScatterElements)."
+        ),
+    )
+    parser.add_argument(
+        "--export-single-decoder",
+        action="store_true",
+        help=(
+            "Deprecated alias for --decoder-graph-mode single. "
+            "Exports only decoder_single.onnx, a unified decoder graph that handles prefill and step via one packed KV-cache input."
+        ),
+    )
+    parser.add_argument(
+        "--static-kv-max-tokens",
+        type=int,
+        default=6144,
+        help=(
+            "Pre-allocated KV buffer length for --decoder-graph-mode static-single. "
+            "Must be >= the maximum number of tokens (prefill + decode) that will be generated. "
+            "VRAM cost: 2 × num_layers × num_kv_heads × max_tokens × head_dim × dtype_bytes "
+            "(e.g. 56 × [1,4,6144,128] float32 ≈ 706 MB). Default: 6144 (~10-min audio at ~10 tok/s)."
+        ),
+    )
+    parser.add_argument(
+        "--f32-kv-cache",
+        action="store_true",
+        help=(
+            "Export decoder_single.onnx with float32 KV cache and float32 attention dot products. "
+            "Patches Qwen2Attention during export so Q, K, and V are upcast to float32 before the "
+            "Q*K^T and V*attn matmuls, and K/V are stored as float32 in the cache. "
+            "Adds explicit Cast nodes to the ONNX graph so ORT executes float32 attention at inference. "
+            "VRAM impact: ~2x KV cache size (typically +50-300 MB). "
+            "Addresses BF16 matmul non-determinism that causes token-level drift between ORT and PyTorch."
+        ),
+    )
+    parser.add_argument(
+        "--f32-lm-head",
+        action="store_true",
+        help=(
+            "Export decoder_single.onnx with a float32 lm_head projection. "
+            "Patches lm_head during export so hidden states and weights are cast to float32 before "
+            "the final vocab projection, giving float32-precision logits. "
+            "Eliminates BF16 matmul accumulation differences in the lm_head that cause ORT and PyTorch "
+            "to disagree at token positions where multiple logits round to the same BF16 value. "
+            "VRAM impact: lm_head weight (~1.1 GB) is cast to float32 at inference time. "
+            "Can be combined with --f32-kv-cache."
+        ),
+    )
+    args = parser.parse_args()
+    if args.export_single_decoder:
+        args.decoder_graph_mode = "single"
+    return args
+
+
+def infer_export_chunk_size(
+    *,
+    requested_chunk_size: int | None,
+    default_chunk_size: int,
+    sampling_rate: int,
+    dummy_audio_seconds: float,
+    processor: Any,
+) -> int:
+    if requested_chunk_size is not None:
+        return int(requested_chunk_size)
+
+    pad_multiple = getattr(processor.feature_extractor, "pad_to_multiple_of", None) or 3200
+    requested_samples = max(pad_multiple, int(round(dummy_audio_seconds * sampling_rate)))
+    rounded = ((requested_samples + pad_multiple - 1) // pad_multiple) * pad_multiple
+
+    # Use the smaller of:
+    # - the model's full production chunk size
+    # - the test export's requested dummy duration rounded to the tokenizer step
+    return max(pad_multiple, min(default_chunk_size, rounded))
+
+
+def round_up_to_multiple(value: int, multiple: int) -> int:
+    if multiple <= 0:
+        return value
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def resolve_decoder_exporter(choice: str) -> str:
+    if choice == "auto":
+        return "torch-export"
+    return choice
+
+
+def resolve_audio_exporter(choice: str) -> str:
+    if choice == "auto":
+        return "legacy"
+    return choice
+
+
+def resolve_audio_export_dtype(dtype: Any, torch: Any, exporter: str) -> tuple[Any, str | None]:
+    if dtype == torch.bfloat16 and exporter == "legacy":
+        return (
+            torch.bfloat16,
+            "audio_encoder.onnx keeps bf16 inputs/outputs when --dtype bfloat16 is requested, but the Conv-heavy tokenizer towers are promoted to float32 during export because ONNX Runtime rejects bf16 Conv nodes in the current audio graph.",
+        )
+    return dtype, None
+
+
+class AudioEncoderWrapper(torch.nn.Module):
+    def __init__(self, model: Any, deterministic_audio: bool, encoder_compute_dtype: Any, projector_dtype: Any):
+        super().__init__()
+        self.model = model
+        self.deterministic_audio = deterministic_audio
+        self.encoder_compute_dtype = encoder_compute_dtype
+        self.projector_dtype = projector_dtype
+
+    def forward(self, input_values, padding_mask):
+        # Export the tokenizer towers as one full-waveform pass. The chunked
+        # streaming path traces `torch.split(...)` into a fixed ONNX `Split`
+        # layout, which makes the current graph only look dynamic in metadata.
+        # A single pass preserves a truly dynamic sample axis for offline export.
+        audio = input_values.to(self.encoder_compute_dtype).unsqueeze(1)
+        acoustic_latents = self.model.acoustic_tokenizer_encoder(
+            audio,
+            padding_cache=None,
+            use_cache=False,
+        ).latents
+        semantic_latents = self.model.semantic_tokenizer_encoder(
+            audio,
+            padding_cache=None,
+            use_cache=False,
+        ).latents
+
+        if not self.deterministic_audio:
+            noise_std = self.model.config.acoustic_tokenizer_encoder_config.vae_std * torch.randn(
+                acoustic_latents.shape[0], device=acoustic_latents.device, dtype=acoustic_latents.dtype
+            )
+            acoustic_latents = acoustic_latents + noise_std[:, None, None] * torch.randn_like(acoustic_latents)
+
+        combined_features = self.model.multi_modal_projector(
+            acoustic_latents.to(self.projector_dtype),
+            semantic_latents.to(self.projector_dtype),
+        )
+        if padding_mask is not None:
+            num_audio_tokens = torch.ceil(
+                padding_mask.sum(dim=-1) / self.model.config.acoustic_tokenizer_encoder_config.hop_length
+            ).to(torch.int64)
+            token_mask = torch.arange(num_audio_tokens.max(), device=combined_features.device) < num_audio_tokens[
+                :, None
+            ].to(combined_features.device)
+            combined_features = combined_features[token_mask]
+        return combined_features
+
+
+class DecoderPrefillWrapper(torch.nn.Module):
+    def __init__(self, model: Any):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask, audio_embeddings):
+        inputs_embeds = self.model.get_input_embeddings()(input_ids)
+        inputs_embeds = replace_audio_token_embeddings(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            audio_embeddings=audio_embeddings,
+            audio_token_id=int(self.model.config.audio_token_id),
+        )
+        full_attention_mask = build_full_attention_mask(
+            attention_mask=attention_mask,
+            query_length=inputs_embeds.shape[1],
+            kv_length=inputs_embeds.shape[1],
+            past_length=0,
+            dtype=inputs_embeds.dtype,
+            device=inputs_embeds.device,
+        )
+        outputs = self.model.language_model(
+            inputs_embeds=inputs_embeds,
+            attention_mask={"full_attention": full_attention_mask},
+            use_cache=True,
+        )
+        return (outputs.logits, *flatten_past_key_values(outputs.past_key_values))
+
+
+class DecoderStepWrapper(torch.nn.Module):
+    def __init__(self, model: Any):
+        super().__init__()
+        self.model = model
+        self.num_layers = int(model.config.text_config.num_hidden_layers)
+
+    def forward(self, input_ids, attention_mask, *past_key_values):
+        past_length = past_key_values[0].shape[2] if past_key_values else 0
+        full_attention_mask = build_full_attention_mask(
+            attention_mask=attention_mask,
+            query_length=input_ids.shape[1],
+            kv_length=past_length + input_ids.shape[1],
+            past_length=past_length,
+            dtype=self.model.get_input_embeddings().weight.dtype,
+            device=input_ids.device,
+        )
+        cache = DynamicCache(
+            ddp_cache_data=tuple(
+                (past_key_values[i], past_key_values[i + 1]) for i in range(0, len(past_key_values), 2)
+            ),
+            config=self.model.config,
+        )
+        outputs = self.model.language_model(
+            input_ids=input_ids,
+            attention_mask={"full_attention": full_attention_mask},
+            past_key_values=cache,
+            use_cache=True,
+        )
+        return (outputs.logits, *flatten_past_key_values(outputs.past_key_values))
+
+
+class DecoderSingleWrapper(torch.nn.Module):
+    def __init__(self, model: Any):
+        super().__init__()
+        self.model = model
+        self.num_layers = int(model.config.text_config.num_hidden_layers)
+
+    def forward(self, prefix_input_ids, audio_embeddings, suffix_input_ids, *past_key_values):
+        prefix_embeds = self.model.get_input_embeddings()(prefix_input_ids)
+        suffix_embeds = self.model.get_input_embeddings()(suffix_input_ids)
+        inputs_embeds = torch.cat(
+            (prefix_embeds, audio_embeddings.to(prefix_embeds.device).unsqueeze(0), suffix_embeds),
+            dim=1,
+        )
+
+        past_length = past_key_values[0].shape[2] if past_key_values else 0
+        position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device).unsqueeze(0) + past_length
+        full_attention_mask = build_full_attention_mask(
+            attention_mask=None,
+            query_length=inputs_embeds.shape[1],
+            kv_length=past_length + inputs_embeds.shape[1],
+            past_length=past_length,
+            dtype=inputs_embeds.dtype,
+            device=inputs_embeds.device,
+        )
+
+        cache = DynamicCache(
+            ddp_cache_data=tuple(
+                (past_key_values[i], past_key_values[i + 1]) for i in range(0, len(past_key_values), 2)
+            ),
+            config=self.model.config,
+        )
+        outputs = self.model.language_model(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            attention_mask={"full_attention": full_attention_mask},
+            past_key_values=cache,
+            use_cache=True,
+        )
+        return (outputs.logits, *flatten_past_key_values(outputs.past_key_values))
+
+
+class StaticKVCache:
+    """
+    Drop-in for DynamicCache that writes K/V into pre-allocated static buffers via
+    torch.scatter (ONNX ScatterElements) instead of torch.cat (ONNX Concat).
+
+    Performance rationale: Concat is O(past_len + new_len) because it allocates and
+    copies the entire growing tensor each step. Scatter is O(new_len) — it writes only
+    the new slice into a fixed-size buffer. For a 600-second recording (~4720 decode steps
+    after prefill of ~1200 tokens), each Concat copies an average of ~252 MB of KV data
+    per step; scatter copies ~112 KB.
+
+    Interface (matching DynamicCache.update):
+        update(key_states, value_states, layer_idx) → (full_key_buffer, full_val_buffer)
+    The returned full buffers are passed to attention; positions beyond the current fill
+    position are masked out by the causal attention mask.
+    """
+
+    def __init__(
+        self,
+        key_buffers: list[Any],
+        val_buffers: list[Any],
+        kv_pos: Any,  # int64 scalar tensor (may be symbolic during torch.export)
+    ) -> None:
+        self._keys = list(key_buffers)  # [num_layers] × [1, kv_heads, max_tokens, head_dim]
+        self._vals = list(val_buffers)
+        self._pos  = kv_pos
+
+    def update(self, key_states: Any, value_states: Any, layer_idx: int) -> tuple[Any, Any]:
+        # key_states: [1, kv_heads, seq_len, head_dim]
+        seq_len  = key_states.shape[2]
+        kv_heads = key_states.shape[1]
+        head_dim = key_states.shape[3]
+        device   = key_states.device
+
+        # Build scatter index: positions [kv_pos, kv_pos+1, ..., kv_pos+seq_len-1]
+        # broadcast to [1, kv_heads, seq_len, head_dim] — matches key_states shape.
+        pos = torch.arange(seq_len, device=device, dtype=torch.int64) + self._pos
+        idx = pos.view(1, 1, seq_len, 1).expand(1, kv_heads, seq_len, head_dim)
+
+        # Scatter new K/V into the pre-allocated buffers.
+        # torch.scatter → ONNX ScatterElements: only writes the seq_len new positions.
+        kb = torch.scatter(self._keys[layer_idx], 2, idx, key_states)
+        vb = torch.scatter(self._vals[layer_idx], 2, idx, value_states)
+        self._keys[layer_idx] = kb
+        self._vals[layer_idx] = vb
+        # Return the full updated buffer for attention computation.
+        # Positions beyond kv_pos+seq_len contain stale or zero data but are masked
+        # to -inf by the causal attention mask built from kv_pos, so they are inert.
+        return kb, vb
+
+    def get_seq_length(self, layer_idx: int = 0) -> Any:
+        # Return the current fill position so callers that query cache length see
+        # kv_pos rather than max_tokens.
+        return self._pos
+
+
+class DecoderSingleStaticWrapper(torch.nn.Module):
+    """
+    decoder_single_static.onnx: unified prefill+decode with pre-allocated KV buffers.
+
+    Interface:
+        inputs:
+            prefix_input_ids    [1, prefix_len]
+            audio_embeddings    [num_audio_tokens, hidden_size]
+            suffix_input_ids    [1, suffix_len]
+            kv_pos              [] (int64 scalar: current fill position in KV buffers)
+            past_key_0..27      [1, kv_heads, max_tokens, head_dim]  float32
+            past_value_0..27    [1, kv_heads, max_tokens, head_dim]  float32
+        outputs:
+            logits              [1, seq_len, vocab_size]
+            present_key_0..27   [1, kv_heads, max_tokens, head_dim]  (SAME shape — no growth)
+            present_value_0..27 [1, kv_heads, max_tokens, head_dim]
+
+    kv_pos tells the model where to scatter new K/V; it does NOT increment kv_pos —
+    the C# runtime advances kv_pos by seq_len after each call.
+
+    Output shape is FIXED (max_tokens). This allows ORT's BFC arena to reuse the same
+    CUDA memory blocks each step without growing allocations, and opens the door to
+    binding outputs once rather than re-registering them every step.
+    """
+
+    def __init__(self, model: Any) -> None:
+        super().__init__()
+        self.model = model
+        self.num_layers = int(model.config.text_config.num_hidden_layers)
+
+    def forward(
+        self,
+        prefix_input_ids: Any,
+        audio_embeddings: Any,
+        suffix_input_ids: Any,
+        kv_pos: Any,        # int64 scalar tensor
+        *kv_buffers: Any,   # 2 × num_layers tensors: key_0, val_0, key_1, val_1, ...
+    ) -> tuple[Any, ...]:
+        prefix_embeds = self.model.get_input_embeddings()(prefix_input_ids)
+        suffix_embeds = self.model.get_input_embeddings()(suffix_input_ids)
+        inputs_embeds = torch.cat(
+            (prefix_embeds, audio_embeddings.to(prefix_embeds.device).unsqueeze(0), suffix_embeds),
+            dim=1,
+        )
+
+        seq_len    = inputs_embeds.shape[1]
+        max_tokens = kv_buffers[0].shape[2]  # pre-allocated buffer length
+
+        # Position IDs for the new tokens start at kv_pos.
+        position_ids = (
+            torch.arange(seq_len, device=inputs_embeds.device).unsqueeze(0) + kv_pos
+        )
+
+        # Causal attention mask over the full pre-allocated buffer.
+        # query positions: kv_pos .. kv_pos+seq_len-1
+        # kv positions:    0 .. max_tokens-1
+        # Positions beyond kv_pos+seq_len-1 are masked to -inf by the causal logic,
+        # so they do not contribute to attention regardless of buffer content.
+        full_attention_mask = build_full_attention_mask(
+            attention_mask=None,
+            query_length=seq_len,
+            kv_length=max_tokens,
+            past_length=kv_pos,        # tensor is valid here — arithmetic broadcasts
+            dtype=inputs_embeds.dtype,
+            device=inputs_embeds.device,
+        )
+
+        key_buffers = [kv_buffers[i * 2]     for i in range(self.num_layers)]
+        val_buffers = [kv_buffers[i * 2 + 1] for i in range(self.num_layers)]
+        cache = StaticKVCache(key_buffers, val_buffers, kv_pos)
+
+        outputs = self.model.language_model(
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            attention_mask={"full_attention": full_attention_mask},
+            past_key_values=cache,
+            use_cache=True,
+        )
+
+        # Flatten updated K/V buffers to match kv_output_names ordering.
+        updated_kv: list[Any] = []
+        for i in range(self.num_layers):
+            updated_kv.append(cache._keys[i])
+            updated_kv.append(cache._vals[i])
+
+        return (outputs.logits, *updated_kv)
+
+
+def copy_metadata_files(processor: Any, model: Any, output_dir: Path) -> None:
+    model.config.save_pretrained(output_dir)
+    processor.save_pretrained(output_dir)
+
+
+def build_tokenizer_extras(
+    processor: Any,
+    dummy_samples: int,
+    dummy_prompt: str,
+) -> dict[str, Any]:
+    """
+    Pre-compute prefix/suffix token arrays and digit→token_id map for C# inference.
+
+    The C# VibeVoiceAsr class reads these from export-report.json so it does not
+    need a full BPE tokenizer at runtime — only a trivial character lookup for the
+    audio-duration float formatted as "%.2f".
+
+    Returned dict is stored under the "tokenizer" key in export-report.json.
+    """
+    sample_rate = int(processor.feature_extractor.sampling_rate)
+
+    prompt_inputs = processor.apply_transcription_request(
+        [np.zeros(dummy_samples, dtype=np.float32)],
+        prompt=[dummy_prompt],
+    )
+    ids: list[int] = prompt_inputs["input_ids"][0].tolist()
+
+    audio_bos_id: int = processor.tokenizer.convert_tokens_to_ids("<|object_ref_start|>")
+    audio_eos_id: int = processor.tokenizer.convert_tokens_to_ids("<|object_ref_end|>")
+    eos_token_id: int = int(processor.tokenizer.eos_token_id)
+    im_end_token_id: int = int(processor.tokenizer.convert_tokens_to_ids("<|im_end|>"))
+
+    bos_pos = ids.index(audio_bos_id)
+    eos_pos = ids.index(audio_eos_id)
+
+    prefix_token_ids: list[int] = ids[: bos_pos + 1]   # includes audio_bos_token
+    suffix_all: list[int] = ids[eos_pos:]               # includes audio_eos_token
+
+    # Build digit-char→token_id map by encoding each character individually.
+    # Qwen2 tokenises decimal digit characters as single tokens; verify this.
+    digit_char_to_token_id: dict[str, int] = {}
+    for ch in "0123456789.":
+        tok_ids = processor.tokenizer.encode(ch, add_special_tokens=False)
+        if len(tok_ids) != 1:
+            raise ValueError(
+                f"Digit character '{ch}' tokenises to {len(tok_ids)} tokens; "
+                "expected exactly 1. The C# inference path cannot handle this."
+            )
+        digit_char_to_token_id[ch] = tok_ids[0]
+
+    # Find the duration string in the suffix by matching the tokenised digits.
+    duration_sec = dummy_samples / sample_rate
+    duration_str = f"{duration_sec:.2f}"
+    duration_token_ids = [digit_char_to_token_id[c] for c in duration_str]
+
+    split_pos: int | None = None
+    for i in range(len(suffix_all) - len(duration_token_ids) + 1):
+        if suffix_all[i : i + len(duration_token_ids)] == duration_token_ids:
+            split_pos = i
+            break
+    if split_pos is None:
+        raise ValueError(
+            f"Duration token sequence {duration_token_ids} not found in suffix {suffix_all}."
+        )
+
+    suffix_before_duration = suffix_all[:split_pos]
+    suffix_after_duration = suffix_all[split_pos + len(duration_token_ids):]
+
+    return {
+        "prefix_token_ids": prefix_token_ids,
+        "suffix_before_duration_token_ids": suffix_before_duration,
+        "suffix_after_duration_token_ids": suffix_after_duration,
+        "digit_char_to_token_id": digit_char_to_token_id,
+        "eos_token_id": eos_token_id,
+        "im_end_token_id": im_end_token_id,
+    }
+
+
+def build_cache_from_packed_past(model: Any, packed_past_key_values: torch.Tensor) -> DynamicCache:
+    cache = DynamicCache(config=model.config)
+    past_length = packed_past_key_values.shape[4]
+
+    for layer_idx, layer_cache in enumerate(cache.layers):
+        layer_keys = packed_past_key_values[layer_idx, 0].contiguous()
+        layer_values = packed_past_key_values[layer_idx, 1].contiguous()
+        layer_cache.keys = layer_keys
+        layer_cache.values = layer_values
+        layer_cache.is_initialized = True
+        layer_cache.dtype = layer_keys.dtype
+        layer_cache.device = layer_keys.device
+
+        if hasattr(layer_cache, "cumulative_length"):
+            cumulative_length = getattr(layer_cache, "cumulative_length")
+            if torch.is_tensor(cumulative_length):
+                layer_cache.cumulative_length = torch.full_like(cumulative_length, past_length)
+            else:
+                layer_cache.cumulative_length = past_length
+        if hasattr(layer_cache, "cumulative_length_int"):
+            layer_cache.cumulative_length_int = int(past_length)
+
+    return cache
+
+
+def replace_audio_token_embeddings(
+    *,
+    input_ids: torch.Tensor,
+    inputs_embeds: torch.Tensor,
+    audio_embeddings: torch.Tensor,
+    audio_token_id: int,
+) -> torch.Tensor:
+    audio_positions = torch.nonzero(input_ids[0] == audio_token_id, as_tuple=False).squeeze(-1)
+    updated = inputs_embeds[0].index_copy(0, audio_positions, audio_embeddings.to(inputs_embeds.device))
+    return updated.unsqueeze(0)
+
+
+def attention_mask_fill_value(dtype: torch.dtype) -> float:
+    if dtype in (torch.float16, torch.bfloat16):
+        return -1.0e4
+    return float(torch.finfo(dtype).min)
+
+
+def build_full_attention_mask(
+    *,
+    attention_mask: torch.Tensor | None,
+    query_length: int,
+    kv_length: int,
+    past_length: int,
+    dtype: torch.dtype,
+    device: torch.device | str,
+) -> torch.Tensor:
+    batch_size = 1
+    min_value = attention_mask_fill_value(dtype)
+
+    q_positions = torch.arange(query_length, device=device).view(1, 1, query_length, 1) + past_length
+    kv_positions = torch.arange(kv_length, device=device).view(1, 1, 1, kv_length)
+    causal = kv_positions <= q_positions
+
+    if attention_mask is not None:
+        kv_keep = attention_mask[:, -kv_length:].to(torch.bool).view(batch_size, 1, 1, kv_length)
+        causal = causal & kv_keep
+
+    zeros = torch.zeros((batch_size, 1, query_length, kv_length), dtype=dtype, device=device)
+    return torch.where(causal, zeros, torch.full_like(zeros, min_value))
+
+
+def force_eager_attention(model: Any) -> None:
+    for cfg in [getattr(model, "config", None), getattr(getattr(model, "language_model", None), "config", None)]:
+        if cfg is None:
+            continue
+        setattr(cfg, "_attn_implementation", "eager")
+        setattr(cfg, "_attn_implementation_internal", "eager")
+
+    language_model = getattr(model, "language_model", None)
+    if language_model is not None and hasattr(language_model, "model") and hasattr(language_model.model, "config"):
+        setattr(language_model.model.config, "_attn_implementation", "eager")
+        setattr(language_model.model.config, "_attn_implementation_internal", "eager")
+
+
+@contextlib.contextmanager
+def f32_kv_cache_context():
+    """Patch Qwen2Attention to store the KV cache in float32 and compute attention in float32.
+
+    Addresses accumulated BF16 numerical drift across decode steps:
+    - New K/V tensors (computed in BF16 via linear projections) are upcast to float32
+      before being concatenated into the cache.
+    - Q is upcast to float32 for the Q*K^T dot product.
+    - The attention mask is cast to float32 to match.
+    - All attention dot products (Q*K^T, V*attn) are float32; softmax is already float32
+      in Qwen2 eager mode.
+    - The attention output is cast back to BF16 before the output projection so the
+      residual stream and MLP remain BF16.
+
+    VRAM impact: the KV cache doubles in dtype width (~50-300 MB for 1K-5K token sequences).
+    All linear projections and MLP operations remain BF16.
+
+    The exported ONNX graph will contain explicit Cast nodes for all these transitions so
+    ORT executes the same float32 attention path at inference time without any runtime patching.
+    """
+    from transformers.models.qwen2.modeling_qwen2 import (
+        Qwen2Attention,
+        apply_rotary_pos_emb,
+        eager_attention_forward,
+    )
+
+    original_forward = Qwen2Attention.forward
+
+    def _f32_kv_forward(self, hidden_states, position_embeddings, attention_mask, past_key_values=None, **kwargs):
+        compute_dtype = hidden_states.dtype
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        # Upcast new K/V to float32 before cache storage.
+        # This ensures the DynamicLayer torch.cat sees matching float32 tensors
+        # (past cache is float32 because packed_past_key_values is float32).
+        key_states = key_states.to(torch.float32)
+        value_states = value_states.to(torch.float32)
+
+        if past_key_values is not None:
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+        # Upcast Q and attention mask to float32 for the dot products.
+        query_states = query_states.to(torch.float32)
+        f32_mask = attention_mask.to(torch.float32) if attention_mask is not None else None
+
+        # eager_attention_forward: Q*K^T, softmax, V*attn — all float32.
+        # The softmax line does `.to(query.dtype)` = `.to(float32)` which is a no-op.
+        attn_output, attn_weights = eager_attention_forward(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            f32_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+            **kwargs,
+        )
+
+        # Cast back to BF16 before the output projection so the residual stream stays BF16.
+        attn_output = attn_output.to(compute_dtype)
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+    Qwen2Attention.forward = _f32_kv_forward
+    try:
+        yield
+    finally:
+        Qwen2Attention.forward = original_forward
+
+
+@contextlib.contextmanager
+def f32_lm_head_context(model: Any):
+    """Patch the lm_head to cast hidden states and weights to float32 before the projection.
+
+    The lm_head is a large BF16 linear layer (hidden_size -> vocab_size).  BF16 matmul
+    accumulation for this projection can collapse distinct logit values into the same BF16
+    representable, creating false ties that different CUDA runtimes (PyTorch vs ORT) resolve
+    differently.  Casting to float32 before the matmul gives float32-precision logits so the
+    true winner is unambiguous and both runtimes agree.
+
+    Weights stay stored in BF16; the Cast to float32 happens at compute time.  VRAM impact at
+    inference is the weight cast (~1.1 GB temporarily during the lm_head step).  All other
+    layers remain BF16.
+
+    When used during torch.export, the traced ONNX graph contains explicit Cast nodes before
+    the lm_head MatMul so ORT executes float32 logits at inference without runtime patching.
+    """
+    import torch
+    import torch.nn.functional as F
+
+    lm_head = model.language_model.lm_head
+    original_forward = lm_head.forward
+
+    def _f32_forward(hidden_states: torch.Tensor) -> torch.Tensor:
+        return F.linear(
+            hidden_states.to(torch.float32),
+            lm_head.weight.to(torch.float32),
+            lm_head.bias.to(torch.float32) if lm_head.bias is not None else None,
+        )
+
+    lm_head.forward = _f32_forward
+    try:
+        yield
+    finally:
+        lm_head.forward = original_forward
+
+
+def export_audio_encoder(
+    *,
+    model: Any,
+    output_dir: Path,
+    opset: int,
+    dtype: Any,
+    device: str,
+    dummy_samples: int,
+    deterministic_audio: bool,
+    exporter: str,
+    torch_export_debug_artifacts: bool,
+) -> None:
+    # Drop the decoder before tracing the audio path so the 9B LM weights do not
+    # stay resident during audio export.
+    if hasattr(model, "language_model"):
+        del model.language_model
+        gc.collect()
+
+    model.to(device=device, dtype=dtype)
+    encoder_compute_dtype = dtype
+    projector_dtype = dtype
+    if dtype == torch.bfloat16 and exporter == "legacy":
+        # Keep the external audio graph in bf16, but promote the Conv-heavy tokenizer
+        # towers to fp32 so ORT sees legal Conv dtypes without forcing the whole audio
+        # graph or projector into fp32/fp16.
+        encoder_compute_dtype = torch.float32
+        model.acoustic_tokenizer_encoder.to(dtype=encoder_compute_dtype)
+        model.semantic_tokenizer_encoder.to(dtype=encoder_compute_dtype)
+        model.multi_modal_projector.to(dtype=projector_dtype)
+
+    dummy_audio = torch.zeros((1, dummy_samples), dtype=dtype, device=device)
+    dummy_padding_mask = torch.ones((1, dummy_samples), dtype=torch.bool, device=device)
+    audio_wrapper = AudioEncoderWrapper(
+        model,
+        deterministic_audio=deterministic_audio,
+        encoder_compute_dtype=encoder_compute_dtype,
+        projector_dtype=projector_dtype,
+    ).eval()
+
+    print("Exporting audio_encoder.onnx ...")
+    export_onnx_graph(
+        model=audio_wrapper,
+        args=(dummy_audio, dummy_padding_mask),
+        output_path=output_dir / "audio_encoder.onnx",
+        input_names=["input_values", "padding_mask"],
+        output_names=["audio_embeddings"],
+        opset=opset,
+        dynamic_axes={
+            "input_values": {1: "num_samples"},
+            "padding_mask": {1: "num_samples"},
+            "audio_embeddings": {0: "num_audio_tokens"},
+        },
+        exporter=exporter,
+        dynamic_shapes=(
+            {1: torch.export.Dim("num_samples")},
+            {1: torch.export.Dim("num_samples")},
+        )
+        if exporter == "torch-export" and getattr(torch.export, "Dim", None) is not None
+        else None,
+        debug_artifacts=torch_export_debug_artifacts,
+    )
+
+
+def build_torch_export_dynamic_shapes(
+    *,
+    mode: str,
+    num_layers: int = 0,
+) -> tuple[Any, ...] | None:
+    dim_ctor = getattr(torch.export, "Dim", None)
+    if dim_ctor is None:
+        return None
+
+    if mode == "prefill":
+        prompt_len = dim_ctor("prompt_len")
+        num_audio_tokens = dim_ctor("num_audio_tokens")
+        return (
+            {1: prompt_len},
+            {1: prompt_len},
+            {0: num_audio_tokens},
+        )
+
+    if mode == "step":
+        # The decoder step wrapper currently exposes KV cache as varargs.
+        # torch.export shape validation treats that signature differently from
+        # the legacy tracer, and the simple per-tensor dynamic spec used for
+        # prefill does not line up with the captured input structure here.
+        #
+        # Until we redesign step export around a non-vararg cache interface,
+        # keep the torch.export step graph on the fixed cache length used at
+        # export time. This still lets us compare graph structure and memory
+        # behavior without blocking on the dynamic-shapes API mismatch.
+        return None
+
+    if mode == "single":
+        # decoder_single uses *past_key_values varargs (56 tensors).
+        # torch.export sees the function signature as 4 positional args:
+        #   (prefix_input_ids, audio_embeddings, suffix_input_ids, *past_key_values)
+        # dynamic_shapes must match this 4-element pytree structure exactly, with
+        # the varargs represented as a tuple of per-tensor shape dicts.
+        cache_len = dim_ctor("cache_len")
+        return (
+            {1: dim_ctor("prefix_len")},   # prefix_input_ids
+            {0: dim_ctor("num_audio_tokens")},  # audio_embeddings
+            {1: dim_ctor("suffix_len")},   # suffix_input_ids
+            tuple({2: cache_len} for _ in range(num_layers * 2)),  # *past_key_values
+        )
+
+    if mode == "static_single":
+        # decoder_single_static uses *kv_buffers varargs (56 tensors) plus a kv_pos scalar.
+        # torch.export sees the function signature as 5 positional args:
+        #   (prefix_input_ids, audio_embeddings, suffix_input_ids, kv_pos, *kv_buffers)
+        # kv_pos is a scalar (0-d tensor) — empty dict means no dynamic dims.
+        # max_tokens is the pre-allocated buffer size; it can vary between export runs.
+        max_tokens = dim_ctor("max_tokens")
+        return (
+            {1: dim_ctor("prefix_len")},        # prefix_input_ids
+            {0: dim_ctor("num_audio_tokens")},  # audio_embeddings
+            {1: dim_ctor("suffix_len")},        # suffix_input_ids
+            {},                                  # kv_pos (scalar — no dynamic dims)
+            tuple({2: max_tokens} for _ in range(num_layers * 2)),  # *kv_buffers
+        )
+
+    return None
+
+
+def aggregate_onnx_external_data(onnx_path: Path) -> None:
+    """Merge scattered per-tensor external-data files into one canonical <name>.data file.
+
+    ``torch.onnx.export(..., external_data=True)`` writes one file per weight tensor
+    (e.g. ``model.lm_head.weight``, ``model.layers.0.mlp.up_proj.weight``, …).
+    ORT requires these files to exist *in the same directory as the .onnx file*, so a
+    single-file aggregation is far more portable and easier to manage.
+
+    Strategy (avoids loading the full model into CPU RAM twice):
+      1. Load the proto *without* tensor bytes to discover which scattered files exist.
+      2. If already aggregated (only one data file, already named correctly), return early.
+      3. Load all tensor bytes into the proto (unavoidable spike; matches what's already
+         on disk), re-save with ``all_tensors_to_one_file=True``, then delete the old files.
+    """
+    target_data_name = onnx_path.name + ".data"
+    target_data_path = onnx_path.parent / target_data_name
+
+    # Inspect proto metadata to find referenced external-data files.
+    proto = onnx.load(str(onnx_path), load_external_data=False)
+    scattered: set[Path] = set()
+    for init in proto.graph.initializer:
+        if init.data_location == onnx.TensorProto.EXTERNAL:
+            for entry in init.external_data:
+                if entry.key == "location":
+                    scattered.add(onnx_path.parent / entry.value)
+
+    if not scattered:
+        return  # No external data at all — nothing to do.
+
+    if scattered == {target_data_path}:
+        return  # Already a single correctly-named data file.
+
+    print(f"  Aggregating {len(scattered)} external-data file(s) → {target_data_name} …", flush=True)
+
+    # Pull all tensor bytes into proto memory, then overwrite with aggregated layout.
+    load_external_data_for_model(proto, str(onnx_path.parent))
+    onnx.save_model(
+        proto,
+        str(onnx_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=target_data_name,
+        size_threshold=0,
+        convert_attribute=False,
+    )
+
+    # Remove the old scattered files (the new aggregated file has a different name).
+    for f in scattered:
+        if f != target_data_path and f.exists():
+            f.unlink()
+
+
+def export_onnx_graph(
+    *,
+    model: torch.nn.Module,
+    args: tuple[Any, ...],
+    output_path: Path,
+    input_names: list[str],
+    output_names: list[str],
+    opset: int,
+    dynamic_axes: dict[str, dict[int, str]] | None,
+    exporter: str,
+    dynamic_shapes: tuple[Any, ...] | None = None,
+    debug_artifacts: bool = False,
+) -> None:
+    export_kwargs: dict[str, Any] = {
+        "f": str(output_path),
+        "input_names": input_names,
+        "output_names": output_names,
+        "opset_version": opset,
+        "external_data": True,
+    }
+
+    if dynamic_axes is not None and exporter == "legacy":
+        export_kwargs["dynamic_axes"] = dynamic_axes
+
+    if exporter == "legacy":
+        export_kwargs["dynamo"] = False
+        export_kwargs["do_constant_folding"] = False
+    elif exporter == "torch-export":
+        export_kwargs["dynamo"] = True
+        export_kwargs["optimize"] = False
+        export_kwargs["verify"] = False
+        export_kwargs["report"] = debug_artifacts
+        export_kwargs["dump_exported_program"] = debug_artifacts
+        if debug_artifacts:
+            artifacts_dir = output_path.parent / "export_artifacts" / output_path.stem
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+            export_kwargs["artifacts_dir"] = str(artifacts_dir)
+        if dynamic_shapes is not None:
+            export_kwargs["dynamic_shapes"] = dynamic_shapes
+    else:
+        raise ValueError(f"Unsupported exporter: {exporter}")
+
+    torch.onnx.export(model, args=args, **export_kwargs)
+    aggregate_onnx_external_data(output_path)
+
+
+def export_decoder_graphs(
+    *,
+    model: Any,
+    processor: Any,
+    output_dir: Path,
+    opset: int,
+    dtype: Any,
+    device: str,
+    dummy_samples: int,
+    dummy_prompt: str,
+    chunk_size: int,
+    exporter: str,
+    export_prefill: bool,
+    export_step: bool,
+    export_single: bool,
+    export_static_single: bool,
+    torch_export_debug_artifacts: bool,
+    f32_kv_cache: bool = False,
+    f32_lm_head: bool = False,
+    static_kv_max_tokens: int = 6144,
+) -> dict[str, int]:
+    # Drop the audio towers before tracing the decoder path so only the LM stays resident.
+    for attr in ("acoustic_tokenizer_encoder", "semantic_tokenizer_encoder", "multi_modal_projector"):
+        if hasattr(model, attr):
+            delattr(model, attr)
+    gc.collect()
+
+    # Qwen2's SDPA mask path currently trips over ONNX tracing here. Force the
+    # eager attention implementation for export stability.
+    force_eager_attention(model)
+
+    prompt_inputs = processor.apply_transcription_request(
+        [np.zeros(dummy_samples, dtype=np.float32)],
+        prompt=[dummy_prompt],
+    )
+    prompt_input_ids = prompt_inputs["input_ids"].to(device)
+    prompt_attention_mask = prompt_inputs["attention_mask"].to(device)
+
+    hidden_size = int(model.config.text_config.hidden_size)
+    num_layers = int(model.config.text_config.num_hidden_layers)
+    num_kv_heads = int(model.config.text_config.num_key_value_heads)
+    num_heads = int(model.config.text_config.num_attention_heads)
+    head_dim = hidden_size // num_heads
+    prompt_len = int(prompt_input_ids.shape[1])
+    num_audio_tokens = int((prompt_input_ids == int(model.config.audio_token_id)).sum().item())
+    if num_audio_tokens <= 0:
+        raise SystemExit("Expected the dummy prompt to contain at least one audio placeholder token.")
+    audio_positions = torch.nonzero(prompt_input_ids[0] == int(model.config.audio_token_id), as_tuple=False).squeeze(-1)
+    prompt_prefix_input_ids = prompt_input_ids[:, : audio_positions[0]]
+    prompt_suffix_input_ids = prompt_input_ids[:, audio_positions[-1] + 1 :]
+
+    dummy_audio_embeddings = torch.zeros((num_audio_tokens, hidden_size), dtype=dtype, device=device)
+
+    if export_prefill:
+        prefill_wrapper = DecoderPrefillWrapper(model).eval()
+        print("Exporting decoder_prefill.onnx ...")
+        export_onnx_graph(
+            model=prefill_wrapper,
+            args=(prompt_input_ids, prompt_attention_mask, dummy_audio_embeddings),
+            output_path=output_dir / "decoder_prefill.onnx",
+            input_names=["input_ids", "attention_mask", "audio_embeddings"],
+            output_names=["logits", *kv_output_names(num_layers)],
+            opset=opset,
+            dynamic_axes={
+                "input_ids": {1: "prompt_len"},
+                "attention_mask": {1: "prompt_len"},
+                "audio_embeddings": {0: "num_audio_tokens"},
+                "logits": {1: "prompt_len"},
+                **{name: {2: "cache_len"} for name in kv_output_names(num_layers)},
+            },
+            exporter=exporter,
+            dynamic_shapes=build_torch_export_dynamic_shapes(mode="prefill"),
+            debug_artifacts=torch_export_debug_artifacts,
+        )
+        del prefill_wrapper
+        gc.collect()
+
+    if export_step:
+        step_wrapper = DecoderStepWrapper(model).eval()
+        step_input_ids = torch.ones((1, 1), dtype=torch.long, device=device) * int(model.config.audio_eos_token_id)
+        step_attention_mask = torch.ones((1, prompt_len + 1), dtype=torch.long, device=device)
+        dummy_kv = []
+        for _ in range(num_layers):
+            kv_shape = (1, num_kv_heads, prompt_len, head_dim)
+            dummy_kv.append(torch.zeros(kv_shape, dtype=dtype, device=device))
+            dummy_kv.append(torch.zeros(kv_shape, dtype=dtype, device=device))
+
+        print("Exporting decoder_step.onnx ...")
+        export_onnx_graph(
+            model=step_wrapper,
+            args=(step_input_ids, step_attention_mask, *dummy_kv),
+            output_path=output_dir / "decoder_step.onnx",
+            input_names=["input_ids", "attention_mask", *kv_input_names(num_layers)],
+            output_names=["logits", *kv_output_names(num_layers)],
+            opset=opset,
+            dynamic_axes={
+                "attention_mask": {1: "total_seq_len"},
+                "logits": {1: "step_len"},
+                **{name: {2: "cache_len"} for name in kv_input_names(num_layers)},
+                **{name: {2: "cache_len_out"} for name in kv_output_names(num_layers)},
+            },
+            exporter=exporter,
+            dynamic_shapes=build_torch_export_dynamic_shapes(mode="step", num_layers=num_layers),
+            debug_artifacts=torch_export_debug_artifacts,
+        )
+        del step_wrapper
+        del dummy_kv
+        gc.collect()
+
+    if export_single:
+        single_wrapper = DecoderSingleWrapper(model).eval()
+        # Use float32 for the KV cache when --f32-kv-cache is requested; activations stay BF16.
+        kv_cache_dtype = torch.float32 if f32_kv_cache else dtype
+        # 56 separate empty KV tensors: [1, num_kv_heads, 0, head_dim] per layer × 2 (K+V).
+        dummy_kv_single: list[Any] = []
+        for _ in range(num_layers):
+            kv_shape = (1, num_kv_heads, 0, head_dim)
+            dummy_kv_single.append(torch.zeros(kv_shape, dtype=kv_cache_dtype, device=device))
+            dummy_kv_single.append(torch.zeros(kv_shape, dtype=kv_cache_dtype, device=device))
+        single_exporter = exporter
+
+        print(f"Exporting decoder_single.onnx (kv_cache_dtype={kv_cache_dtype}, f32_lm_head={f32_lm_head}) ...")
+        kv_ctx = f32_kv_cache_context() if f32_kv_cache else contextlib.nullcontext()
+        lm_ctx = f32_lm_head_context(model) if f32_lm_head else contextlib.nullcontext()
+        with kv_ctx, lm_ctx:
+            export_onnx_graph(
+                model=single_wrapper,
+                args=(prompt_prefix_input_ids, dummy_audio_embeddings, prompt_suffix_input_ids, *dummy_kv_single),
+                output_path=output_dir / "decoder_single.onnx",
+                input_names=["prefix_input_ids", "audio_embeddings", "suffix_input_ids", *kv_input_names(num_layers)],
+                output_names=["logits", *kv_output_names(num_layers)],
+                opset=opset,
+                dynamic_axes={
+                    "prefix_input_ids": {1: "prefix_len"},
+                    "audio_embeddings": {0: "num_audio_tokens"},
+                    "suffix_input_ids": {1: "suffix_len"},
+                    **{name: {2: "cache_len"} for name in kv_input_names(num_layers)},
+                    "logits": {1: "seq_len"},
+                    **{name: {2: "cache_len_out"} for name in kv_output_names(num_layers)},
+                },
+                exporter=single_exporter,
+                dynamic_shapes=build_torch_export_dynamic_shapes(mode="single", num_layers=num_layers) if single_exporter == "torch-export" else None,
+                debug_artifacts=torch_export_debug_artifacts,
+            )
+        del single_wrapper
+        del dummy_kv_single
+        gc.collect()
+
+    if export_static_single:
+        static_wrapper = DecoderSingleStaticWrapper(model).eval()
+        kv_cache_dtype = torch.float32 if f32_kv_cache else dtype
+        kv_pos_dummy = torch.tensor(0, dtype=torch.int64, device=device)
+        # Pre-allocated dummy KV buffers: [1, num_kv_heads, max_tokens, head_dim]
+        dummy_kv_static: list[Any] = []
+        for _ in range(num_layers):
+            kv_shape = (1, num_kv_heads, static_kv_max_tokens, head_dim)
+            dummy_kv_static.append(torch.zeros(kv_shape, dtype=kv_cache_dtype, device=device))
+            dummy_kv_static.append(torch.zeros(kv_shape, dtype=kv_cache_dtype, device=device))
+
+        print(
+            f"Exporting decoder_single_static.onnx "
+            f"(kv_cache_dtype={kv_cache_dtype}, max_tokens={static_kv_max_tokens}, "
+            f"f32_lm_head={f32_lm_head}) ..."
+        )
+        kv_ctx = f32_kv_cache_context() if f32_kv_cache else contextlib.nullcontext()
+        lm_ctx = f32_lm_head_context(model) if f32_lm_head else contextlib.nullcontext()
+        with kv_ctx, lm_ctx:
+            export_onnx_graph(
+                model=static_wrapper,
+                args=(
+                    prompt_prefix_input_ids,
+                    dummy_audio_embeddings,
+                    prompt_suffix_input_ids,
+                    kv_pos_dummy,
+                    *dummy_kv_static,
+                ),
+                output_path=output_dir / "decoder_single_static.onnx",
+                input_names=[
+                    "prefix_input_ids", "audio_embeddings", "suffix_input_ids", "kv_pos",
+                    *kv_input_names(num_layers),
+                ],
+                output_names=["logits", *kv_output_names(num_layers)],
+                opset=opset,
+                dynamic_axes={
+                    "prefix_input_ids": {1: "prefix_len"},
+                    "audio_embeddings": {0: "num_audio_tokens"},
+                    "suffix_input_ids": {1: "suffix_len"},
+                    "logits": {1: "seq_len"},
+                    **{name: {2: "max_tokens"} for name in kv_input_names(num_layers)},
+                    **{name: {2: "max_tokens"} for name in kv_output_names(num_layers)},
+                },
+                exporter=exporter,
+                dynamic_shapes=(
+                    build_torch_export_dynamic_shapes(mode="static_single", num_layers=num_layers)
+                    if exporter == "torch-export"
+                    else None
+                ),
+                debug_artifacts=torch_export_debug_artifacts,
+            )
+        del static_wrapper
+        del dummy_kv_static
+        gc.collect()
+
+    return {
+        "hidden_size": hidden_size,
+        "num_layers": num_layers,
+        "num_kv_heads": num_kv_heads,
+        "head_dim": head_dim,
+        "prompt_len": prompt_len,
+        "num_audio_tokens": num_audio_tokens,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+
+    device = resolve_device(torch, args.device)
+    dtype = resolve_dtype(torch, args.dtype)
+    decoder_exporter = resolve_decoder_exporter(args.decoder_exporter)
+    audio_exporter = resolve_audio_exporter(args.audio_exporter)
+    export_split_decoders       = args.decoder_graph_mode in ("split", "both")
+    export_single_decoder       = args.decoder_graph_mode in ("single", "both")
+    export_static_single_decoder = args.decoder_graph_mode in ("static-single",)
+    ensure_output_dir(args.output_dir, args.overwrite, EXPORT_FILES)
+
+    model_config_dict: dict[str, Any] | None = None
+    processor: Any | None = None
+    report_dims: dict[str, int] = {}
+    audio_export_dtype, audio_export_note = resolve_audio_export_dtype(dtype, torch, audio_exporter)
+    if audio_export_note:
+        print(f"[export] {audio_export_note}")
+
+    if not args.skip_audio_encoder:
+        audio_model, processor = load_model_and_processor(args.model_repo, args.revision, device, dtype, torch)
+        copy_metadata_files(processor, audio_model, args.output_dir)
+        model_config_dict = audio_model.config.to_dict()
+
+        chunk_size = infer_export_chunk_size(
+            requested_chunk_size=args.acoustic_tokenizer_chunk_size,
+            default_chunk_size=int(audio_model.config.acoustic_tokenizer_chunk_size),
+            sampling_rate=int(processor.feature_extractor.sampling_rate),
+            dummy_audio_seconds=args.dummy_audio_seconds,
+            processor=processor,
+        )
+
+        dummy_samples = round_up_to_multiple(
+            int(round(args.dummy_audio_seconds * processor.feature_extractor.sampling_rate)),
+            chunk_size,
+        )
+        export_audio_encoder(
+            model=audio_model,
+            output_dir=args.output_dir,
+            opset=args.opset,
+            dtype=audio_export_dtype,
+            device=device,
+            dummy_samples=dummy_samples,
+            deterministic_audio=args.deterministic_audio,
+            exporter=audio_exporter,
+            torch_export_debug_artifacts=args.torch_export_debug_artifacts,
+        )
+        del audio_model
+        gc.collect()
+    else:
+        # Import the model class first so AutoProcessor can find the custom processing class.
+        # VibeVoiceAsrForConditionalGeneration is present in the vibevoice-asr transformers build
+        # but may not be a top-level export in all environments.  Fall back to trust_remote_code.
+        try:
+            from transformers import AutoProcessor, VibeVoiceAsrForConditionalGeneration as _VVA  # noqa: F401
+        except ImportError:
+            from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained(args.model_repo, revision=args.revision, trust_remote_code=True)
+        chunk_size = infer_export_chunk_size(
+            requested_chunk_size=args.acoustic_tokenizer_chunk_size,
+            default_chunk_size=1440000,
+            sampling_rate=int(processor.feature_extractor.sampling_rate),
+            dummy_audio_seconds=args.dummy_audio_seconds,
+            processor=processor,
+        )
+        dummy_samples = round_up_to_multiple(
+            int(round(args.dummy_audio_seconds * processor.feature_extractor.sampling_rate)),
+            chunk_size,
+        )
+
+    if not (
+        (not export_split_decoders or (args.skip_prefill and args.skip_step))
+        and not export_single_decoder
+        and not export_static_single_decoder
+    ):
+        decoder_model, decoder_processor = load_model_and_processor(args.model_repo, args.revision, device, dtype, torch)
+        if model_config_dict is None:
+            copy_metadata_files(decoder_processor, decoder_model, args.output_dir)
+            model_config_dict = decoder_model.config.to_dict()
+        report_dims = export_decoder_graphs(
+            model=decoder_model,
+            processor=decoder_processor,
+            output_dir=args.output_dir,
+            opset=args.opset,
+            dtype=dtype,
+            device=device,
+            dummy_samples=dummy_samples,
+            dummy_prompt=args.dummy_prompt,
+            chunk_size=chunk_size,
+            exporter=decoder_exporter,
+            export_prefill=export_split_decoders and not args.skip_prefill,
+            export_step=export_split_decoders and not args.skip_step,
+            export_single=export_single_decoder,
+            export_static_single=export_static_single_decoder,
+            torch_export_debug_artifacts=args.torch_export_debug_artifacts,
+            f32_kv_cache=args.f32_kv_cache,
+            f32_lm_head=args.f32_lm_head,
+            static_kv_max_tokens=args.static_kv_max_tokens,
+        )
+        del decoder_model
+        gc.collect()
+
+    if model_config_dict is None:
+        raise SystemExit("Nothing to export. Remove one of --skip-* flags and try again.")
+
+    tokenizer_extras = build_tokenizer_extras(processor, dummy_samples, args.dummy_prompt)
+
+    save_export_report(
+        args.output_dir / "export-report.json",
+        repo_id=args.model_repo,
+        revision=args.revision,
+        device=device,
+        dtype=torch_dtype_name(dtype),
+        opset=args.opset,
+        acoustic_tokenizer_chunk_size=chunk_size,
+        deterministic_audio=args.deterministic_audio,
+        model_config=model_config_dict,
+        extra={
+            "dummy_audio_seconds": args.dummy_audio_seconds,
+            "audio_export_input_samples": dummy_samples,
+            "dummy_prompt": args.dummy_prompt,
+            "audio_exporter": audio_exporter,
+            "decoder_exporter": decoder_exporter,
+            "decoder_graph_mode": args.decoder_graph_mode,
+            "audio_encoder_dtype": torch_dtype_name(audio_export_dtype),
+            "decoder_dtype": torch_dtype_name(dtype),
+            "f32_kv_cache": args.f32_kv_cache,
+            "f32_lm_head": args.f32_lm_head,
+            "static_kv_cache": export_static_single_decoder,
+            "static_kv_max_tokens": args.static_kv_max_tokens if export_static_single_decoder else 0,
+            "mixed_precision_note": audio_export_note,
+            "tokenizer": tokenizer_extras,
+            **report_dims,
+        },
+    )
+
+    print(f"Export completed in {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vibevoice_export/requirements.txt
+++ b/scripts/vibevoice_export/requirements.txt
@@ -1,0 +1,15 @@
+# VibeVoice-ASR currently lands in bleeding-edge Transformers first.
+# Pin to git main until the required release is available.
+git+https://github.com/huggingface/transformers.git
+accelerate>=1.10,<2
+huggingface_hub>=0.34,<2
+onnx>=1.17,<2
+onnxscript>=0.3,<1
+onnxruntime-gpu>=1.22,<2
+numpy>=1.26,<3
+ml_dtypes>=0.5,<1
+soundfile>=0.12,<1
+librosa>=0.10,<1
+sentencepiece>=0.2,<1
+tiktoken>=0.9,<1
+safetensors>=0.5,<1

--- a/scripts/vibevoice_export/test_static_kv_parity.py
+++ b/scripts/vibevoice_export/test_static_kv_parity.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+Quick parity check: run decoder_single_static.onnx and compare tokens against
+decoder_single.onnx (the reference f32kv dynamic model).
+
+Usage:
+  python test_static_kv_parity.py \
+      --static-dir  models/vibevoice_asr_static_bf16_f32kv \
+      --dynamic-dir models/vibevoice_asr_single_bf16_f32kv \
+      --audio       data/test_audio/en-US/en-US_sample_01.wav \
+      --max-tokens  256
+"""
+
+from __future__ import annotations
+import argparse
+import ctypes
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+import soundfile as sf
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def read_export_report(model_dir: Path) -> dict:
+    return json.loads((model_dir / "export-report.json").read_text())
+
+
+def make_session(onnx_path: Path, use_cuda: bool = True) -> ort.InferenceSession:
+    opts = ort.SessionOptions()
+    opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"] if use_cuda else ["CPUExecutionProvider"]
+    return ort.InferenceSession(str(onnx_path), opts, providers=providers)
+
+
+def _ort_value_to_f32(val: ort.OrtValue) -> np.ndarray:
+    """Convert an OrtValue (possibly bfloat16) to a float32 numpy array."""
+    try:
+        arr = val.numpy()
+        return arr.astype(np.float32) if arr.dtype != np.float32 else arr
+    except RuntimeError:
+        # bfloat16 OrtValue: read raw bytes, reinterpret as uint16 → bfloat16 → float32
+        import ml_dtypes
+        raw = ctypes.string_at(val.data_ptr(), val.tensor_size_in_bytes())
+        arr_u16 = np.frombuffer(raw, dtype=np.uint16).reshape(val.shape())
+        return arr_u16.view(ml_dtypes.bfloat16).astype(np.float32)
+
+
+def _decoder_fp_inputs(session: ort.InferenceSession) -> dict[str, np.dtype]:
+    """Return {name: dtype} for non-float32 floating point inputs (bfloat16, float16)."""
+    result = {}
+    for inp in session.get_inputs():
+        t = str(inp.type).lower()
+        if "bfloat16" in t:
+            import ml_dtypes
+            result[inp.name] = ml_dtypes.bfloat16
+        elif "float16" in t:
+            result[inp.name] = np.float16
+    return result
+
+
+def _np_to_ort(name: str, arr: np.ndarray, fp_casts: dict[str, np.dtype]) -> ort.OrtValue:
+    """Wrap a numpy array as an OrtValue; cast float32 → bfloat16/float16 when needed."""
+    if name in fp_casts:
+        target = fp_casts[name]
+        import ml_dtypes
+        if target == ml_dtypes.bfloat16:
+            u16 = arr.astype(ml_dtypes.bfloat16).view(np.uint16)
+            return ort.OrtValue.ortvalue_from_numpy_with_onnx_type(u16, 16)
+        else:
+            return ort.OrtValue.ortvalue_from_numpy(arr.astype(target))
+    return ort.OrtValue.ortvalue_from_numpy(np.ascontiguousarray(arr))
+
+
+def run_decoder_session(session: ort.InferenceSession, feed: dict[str, np.ndarray],
+                        fp_casts: dict[str, np.dtype], output_names: list[str]) -> list[np.ndarray]:
+    """Run decoder session handling bfloat16/float16 I/O; returns all outputs as float32."""
+    ort_feed = {name: _np_to_ort(name, arr, fp_casts) for name, arr in feed.items()}
+    out_vals = session.run_with_ort_values(output_names, ort_feed)
+    return [_ort_value_to_f32(v) for v in out_vals]
+
+
+def run_audio_encoder(
+    encoder: ort.InferenceSession,
+    audio: np.ndarray,   # float32 [T]
+    chunk_samples: int,
+) -> np.ndarray:
+    """Returns audio embeddings float32 [N, hidden]."""
+    input_meta = {inp.name: inp for inp in encoder.get_inputs()}
+    bf16_input = "bfloat16" in str(input_meta.get("input_values", object()).type).lower()
+
+    all_embs = []
+    for start in range(0, len(audio), chunk_samples):
+        chunk = audio[start: start + chunk_samples]
+        # pad to chunk_samples
+        padded = np.zeros(chunk_samples, dtype=np.float32)
+        padded[:len(chunk)] = chunk
+        mask = np.zeros(chunk_samples, dtype=bool)
+        mask[:len(chunk)] = True
+
+        if bf16_input:
+            import ml_dtypes
+            # Cast float32 → bfloat16, view as uint16 for ORT ONNX type 16
+            padded_u16 = padded.astype(ml_dtypes.bfloat16).view(np.uint16)
+            feed = {
+                "input_values": ort.OrtValue.ortvalue_from_numpy_with_onnx_type(padded_u16[None], 16),
+                "padding_mask": ort.OrtValue.ortvalue_from_numpy(np.ascontiguousarray(mask[None])),
+            }
+            [emb_val] = encoder.run_with_ort_values(["audio_embeddings"], feed)
+            emb = _ort_value_to_f32(emb_val)
+        else:
+            emb = encoder.run(None, {"input_values": padded[None], "padding_mask": mask[None]})[0]
+        all_embs.append(emb)
+    return np.concatenate(all_embs, axis=0)
+
+
+# ── dynamic KV runner ─────────────────────────────────────────────────────────
+
+def run_dynamic(
+    decoder: ort.InferenceSession,
+    audio_emb: np.ndarray,
+    prefix_ids: np.ndarray,
+    suffix_ids: np.ndarray,
+    num_layers: int,
+    kv_dtype: np.dtype,
+    kv_heads: int,
+    head_dim: int,
+    max_tokens: int,
+    eos_ids: set[int],
+) -> list[int]:
+    """Run decoder_single.onnx with growing KV cache."""
+    bf16_ins = _decoder_fp_inputs(decoder)
+    out_names = (["logits"]
+                 + [f"present_key_{i}" for i in range(num_layers)]
+                 + [f"present_value_{i}" for i in range(num_layers)])
+
+    # Initial empty KV
+    kv_shape = (1, kv_heads, 0, head_dim)
+    past_kvs = [np.zeros(kv_shape, dtype=kv_dtype) for _ in range(num_layers * 2)]
+
+    def run_once(pfx, audio_start, audio_count, sfx):
+        nonlocal past_kvs
+        feed = {
+            "prefix_input_ids": pfx.astype(np.int64)[None],
+            "audio_embeddings": (
+                audio_emb[audio_start: audio_start + audio_count]
+                if audio_count > 0
+                else np.zeros((0, audio_emb.shape[1]), dtype=audio_emb.dtype)
+            ),
+            "suffix_input_ids": sfx.astype(np.int64)[None],
+        }
+        for i, kv in enumerate(past_kvs):
+            name = f"past_key_{i//2}" if i % 2 == 0 else f"past_value_{i//2}"
+            feed[name] = kv
+
+        results = run_decoder_session(decoder, feed, bf16_ins, out_names)
+        logits = results[0]      # float32 [1, seq, vocab]
+        new_kvs = results[1:]
+
+        # reorder: ORT returns present_key_0..27, present_value_0..27
+        # match past_kvs order: k0,v0,k1,v1,...
+        reordered = []
+        for i in range(num_layers):
+            reordered.append(new_kvs[i])
+            reordered.append(new_kvs[i + num_layers])
+        past_kvs = reordered
+
+        seq_len = pfx.shape[0] + audio_count + sfx.shape[0]
+        return int(np.argmax(logits[0, seq_len - 1, :]))
+
+    # prefill
+    n = len(audio_emb)
+    chunk = 512
+    num_chunks = (n + chunk - 1) // max(1, chunk)
+    last_token = 0
+    for ci in range(num_chunks):
+        start = ci * chunk
+        count = min(chunk, n - start)
+        pfx = prefix_ids if ci == 0 else np.array([], dtype=np.int64)
+        sfx = suffix_ids if ci == num_chunks - 1 else np.array([], dtype=np.int64)
+        last_token = run_once(pfx, start, count, sfx)
+
+    # decode
+    tokens = []
+    tok = last_token
+    for _ in range(max_tokens):
+        if tok in eos_ids:
+            break
+        tokens.append(tok)
+        tok = run_once(np.array([tok], dtype=np.int64), 0, 0, np.array([], dtype=np.int64))
+
+    return tokens
+
+
+# ── static KV runner ──────────────────────────────────────────────────────────
+
+def run_static(
+    decoder: ort.InferenceSession,
+    audio_emb: np.ndarray,
+    prefix_ids: np.ndarray,
+    suffix_ids: np.ndarray,
+    num_layers: int,
+    kv_dtype: np.dtype,
+    kv_heads: int,
+    head_dim: int,
+    max_kv_tokens: int,
+    max_tokens: int,
+    eos_ids: set[int],
+) -> list[int]:
+    """Run decoder_single_static.onnx with pre-allocated static KV buffers."""
+    bf16_ins = _decoder_fp_inputs(decoder)
+    out_names = (["logits"]
+                 + [f"present_key_{i}" for i in range(num_layers)]
+                 + [f"present_value_{i}" for i in range(num_layers)])
+
+    kv_shape = (1, kv_heads, max_kv_tokens, head_dim)
+    past_kvs = [np.zeros(kv_shape, dtype=kv_dtype) for _ in range(num_layers * 2)]
+    kv_pos = 0
+
+    def run_once(pfx, audio_start, audio_count, sfx):
+        nonlocal past_kvs, kv_pos
+        feed = {
+            "prefix_input_ids": pfx.astype(np.int64)[None],
+            "audio_embeddings": (
+                audio_emb[audio_start: audio_start + audio_count]
+                if audio_count > 0
+                else np.zeros((0, audio_emb.shape[1]), dtype=audio_emb.dtype)
+            ),
+            "suffix_input_ids": sfx.astype(np.int64)[None],
+            "kv_pos": np.array(kv_pos, dtype=np.int64),
+        }
+        for i, kv in enumerate(past_kvs):
+            name = f"past_key_{i//2}" if i % 2 == 0 else f"past_value_{i//2}"
+            feed[name] = kv
+
+        results = run_decoder_session(decoder, feed, bf16_ins, out_names)
+        logits = results[0]  # float32 [1, seq, vocab]
+        new_kvs = results[1:]
+
+        # reorder present_key_0..27, present_value_0..27 → k0,v0,k1,v1,...
+        reordered = []
+        for i in range(num_layers):
+            reordered.append(new_kvs[i])
+            reordered.append(new_kvs[i + num_layers])
+        past_kvs = reordered
+
+        seq_len = pfx.shape[0] + audio_count + sfx.shape[0]
+        token = int(np.argmax(logits[0, seq_len - 1, :]))
+        kv_pos += seq_len
+        return token
+
+    # prefill
+    n = len(audio_emb)
+    chunk = 512
+    num_chunks = (n + chunk - 1) // max(1, chunk)
+    last_token = 0
+    for ci in range(num_chunks):
+        start = ci * chunk
+        count = min(chunk, n - start)
+        pfx = prefix_ids if ci == 0 else np.array([], dtype=np.int64)
+        sfx = suffix_ids if ci == num_chunks - 1 else np.array([], dtype=np.int64)
+        last_token = run_once(pfx, start, count, sfx)
+
+    # decode
+    tokens = []
+    tok = last_token
+    for _ in range(max_tokens):
+        if tok in eos_ids:
+            break
+        tokens.append(tok)
+        tok = run_once(np.array([tok], dtype=np.int64), 0, 0, np.array([], dtype=np.int64))
+
+    return tokens
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--static-dir",  type=Path, required=True)
+    ap.add_argument("--dynamic-dir", type=Path, required=True)
+    ap.add_argument("--audio",       type=Path, required=True)
+    ap.add_argument("--max-tokens",  type=int, default=256)
+    ap.add_argument("--no-cuda",     action="store_true")
+    args = ap.parse_args()
+
+    use_cuda = not args.no_cuda
+
+    # Load reports
+    static_report  = read_export_report(args.static_dir)
+    dynamic_report = read_export_report(args.dynamic_dir)
+
+    num_layers   = static_report["num_layers"]
+    kv_heads     = static_report["num_kv_heads"]
+    head_dim     = static_report["head_dim"]
+    max_kv_tokens = static_report["static_kv_max_tokens"]
+    enc_chunk    = static_report["acoustic_tokenizer_chunk_size"]
+
+    kv_dtype_s = np.float32 if static_report.get("f32_kv_cache") else np.float16
+    kv_dtype_d = np.float32 if dynamic_report.get("f32_kv_cache") else np.float16
+
+    prefix_ids = np.array(static_report["tokenizer"]["prefix_token_ids"], dtype=np.int64)
+    # Build a short-audio suffix (just use the first sample's duration)
+    audio_data, sr = sf.read(str(args.audio), dtype="float32")
+    if audio_data.ndim > 1:
+        audio_data = audio_data.mean(axis=1)
+    # Resample to 24 kHz if needed
+    if sr != 24000:
+        import resampy
+        audio_data = resampy.resample(audio_data, sr, 24000)
+        sr = 24000
+    dur = len(audio_data) / sr
+
+    # Build suffix (before + duration digits + after)
+    dur_str = f"{dur:.2f}"
+    digit_map = {k: v for k, v in static_report["tokenizer"]["digit_char_to_token_id"].items()}
+    sfx_before = np.array(static_report["tokenizer"]["suffix_before_duration_token_ids"], dtype=np.int64)
+    sfx_after  = np.array(static_report["tokenizer"]["suffix_after_duration_token_ids"],  dtype=np.int64)
+    dur_tokens = np.array([digit_map[c] for c in dur_str], dtype=np.int64)
+    suffix_ids = np.concatenate([sfx_before, dur_tokens, sfx_after])
+
+    eos_ids = {
+        static_report["tokenizer"]["eos_token_id"],
+        static_report["tokenizer"]["im_end_token_id"],
+    }
+
+    # Pad audio to stride multiple
+    stride = 3200
+    pad = (stride - len(audio_data) % stride) % stride
+    audio_padded = np.concatenate([audio_data, np.zeros(pad, dtype=np.float32)])
+
+    print(f"Audio: {dur:.1f}s  |  max_tokens={args.max_tokens}")
+
+    # Load audio encoder (shared)
+    print("Loading audio encoder ...")
+    encoder = make_session(args.static_dir / "audio_encoder.onnx", use_cuda)
+    audio_emb = run_audio_encoder(encoder, audio_padded, enc_chunk)
+    print(f"Audio embeddings: {audio_emb.shape}")
+    del encoder
+
+    # Run dynamic (reference)
+    print("\n=== Running DYNAMIC decoder (reference) ===")
+    dec_dyn = make_session(args.dynamic_dir / "decoder_single.onnx", use_cuda)
+    tokens_dyn = run_dynamic(
+        dec_dyn, audio_emb.astype(np.float32),
+        prefix_ids, suffix_ids, num_layers,
+        kv_dtype_d, kv_heads, head_dim,
+        args.max_tokens, eos_ids,
+    )
+    del dec_dyn
+    print(f"  → {len(tokens_dyn)} tokens generated")
+
+    # Run static
+    print("\n=== Running STATIC decoder ===")
+    dec_sta = make_session(args.static_dir / "decoder_single_static.onnx", use_cuda)
+    tokens_sta = run_static(
+        dec_sta, audio_emb.astype(np.float32),
+        prefix_ids, suffix_ids, num_layers,
+        kv_dtype_s, kv_heads, head_dim,
+        max_kv_tokens, args.max_tokens, eos_ids,
+    )
+    del dec_sta
+    print(f"  → {len(tokens_sta)} tokens generated")
+
+    # Compare
+    n = min(len(tokens_dyn), len(tokens_sta), args.max_tokens)
+    first_div = None
+    for i in range(n):
+        if tokens_dyn[i] != tokens_sta[i]:
+            first_div = i
+            break
+
+    print(f"\n=== Parity: dynamic vs static (first {n} tokens) ===")
+    if first_div is None:
+        print(f"  ✅  IDENTICAL for all {n} tokens compared")
+    else:
+        print(f"  ❌  First divergence at position {first_div}")
+        print(f"       dynamic token: {tokens_dyn[first_div]}")
+        print(f"       static  token: {tokens_sta[first_div]}")
+        matches = sum(1 for a, b in zip(tokens_dyn[:n], tokens_sta[:n]) if a == b)
+        print(f"       Agreement: {matches}/{n} = {100*matches/n:.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -4,7 +4,7 @@ namespace Vernacula.App.Models;
 
 public enum AppTheme    { Dark, Light }
 public enum PlaybackMode { Single, AutoAdvance, Continuous }
-public enum AsrBackend { Parakeet, Cohere }
+public enum AsrBackend { Parakeet, Cohere, VibeVoice }
 
 public class AppSettings
 {

--- a/src/Vernacula.Avalonia/Models/JobRecord.cs
+++ b/src/Vernacula.Avalonia/Models/JobRecord.cs
@@ -28,6 +28,7 @@ public class JobRecord : ObservableObject
     public string  AsrLanguageCode           { get; set; } = "auto";
     public string? AudioFileDatestamp        { get; set; }
     public string? TranscriptionRunDatestamp { get; set; }
+    public DateTime? TranscriptionRunStartedAt { get; set; }
     public string  CreatedAt                 { get; set; } = "";
 
     private string? _errorMessage;

--- a/src/Vernacula.Avalonia/Services/ControlDb.cs
+++ b/src/Vernacula.Avalonia/Services/ControlDb.cs
@@ -239,6 +239,26 @@ internal sealed class ControlDb : IDisposable
         return result is DBNull or null or "" ? "nvidia/parakeet-tdt-0.6b-v3" : (string)result;
     }
 
+    public DateTime? GetJobRunStartedAt(int jobId)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = "SELECT transcription_run_datestamp FROM jobs WHERE job_id = $id";
+        cmd.Parameters.AddWithValue("$id", jobId);
+        var result = cmd.ExecuteScalar();
+        if (result is DBNull or null)
+            return null;
+
+        string value = (string)result;
+        return DateTime.TryParseExact(
+            value,
+            "yyyy-MM-dd HH:mm:ss",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeLocal,
+            out DateTime parsed)
+            ? parsed
+            : null;
+    }
+
     public List<JobRecord> GetJobs()
     {
         var jobs = new List<JobRecord>();

--- a/src/Vernacula.Avalonia/Services/ControlDb.cs
+++ b/src/Vernacula.Avalonia/Services/ControlDb.cs
@@ -1,5 +1,6 @@
 using Microsoft.Data.Sqlite;
 using Vernacula.App.Models;
+using System.Globalization;
 
 namespace Vernacula.App.Services;
 
@@ -262,7 +263,23 @@ internal sealed class ControlDb : IDisposable
         string? GetNullable(string col) =>
             r.IsDBNull(r.GetOrdinal(col)) ? null : r.GetString(r.GetOrdinal(col));
 
+        static DateTime? ParseStamp(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return null;
+
+            return DateTime.TryParseExact(
+                value,
+                "yyyy-MM-dd HH:mm:ss",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeLocal,
+                out DateTime parsed)
+                ? parsed
+                : null;
+        }
+
         int siOrd = r.GetOrdinal("stream_index");
+        string? runStamp = GetNullable("transcription_run_datestamp");
         return new JobRecord
         {
             JobId                     = r.GetInt32(r.GetOrdinal("job_id")),
@@ -273,7 +290,8 @@ internal sealed class ControlDb : IDisposable
             AsrModelName              = GetNullable("asr_model_name") ?? "nvidia/parakeet-tdt-0.6b-v3",
             AsrLanguageCode           = GetNullable("asr_language_code") ?? "auto",
             AudioFileDatestamp        = GetNullable("audio_file_datestamp"),
-            TranscriptionRunDatestamp = GetNullable("transcription_run_datestamp"),
+            TranscriptionRunDatestamp = runStamp,
+            TranscriptionRunStartedAt = ParseStamp(runStamp),
             Status = Enum.Parse<JobStatus>(
                 r.GetString(r.GetOrdinal("status")), ignoreCase: true),
             CreatedAt         = r.GetString(r.GetOrdinal("created_at")),

--- a/src/Vernacula.Avalonia/Services/JobQueueService.cs
+++ b/src/Vernacula.Avalonia/Services/JobQueueService.cs
@@ -308,8 +308,9 @@ internal sealed class JobQueueService
 
     private string GetJobAsrModelName() => _settings.Current.AsrBackend switch
     {
-        AsrBackend.Cohere => "CohereLabs/cohere-transcribe-03-2026",
-        _                 => "nvidia/parakeet-tdt-0.6b-v3",
+        AsrBackend.Cohere     => "CohereLabs/cohere-transcribe-03-2026",
+        AsrBackend.VibeVoice  => "vibevoice/vibevoice-asr",
+        _                     => "nvidia/parakeet-tdt-0.6b-v3",
     };
 
     private string GetJobAsrLanguageCode()

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -75,8 +75,8 @@ internal class ModelManagerService
     private static readonly ModelAsset[] VibeVoiceFiles =
         [
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.AudioEncoderFile),                       VibeVoiceAsr.AudioEncoderFile),
-            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.DecoderSingleFile),                      VibeVoiceAsr.DecoderSingleFile),
-            new(Path.Combine(Config.VibeVoiceSubDir, $"{VibeVoiceAsr.DecoderSingleFile}.data"),             $"{VibeVoiceAsr.DecoderSingleFile}.data"),
+            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.DecoderSingleStaticFile),                  VibeVoiceAsr.DecoderSingleStaticFile),
+            new(Path.Combine(Config.VibeVoiceSubDir, $"{VibeVoiceAsr.DecoderSingleStaticFile}.data"),       $"{VibeVoiceAsr.DecoderSingleStaticFile}.data"),
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.ExportReportFile),                       VibeVoiceAsr.ExportReportFile),
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile),                          VibeVoiceAsr.TokenizerFile),
         ];

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -75,8 +75,8 @@ internal class ModelManagerService
     private static readonly ModelAsset[] VibeVoiceFiles =
         [
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.AudioEncoderFile),                       VibeVoiceAsr.AudioEncoderFile),
-            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.DecoderSingleStaticFile),                  VibeVoiceAsr.DecoderSingleStaticFile),
-            new(Path.Combine(Config.VibeVoiceSubDir, $"{VibeVoiceAsr.DecoderSingleStaticFile}.data"),       $"{VibeVoiceAsr.DecoderSingleStaticFile}.data"),
+            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.DecoderSingleFile),                     VibeVoiceAsr.DecoderSingleFile),
+            new(Path.Combine(Config.VibeVoiceSubDir, $"{VibeVoiceAsr.DecoderSingleFile}.data"),            $"{VibeVoiceAsr.DecoderSingleFile}.data"),
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.ExportReportFile),                       VibeVoiceAsr.ExportReportFile),
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile),                          VibeVoiceAsr.TokenizerFile),
         ];

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -70,30 +70,54 @@ internal class ModelManagerService
             new(Path.Combine("cohere_transcribe", CohereTranscribe.ConfigFile), CohereTranscribe.ConfigFile),
         ];
 
+    // VibeVoice-ASR files must be placed manually in the vibevoice_asr subdirectory.
+    // Each .onnx has a single aggregated companion .data file produced by the export script.
+    private static readonly ModelAsset[] VibeVoiceFiles =
+        [
+            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.AudioEncoderFile),                       VibeVoiceAsr.AudioEncoderFile),
+            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.DecoderSingleFile),                      VibeVoiceAsr.DecoderSingleFile),
+            new(Path.Combine(Config.VibeVoiceSubDir, $"{VibeVoiceAsr.DecoderSingleFile}.data"),             $"{VibeVoiceAsr.DecoderSingleFile}.data"),
+            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.ExportReportFile),                       VibeVoiceAsr.ExportReportFile),
+            new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile),                          VibeVoiceAsr.TokenizerFile),
+        ];
+
     private readonly SettingsService _settings;
     private readonly HttpClient _http = new(new HttpClientHandler { AllowAutoRedirect = true });
 
     public ModelManagerService(SettingsService settings) => _settings = settings;
 
-    private AssetRepo[] ActiveRepos() => _settings.Current.AsrBackend switch
+    private AssetRepo[] ActiveRepos()
     {
-        AsrBackend.Cohere =>
-        [
-            new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
-            new AssetRepo(CohereRepoBase, CohereManifestUrl, CohereFiles),
-        ],
-        _ =>
-        [
-            new AssetRepo(CoreRepoBase, CoreManifestUrl, [.. CoreDiarizationFiles, .. AsrFilesFp32]),
-        ],
-    };
+        // VibeVoice is triggered by either the ASR backend or the segmentation mode.
+        // Files must be placed manually; no auto-download URL is configured (empty RepoBase).
+        if (_settings.Current.AsrBackend == AsrBackend.VibeVoice ||
+            _settings.Current.Segmentation == SegmentationMode.VibeVoiceBuiltin)
+        {
+            return [new AssetRepo("", "", VibeVoiceFiles)];
+        }
+
+        return _settings.Current.AsrBackend switch
+        {
+            AsrBackend.Cohere =>
+            [
+                new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
+                new AssetRepo(CohereRepoBase, CohereManifestUrl, CohereFiles),
+            ],
+            _ =>
+            [
+                new AssetRepo(CoreRepoBase, CoreManifestUrl, [.. CoreDiarizationFiles, .. AsrFilesFp32]),
+            ],
+        };
+    }
 
     private ModelAsset[] RequiredFiles() =>
         [.. ActiveRepos().SelectMany(repo => repo.Assets)];
 
     private RepoAsset[] DownloadableFiles() =>
-        [.. ActiveRepos().SelectMany(repo => repo.Assets.Select(asset =>
-            new RepoAsset(repo.RepoBase, asset.LocalRelativePath, asset.RemoteRelativePath)))];
+        [.. ActiveRepos()
+            .Where(repo => !string.IsNullOrEmpty(repo.RepoBase))
+            .SelectMany(repo => repo.Assets.Select(asset =>
+                new RepoAsset(repo.RepoBase, asset.LocalRelativePath, asset.RemoteRelativePath)))];
 
     public IReadOnlyList<string> GetMissingFiles()
     {

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -28,6 +28,11 @@ internal class ModelManagerService
     private const string CohereManifestUrl =
         "https://huggingface.co/christopherthompson81/cohere-transcribe-03-2026-onnx/resolve/main/manifest.json";
 
+    private const string VibeVoiceRepoBase =
+        "https://huggingface.co/christopherthompson81/vibevoice-asr-onnx/resolve/main";
+    private const string VibeVoiceManifestUrl =
+        "https://huggingface.co/christopherthompson81/vibevoice-asr-onnx/resolve/main/manifest.json";
+
     private static readonly ModelAsset[] CoreDiarizationFiles =
         [
             new("diar_streaming_sortformer_4spk-v2.1.onnx", "diar_streaming_sortformer_4spk-v2.1.onnx"),
@@ -70,13 +75,16 @@ internal class ModelManagerService
             new(Path.Combine("cohere_transcribe", CohereTranscribe.ConfigFile), CohereTranscribe.ConfigFile),
         ];
 
-    // VibeVoice-ASR files must be placed manually in the vibevoice_asr subdirectory.
-    // Each .onnx has a single aggregated companion .data file produced by the export script.
     private static readonly ModelAsset[] VibeVoiceFiles =
         [
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.AudioEncoderFile),                       VibeVoiceAsr.AudioEncoderFile),
+            new(Path.Combine(Config.VibeVoiceSubDir, $"{VibeVoiceAsr.AudioEncoderFile}.data"),            $"{VibeVoiceAsr.AudioEncoderFile}.data"),
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.DecoderSingleFile),                     VibeVoiceAsr.DecoderSingleFile),
             new(Path.Combine(Config.VibeVoiceSubDir, $"{VibeVoiceAsr.DecoderSingleFile}.data"),            $"{VibeVoiceAsr.DecoderSingleFile}.data"),
+            new(Path.Combine(Config.VibeVoiceSubDir, "config.json"),                                      "config.json"),
+            new(Path.Combine(Config.VibeVoiceSubDir, "processor_config.json"),                            "processor_config.json"),
+            new(Path.Combine(Config.VibeVoiceSubDir, "tokenizer_config.json"),                            "tokenizer_config.json"),
+            new(Path.Combine(Config.VibeVoiceSubDir, "chat_template.jinja"),                              "chat_template.jinja"),
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.ExportReportFile),                       VibeVoiceAsr.ExportReportFile),
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile),                          VibeVoiceAsr.TokenizerFile),
         ];
@@ -88,12 +96,10 @@ internal class ModelManagerService
 
     private AssetRepo[] ActiveRepos()
     {
-        // VibeVoice is triggered by either the ASR backend or the segmentation mode.
-        // Files must be placed manually; no auto-download URL is configured (empty RepoBase).
         if (_settings.Current.AsrBackend == AsrBackend.VibeVoice ||
             _settings.Current.Segmentation == SegmentationMode.VibeVoiceBuiltin)
         {
-            return [new AssetRepo("", "", VibeVoiceFiles)];
+            return [new AssetRepo(VibeVoiceRepoBase, VibeVoiceManifestUrl, VibeVoiceFiles)];
         }
 
         return _settings.Current.AsrBackend switch

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -83,6 +83,9 @@ internal class SettingsService
     public string GetCohereModelsDir() =>
         Path.Combine(GetModelsDir(), "cohere_transcribe");
 
+    public string GetVibeVoiceModelsDir() =>
+        Path.Combine(GetModelsDir(), "vibevoice_asr");
+
     public string GetJobsDir()
     {
         string dir = Path.Combine(

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -82,8 +82,18 @@ internal class TranscriptionService
         ct.ThrowIfCancellationRequested();
         var (rawSamples, sampleRate, channels) = AudioUtils.ReadAudio(audioPath, streamIndex);
 
+        // ── ASR backend / segmentation flags ─────────────────────────────────
+        bool useVibeVoiceAsr  = string.Equals(asrModelName, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+        bool useCohereAsr     = string.Equals(asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+        var  segmentationMode = _settings.Current.Segmentation;
+        bool runVibeVoice     = useVibeVoiceAsr || segmentationMode == SegmentationMode.VibeVoiceBuiltin;
+
         // ── Phase 1b: Denoising (optional) ────────────────────────────────────
+        // For VibeVoice, also track the audio to pass to Transcribe() — it accepts any sample rate.
         float[] audio;
+        float[] vibeVoiceAudio;
+        int     vibeVoiceSampleRate;
+        int     vibeVoiceChannels;
         var denoiserMode = _settings.Current.Denoiser;
         if (denoiserMode == DenoiserMode.DeepFilterNet3)
         {
@@ -116,10 +126,20 @@ internal class TranscriptionService
                 // Resample to 16 kHz for ASR
                 return DFN3Denoiser.ResampleFrom48k(enhanced48k, Vernacula.Base.AudioUtils.AsrSampleRate);
             }, ct);
+            // VibeVoice uses the denoised 16 kHz mono audio directly.
+            vibeVoiceAudio      = audio;
+            vibeVoiceSampleRate = Vernacula.Base.AudioUtils.AsrSampleRate;
+            vibeVoiceChannels   = 1;
         }
         else
         {
-            audio = AudioUtils.AudioTo16000Mono(rawSamples, sampleRate, channels);
+            // VibeVoice accepts raw audio at any sample rate; skip the 16 kHz conversion.
+            vibeVoiceAudio      = rawSamples;
+            vibeVoiceSampleRate = sampleRate;
+            vibeVoiceChannels   = channels;
+            audio = runVibeVoice
+                ? Array.Empty<float>()   // not used on the VibeVoice path
+                : AudioUtils.AudioTo16000Mono(rawSamples, sampleRate, channels);
         }
 
         // ── Phase 2: Open results DB ──────────────────────────────────────────
@@ -131,14 +151,96 @@ internal class TranscriptionService
         db.UpdateMetadata("asr_language_code",
             string.IsNullOrWhiteSpace(asrLanguageCode) ? "auto" : asrLanguageCode);
 
-        bool useCohereAsr = string.Equals(
-            asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+        // ── VibeVoice: combined diarization + ASR in a single model pass ────────
+        if (runVibeVoice)
+        {
+            if (!db.CheckDiarization())
+            {
+                progress.Report(new TranscriptionProgress(
+                    TranscriptionPhase.Recognizing, 0, 1, "Running VibeVoice-ASR…"));
+
+                ct.ThrowIfCancellationRequested();
+                string vibeVoiceDir = _settings.GetVibeVoiceModelsDir();
+                IReadOnlyList<VibeVoiceSegment> vibeSegs = await Task.Run(() =>
+                {
+                    using var vibe = new VibeVoiceAsr(vibeVoiceDir);
+                    return vibe.Transcribe(vibeVoiceAudio, vibeVoiceSampleRate, vibeVoiceChannels, ct: ct);
+                }, ct).ConfigureAwait(false);
+
+                db.BeginBulkInsert();
+                var seenVibeSpeakers = new HashSet<int>();
+                for (int i = 0; i < vibeSegs.Count; i++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var    seg      = vibeSegs[i];
+                    string spkId   = $"speaker_{seg.Speaker}";
+                    int diarSpkId  = seg.Speaker + 1;
+
+                    if (seenVibeSpeakers.Add(seg.Speaker))
+                        db.InsertSpeaker(spkId);
+
+                    db.InsertResult(
+                        diarizationSpeakerId: diarSpkId,
+                        speakerId:            diarSpkId,
+                        startTime:            seg.Start,
+                        endTime:              seg.End,
+                        startTimeF:           AudioUtils.SecondsToHhMmSs(Math.Round(seg.Start)),
+                        endTimeF:             AudioUtils.SecondsToHhMmSs(Math.Round(seg.End)),
+                        asrContent:           seg.Content,
+                        content:              seg.Content,
+                        tokens:               "[]",
+                        timestamps:           "[]",
+                        logprobs:             null);
+
+                    onSegmentAdded(new SegmentRow
+                    {
+                        SegmentId          = i,
+                        SpeakerTag         = spkId,
+                        SpeakerDisplayName = spkId,
+                        StartTime          = seg.Start,
+                        EndTime            = seg.End,
+                    });
+                    onSegmentText(i, seg.Content);
+
+                    string vibeText = Loc.Instance.T("progress_recognizing_segment", new() {
+                        ["i"]     = (i + 1).ToString(),
+                        ["count"] = vibeSegs.Count.ToString() });
+                    progress.Report(new TranscriptionProgress(
+                        TranscriptionPhase.Recognizing, i + 1, vibeSegs.Count, vibeText, i, seg.Content));
+                }
+                db.CommitBulkInsert();
+                db.MarkDiarizationComplete();
+            }
+            else
+            {
+                // Resume path: diarization + ASR already complete — just notify the UI.
+                var existingSegs  = db.GetSegments();
+                var existingTexts = db.GetResultContents();
+                for (int i = 0; i < existingSegs.Count; i++)
+                {
+                    var (start, end, spkId) = existingSegs[i];
+                    onSegmentAdded(new SegmentRow
+                    {
+                        SegmentId          = i,
+                        SpeakerTag         = spkId,
+                        SpeakerDisplayName = spkId,
+                        StartTime          = start,
+                        EndTime            = end,
+                    });
+                    if (i < existingTexts.Count)
+                        onSegmentText(i, existingTexts[i]);
+                }
+            }
+
+            progress.Report(new TranscriptionProgress(
+                TranscriptionPhase.Done, 1, 1,
+                Loc.Instance["transcription_complete"], OverridePercent: 100));
+            return;
+        }
 
         // ── Phase 3: Segmentation (Diarization or VAD) ───────────────────────
         List<(double start, double end, string spkId)> segs;
         bool inlineAsrDone = false;
-
-        var segmentationMode = _settings.Current.Segmentation;
 
         if (!db.CheckDiarization() && segmentationMode == SegmentationMode.SileroVad)
         {

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -201,6 +201,20 @@ internal class TranscriptionService
                     if (seenVibeSpeakers.Add(seg.Speaker))
                         db.InsertSpeaker(spkId);
 
+                    // Word-level synthetic tokens let the transcript editor split segments.
+                    // One token per word; timestamps uniformly distributed over the segment.
+                    string[] words     = (seg.Content ?? "").Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    int      wordCount = Math.Max(1, words.Length);
+                    const double frameSeconds = Config.HopLength * 8.0 / Config.SampleRate;
+                    double segDuration = seg.End - seg.Start;
+                    var syntheticTokens     = new int[wordCount];
+                    var syntheticTimestamps = new int[wordCount];
+                    for (int wi = 0; wi < wordCount; wi++)
+                    {
+                        syntheticTokens[wi]     = wi;
+                        syntheticTimestamps[wi] = (int)((double)wi / wordCount * segDuration / frameSeconds);
+                    }
+
                     db.InsertResult(
                         diarizationSpeakerId: diarSpkId,
                         speakerId:            diarSpkId,
@@ -210,8 +224,8 @@ internal class TranscriptionService
                         endTimeF:             AudioUtils.SecondsToHhMmSs(Math.Round(seg.End)),
                         asrContent:           seg.Content,
                         content:              seg.Content,
-                        tokens:               "[]",
-                        timestamps:           "[]",
+                        tokens:               JsonSerializer.Serialize(syntheticTokens),
+                        timestamps:           JsonSerializer.Serialize(syntheticTimestamps),
                         logprobs:             null);
                 }
                 db.CommitBulkInsert();

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -167,7 +167,10 @@ internal class TranscriptionService
 
                 IReadOnlyList<VibeVoiceSegment> vibeSegs = await Task.Run(() =>
                 {
-                    using var vibe = new VibeVoiceAsr(vibeVoiceDir, allowStaticKvCache: false);
+                    using var vibe = new VibeVoiceAsr(
+                        vibeVoiceDir,
+                        persistEncoder: false,
+                        allowStaticKvCache: false);
                     return vibe.Transcribe(
                         vibeVoiceAudio, vibeVoiceSampleRate, vibeVoiceChannels,
                         onSegment: seg =>
@@ -204,10 +207,10 @@ internal class TranscriptionService
 
                     // VibeVoice does not emit timestamps, so we synthesize them uniformly over
                     // the segment while preserving the real decoder token ids and logprobs.
-                    int tokenCount = Math.Max(1, Math.Max(seg.TokenIds.Count, seg.TokenLogprobs.Count));
+                    int tokenCount = Math.Max(seg.TokenIds.Count, seg.TokenLogprobs.Count);
                     const double frameSeconds = Config.HopLength * 8.0 / Config.SampleRate;
                     double segDuration = seg.End - seg.Start;
-                    var persistedTokens     = seg.TokenIds.Count > 0 ? seg.TokenIds.ToArray() : new int[tokenCount];
+                    var persistedTokens     = seg.TokenIds.Count > 0 ? seg.TokenIds.ToArray() : Array.Empty<int>();
                     var syntheticTimestamps = new int[tokenCount];
                     for (int wi = 0; wi < tokenCount; wi++)
                     {

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -147,7 +147,8 @@ internal class TranscriptionService
         if (!db.CheckMetadata(audioPath))
             db.PopulateMetadata(audioPath);
 
-        db.UpdateMetadata("asr_model", asrModelName);
+        string effectiveAsrModelName = runVibeVoice ? "vibevoice/vibevoice-asr" : asrModelName;
+        db.UpdateMetadata("asr_model", effectiveAsrModelName);
         db.UpdateMetadata("asr_language_code",
             string.IsNullOrWhiteSpace(asrLanguageCode) ? "auto" : asrLanguageCode);
 
@@ -201,18 +202,16 @@ internal class TranscriptionService
                     if (seenVibeSpeakers.Add(seg.Speaker))
                         db.InsertSpeaker(spkId);
 
-                    // Word-level synthetic tokens let the transcript editor split segments.
-                    // One token per word; timestamps uniformly distributed over the segment.
-                    string[] words     = (seg.Content ?? "").Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                    int      wordCount = Math.Max(1, words.Length);
+                    // VibeVoice does not emit timestamps, so we synthesize them uniformly over
+                    // the segment while preserving the real decoder token ids and logprobs.
+                    int tokenCount = Math.Max(1, Math.Max(seg.TokenIds.Count, seg.TokenLogprobs.Count));
                     const double frameSeconds = Config.HopLength * 8.0 / Config.SampleRate;
                     double segDuration = seg.End - seg.Start;
-                    var syntheticTokens     = new int[wordCount];
-                    var syntheticTimestamps = new int[wordCount];
-                    for (int wi = 0; wi < wordCount; wi++)
+                    var persistedTokens     = seg.TokenIds.Count > 0 ? seg.TokenIds.ToArray() : new int[tokenCount];
+                    var syntheticTimestamps = new int[tokenCount];
+                    for (int wi = 0; wi < tokenCount; wi++)
                     {
-                        syntheticTokens[wi]     = wi;
-                        syntheticTimestamps[wi] = (int)((double)wi / wordCount * segDuration / frameSeconds);
+                        syntheticTimestamps[wi] = (int)((double)wi / tokenCount * segDuration / frameSeconds);
                     }
 
                     db.InsertResult(
@@ -224,9 +223,10 @@ internal class TranscriptionService
                         endTimeF:             AudioUtils.SecondsToHhMmSs(Math.Round(seg.End)),
                         asrContent:           seg.Content,
                         content:              seg.Content,
-                        tokens:               JsonSerializer.Serialize(syntheticTokens),
+                        tokens:               JsonSerializer.Serialize(persistedTokens),
                         timestamps:           JsonSerializer.Serialize(syntheticTimestamps),
-                        logprobs:             null);
+                        logprobs:             JsonSerializer.Serialize(
+                                                  seg.TokenLogprobs.Count > 0 ? seg.TokenLogprobs : seg.WordLogprobs));
                 }
                 db.CommitBulkInsert();
                 db.MarkDiarizationComplete();

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -167,7 +167,7 @@ internal class TranscriptionService
 
                 IReadOnlyList<VibeVoiceSegment> vibeSegs = await Task.Run(() =>
                 {
-                    using var vibe = new VibeVoiceAsr(vibeVoiceDir);
+                    using var vibe = new VibeVoiceAsr(vibeVoiceDir, allowStaticKvCache: false);
                     return vibe.Transcribe(
                         vibeVoiceAudio, vibeVoiceSampleRate, vibeVoiceChannels,
                         onSegment: seg =>

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -157,24 +157,46 @@ internal class TranscriptionService
             if (!db.CheckDiarization())
             {
                 progress.Report(new TranscriptionProgress(
-                    TranscriptionPhase.Recognizing, 0, 1, "Running VibeVoice-ASR…"));
+                    TranscriptionPhase.Recognizing, 0, 100, "Running VibeVoice-ASR…"));
 
                 ct.ThrowIfCancellationRequested();
-                string vibeVoiceDir = _settings.GetVibeVoiceModelsDir();
+                string vibeVoiceDir  = _settings.GetVibeVoiceModelsDir();
+                double vibeDuration  = (double)vibeVoiceAudio.Length / vibeVoiceSampleRate / Math.Max(1, vibeVoiceChannels);
+                int    streamSegIdx  = 0;
+
                 IReadOnlyList<VibeVoiceSegment> vibeSegs = await Task.Run(() =>
                 {
                     using var vibe = new VibeVoiceAsr(vibeVoiceDir);
-                    return vibe.Transcribe(vibeVoiceAudio, vibeVoiceSampleRate, vibeVoiceChannels, ct: ct);
+                    return vibe.Transcribe(
+                        vibeVoiceAudio, vibeVoiceSampleRate, vibeVoiceChannels,
+                        onSegment: seg =>
+                        {
+                            int    i     = streamSegIdx++;
+                            string spkId = $"speaker_{seg.Speaker}";
+                            onSegmentAdded(new SegmentRow
+                            {
+                                SegmentId          = i,
+                                SpeakerTag         = spkId,
+                                SpeakerDisplayName = spkId,
+                                StartTime          = seg.Start,
+                                EndTime            = seg.End,
+                            });
+                            onSegmentText(i, seg.Content);
+                            double pct = vibeDuration > 0 ? seg.End / vibeDuration * 100.0 : 0;
+                            progress.Report(new TranscriptionProgress(
+                                TranscriptionPhase.Recognizing, 0, 100,
+                                $"{seg.End:F1}s / {vibeDuration:F1}s",
+                                i, seg.Content, OverridePercent: pct));
+                        },
+                        ct: ct);
                 }, ct).ConfigureAwait(false);
 
                 db.BeginBulkInsert();
                 var seenVibeSpeakers = new HashSet<int>();
-                for (int i = 0; i < vibeSegs.Count; i++)
+                foreach (var seg in vibeSegs)
                 {
-                    ct.ThrowIfCancellationRequested();
-                    var    seg      = vibeSegs[i];
-                    string spkId   = $"speaker_{seg.Speaker}";
-                    int diarSpkId  = seg.Speaker + 1;
+                    string spkId    = $"speaker_{seg.Speaker}";
+                    int diarSpkId   = seg.Speaker + 1;
 
                     if (seenVibeSpeakers.Add(seg.Speaker))
                         db.InsertSpeaker(spkId);
@@ -191,22 +213,6 @@ internal class TranscriptionService
                         tokens:               "[]",
                         timestamps:           "[]",
                         logprobs:             null);
-
-                    onSegmentAdded(new SegmentRow
-                    {
-                        SegmentId          = i,
-                        SpeakerTag         = spkId,
-                        SpeakerDisplayName = spkId,
-                        StartTime          = seg.Start,
-                        EndTime            = seg.End,
-                    });
-                    onSegmentText(i, seg.Content);
-
-                    string vibeText = Loc.Instance.T("progress_recognizing_segment", new() {
-                        ["i"]     = (i + 1).ToString(),
-                        ["count"] = vibeSegs.Count.ToString() });
-                    progress.Report(new TranscriptionProgress(
-                        TranscriptionPhase.Recognizing, i + 1, vibeSegs.Count, vibeText, i, seg.Content));
                 }
                 db.CommitBulkInsert();
                 db.MarkDiarizationComplete();

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -108,12 +108,12 @@ internal class VocabService
 
     /// <summary>Returns (text, logprob) pairs for each token.</summary>
     public IReadOnlyList<(string text, float logprob)> GetTokenRuns(
-        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
+        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs, string? targetText = null)
     {
         if (_kind == VocabKind.Cohere)
             return GetCohereTokenRuns(tokens, logprobs);
         if (_kind == VocabKind.VibeVoice)
-            return GetVibeVoiceTokenRuns(tokens, logprobs);
+            return GetVibeVoiceTokenRuns(tokens, logprobs, targetText);
 
         var runs = new List<(string, float)>(tokens.Count);
         for (int i = 0; i < tokens.Count; i++)
@@ -240,7 +240,7 @@ internal class VocabService
     }
 
     private IReadOnlyList<(string text, float logprob)> GetVibeVoiceTokenRuns(
-        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
+        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs, string? targetText)
     {
         var runs = new List<(string, float)>(tokens.Count);
         Decoder decoder = Encoding.UTF8.GetDecoder();
@@ -265,21 +265,7 @@ internal class VocabService
             runs.Add((runText, lp));
         }
 
-        int firstNonEmpty = runs.FindIndex(r => r.Item1.Length > 0);
-        if (firstNonEmpty >= 0 && runs[firstNonEmpty].Item1.StartsWith('"'))
-        {
-            var run = runs[firstNonEmpty];
-            runs[firstNonEmpty] = (run.Item1[1..], run.Item2);
-        }
-
-        int lastNonEmpty = runs.FindLastIndex(r => r.Item1.Length > 0);
-        if (lastNonEmpty >= 0 && runs[lastNonEmpty].Item1.EndsWith('"'))
-        {
-            var run = runs[lastNonEmpty];
-            runs[lastNonEmpty] = (run.Item1[..^1], run.Item2);
-        }
-
-        return runs;
+        return ClipRunsToTargetText(runs, targetText);
     }
 
     private byte[] GetVibeVoiceTokenBytes(int token)
@@ -334,6 +320,55 @@ internal class VocabService
         }
 
         return dict;
+    }
+
+    private static IReadOnlyList<(string text, float logprob)> ClipRunsToTargetText(
+        List<(string text, float logprob)> runs, string? targetText)
+    {
+        if (string.IsNullOrEmpty(targetText) || runs.Count == 0)
+            return runs;
+
+        string combined = string.Concat(runs.Select(r => r.text));
+        int targetStart = combined.IndexOf(targetText, StringComparison.Ordinal);
+        if (targetStart < 0)
+        {
+            string trimmed = TrimVibeVoiceBoundaryQuotes(combined);
+            if (string.Equals(trimmed, targetText, StringComparison.Ordinal))
+            {
+                targetStart = combined.StartsWith('"') ? 1 : 0;
+            }
+            else
+            {
+                return runs;
+            }
+        }
+
+        int targetEnd = targetStart + targetText.Length;
+        var clipped = new List<(string text, float logprob)>(runs.Count);
+        int pos = 0;
+
+        foreach (var run in runs)
+        {
+            int runStart = pos;
+            int runEnd   = pos + run.text.Length;
+            int clipStart = Math.Max(runStart, targetStart);
+            int clipEnd   = Math.Min(runEnd, targetEnd);
+
+            if (clipStart < clipEnd)
+            {
+                int localStart = clipStart - runStart;
+                int localLength = clipEnd - clipStart;
+                clipped.Add((run.text.Substring(localStart, localLength), run.logprob));
+            }
+            else
+            {
+                clipped.Add(("", run.logprob));
+            }
+
+            pos = runEnd;
+        }
+
+        return clipped;
     }
 
     private static string TrimVibeVoiceBoundaryQuotes(string text)

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -13,10 +13,12 @@ namespace Vernacula.App.Services;
 /// </summary>
 internal class VocabService
 {
-    private enum VocabKind { Parakeet, Cohere }
+    private enum VocabKind { Parakeet, Cohere, VibeVoice }
 
     private readonly Dictionary<int, string> _vocab;
     private readonly VocabKind _kind;
+    private readonly Dictionary<int, string> _addedContent = [];
+    private readonly Dictionary<char, byte> _byteLevelDecode = [];
 
     public VocabService(string modelsDir, string? asrModel = null)
     {
@@ -24,6 +26,12 @@ internal class VocabService
         {
             _kind = VocabKind.Cohere;
             _vocab = LoadCohereVocab(Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile));
+        }
+        else if (string.Equals(asrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal))
+        {
+            _kind = VocabKind.VibeVoice;
+            (_vocab, _addedContent) = LoadVibeVoiceVocab(Path.Combine(modelsDir, Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile));
+            _byteLevelDecode = BuildByteLevelDecode();
         }
         else
         {
@@ -65,6 +73,27 @@ internal class VocabService
         return vocab;
     }
 
+    private static (Dictionary<int, string> vocab, Dictionary<int, string> addedContent) LoadVibeVoiceVocab(string vocabPath)
+    {
+        var vocab = new Dictionary<int, string>();
+        var addedContent = new Dictionary<int, string>();
+        if (!File.Exists(vocabPath)) return (vocab, addedContent);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(vocabPath));
+        var root = doc.RootElement;
+
+        foreach (var kv in root.GetProperty("model").GetProperty("vocab").EnumerateObject())
+            vocab[kv.Value.GetInt32()] = kv.Name;
+
+        if (root.TryGetProperty("added_tokens", out var addedTokens))
+        {
+            foreach (var at in addedTokens.EnumerateArray())
+                addedContent[at.GetProperty("id").GetInt32()] = at.GetProperty("content").GetString() ?? "";
+        }
+
+        return (vocab, addedContent);
+    }
+
     // ── Token decoding ────────────────────────────────────────────────────────
 
     public string DecodeTokens(IReadOnlyList<int> tokens)
@@ -72,6 +101,7 @@ internal class VocabService
         return _kind switch
         {
             VocabKind.Cohere   => DecodeCohereTokens(tokens),
+            VocabKind.VibeVoice => DecodeVibeVoiceTokens(tokens),
             _                  => DecodeParakeetTokens(tokens),
         };
     }
@@ -82,6 +112,8 @@ internal class VocabService
     {
         if (_kind == VocabKind.Cohere)
             return GetCohereTokenRuns(tokens, logprobs);
+        if (_kind == VocabKind.VibeVoice)
+            return GetVibeVoiceTokenRuns(tokens, logprobs);
 
         var runs = new List<(string, float)>(tokens.Count);
         for (int i = 0; i < tokens.Count; i++)
@@ -141,6 +173,14 @@ internal class VocabService
         return text.Length > 0 && text[0] == ' ' ? text[1..] : text;
     }
 
+    private string DecodeVibeVoiceTokens(IReadOnlyList<int> tokens)
+    {
+        var bytes = new List<byte>(tokens.Count * 4);
+        foreach (int token in tokens)
+            bytes.AddRange(GetVibeVoiceTokenBytes(token));
+        return Encoding.UTF8.GetString(bytes.ToArray());
+    }
+
     private string DecodeToken(int token)
     {
         if (!_vocab.TryGetValue(token, out var value))
@@ -148,6 +188,9 @@ internal class VocabService
 
         if (_kind == VocabKind.Parakeet)
             return value;
+
+        if (_kind == VocabKind.VibeVoice)
+            return Encoding.UTF8.GetString(GetVibeVoiceTokenBytes(token));
 
         if (value.Length == 6 && value[0] == '<' && value[1] == '0' && value[2] == 'x' && value[5] == '>')
         {
@@ -196,6 +239,50 @@ internal class VocabService
         return Encoding.UTF8.GetBytes(value.Replace('\u2581', ' '));
     }
 
+    private IReadOnlyList<(string text, float logprob)> GetVibeVoiceTokenRuns(
+        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
+    {
+        var runs = new List<(string, float)>(tokens.Count);
+        Decoder decoder = Encoding.UTF8.GetDecoder();
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            byte[] tokenBytes = GetVibeVoiceTokenBytes(tokens[i]);
+            string runText;
+            if (tokenBytes.Length == 0)
+            {
+                runText = "";
+            }
+            else
+            {
+                int charCount = decoder.GetCharCount(tokenBytes, 0, tokenBytes.Length, flush: false);
+                char[] chars = new char[charCount];
+                decoder.GetChars(tokenBytes, 0, tokenBytes.Length, chars, 0, flush: false);
+                runText = new string(chars);
+            }
+
+            float lp = i < logprobs.Count ? logprobs[i] : 0f;
+            runs.Add((runText, lp));
+        }
+
+        return runs;
+    }
+
+    private byte[] GetVibeVoiceTokenBytes(int token)
+    {
+        if (_addedContent.TryGetValue(token, out var special))
+            return Encoding.UTF8.GetBytes(special);
+
+        if (!_vocab.TryGetValue(token, out var raw))
+            return [];
+
+        var bytes = new List<byte>(raw.Length);
+        foreach (char ch in raw)
+            if (_byteLevelDecode.TryGetValue(ch, out byte b))
+                bytes.Add(b);
+        return bytes.ToArray();
+    }
+
     private static bool TryParseHexByte(char hi, char lo, out byte value)
     {
         int h = HexVal(hi);
@@ -212,6 +299,28 @@ internal class VocabService
         >= 'A' and <= 'F' => c - 'A' + 10,
         _ => -1,
     };
+
+    private static Dictionary<char, byte> BuildByteLevelDecode()
+    {
+        var printable = new HashSet<int>(
+            Enumerable.Range(33, 94)
+            .Concat(Enumerable.Range(161, 12))
+            .Concat(Enumerable.Range(174, 82)));
+
+        var dict = new Dictionary<char, byte>(280);
+
+        foreach (int b in printable)
+            dict[(char)b] = (byte)b;
+
+        int extra = 0;
+        for (int b = 0; b < 256; b++)
+        {
+            if (!printable.Contains(b))
+                dict[(char)(0x100 + extra++)] = (byte)b;
+        }
+
+        return dict;
+    }
 
     // ── Confidence highlight ──────────────────────────────────────────────────
 

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -178,7 +178,7 @@ internal class VocabService
         var bytes = new List<byte>(tokens.Count * 4);
         foreach (int token in tokens)
             bytes.AddRange(GetVibeVoiceTokenBytes(token));
-        return Encoding.UTF8.GetString(bytes.ToArray());
+        return TrimVibeVoiceBoundaryQuotes(Encoding.UTF8.GetString(bytes.ToArray()));
     }
 
     private string DecodeToken(int token)
@@ -265,6 +265,20 @@ internal class VocabService
             runs.Add((runText, lp));
         }
 
+        int firstNonEmpty = runs.FindIndex(r => r.Item1.Length > 0);
+        if (firstNonEmpty >= 0 && runs[firstNonEmpty].Item1.StartsWith('"'))
+        {
+            var run = runs[firstNonEmpty];
+            runs[firstNonEmpty] = (run.Item1[1..], run.Item2);
+        }
+
+        int lastNonEmpty = runs.FindLastIndex(r => r.Item1.Length > 0);
+        if (lastNonEmpty >= 0 && runs[lastNonEmpty].Item1.EndsWith('"'))
+        {
+            var run = runs[lastNonEmpty];
+            runs[lastNonEmpty] = (run.Item1[..^1], run.Item2);
+        }
+
         return runs;
     }
 
@@ -320,6 +334,15 @@ internal class VocabService
         }
 
         return dict;
+    }
+
+    private static string TrimVibeVoiceBoundaryQuotes(string text)
+    {
+        if (text.StartsWith('"'))
+            text = text[1..];
+        if (text.EndsWith('"'))
+            text = text[..^1];
+        return text;
     }
 
     // ── Confidence highlight ──────────────────────────────────────────────────

--- a/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
@@ -69,13 +69,21 @@ internal partial class HomeViewModel : ObservableObject
     private void UpdateStatusText()
     {
         if (ModelsReady)
+        {
             ModelStatusText = Loc.Instance.T("model_status_ok", new() { ["count"] = _modelMgr.GetPresentFiles().Count.ToString() });
-        else if (ModelsWarning)
-            ModelStatusText = _settings.Current.AsrBackend == AsrBackend.Cohere
-                ? $"Cohere Transcribe weights are missing. Place them in {_settings.GetCohereModelsDir()}."
-                : _settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen
-                ? "DiariZen external weights are missing. Open Settings to review the notice and import or download them."
-                : Loc.Instance["settings_model_warning"];
+            return;
+        }
+        if (!ModelsWarning) return;
+
+        if (_settings.Current.AsrBackend == AsrBackend.Cohere)
+            ModelStatusText = $"Cohere Transcribe weights are missing. Place them in {_settings.GetCohereModelsDir()}.";
+        else if (_settings.Current.AsrBackend == AsrBackend.VibeVoice ||
+                 _settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.VibeVoiceBuiltin)
+            ModelStatusText = $"VibeVoice-ASR weights are missing. Place them in {_settings.GetVibeVoiceModelsDir()}.";
+        else if (_settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen)
+            ModelStatusText = "DiariZen external weights are missing. Open Settings to review the notice and import or download them.";
+        else
+            ModelStatusText = Loc.Instance["settings_model_warning"];
     }
 
       public async Task InitializeAsync()

--- a/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
@@ -79,7 +79,7 @@ internal partial class HomeViewModel : ObservableObject
             ModelStatusText = $"Cohere Transcribe weights are missing. Place them in {_settings.GetCohereModelsDir()}.";
         else if (_settings.Current.AsrBackend == AsrBackend.VibeVoice ||
                  _settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.VibeVoiceBuiltin)
-            ModelStatusText = $"VibeVoice-ASR weights are missing. Place them in {_settings.GetVibeVoiceModelsDir()}.";
+            ModelStatusText = $"VibeVoice-ASR weights are missing. Use Download Missing Models, or place them in {_settings.GetVibeVoiceModelsDir()}.";
         else if (_settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen)
             ModelStatusText = "DiariZen external weights are missing. Open Settings to review the notice and import or download them.";
         else

--- a/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
@@ -13,6 +13,8 @@ internal enum AppPanel { Home, Progress, Results }
 
 internal partial class MainViewModel : ObservableObject
 {
+    private static readonly TimeSpan RunningJobClockInterval = TimeSpan.FromSeconds(1);
+
     [ObservableProperty]
     private AppPanel _currentPanel = AppPanel.Home;
 
@@ -37,6 +39,7 @@ internal partial class MainViewModel : ObservableObject
 
     private readonly JobQueueService _queue;
     private Window? _mainWindow;
+    private DispatcherTimer? _runningJobsClockTimer;
 
     public bool IsAnyJobRunning => _queue.IsAnyJobRunning || Progress.IsRunning;
 
@@ -279,6 +282,9 @@ internal partial class MainViewModel : ObservableObject
                     job.IsIndeterminate = true; // running but no progress event yet
             }
         }
+
+        RefreshRunningJobClocks();
+        UpdateRunningJobClockTimer();
     }
 
     private void ApplyJobStatus(int jobId, JobStatus status, string? error = null,
@@ -295,6 +301,8 @@ internal partial class MainViewModel : ObservableObject
 
         if (status == JobStatus.Running)
         {
+            job.TranscriptionRunStartedAt ??= DateTime.Now;
+            job.RunTimeSeconds = Math.Max(0, (int)(DateTime.Now - job.TranscriptionRunStartedAt.Value).TotalSeconds);
             job.IsIndeterminate = true; // refined when first progress event fires
         }
         else if (status is JobStatus.Complete or JobStatus.Failed or JobStatus.Cancelled)
@@ -303,6 +311,8 @@ internal partial class MainViewModel : ObservableObject
             job.PhaseLabel      = "";
             job.IsIndeterminate = false;
         }
+
+        UpdateRunningJobClockTimer();
     }
 
     private void ApplyJobProgress(int jobId, double percent)
@@ -326,5 +336,42 @@ internal partial class MainViewModel : ObservableObject
             _                               => ""
         };
         job.IsIndeterminate = progress.TotalSteps == 0 || progress.Phase == TranscriptionPhase.LoadingAudio;
+    }
+
+    private void UpdateRunningJobClockTimer()
+    {
+        bool hasRunningJobs = Home.Jobs.Any(j => j.Status == JobStatus.Running);
+        if (!hasRunningJobs)
+        {
+            _runningJobsClockTimer?.Stop();
+            return;
+        }
+
+        _runningJobsClockTimer ??= new DispatcherTimer { Interval = RunningJobClockInterval };
+        _runningJobsClockTimer.Tick -= OnRunningJobClockTick;
+        _runningJobsClockTimer.Tick += OnRunningJobClockTick;
+
+        if (!_runningJobsClockTimer.IsEnabled)
+            _runningJobsClockTimer.Start();
+    }
+
+    private void OnRunningJobClockTick(object? sender, EventArgs e)
+    {
+        RefreshRunningJobClocks();
+        if (!Home.Jobs.Any(j => j.Status == JobStatus.Running))
+            _runningJobsClockTimer?.Stop();
+    }
+
+    private void RefreshRunningJobClocks()
+    {
+        DateTime now = DateTime.Now;
+        foreach (var job in Home.Jobs)
+        {
+            if (job.Status != JobStatus.Running)
+                continue;
+
+            DateTime startedAt = job.TranscriptionRunStartedAt ?? now;
+            job.RunTimeSeconds = Math.Max(0, (int)(now - startedAt).TotalSeconds);
+        }
     }
 }

--- a/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
@@ -37,6 +37,7 @@ internal partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(CurrentPanelViewModel));
     }
 
+    private readonly ControlDb _controlDb;
     private readonly JobQueueService _queue;
     private Window? _mainWindow;
     private DispatcherTimer? _runningJobsClockTimer;
@@ -59,6 +60,7 @@ internal partial class MainViewModel : ObservableObject
         JobQueueService      queue,
         ExportService        export)
     {
+        _controlDb = controlDb;
         _queue   = queue;
         Settings = new SettingsViewModel(settings, modelManager);
         Home     = new HomeViewModel(modelManager, controlDb, settings);
@@ -301,7 +303,7 @@ internal partial class MainViewModel : ObservableObject
 
         if (status == JobStatus.Running)
         {
-            job.TranscriptionRunStartedAt ??= DateTime.Now;
+            job.TranscriptionRunStartedAt ??= _controlDb.GetJobRunStartedAt(jobId) ?? DateTime.Now;
             job.RunTimeSeconds = Math.Max(0, (int)(DateTime.Now - job.TranscriptionRunStartedAt.Value).TotalSeconds);
             job.IsIndeterminate = true; // refined when first progress event fires
         }

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -30,7 +30,7 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -66,6 +66,11 @@ internal partial class SettingsViewModel : ObservableObject
     public bool IsAsrParakeet       => SelectedAsrBackend == AsrBackend.Parakeet;
     public bool IsAsrCohere         => SelectedAsrBackend == AsrBackend.Cohere;
     public bool IsAsrVibeVoice      => SelectedAsrBackend == AsrBackend.VibeVoice;
+    public bool CanUseVibeVoiceAsr  => CudaEpWorking;
+    public string VibeVoiceAsrLabel => CanUseVibeVoiceAsr ? "VibeVoice-ASR" : "VibeVoice-ASR (Unavailable - CUDA Missing)";
+    public string VibeVoiceAsrDescription => CanUseVibeVoiceAsr
+        ? "Whole-recording ASR with built-in diarization. Requires local weights in the vibevoice_asr models folder."
+        : "Unavailable because the CUDA execution provider check did not pass.";
     public bool ShowCohereLanguagePicker => SelectedAsrBackend == AsrBackend.Cohere;
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
@@ -218,6 +223,12 @@ internal partial class SettingsViewModel : ObservableObject
 
     partial void OnSelectedAsrBackendChanged(AsrBackend value)
     {
+        if (value == AsrBackend.VibeVoice && !CanUseVibeVoiceAsr)
+        {
+            SelectedAsrBackend = AsrBackend.Parakeet;
+            return;
+        }
+
         if (value == AsrBackend.VibeVoice && SelectedSegmentation != SegmentationMode.VibeVoiceBuiltin)
             _lastNonVibeSegmentation = NormalizeSegmentationForBackend(SelectedSegmentation, AsrBackend.Parakeet);
 
@@ -315,6 +326,12 @@ internal partial class SettingsViewModel : ObservableObject
             (cudaOk, _)          = _modelMgr.CheckCuda();
         });
         CudaEpWorking = cudaOk;
+        OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
+        OnPropertyChanged(nameof(VibeVoiceAsrLabel));
+        OnPropertyChanged(nameof(VibeVoiceAsrDescription));
+
+        if (!CudaEpWorking && SelectedAsrBackend == AsrBackend.VibeVoice)
+            SelectedAsrBackend = AsrBackend.Parakeet;
 
         // Batch ceiling — query free VRAM (accurate post-load figure)
         var (_, freeMb) = HardwareInfo.GetGpuMemoryMb();

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -25,11 +25,11 @@ internal partial class SettingsViewModel : ObservableObject
     private AppTheme _selectedTheme;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsSileroVad), nameof(IsSortformer), nameof(IsDiariZen))]
+    [NotifyPropertyChangedFor(nameof(IsSileroVad), nameof(IsSortformer), nameof(IsDiariZen), nameof(IsVibeVoiceBuiltin))]
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrVibeVoice))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -61,8 +61,10 @@ internal partial class SettingsViewModel : ObservableObject
     public bool IsSileroVad         => SelectedSegmentation == SegmentationMode.SileroVad;
     public bool IsSortformer        => SelectedSegmentation == SegmentationMode.Sortformer;
     public bool IsDiariZen          => SelectedSegmentation == SegmentationMode.DiariZen;
+    public bool IsVibeVoiceBuiltin  => SelectedSegmentation == SegmentationMode.VibeVoiceBuiltin;
     public bool IsAsrParakeet       => SelectedAsrBackend == AsrBackend.Parakeet;
     public bool IsAsrCohere         => SelectedAsrBackend == AsrBackend.Cohere;
+    public bool IsAsrVibeVoice      => SelectedAsrBackend == AsrBackend.VibeVoice;
     public bool ShowCohereLanguagePicker => SelectedAsrBackend == AsrBackend.Cohere;
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
@@ -352,6 +354,13 @@ internal partial class SettingsViewModel : ObservableObject
         {
             ModelStatusText = $"Missing {_lastMissing.Count} required model file(s): {string.Join(", ", _lastMissing)}. " +
                               $"Place Cohere weights under {_svc.GetCohereModelsDir()}.";
+            return;
+        }
+
+        if (SelectedAsrBackend == AsrBackend.VibeVoice)
+        {
+            ModelStatusText = $"Missing {_lastMissing.Count} required model file(s): {string.Join(", ", _lastMissing)}. " +
+                              $"Place VibeVoice-ASR weights under {_svc.GetVibeVoiceModelsDir()}.";
             return;
         }
 

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -69,7 +69,7 @@ internal partial class SettingsViewModel : ObservableObject
     public bool CanUseVibeVoiceAsr  => CudaEpWorking;
     public string VibeVoiceAsrLabel => CanUseVibeVoiceAsr ? "VibeVoice-ASR" : "VibeVoice-ASR (Unavailable - CUDA Missing)";
     public string VibeVoiceAsrDescription => CanUseVibeVoiceAsr
-        ? "Whole-recording ASR with built-in diarization. Requires local weights in the vibevoice_asr models folder."
+        ? "Whole-recording ASR with built-in diarization. Downloads into the vibevoice_asr models folder."
         : "Unavailable because the CUDA execution provider check did not pass.";
     public bool ShowCohereLanguagePicker => SelectedAsrBackend == AsrBackend.Cohere;
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
@@ -408,7 +408,7 @@ internal partial class SettingsViewModel : ObservableObject
         if (SelectedAsrBackend == AsrBackend.VibeVoice)
         {
             ModelStatusText = $"Missing {_lastMissing.Count} required model file(s): {string.Join(", ", _lastMissing)}. " +
-                              $"Place VibeVoice-ASR weights under {_svc.GetVibeVoiceModelsDir()}.";
+                              $"Use Download Missing Models, or place VibeVoice-ASR weights under {_svc.GetVibeVoiceModelsDir()}.";
             return;
         }
 

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -26,10 +26,11 @@ internal partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsSileroVad), nameof(IsSortformer), nameof(IsDiariZen), nameof(IsVibeVoiceBuiltin))]
+    [NotifyPropertyChangedFor(nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint))]
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrVibeVoice))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -68,7 +69,10 @@ internal partial class SettingsViewModel : ObservableObject
     public bool ShowCohereLanguagePicker => SelectedAsrBackend == AsrBackend.Cohere;
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
-    public bool ShowDiariZenInSegmentation => HasAcceptedDiariZenNotice;
+    public bool ShowStandardSegmentationOptions => SelectedAsrBackend != AsrBackend.VibeVoice;
+    public bool ShowVibeVoiceBuiltinSegmentation => SelectedAsrBackend == AsrBackend.VibeVoice;
+    public bool ShowDiariZenInSegmentation => HasAcceptedDiariZenNotice && ShowStandardSegmentationOptions;
+    public bool ShowGatedSegmentationHint => !HasAcceptedDiariZenNotice && ShowStandardSegmentationOptions;
     public bool IsEditorSingle      => SelectedEditorPlaybackMode == PlaybackMode.Single;
     public bool IsEditorAutoAdvance => SelectedEditorPlaybackMode == PlaybackMode.AutoAdvance;
     public bool IsEditorContinuous  => SelectedEditorPlaybackMode == PlaybackMode.Continuous;
@@ -137,6 +141,7 @@ internal partial class SettingsViewModel : ObservableObject
     private bool                      _modelCheckDone = false;
     private double                    _batchSecs      = 0;
     private bool                      _batchIsFallback = true;
+    private SegmentationMode          _lastNonVibeSegmentation = SegmentationMode.Sortformer;
 
     // ── Construction ─────────────────────────────────────────────────────────
 
@@ -145,10 +150,14 @@ internal partial class SettingsViewModel : ObservableObject
         _svc                   = svc;
         _modelMgr              = modelMgr;
         _selectedTheme                = svc.Current.Theme;
-        _selectedSegmentation         = svc.Current.Segmentation == SegmentationMode.DiariZen && !svc.IsGatedModelAccepted(DiariZenGatedModelId)
-            ? SegmentationMode.Sortformer
-            : svc.Current.Segmentation;
         _selectedAsrBackend           = svc.Current.AsrBackend;
+        _selectedSegmentation         = NormalizeSegmentationForBackend(
+            svc.Current.Segmentation == SegmentationMode.DiariZen && !svc.IsGatedModelAccepted(DiariZenGatedModelId)
+                ? SegmentationMode.Sortformer
+                : svc.Current.Segmentation,
+            _selectedAsrBackend);
+        if (_selectedSegmentation != SegmentationMode.VibeVoiceBuiltin)
+            _lastNonVibeSegmentation = _selectedSegmentation;
         _selectedCohereLanguage       = CohereLanguages.FirstOrDefault(l => l.Code == svc.Current.CohereLanguage)
                                         ?? CohereLanguages[0];
         _selectedDenoiser             = svc.Current.Denoiser;
@@ -189,8 +198,18 @@ internal partial class SettingsViewModel : ObservableObject
 
     partial void OnSelectedSegmentationChanged(SegmentationMode value)
     {
+        SegmentationMode normalized = NormalizeSegmentationForBackend(value, SelectedAsrBackend);
+        if (normalized != value)
+        {
+            SelectedSegmentation = normalized;
+            return;
+        }
+
         if (value == SegmentationMode.DiariZen && !HasAcceptedDiariZenNotice)
             return;
+
+        if (value != SegmentationMode.VibeVoiceBuiltin)
+            _lastNonVibeSegmentation = value;
 
         _svc.Current.Segmentation = value;
         _svc.Save();
@@ -199,7 +218,19 @@ internal partial class SettingsViewModel : ObservableObject
 
     partial void OnSelectedAsrBackendChanged(AsrBackend value)
     {
+        if (value == AsrBackend.VibeVoice && SelectedSegmentation != SegmentationMode.VibeVoiceBuiltin)
+            _lastNonVibeSegmentation = NormalizeSegmentationForBackend(SelectedSegmentation, AsrBackend.Parakeet);
+
         _svc.Current.AsrBackend = value;
+        SegmentationMode normalized = NormalizeSegmentationForBackend(SelectedSegmentation, value);
+        if (normalized != SelectedSegmentation)
+            SelectedSegmentation = normalized;
+        else
+        {
+            _svc.Current.Segmentation = normalized;
+            _svc.Save();
+        }
+
         _svc.Save();
         OnPropertyChanged(nameof(ShowCohereLanguagePicker));
         OnSegmentationChanged?.Invoke();
@@ -428,8 +459,30 @@ internal partial class SettingsViewModel : ObservableObject
 
         OnPropertyChanged(nameof(HasAcceptedDiariZenNotice));
         OnPropertyChanged(nameof(ShowDiariZenInSegmentation));
+        OnPropertyChanged(nameof(ShowGatedSegmentationHint));
         OnPropertyChanged(nameof(HasUnlockedGatedModels));
         OnPropertyChanged(nameof(GatedModelsStatusText));
+    }
+
+    private SegmentationMode NormalizeSegmentationForBackend(SegmentationMode requested, AsrBackend backend)
+    {
+        if (backend == AsrBackend.VibeVoice)
+            return SegmentationMode.VibeVoiceBuiltin;
+
+        if (requested == SegmentationMode.VibeVoiceBuiltin)
+            return NormalizeStandardSegmentation(_lastNonVibeSegmentation);
+
+        return NormalizeStandardSegmentation(requested);
+    }
+
+    private SegmentationMode NormalizeStandardSegmentation(SegmentationMode requested)
+    {
+        if (requested == SegmentationMode.DiariZen && !HasAcceptedDiariZenNotice)
+            return SegmentationMode.Sortformer;
+
+        return requested == SegmentationMode.VibeVoiceBuiltin
+            ? SegmentationMode.Sortformer
+            : requested;
     }
 
     internal async Task SetDiariZenModelsDirAsync(string path)

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -901,7 +901,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             Loc.Instance["editor_unsuppress"],
             canMergePrev: !redoAsrRunning && card.Index > 0,
             canMergeNext: !redoAsrRunning && card.Index < totalCardCount - 1,
-            canSplit: !redoAsrRunning && seg.Tokens.Count > 1,
+            canSplit: !redoAsrRunning && hasVocab && seg.Tokens.Count > 1,
             canRedoAsr: !redoAsrRunning && asrModelsAvailable && HasAudio,
             canAdjustTimes: !redoAsrRunning);
     }
@@ -1089,7 +1089,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             if (string.IsNullOrWhiteSpace(vibeVoiceModelsDir))
                 return null;
 
-            using var vibe = new VibeVoiceAsr(vibeVoiceModelsDir, persistEncoder: false);
+            using var vibe = new VibeVoiceAsr(vibeVoiceModelsDir, persistEncoder: false, allowStaticKvCache: false);
             var vibeSegs = vibe.Transcribe(mono16k, Config.SampleRate, 1);
             text = string.Join(" ", vibeSegs.Select(s => s.Content));
             tokens         = vibeSegs.SelectMany(s => s.TokenIds).ToList();

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -901,7 +901,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             Loc.Instance["editor_unsuppress"],
             canMergePrev: !redoAsrRunning && card.Index > 0,
             canMergeNext: !redoAsrRunning && card.Index < totalCardCount - 1,
-            canSplit: !redoAsrRunning && hasVocab && seg.Tokens.Count > 1,
+            canSplit: !redoAsrRunning && seg.Tokens.Count > 1,
             canRedoAsr: !redoAsrRunning && asrModelsAvailable && HasAudio,
             canAdjustTimes: !redoAsrRunning);
     }
@@ -1025,7 +1025,8 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             string encoderFile,
             string decoderJointFile,
             string? cohereModelsDir = null,
-            string? cohereLanguageCode = null)
+            string? cohereLanguageCode = null,
+            string? vibeVoiceModelsDir = null)
     {
         if (index < 0 || index >= Segments.Count || _dbPath is null || _fullAudio is null)
             return null;
@@ -1082,6 +1083,21 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
                     syntheticTimestamps: true,
                     timestampMode: CohereSyntheticTimestampMode);
             }
+        }
+        else if (string.Equals(asrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal))
+        {
+            if (string.IsNullOrWhiteSpace(vibeVoiceModelsDir))
+                return null;
+
+            using var vibe = new VibeVoiceAsr(vibeVoiceModelsDir, persistEncoder: false);
+            var vibeSegs = vibe.Transcribe(mono16k, Config.SampleRate, 1);
+            text = string.Join(" ", vibeSegs.Select(s => s.Content));
+            // Word-level synthetic tokens — same scheme used during initial transcription
+            string[] words    = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            int wordCount     = Math.Max(1, words.Length);
+            tokens            = Enumerable.Range(0, wordCount).ToList();
+            timestamps        = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, wordCount);
+            // logprobs stays [] — VibeVoice does not expose per-token confidences
         }
         else
         {

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1092,12 +1092,12 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             using var vibe = new VibeVoiceAsr(vibeVoiceModelsDir, persistEncoder: false);
             var vibeSegs = vibe.Transcribe(mono16k, Config.SampleRate, 1);
             text = string.Join(" ", vibeSegs.Select(s => s.Content));
-            // Word-level synthetic tokens — same scheme used during initial transcription
-            string[] words    = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            int wordCount     = Math.Max(1, words.Length);
-            tokens            = Enumerable.Range(0, wordCount).ToList();
-            timestamps        = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, wordCount);
-            // logprobs stays [] — VibeVoice does not expose per-token confidences
+            tokens         = vibeSegs.SelectMany(s => s.TokenIds).ToList();
+            logprobs       = vibeSegs.SelectMany(s => s.TokenLogprobs).ToList();
+            int tokenCount = Math.Max(1, Math.Max(tokens.Count, logprobs.Count));
+            if (tokens.Count == 0)
+                tokens = Enumerable.Range(0, tokenCount).ToList();
+            timestamps = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, tokenCount);
         }
         else
         {

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -941,7 +941,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             return;
         }
 
-        var runs = vocab.GetTokenRuns(seg.Tokens, seg.Logprobs)
+        var runs = vocab.GetTokenRuns(seg.Tokens, seg.Logprobs, seg.Content)
             .Select(r => (
                 r.text,
                 VocabService.GetConfidenceHighlight(r.logprob, confidenceLowColor)))
@@ -999,7 +999,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             return;
         }
 
-        var runs = vocab.GetTokenRuns(card.Segment.Tokens, card.Segment.Logprobs)
+        var runs = vocab.GetTokenRuns(card.Segment.Tokens, card.Segment.Logprobs, card.Segment.Content)
             .Select(r => (
                 r.text,
                 VocabService.GetConfidenceHighlight(r.logprob, confidenceLowColor)))
@@ -1094,9 +1094,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             text = string.Join(" ", vibeSegs.Select(s => s.Content));
             tokens         = vibeSegs.SelectMany(s => s.TokenIds).ToList();
             logprobs       = vibeSegs.SelectMany(s => s.TokenLogprobs).ToList();
-            int tokenCount = Math.Max(1, Math.Max(tokens.Count, logprobs.Count));
-            if (tokens.Count == 0)
-                tokens = Enumerable.Range(0, tokenCount).ToList();
+            int tokenCount = Math.Max(tokens.Count, logprobs.Count);
             timestamps = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, tokenCount);
         }
         else
@@ -1214,8 +1212,11 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         string firstAsr, secondAsr, firstCon, secondCon;
         if (vocab != null && firstTokens.Count > 0 && secondTokens.Count > 0)
         {
-            firstAsr  = vocab.DecodeTokens(firstTokens);
-            secondAsr = vocab.DecodeTokens(secondTokens);
+            var allRunTexts = vocab.GetTokenRuns(seg.Tokens, seg.Logprobs, seg.AsrContent)
+                .Select(r => r.text)
+                .ToList();
+            firstAsr  = string.Concat(allRunTexts.Take(splitIndex)).Trim();
+            secondAsr = string.Concat(allRunTexts.Skip(splitIndex)).Trim();
             firstCon  = firstAsr;
             secondCon = secondAsr;
         }

--- a/src/Vernacula.Avalonia/Views/HomeView.axaml
+++ b/src/Vernacula.Avalonia/Views/HomeView.axaml
@@ -183,11 +183,13 @@
                                         <Border Background="{Binding StatusBrush}"
                                                 BorderBrush="{Binding StatusBrush}"
                                                 BorderThickness="1"
-                                                HorizontalAlignment="Left"
+                                                HorizontalAlignment="Center"
                                                 VerticalAlignment="Center"
                                                 Padding="6,1"
                                                 MinHeight="0"
-                                                CornerRadius="999">
+                                                CornerRadius="999"
+                                                Cursor="Hand"
+                                                PointerPressed="StatusChip_PointerPressed">
                                             <TextBlock Text="{Binding StatusLabel}"
                                                        Foreground="{DynamicResource BgBrush}"
                                                        FontWeight="SemiBold"

--- a/src/Vernacula.Avalonia/Views/HomeView.axaml
+++ b/src/Vernacula.Avalonia/Views/HomeView.axaml
@@ -194,7 +194,7 @@
                                                        Foreground="{DynamicResource BgBrush}"
                                                        FontWeight="SemiBold"
                                                        FontSize="11"
-                                                       LineHeight="13"
+                                                       LineHeight="16"
                                                        VerticalAlignment="Center" />
                                         </Border>
                                     </DataTemplate>

--- a/src/Vernacula.Avalonia/Views/HomeView.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/HomeView.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.VisualTree;
 using System.ComponentModel;
+using Vernacula.App.Models;
 
 namespace Vernacula.App.Views;
 
@@ -64,5 +65,17 @@ public partial class HomeView : UserControl
         JobsGrid.SelectedItem = null;
         JobsGrid.SelectedIndex = -1;
         Focus();
+    }
+
+    private async void StatusChip_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is not Control el) return;
+        if (el.DataContext is not JobRecord { Status: JobStatus.Failed, ErrorMessage: { } error }) return;
+
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is not null)
+            await clipboard.SetTextAsync(error);
+
+        e.Handled = true;
     }
 }

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -84,6 +84,12 @@
             <Setter Property="Background" Value="{DynamicResource OverlayBrush}" />
         </Style>
 
+        <Style Selector="RadioButton:disabled">
+            <Setter Property="Foreground" Value="{DynamicResource SubtextBrush}" />
+            <Setter Property="Background" Value="{DynamicResource SurfaceBrush}" />
+            <Setter Property="Opacity" Value="0.68" />
+        </Style>
+
         <Style Selector="RadioButton /template/ ContentPresenter">
             <Setter Property="TextElement.Foreground" Value="{DynamicResource TextBrush}" />
         </Style>
@@ -94,6 +100,10 @@
 
         <Style Selector="RadioButton:pressed /template/ ContentPresenter">
             <Setter Property="TextElement.Foreground" Value="{DynamicResource TextBrush}" />
+        </Style>
+
+        <Style Selector="RadioButton:disabled /template/ ContentPresenter">
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource SubtextBrush}" />
         </Style>
 
         <Style Selector="RadioButton:not(:checked) /template/ Ellipse#OuterRing">
@@ -108,12 +118,25 @@
             <Setter Property="IsVisible" Value="True" />
         </Style>
 
+        <Style Selector="RadioButton:disabled /template/ Ellipse#OuterRing">
+            <Setter Property="Stroke" Value="{DynamicResource SecondaryBrush}" />
+        </Style>
+
+        <Style Selector="RadioButton:disabled /template/ Ellipse#InnerDot">
+            <Setter Property="Fill" Value="{DynamicResource SecondaryBrush}" />
+        </Style>
+
         <Style Selector="RadioButton:not(:checked):pointerover /template/ Ellipse#OuterRing">
             <Setter Property="Stroke" Value="{DynamicResource TextBrush}" />
         </Style>
 
         <Style Selector="RadioButton:checked:pointerover /template/ Ellipse#OuterRing">
             <Setter Property="Stroke" Value="{DynamicResource AccentBrush}" />
+        </Style>
+
+        <Style Selector="RadioButton:disabled TextBlock">
+            <Setter Property="Foreground" Value="{DynamicResource SubtextBrush}" />
+            <Setter Property="Opacity" Value="0.9" />
         </Style>
 
         <Style Selector="Button.link-button">

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -434,12 +434,13 @@
                                      IsChecked="{Binding IsAsrVibeVoice, Mode=OneWay}"
                                      Command="{Binding SetAsrBackendCommand}"
                                      CommandParameter="VibeVoice"
-                                     Foreground="{DynamicResource TextBrush}">
+                                     Foreground="{DynamicResource TextBrush}"
+                                     IsEnabled="{Binding CanUseVibeVoiceAsr}">
                             <StackPanel>
-                                <TextBlock Text="VibeVoice-ASR"
+                                <TextBlock Text="{Binding VibeVoiceAsrLabel}"
                                            FontWeight="SemiBold"
                                            Foreground="{DynamicResource TextBrush}" />
-                                <TextBlock Text="Whole-recording ASR with built-in diarization. Requires local weights in the vibevoice_asr models folder."
+                                <TextBlock Text="{Binding VibeVoiceAsrDescription}"
                                            Foreground="{DynamicResource SubtextBrush}"
                                            FontSize="11"
                                            TextWrapping="Wrap" />

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -490,7 +490,9 @@
                                      Command="{Binding SetSegmentationCommand}"
                                      CommandParameter="SileroVad"
                                      Foreground="{DynamicResource TextBrush}"
-                                     Margin="0,0,0,4">
+                                     Margin="0,0,0,4"
+                                     IsVisible="{Binding ShowStandardSegmentationOptions,
+                                                         Converter={StaticResource BoolToVis}}">
                             <StackPanel>
                                 <TextBlock x:Name="SegmentationSileroLabel"
                                            Text="{Binding Source={x:Static local:Loc.Instance}, Path=[settings_segmentation_vad]}"
@@ -504,7 +506,9 @@
                             </StackPanel>
                         </RadioButton>
 
-                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8"
+                                   IsVisible="{Binding ShowStandardSegmentationOptions,
+                                                       Converter={StaticResource BoolToVis}}" />
 
                         <!-- Sortformer option -->
                         <RadioButton GroupName="Segmentation"
@@ -512,7 +516,9 @@
                                      Command="{Binding SetSegmentationCommand}"
                                      CommandParameter="Sortformer"
                                      Foreground="{DynamicResource TextBrush}"
-                                     Margin="0,0,0,4">
+                                     Margin="0,0,0,4"
+                                     IsVisible="{Binding ShowStandardSegmentationOptions,
+                                                         Converter={StaticResource BoolToVis}}">
                             <StackPanel>
                                 <TextBlock x:Name="SegmentationSortformerLabel"
                                            Text="{Binding Source={x:Static local:Loc.Instance}, Path=[settings_segmentation_diarization]}"
@@ -526,7 +532,9 @@
                             </StackPanel>
                         </RadioButton>
 
-                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8"
+                                   IsVisible="{Binding ShowStandardSegmentationOptions,
+                                                       Converter={StaticResource BoolToVis}}" />
 
                         <TextBlock x:Name="GatedSegmentationHintText"
                                    Text="Additional gated segmentation models can be enabled from Models."
@@ -534,8 +542,8 @@
                                    FontSize="11"
                                    TextWrapping="Wrap"
                                    Margin="0,0,0,8"
-                                   IsVisible="{Binding ShowDiariZenInSegmentation,
-                                                       Converter={StaticResource InvBoolToVis}}" />
+                                   IsVisible="{Binding ShowGatedSegmentationHint,
+                                                       Converter={StaticResource BoolToVis}}" />
 
                         <!-- DiariZen option -->
                         <RadioButton GroupName="Segmentation"
@@ -558,14 +566,18 @@
                             </StackPanel>
                         </RadioButton>
 
-                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8"
+                                   IsVisible="{Binding ShowStandardSegmentationOptions,
+                                                       Converter={StaticResource BoolToVis}}" />
 
                         <!-- VibeVoice built-in diarization + ASR option -->
                         <RadioButton GroupName="Segmentation"
                                      IsChecked="{Binding IsVibeVoiceBuiltin, Mode=OneWay}"
                                      Command="{Binding SetSegmentationCommand}"
                                      CommandParameter="VibeVoiceBuiltin"
-                                     Foreground="{DynamicResource TextBrush}">
+                                     Foreground="{DynamicResource TextBrush}"
+                                     IsVisible="{Binding ShowVibeVoiceBuiltinSegmentation,
+                                                         Converter={StaticResource BoolToVis}}">
                             <StackPanel>
                                 <TextBlock Text="VibeVoice-ASR (built-in)"
                                            FontWeight="SemiBold"

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -428,6 +428,24 @@
                             </StackPanel>
                         </RadioButton>
 
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+
+                        <RadioButton GroupName="AsrBackend"
+                                     IsChecked="{Binding IsAsrVibeVoice, Mode=OneWay}"
+                                     Command="{Binding SetAsrBackendCommand}"
+                                     CommandParameter="VibeVoice"
+                                     Foreground="{DynamicResource TextBrush}">
+                            <StackPanel>
+                                <TextBlock Text="VibeVoice-ASR"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextBrush}" />
+                                <TextBlock Text="Whole-recording ASR with built-in diarization. Requires local weights in the vibevoice_asr models folder."
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </RadioButton>
+
                         <StackPanel Margin="24,10,0,0"
                                     IsVisible="{Binding ShowCohereLanguagePicker}">
                             <TextBlock Text="Forced Language"
@@ -534,6 +552,25 @@
                                            Foreground="{DynamicResource TextBrush}" />
                                 <TextBlock x:Name="SegmentationDiariZenDescription"
                                            Text="{Binding Source={x:Static local:Loc.Instance}, Path=[settings_segmentation_diarizen_desc]}"
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+
+                        <!-- VibeVoice built-in diarization + ASR option -->
+                        <RadioButton GroupName="Segmentation"
+                                     IsChecked="{Binding IsVibeVoiceBuiltin, Mode=OneWay}"
+                                     Command="{Binding SetSegmentationCommand}"
+                                     CommandParameter="VibeVoiceBuiltin"
+                                     Foreground="{DynamicResource TextBrush}">
+                            <StackPanel>
+                                <TextBlock Text="VibeVoice-ASR (built-in)"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextBrush}" />
+                                <TextBlock Text="Whole-recording model with built-in diarization and ASR. Overrides the ASR backend selection. Requires weights in the vibevoice_asr models folder."
                                            Foreground="{DynamicResource SubtextBrush}"
                                            FontSize="11"
                                            TextWrapping="Wrap" />

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -49,6 +49,7 @@ public partial class TranscriptEditorWindow : Window
     private readonly string _jobAsrLanguageCode = "auto";
     private readonly bool _asrModelsAvailable;
     private readonly bool _showApproximateTimingNotice;
+    private readonly string _approximateTimingNoticeText = "";
     private bool _isUpdatingUi;
     private bool _isLoading;
     private bool _suppressSegmentCollectionChanged;
@@ -95,13 +96,14 @@ public partial class TranscriptEditorWindow : Window
         _jobAsrLanguageCode = string.IsNullOrWhiteSpace(asrLanguageCode)
             ? "auto"
             : asrLanguageCode;
-        _showApproximateTimingNotice = string.Equals(
-            _jobAsrModel,
-            "CohereLabs/cohere-transcribe-03-2026",
-            StringComparison.Ordinal);
-
         bool isCohere    = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
         bool isVibeVoice = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+        _showApproximateTimingNotice = isCohere || isVibeVoice;
+        _approximateTimingNoticeText = isCohere
+            ? "Cohere Transcribe: no word-level timing; token sync is approximate."
+            : isVibeVoice
+                ? "VibeVoice-ASR: no token-level timing; token sync is approximate."
+                : "";
 
         string? vocabPath = isCohere
             ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)
@@ -535,7 +537,7 @@ public partial class TranscriptEditorWindow : Window
     {
         _state.SetHeader(_audioBaseName, $"{_vm.Segments.Count} {Loc.Instance["results_segments_label"]}");
         _state.SetHeaderNotice(
-            "Cohere Transcribe: no word-level timing; token sync is approximate.",
+            _approximateTimingNoticeText,
             _showApproximateTimingNotice);
     }
 

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -134,8 +134,7 @@ public partial class TranscriptEditorWindow : Window
             string vibeVoiceDir = App.Current.Settings.GetVibeVoiceModelsDir();
             _asrModelsAvailable =
                 File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.AudioEncoderFile)) &&
-                (File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.DecoderSingleStaticFile)) ||
-                 File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.DecoderSingleFile)));
+                File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.DecoderSingleFile));
         }
         else
         {

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -1203,7 +1203,7 @@ public partial class TranscriptEditorWindow : Window
 
         IReadOnlyList<string> tokenTexts;
         tokenTexts = _vocab != null
-            ? _vocab.GetTokenRuns(seg.Tokens, seg.Logprobs).Select(r => r.text).ToList()
+            ? _vocab.GetTokenRuns(seg.Tokens, seg.Logprobs, seg.Content).Select(r => r.text).ToList()
             : seg.Tokens.Select(t => $"[{t}]").ToList();
 
         var dialog = new SplitSegmentDialog(tokenTexts);

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -100,15 +100,21 @@ public partial class TranscriptEditorWindow : Window
             "CohereLabs/cohere-transcribe-03-2026",
             StringComparison.Ordinal);
 
-        string vocabPath = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal)
+        bool isCohere    = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+        bool isVibeVoice = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+
+        // VibeVoice has its own GPT-2 BPE tokenizer — don't load Parakeet vocab for it
+        string? vocabPath = isCohere
             ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)
-            : Path.Combine(modelsDir, Config.VocabFile);
-        if (File.Exists(vocabPath))
+            : isVibeVoice
+                ? null
+                : Path.Combine(modelsDir, Config.VocabFile);
+        if (vocabPath is not null && File.Exists(vocabPath))
         {
             _vocab = new VocabService(modelsDir, _jobAsrModel);
         }
 
-        if (string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal))
+        if (isCohere)
         {
             string cohereDir = App.Current.Settings.GetCohereModelsDir();
             _asrModelsAvailable =
@@ -121,6 +127,14 @@ public partial class TranscriptEditorWindow : Window
                 File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.DecoderStepFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.VocabFile)) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.ConfigFile));
+        }
+        else if (isVibeVoice)
+        {
+            string vibeVoiceDir = App.Current.Settings.GetVibeVoiceModelsDir();
+            _asrModelsAvailable =
+                File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.AudioEncoderFile)) &&
+                (File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.DecoderSingleStaticFile)) ||
+                 File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.DecoderSingleFile)));
         }
         else
         {
@@ -1187,11 +1201,22 @@ public partial class TranscriptEditorWindow : Window
             return;
         }
 
-        IReadOnlyList<string> tokenTexts = _vocab != null
-            ? _vocab.GetTokenRuns(seg.Tokens, seg.Logprobs)
-                .Select(r => r.text)
-                .ToList()
-            : seg.Tokens.Select(t => $"[{t}]").ToList();
+        // For VibeVoice, tokens are word indices — show the actual words in the split dialog
+        IReadOnlyList<string> tokenTexts;
+        if (string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal)
+            && seg.Content.Length > 0)
+        {
+            string[] words = seg.Content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            tokenTexts = words.Length > 0
+                ? words
+                : seg.Tokens.Select(t => $"[{t}]").ToArray();
+        }
+        else
+        {
+            tokenTexts = _vocab != null
+                ? _vocab.GetTokenRuns(seg.Tokens, seg.Logprobs).Select(r => r.text).ToList()
+                : seg.Tokens.Select(t => $"[{t}]").ToList();
+        }
 
         var dialog = new SplitSegmentDialog(tokenTexts);
         await dialog.ShowDialog(this);
@@ -1254,7 +1279,8 @@ public partial class TranscriptEditorWindow : Window
                 encoderFile,
                 decoderJointFile,
                 cohereModelsDir,
-                _jobAsrLanguageCode));
+                _jobAsrLanguageCode,
+                vibeVoiceModelsDir: App.Current.Settings.GetVibeVoiceModelsDir()));
             if (result is null)
             {
                 SetCardStatus(card, "Redo ASR did not produce a result.");

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -103,11 +103,10 @@ public partial class TranscriptEditorWindow : Window
         bool isCohere    = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
         bool isVibeVoice = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
 
-        // VibeVoice has its own GPT-2 BPE tokenizer — don't load Parakeet vocab for it
         string? vocabPath = isCohere
             ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)
             : isVibeVoice
-                ? null
+                ? Path.Combine(modelsDir, Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile)
                 : Path.Combine(modelsDir, Config.VocabFile);
         if (vocabPath is not null && File.Exists(vocabPath))
         {
@@ -1201,22 +1200,10 @@ public partial class TranscriptEditorWindow : Window
             return;
         }
 
-        // For VibeVoice, tokens are word indices — show the actual words in the split dialog
         IReadOnlyList<string> tokenTexts;
-        if (string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal)
-            && seg.Content.Length > 0)
-        {
-            string[] words = seg.Content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            tokenTexts = words.Length > 0
-                ? words
-                : seg.Tokens.Select(t => $"[{t}]").ToArray();
-        }
-        else
-        {
-            tokenTexts = _vocab != null
-                ? _vocab.GetTokenRuns(seg.Tokens, seg.Logprobs).Select(r => r.text).ToList()
-                : seg.Tokens.Select(t => $"[{t}]").ToList();
-        }
+        tokenTexts = _vocab != null
+            ? _vocab.GetTokenRuns(seg.Tokens, seg.Logprobs).Select(r => r.text).ToList()
+            : seg.Tokens.Select(t => $"[{t}]").ToList();
 
         var dialog = new SplitSegmentDialog(tokenTexts);
         await dialog.ShowDialog(this);

--- a/src/Vernacula.Base/Models/CoreModels.cs
+++ b/src/Vernacula.Base/Models/CoreModels.cs
@@ -2,5 +2,5 @@ namespace Vernacula.Base.Models;
 
 public enum ExecutionProvider { Auto, Cuda, DirectML, Cpu }
 public enum ModelPrecision    { Int8, Fp32 }
-public enum SegmentationMode  { SileroVad, Sortformer, DiariZen }
+public enum SegmentationMode  { SileroVad, Sortformer, DiariZen, VibeVoiceBuiltin }
 public enum DenoiserMode      { None, DeepFilterNet3 }

--- a/src/Vernacula.Base/VadSegmenter.cs
+++ b/src/Vernacula.Base/VadSegmenter.cs
@@ -127,4 +127,59 @@ public sealed class VadSegmenter : IDisposable
 
         return segments;
     }
+
+    // ── Segment merging ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Groups VAD segments so that each group's audio span (first segment start to
+    /// last segment end) is at least <paramref name="minSpanSeconds"/>.
+    ///
+    /// Short segments are absorbed into the current group until the span meets the
+    /// minimum.  A short tail group that never reaches the minimum is merged back
+    /// into the preceding group rather than left as an isolated clip.
+    ///
+    /// Returns one (start, end) per group representing the contiguous audio window
+    /// to extract and pass to ASR.
+    /// </summary>
+    public static List<(double start, double end)> MergeShortGroups(
+        IReadOnlyList<(double start, double end)> segments,
+        double minSpanSeconds)
+    {
+        if (segments.Count == 0)
+            return [];
+
+        var groups = new List<(double start, double end)>();
+        double groupStart = segments[0].start;
+        double groupEnd   = segments[0].end;
+
+        for (int i = 1; i < segments.Count; i++)
+        {
+            if (groupEnd - groupStart >= minSpanSeconds)
+            {
+                // Current group meets minimum — commit it, start a new one.
+                groups.Add((groupStart, groupEnd));
+                groupStart = segments[i].start;
+                groupEnd   = segments[i].end;
+            }
+            else
+            {
+                // Current group is still short — absorb the next segment.
+                groupEnd = segments[i].end;
+            }
+        }
+
+        // Commit the final group.  If it is still too short and a previous group
+        // exists, absorb it there rather than passing a very short clip to ASR.
+        if (groupEnd - groupStart < minSpanSeconds && groups.Count > 0)
+        {
+            var (prevStart, _) = groups[^1];
+            groups[^1] = (prevStart, groupEnd);
+        }
+        else
+        {
+            groups.Add((groupStart, groupEnd));
+        }
+
+        return groups;
+    }
 }

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -53,9 +53,17 @@ public sealed class VibeVoiceAsr : IDisposable
     // The audio encoder is created on demand and disposed after each use so its
     // GPU arena (dual float32 Conv towers) does not compete with the decoder's
     // growing KV cache during the autoregressive decode loop.
-    private readonly string           _audioEncoderPath;
+    private readonly string            _audioEncoderPath;
     private readonly ExecutionProvider _ep;
-    private readonly InferenceSession _decoder;
+    private readonly InferenceSession  _decoder;
+
+    // ── Profiling ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Directory for ORT Chrome-trace JSON files, or null when profiling is off.
+    /// Files are named encoder_&lt;timestamp&gt;.json and decoder_&lt;timestamp&gt;.json.
+    /// </summary>
+    private readonly string? _profileOutputDir;
 
     // ── Model dimensions ──────────────────────────────────────────────────────
 
@@ -87,8 +95,13 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── Construction ──────────────────────────────────────────────────────────
 
-    public VibeVoiceAsr(string modelDir, ExecutionProvider ep = ExecutionProvider.Auto)
+    public VibeVoiceAsr(
+        string modelDir,
+        ExecutionProvider ep = ExecutionProvider.Auto,
+        string? profileOutputDir = null)
     {
+        if (profileOutputDir is not null)
+            Directory.CreateDirectory(profileOutputDir);
         // Load export report
         string reportPath = Path.Combine(modelDir, ExportReportFile);
         using var reportDoc = JsonDocument.Parse(File.ReadAllText(reportPath));
@@ -123,8 +136,10 @@ public sealed class VibeVoiceAsr : IDisposable
         // Transcribe call so its GPU arena is freed before the autoregressive decode loop.
         _audioEncoderPath = Path.Combine(modelDir, AudioEncoderFile);
         _ep               = ep;
+        _profileOutputDir = profileOutputDir;
 
-        var gpuOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED);
+        var gpuOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
+            enableProfiling: profileOutputDir is not null);
         _decoder = new InferenceSession(Path.Combine(modelDir, DecoderSingleFile), gpuOpts);
     }
 
@@ -168,9 +183,20 @@ public sealed class VibeVoiceAsr : IDisposable
         //     GPU arena (float32 Conv towers) is freed before the decoder KV cache grows.
         BFloat16[] audioEmbeddings;
         {
+            // Note: SessionOptions.ProfileOutputPathPrefix is not wired to the native
+            // OrtEnableProfiling call in ORT 1.24.2 managed bindings — ORT always writes
+            // to cwd with the default onnxruntime_profile__{timestamp}.json filename.
+            // We rename/move the file ourselves after EndProfiling().
             using var audioEncoder = new InferenceSession(
-                _audioEncoderPath, MakeSessionOptions(_ep));
+                _audioEncoderPath, MakeSessionOptions(_ep, enableProfiling: _profileOutputDir is not null));
             audioEmbeddings = RunAudioEncoderChunked(audio24k, audioEncoder);
+            if (_profileOutputDir is not null)
+            {
+                string rawPath = Path.GetFullPath(audioEncoder.EndProfiling());
+                string destPath = Path.Combine(_profileOutputDir, "encoder_" + Path.GetFileName(rawPath));
+                File.Move(rawPath, destPath, overwrite: true);
+                Console.Error.WriteLine($"[profile] encoder → {destPath}");
+            }
         }
         int numAudioTokens = audioEmbeddings.Length / _hiddenSize;
 
@@ -183,6 +209,14 @@ public sealed class VibeVoiceAsr : IDisposable
             prefillChunkTokens,
             maxNewTokens,
             ct);
+
+        if (_profileOutputDir is not null)
+        {
+            string rawPath = Path.GetFullPath(_decoder.EndProfiling());
+            string destPath = Path.Combine(_profileOutputDir, "decoder_" + Path.GetFileName(rawPath));
+            File.Move(rawPath, destPath, overwrite: true);
+            Console.Error.WriteLine($"[profile] decoder → {destPath}");
+        }
 
         // 5 — Parse VibeVoice JSON output
         return ParseOutput(jsonText);
@@ -666,10 +700,13 @@ public sealed class VibeVoiceAsr : IDisposable
     // the float32 Conv towers within 24 GB VRAM.
     private static SessionOptions MakeSessionOptions(
         ExecutionProvider ep,
-        GraphOptimizationLevel optLevel = GraphOptimizationLevel.ORT_ENABLE_ALL)
+        GraphOptimizationLevel optLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+        bool enableProfiling = false)
     {
         var opts = new SessionOptions();
         opts.GraphOptimizationLevel = optLevel;
+        if (enableProfiling)
+            opts.EnableProfiling = true;
 
         switch (ep)
         {

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -67,11 +67,12 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── Model dimensions ──────────────────────────────────────────────────────
 
-    private readonly int _numLayers;          // 28
-    private readonly int _numKvHeads;         // 4
-    private readonly int _headDim;            // 128
-    private readonly int _hiddenSize;         // 3584
-    private readonly int _encoderChunkSamples; // from export-report.json acoustic_tokenizer_chunk_size
+    private readonly int  _numLayers;           // 28
+    private readonly int  _numKvHeads;          // 4
+    private readonly int  _headDim;             // 128
+    private readonly int  _hiddenSize;          // 3584
+    private readonly int  _encoderChunkSamples; // from export-report.json acoustic_tokenizer_chunk_size
+    private readonly bool _kvCacheIsFloat32;    // true for --f32-kv-cache exports, false for BF16 KV
 
     // ── Tokenizer ─────────────────────────────────────────────────────────────
 
@@ -112,6 +113,8 @@ public sealed class VibeVoiceAsr : IDisposable
         _headDim             = report.GetProperty("head_dim").GetInt32();
         _hiddenSize          = report.GetProperty("hidden_size").GetInt32();
         _encoderChunkSamples = report.GetProperty("acoustic_tokenizer_chunk_size").GetInt32();
+        _kvCacheIsFloat32    = report.TryGetProperty("f32_kv_cache", out var f32KvProp)
+                               && f32KvProp.GetBoolean();
 
         var tok = report.GetProperty("tokenizer");
         _prefixTokenIds       = ReadLongArray(tok.GetProperty("prefix_token_ids"));
@@ -501,11 +504,15 @@ public sealed class VibeVoiceAsr : IDisposable
 
     private OrtValue[] CreateEmptyKvOrtValues()
     {
-        // shape [1, numKvHeads, 0, headDim] — zero total elements is valid
+        // shape [1, numKvHeads, 0, headDim] — zero total elements is valid.
+        // Element type must match the KV cache dtype baked into the exported model:
+        //   float32 for --f32-kv-cache exports, BFloat16 for the default BF16 KV model.
         var    kvs   = new OrtValue[_numLayers * 2];
         long[] shape = { 1, _numKvHeads, 0, _headDim };
         for (int i = 0; i < kvs.Length; i++)
-            kvs[i] = OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(), shape);
+            kvs[i] = _kvCacheIsFloat32
+                ? OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(),    shape)
+                : OrtValue.CreateTensorValueFromMemory(Array.Empty<BFloat16>(), shape);
         return kvs;
     }
 

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Encodings.Web;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using Vernacula.Base.Models;
@@ -29,6 +30,11 @@ namespace Vernacula.Base;
 /// </summary>
 public sealed class VibeVoiceAsr : IDisposable
 {
+    private static readonly JsonSerializerOptions RelaxedJsonEscaping = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     // ── File names ────────────────────────────────────────────────────────────
 
     public const string AudioEncoderFile        = "audio_encoder.onnx";
@@ -792,7 +798,7 @@ public sealed class VibeVoiceAsr : IDisposable
 
         // Build a char-to-token-index map: charToToken[c] = index of the token in `generated`
         // whose decoded output includes the character at position c in fullJson.
-        var charToToken = new int[fullJson.Length];
+        var charToToken = Enumerable.Repeat(-1, fullJson.Length).ToArray();
         {
             int charPos = 0;
             var tempBuf = new List<byte>(16);
@@ -839,7 +845,7 @@ public sealed class VibeVoiceAsr : IDisposable
 
             if (keyIdx < 0) break;
 
-            string serializedContent = JsonSerializer.Serialize(content);
+            string serializedContent = JsonSerializer.Serialize(content, RelaxedJsonEscaping);
             int serializedContentIdx = fullJson.IndexOf(
                 serializedContent, keyIdx + keyLength, StringComparison.Ordinal);
             if (serializedContentIdx < 0)
@@ -900,7 +906,7 @@ public sealed class VibeVoiceAsr : IDisposable
                 for (int c = wcStart; c < wcEnd && c < charToToken.Length; c++)
                 {
                     int ti = charToToken[c];
-                    if (ti != prevTi && ti < tokenLogprobs.Count)
+                    if (ti >= 0 && ti != prevTi && ti < tokenLogprobs.Count)
                     {
                         sum  += tokenLogprobs[ti];
                         count++;

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -51,10 +51,17 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── ORT sessions ─────────────────────────────────────────────────────────
 
-    // The audio encoder is created on demand and disposed after each use so its
-    // GPU arena (dual float32 Conv towers) does not compete with the decoder's
-    // growing KV cache during the autoregressive decode loop.
-    private readonly string            _audioEncoderPath;
+    // The decoder session is kept for the lifetime of this object.
+    //
+    // The encoder session is optional: when persistEncoder = true (segmented mode)
+    // it is loaded once in the constructor and reused across all Transcribe() calls,
+    // avoiding 70+ session-load round-trips.  When persistEncoder = false
+    // (whole-recording built-in path) the encoder is created and disposed inside
+    // each Transcribe() call so its GPU arena (~1–3 GiB) is freed before the
+    // long autoregressive decode loop starts, giving the KV cache more headroom.
+    private InferenceSession?          _audioEncoder;   // null when not persisted
+    private readonly string            _audioEncoderModelPath;
+    private readonly bool              _persistEncoder;
     private readonly ExecutionProvider _ep;
     private readonly InferenceSession  _decoder;
 
@@ -103,6 +110,7 @@ public sealed class VibeVoiceAsr : IDisposable
     public VibeVoiceAsr(
         string modelDir,
         ExecutionProvider ep = ExecutionProvider.Auto,
+        bool persistEncoder = true,
         string? profileOutputDir = null)
     {
         if (profileOutputDir is not null)
@@ -141,14 +149,18 @@ public sealed class VibeVoiceAsr : IDisposable
         (_idToToken, _addedTokenContent) = LoadTokenizerVocab(Path.Combine(modelDir, TokenizerFile));
         _byteLevelDecode = BuildByteLevelDecode();
 
-        // Create ORT sessions
+        // Create ORT sessions.
         // Both models need CUDA: audio_encoder.onnx contains BFloat16 MatMul nodes in
         // the multimodal projector that CPU EP does not implement.
-        // The audio encoder is NOT loaded here — it is created and disposed within each
-        // Transcribe call so its GPU arena is freed before the autoregressive decode loop.
-        _audioEncoderPath = Path.Combine(modelDir, AudioEncoderFile);
-        _ep               = ep;
-        _profileOutputDir = profileOutputDir;
+        _ep                   = ep;
+        _profileOutputDir     = profileOutputDir;
+        _persistEncoder       = persistEncoder;
+        _audioEncoderModelPath = Path.Combine(modelDir, AudioEncoderFile);
+
+        if (persistEncoder)
+            _audioEncoder = new InferenceSession(
+                _audioEncoderModelPath,
+                MakeSessionOptions(ep, enableProfiling: profileOutputDir is not null));
 
         var gpuOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
             enableProfiling: profileOutputDir is not null);
@@ -194,24 +206,40 @@ public sealed class VibeVoiceAsr : IDisposable
         long[] suffixIds = BuildSuffixTokenIds(durationSeconds);
 
         // 3 — Run audio encoder in chunks → BF16 audio embeddings.
-        //     The encoder session is created here and disposed immediately after so its
-        //     GPU arena (float32 Conv towers) is freed before the decoder KV cache grows.
+        // Note: SessionOptions.ProfileOutputPathPrefix is not wired to the native
+        // OrtEnableProfiling call in ORT 1.24.2 managed bindings — ORT always writes
+        // to cwd with the default onnxruntime_profile__{timestamp}.json filename.
+        // We rename/move the file ourselves after EndProfiling().
+        //
+        // When the encoder is not persisted (whole-recording built-in path), create
+        // a temporary session scoped to this call so its GPU arena is freed before
+        // the long autoregressive decode loop begins.
         BFloat16[] audioEmbeddings;
+        if (_audioEncoder is not null)
         {
-            // Note: SessionOptions.ProfileOutputPathPrefix is not wired to the native
-            // OrtEnableProfiling call in ORT 1.24.2 managed bindings — ORT always writes
-            // to cwd with the default onnxruntime_profile__{timestamp}.json filename.
-            // We rename/move the file ourselves after EndProfiling().
-            using var audioEncoder = new InferenceSession(
-                _audioEncoderPath, MakeSessionOptions(_ep, enableProfiling: _profileOutputDir is not null));
-            audioEmbeddings = RunAudioEncoderChunked(audio24k, audioEncoder);
+            audioEmbeddings = RunAudioEncoderChunked(audio24k, _audioEncoder);
             if (_profileOutputDir is not null)
             {
-                string rawPath = Path.GetFullPath(audioEncoder.EndProfiling());
+                string rawPath = Path.GetFullPath(_audioEncoder.EndProfiling());
                 string destPath = Path.Combine(_profileOutputDir, "encoder_" + Path.GetFileName(rawPath));
                 File.Move(rawPath, destPath, overwrite: true);
                 Console.Error.WriteLine($"[profile] encoder → {destPath}");
             }
+        }
+        else
+        {
+            using var tempEncoder = new InferenceSession(
+                _audioEncoderModelPath,
+                MakeSessionOptions(_ep, enableProfiling: _profileOutputDir is not null));
+            audioEmbeddings = RunAudioEncoderChunked(audio24k, tempEncoder);
+            if (_profileOutputDir is not null)
+            {
+                string rawPath = Path.GetFullPath(tempEncoder.EndProfiling());
+                string destPath = Path.Combine(_profileOutputDir, "encoder_" + Path.GetFileName(rawPath));
+                File.Move(rawPath, destPath, overwrite: true);
+                Console.Error.WriteLine($"[profile] encoder → {destPath}");
+            }
+            // tempEncoder is disposed here → GPU arena freed before decoder loop
         }
         int numAudioTokens = audioEmbeddings.Length / _hiddenSize;
 
@@ -239,6 +267,7 @@ public sealed class VibeVoiceAsr : IDisposable
 
     public void Dispose()
     {
+        _audioEncoder?.Dispose();
         _decoder.Dispose();
     }
 

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -31,10 +31,11 @@ public sealed class VibeVoiceAsr : IDisposable
 {
     // ── File names ────────────────────────────────────────────────────────────
 
-    public const string AudioEncoderFile  = "audio_encoder.onnx";
-    public const string DecoderSingleFile = "decoder_single.onnx";
-    public const string ExportReportFile  = "export-report.json";
-    public const string TokenizerFile     = "tokenizer.json";
+    public const string AudioEncoderFile        = "audio_encoder.onnx";
+    public const string DecoderSingleFile       = "decoder_single.onnx";
+    public const string DecoderSingleStaticFile = "decoder_single_static.onnx";
+    public const string ExportReportFile        = "export-report.json";
+    public const string TokenizerFile           = "tokenizer.json";
 
     // ── Audio ─────────────────────────────────────────────────────────────────
 
@@ -72,7 +73,10 @@ public sealed class VibeVoiceAsr : IDisposable
     private readonly int  _headDim;             // 128
     private readonly int  _hiddenSize;          // 3584
     private readonly int  _encoderChunkSamples; // from export-report.json acoustic_tokenizer_chunk_size
-    private readonly bool _kvCacheIsFloat32;    // true for --f32-kv-cache exports, false for BF16 KV
+    private readonly bool _kvCacheIsFloat32;           // true for --f32-kv-cache exports, false for BF16 KV
+    private readonly bool _staticKvCache;              // true when decoder_single_static.onnx is in use
+    private readonly int  _maxKvTokens;                // pre-allocated KV buffer length (static mode only)
+    private readonly bool _audioEmbeddingIsFloat16;    // true when decoder expects float16 (static export artifact)
 
     // ── Tokenizer ─────────────────────────────────────────────────────────────
 
@@ -115,6 +119,11 @@ public sealed class VibeVoiceAsr : IDisposable
         _encoderChunkSamples = report.GetProperty("acoustic_tokenizer_chunk_size").GetInt32();
         _kvCacheIsFloat32    = report.TryGetProperty("f32_kv_cache", out var f32KvProp)
                                && f32KvProp.GetBoolean();
+        _staticKvCache       = report.TryGetProperty("static_kv_cache", out var staticKvProp)
+                               && staticKvProp.GetBoolean();
+        _maxKvTokens         = _staticKvCache && report.TryGetProperty("static_kv_max_tokens", out var maxTokProp)
+                               ? maxTokProp.GetInt32()
+                               : 0;
 
         var tok = report.GetProperty("tokenizer");
         _prefixTokenIds       = ReadLongArray(tok.GetProperty("prefix_token_ids"));
@@ -143,7 +152,10 @@ public sealed class VibeVoiceAsr : IDisposable
 
         var gpuOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
             enableProfiling: profileOutputDir is not null);
-        _decoder = new InferenceSession(Path.Combine(modelDir, DecoderSingleFile), gpuOpts);
+        string decoderFile = _staticKvCache ? DecoderSingleStaticFile : DecoderSingleFile;
+        _decoder = new InferenceSession(Path.Combine(modelDir, decoderFile), gpuOpts);
+        _audioEmbeddingIsFloat16 = _decoder.InputMetadata.TryGetValue("audio_embeddings", out var audioMeta)
+                                   && audioMeta.ElementDataType == TensorElementType.Float16;
     }
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -363,8 +375,15 @@ public sealed class VibeVoiceAsr : IDisposable
         using var binding     = _decoder.CreateIoBinding();
         using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.DeviceAllocator, 0, OrtMemType.Default);
 
-        // Empty (cache_len = 0) CPU OrtValues for the initial KV inputs
-        OrtValue[] pastKvs = CreateEmptyKvOrtValues();
+        // Initial KV tensors:
+        //   dynamic mode  → shape [1, kv_heads, 0, head_dim] (zero-length, grows via Concat)
+        //   static mode   → shape [1, kv_heads, max_tokens, head_dim] (pre-allocated, zero-filled)
+        OrtValue[] pastKvs = CreateInitialKvOrtValues();
+
+        // kv_pos: current fill position in the KV buffers (static mode only).
+        // For dynamic mode this is unused but still tracked so RunOnce has a uniform signature.
+        long kvPos = 0;
+
         try
         {
             // ── Chunked prefill ───────────────────────────────────────────────
@@ -383,10 +402,12 @@ public sealed class VibeVoiceAsr : IDisposable
                 long[] pfx = ci == 0             ? prefixIds : noIds;
                 long[] sfx = ci == numChunks - 1 ? suffixIds : noIds;
 
+                int seqLen = pfx.Length + count + sfx.Length;
                 var prevKvs = pastKvs;
                 (lastToken, pastKvs) = RunOnce(
-                    pfx, audioEmbeddings, start, count, sfx, pastKvs, binding, runOptions, cudaMemInfo);
+                    kvPos, pfx, audioEmbeddings, start, count, sfx, pastKvs, binding, runOptions, cudaMemInfo);
                 foreach (var kv in prevKvs) kv.Dispose();
+                kvPos += seqLen;
             }
 
             // ── Greedy decode ─────────────────────────────────────────────────
@@ -404,8 +425,9 @@ public sealed class VibeVoiceAsr : IDisposable
                 tokenBuf[0] = nextToken;
                 var prevKvs = pastKvs;
                 (nextToken, pastKvs) = RunOnce(
-                    tokenBuf, audioEmbeddings, 0, 0, noIds, pastKvs, binding, runOptions, cudaMemInfo);
+                    kvPos, tokenBuf, audioEmbeddings, 0, 0, noIds, pastKvs, binding, runOptions, cudaMemInfo);
                 foreach (var kv in prevKvs) kv.Dispose();
+                kvPos += 1;  // decode step always produces exactly 1 token position
             }
 
             return TokensToText(generated);
@@ -429,6 +451,7 @@ public sealed class VibeVoiceAsr : IDisposable
     /// without calling Dispose — so the KV OrtValues it contained are not prematurely freed.
     /// </summary>
     private (long token, OrtValue[] presentKvs) RunOnce(
+        long         kvPos,       // Current KV fill position (used only in static-KV mode)
         long[]       prefixIds,
         BFloat16[]   audioData,
         int          audioStart,
@@ -441,8 +464,10 @@ public sealed class VibeVoiceAsr : IDisposable
     {
         binding.ClearBoundInputs();
 
-        // Re-register outputs every call: the KV cache grows each step, so the shape
-        // changes and ORT cannot reuse a previously allocated output buffer.
+        // Re-register outputs every call.
+        // Dynamic mode: KV cache shape grows each step — must resize.
+        // Static mode:  KV cache shape is fixed (max_tokens) — same size every step,
+        //               so ORT's BFC arena reuses the same memory blocks efficiently.
         binding.ClearBoundOutputs();
         binding.BindOutputToDevice("logits", OrtMemoryInfo.DefaultInstance);
         for (int i = 0; i < _numLayers; i++)
@@ -450,6 +475,13 @@ public sealed class VibeVoiceAsr : IDisposable
             binding.BindOutputToDevice($"present_key_{i}",   cudaMemInfo);
             binding.BindOutputToDevice($"present_value_{i}", cudaMemInfo);
         }
+
+        // kv_pos (static mode only): int64 scalar telling the model where to scatter new K/V.
+        using var kvPosOrtVal = _staticKvCache
+            ? OrtValue.CreateTensorValueFromMemory(new long[] { kvPos }, new long[0])
+            : null;
+        if (kvPosOrtVal is not null)
+            binding.BindInput("kv_pos", kvPosOrtVal);
 
         // prefix_input_ids [1, P]
         using var prefixOrtVal = OrtValue.CreateTensorValueFromMemory(
@@ -459,13 +491,37 @@ public sealed class VibeVoiceAsr : IDisposable
         // audio_embeddings [N, hiddenSize] — zero-length during decode steps
         // Declared at method scope so it stays alive until after RunWithBinding.
         int audioElems = audioCount * _hiddenSize;
-        using var audioOrtVal = audioElems > 0
-            ? OrtValue.CreateTensorValueFromMemory(
-                  OrtMemoryInfo.DefaultInstance,
-                  new Memory<BFloat16>(audioData, audioStart * _hiddenSize, audioElems),
-                  new long[] { audioCount, _hiddenSize })
-            : OrtValue.CreateTensorValueFromMemory(
-                  Array.Empty<BFloat16>(), new long[] { 0, _hiddenSize });
+        OrtValue audioOrtVal;
+        Float16[]? audioF16Scratch = null;   // kept alive until after RunWithBinding
+        if (_audioEmbeddingIsFloat16)
+        {
+            if (audioElems > 0)
+            {
+                // Static model exports with float16 audio_embeddings; convert BF16 → F16.
+                audioF16Scratch = new Float16[audioElems];
+                int srcBase = audioStart * _hiddenSize;
+                for (int j = 0; j < audioElems; j++)
+                    audioF16Scratch[j] = (Float16)(float)audioData[srcBase + j];
+                audioOrtVal = OrtValue.CreateTensorValueFromMemory(
+                    audioF16Scratch, new long[] { audioCount, _hiddenSize });
+            }
+            else
+            {
+                audioOrtVal = OrtValue.CreateTensorValueFromMemory(
+                    Array.Empty<Float16>(), new long[] { 0, _hiddenSize });
+            }
+        }
+        else
+        {
+            audioOrtVal = audioElems > 0
+                ? OrtValue.CreateTensorValueFromMemory(
+                      OrtMemoryInfo.DefaultInstance,
+                      new Memory<BFloat16>(audioData, audioStart * _hiddenSize, audioElems),
+                      new long[] { audioCount, _hiddenSize })
+                : OrtValue.CreateTensorValueFromMemory(
+                      Array.Empty<BFloat16>(), new long[] { 0, _hiddenSize });
+        }
+        // audioOrtVal must stay alive until after RunWithBinding — dispose manually below.
         binding.BindInput("audio_embeddings", audioOrtVal);
 
         // suffix_input_ids [1, S]
@@ -481,6 +537,7 @@ public sealed class VibeVoiceAsr : IDisposable
         }
 
         _decoder.RunWithBinding(runOptions, binding);
+        audioOrtVal.Dispose();
 
         // GetOutputValues() → IDisposableReadOnlyCollection<OrtValue> (a DisposableList).
         // DisposableList has no finalizer, so skipping `using` is safe: GC collects the
@@ -502,17 +559,33 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── Decoder helpers ───────────────────────────────────────────────────────
 
-    private OrtValue[] CreateEmptyKvOrtValues()
+    private OrtValue[] CreateInitialKvOrtValues()
     {
-        // shape [1, numKvHeads, 0, headDim] — zero total elements is valid.
-        // Element type must match the KV cache dtype baked into the exported model:
-        //   float32 for --f32-kv-cache exports, BFloat16 for the default BF16 KV model.
-        var    kvs   = new OrtValue[_numLayers * 2];
-        long[] shape = { 1, _numKvHeads, 0, _headDim };
-        for (int i = 0; i < kvs.Length; i++)
-            kvs[i] = _kvCacheIsFloat32
-                ? OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(),    shape)
-                : OrtValue.CreateTensorValueFromMemory(Array.Empty<BFloat16>(), shape);
+        // Element type must match the KV cache dtype baked into the exported model.
+        var kvs = new OrtValue[_numLayers * 2];
+
+        if (_staticKvCache)
+        {
+            // Static mode: pre-allocate full-size zero-filled buffers.
+            // Shape [1, numKvHeads, maxKvTokens, headDim] — fixed for all steps.
+            // The CLR zero-initialises all arrays; ORT will copy them to CUDA on first use.
+            long[] shape    = { 1, _numKvHeads, _maxKvTokens, _headDim };
+            long   elements = shape[0] * shape[1] * shape[2] * shape[3];
+            for (int i = 0; i < kvs.Length; i++)
+                kvs[i] = _kvCacheIsFloat32
+                    ? OrtValue.CreateTensorValueFromMemory(new float[elements],    shape)
+                    : OrtValue.CreateTensorValueFromMemory(new BFloat16[elements], shape);
+        }
+        else
+        {
+            // Dynamic mode: zero-length initial tensors; shape grows via Concat each step.
+            long[] shape = { 1, _numKvHeads, 0, _headDim };
+            for (int i = 0; i < kvs.Length; i++)
+                kvs[i] = _kvCacheIsFloat32
+                    ? OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(),    shape)
+                    : OrtValue.CreateTensorValueFromMemory(Array.Empty<BFloat16>(), shape);
+        }
+
         return kvs;
     }
 

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -244,8 +244,8 @@ public sealed class VibeVoiceAsr : IDisposable
         }
         int numAudioTokens = audioEmbeddings.Length / _hiddenSize;
 
-        // 4 — Run decoder (chunked prefill + greedy decode) → raw JSON text
-        string jsonText = RunDecoder(
+        // 4 — Run decoder (chunked prefill + greedy decode) → raw JSON text + per-segment token/word data
+        var (jsonText, segTokenIds, segTokenLogprobs, segWordLogprobs) = RunDecoder(
             _prefixTokenIds,
             audioEmbeddings,
             numAudioTokens,
@@ -263,8 +263,17 @@ public sealed class VibeVoiceAsr : IDisposable
             Console.Error.WriteLine($"[profile] decoder → {destPath}");
         }
 
-        // 5 — Parse VibeVoice JSON output
-        return ParseOutput(jsonText);
+        // 5 — Parse VibeVoice JSON output and attach per-word logprobs
+        var rawSegs = ParseOutput(jsonText);
+        var result  = new VibeVoiceSegment[rawSegs.Count];
+        for (int i = 0; i < rawSegs.Count; i++)
+            result[i] = rawSegs[i] with
+            {
+                TokenIds      = i < segTokenIds.Length ? segTokenIds[i] : [],
+                TokenLogprobs = i < segTokenLogprobs.Length ? segTokenLogprobs[i] : [],
+                WordLogprobs  = i < segWordLogprobs.Length ? segWordLogprobs[i] : []
+            };
+        return result;
     }
 
     public void Dispose()
@@ -393,7 +402,7 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── Decoder ───────────────────────────────────────────────────────────────
 
-    private string RunDecoder(
+    private (string json, int[][] segTokenIds, float[][] segTokenLogprobs, float[][] segWordLogprobs) RunDecoder(
         long[] prefixIds,
         BFloat16[] audioEmbeddings,
         int numAudioTokens,
@@ -423,7 +432,8 @@ public sealed class VibeVoiceAsr : IDisposable
             int    chunkSize = prefillChunkTokens > 0 ? prefillChunkTokens : numAudioTokens;
             int    numChunks = (numAudioTokens + chunkSize - 1) / Math.Max(1, chunkSize);
             long[] noIds     = [];
-            long   lastToken = 0;
+            long   lastToken   = 0;
+            float  lastLogprob = 0f;
 
             for (int ci = 0; ci < numChunks; ci++)
             {
@@ -436,7 +446,7 @@ public sealed class VibeVoiceAsr : IDisposable
 
                 int seqLen = pfx.Length + count + sfx.Length;
                 var prevKvs = pastKvs;
-                (lastToken, pastKvs) = RunOnce(
+                (lastToken, lastLogprob, pastKvs) = RunOnce(
                     kvPos, pfx, audioEmbeddings, start, count, sfx, pastKvs, binding, runOptions, cudaMemInfo);
                 foreach (var kv in prevKvs) kv.Dispose();
                 kvPos += seqLen;
@@ -444,9 +454,11 @@ public sealed class VibeVoiceAsr : IDisposable
 
             // ── Greedy decode ─────────────────────────────────────────────────
 
-            var    generated  = new List<long>(maxNewTokens);
-            long   nextToken  = lastToken;
-            long[] tokenBuf   = new long[1]; // reused each step — avoids per-step allocation
+            var    generated     = new List<long>(maxNewTokens);
+            var    tokenLogprobs = new List<float>(maxNewTokens);
+            long   nextToken     = lastToken;
+            float  nextLogprob   = lastLogprob;  // logprob of nextToken, computed at previous step
+            long[] tokenBuf      = new long[1];  // reused each step — avoids per-step allocation
 
             // Streaming: accumulate decoded bytes and emit complete segments via callback.
             List<byte>? streamBytes   = onSegment is not null ? new List<byte>(4096) : null;
@@ -457,6 +469,7 @@ public sealed class VibeVoiceAsr : IDisposable
                 ct.ThrowIfCancellationRequested();
                 if (nextToken == _eosTokenId || nextToken == _imEndTokenId) break;
                 generated.Add(nextToken);
+                tokenLogprobs.Add(nextLogprob);  // store logprob computed at previous RunOnce call
 
                 // Streaming: decode this token's bytes and check for newly closed segments.
                 if (streamBytes is not null)
@@ -483,13 +496,16 @@ public sealed class VibeVoiceAsr : IDisposable
 
                 tokenBuf[0] = nextToken;
                 var prevKvs = pastKvs;
-                (nextToken, pastKvs) = RunOnce(
+                (nextToken, nextLogprob, pastKvs) = RunOnce(
                     kvPos, tokenBuf, audioEmbeddings, 0, 0, noIds, pastKvs, binding, runOptions, cudaMemInfo);
                 foreach (var kv in prevKvs) kv.Dispose();
                 kvPos += 1;  // decode step always produces exactly 1 token position
             }
 
-            return TokensToText(generated);
+            string jsonText = TokensToText(generated);
+            var    segments = ParseOutput(jsonText);
+            var    segData  = ComputeSegmentTokenData(generated, tokenLogprobs, jsonText, segments);
+            return (jsonText, segData.TokenIds, segData.TokenLogprobs, segData.WordLogprobs);
         }
         finally
         {
@@ -509,7 +525,7 @@ public sealed class VibeVoiceAsr : IDisposable
     /// dispose the logits OrtValue immediately, and let the bare DisposableList be GC-collected
     /// without calling Dispose — so the KV OrtValues it contained are not prematurely freed.
     /// </summary>
-    private (long token, OrtValue[] presentKvs) RunOnce(
+    private (long token, float logprob, OrtValue[] presentKvs) RunOnce(
         long         kvPos,       // Current KV fill position (used only in static-KV mode)
         long[]       prefixIds,
         BFloat16[]   audioData,
@@ -603,9 +619,9 @@ public sealed class VibeVoiceAsr : IDisposable
         // list shell without touching the OrtValues inside it.
         var outputs = binding.GetOutputValues();
 
-        // outputs[0] = logits (CPU) — read argmax, then free immediately
-        int  seqLen = prefixIds.Length + audioCount + suffixIds.Length;
-        long token  = ArgmaxOrtValue(outputs[0], seqLen);
+        // outputs[0] = logits (CPU) — read argmax + logprob, then free immediately
+        int   seqLen = prefixIds.Length + audioCount + suffixIds.Length;
+        var   (token, logprob) = ArgmaxAndLogprobOrtValue(outputs[0], seqLen);
         outputs[0].Dispose();
 
         // outputs[1..56] = present_key/value (CUDA) — take ownership
@@ -613,7 +629,7 @@ public sealed class VibeVoiceAsr : IDisposable
         for (int i = 0; i < _numLayers * 2; i++)
             presentKvs[i] = outputs[i + 1];
 
-        return (token, presentKvs);
+        return (token, logprob, presentKvs);
     }
 
     // ── Decoder helpers ───────────────────────────────────────────────────────
@@ -648,7 +664,11 @@ public sealed class VibeVoiceAsr : IDisposable
         return kvs;
     }
 
-    private long ArgmaxOrtValue(OrtValue logits, int seqLen)
+    /// <summary>
+    /// Returns the argmax token id and its log-probability (log softmax of the last
+    /// position's logits).  Mirrors the Parakeet approach: logprob = logit[best] - logsumexp.
+    /// </summary>
+    private (long token, float logprob) ArgmaxAndLogprobOrtValue(OrtValue logits, int seqLen)
     {
         // logits: [1, seqLen, vocabSize] flattened row-major, CPU-resident.
         // Static model outputs float16 logits; dynamic model outputs bfloat16.
@@ -664,7 +684,11 @@ public sealed class VibeVoiceAsr : IDisposable
                 float val = (float)span[offset + v];
                 if (val > bestVal) { bestVal = val; best = v; }
             }
-            return best;
+            // logsumexp (stable): bestVal is already the max
+            double sumExp = 0.0;
+            for (int v = 0; v < vocabSize; v++)
+                sumExp += Math.Exp((float)span[offset + v] - bestVal);
+            return (best, (float)-Math.Log(sumExp));  // = bestVal - bestVal - log(sumExp)
         }
         else
         {
@@ -678,7 +702,10 @@ public sealed class VibeVoiceAsr : IDisposable
                 float val = (float)span[offset + v];
                 if (val > bestVal) { bestVal = val; best = v; }
             }
-            return best;
+            double sumExp = 0.0;
+            for (int v = 0; v < vocabSize; v++)
+                sumExp += Math.Exp((float)span[offset + v] - bestVal);
+            return (best, (float)-Math.Log(sumExp));
         }
     }
 
@@ -727,6 +754,143 @@ public sealed class VibeVoiceAsr : IDisposable
         }
 
         return Encoding.UTF8.GetString(bytes.ToArray());
+    }
+
+    // ── Per-segment word logprob extraction ──────────────────────────────────
+
+    /// <summary>
+    /// For each parsed segment, locate the generated decoder tokens that produced its
+    /// content span, returning both token-level and word-level confidence arrays.
+    ///
+    /// Strategy:
+    ///   1. Replay AppendTokenBytes to build a char-to-token-index map over fullJson.
+    ///   2. For each segment, locate its "content" field value in fullJson (sequential
+    ///      search — segments appear in generation order).
+    ///   3. For each whitespace-delimited word in the content, average the logprobs of
+    ///      every unique token that contributed at least one character to that word.
+    /// </summary>
+    private (int[][] TokenIds, float[][] TokenLogprobs, float[][] WordLogprobs) ComputeSegmentTokenData(
+        List<long>                     generated,
+        List<float>                    tokenLogprobs,
+        string                         fullJson,
+        IReadOnlyList<VibeVoiceSegment> segments)
+    {
+        var tokenIdsResult      = new int[segments.Count][];
+        var tokenLogprobsResult = new float[segments.Count][];
+        var wordLogprobsResult  = new float[segments.Count][];
+        for (int i = 0; i < segments.Count; i++)
+        {
+            tokenIdsResult[i]      = [];
+            tokenLogprobsResult[i] = [];
+            wordLogprobsResult[i]  = [];
+        }
+
+        if (generated.Count == 0 || segments.Count == 0)
+            return (tokenIdsResult, tokenLogprobsResult, wordLogprobsResult);
+
+        // Build a char-to-token-index map: charToToken[c] = index of the token in `generated`
+        // whose decoded output includes the character at position c in fullJson.
+        var charToToken = new int[fullJson.Length];
+        {
+            int charPos = 0;
+            var tempBuf = new List<byte>(16);
+            for (int ti = 0; ti < generated.Count && charPos < fullJson.Length; ti++)
+            {
+                tempBuf.Clear();
+                AppendTokenBytes(generated[ti], tempBuf);
+                if (tempBuf.Count == 0) continue;
+                string tokenStr = Encoding.UTF8.GetString(tempBuf.ToArray());
+                for (int k = 0; k < tokenStr.Length && charPos < charToToken.Length; k++)
+                    charToToken[charPos++] = ti;
+            }
+        }
+
+        // Locate each segment's content value in the JSON and compute word-level logprobs.
+        // The JSON produced by VibeVoice has used PascalCase keys in practice, but we
+        // accept either casing here because older comments/docs referred to lowercase.
+        const string contentKeyPascal = "\"Content\":\"";
+        const string contentKeyCamel  = "\"content\":\"";
+        int searchFrom = 0;
+
+        for (int si = 0; si < segments.Count; si++)
+        {
+            string content = segments[si].Content;
+            if (string.IsNullOrEmpty(content)) continue;
+
+            int keyIdxPascal = fullJson.IndexOf(contentKeyPascal, searchFrom, StringComparison.Ordinal);
+            int keyIdxCamel  = fullJson.IndexOf(contentKeyCamel,  searchFrom, StringComparison.Ordinal);
+            int keyIdx;
+            int keyLength;
+
+            if (keyIdxPascal >= 0 && (keyIdxCamel < 0 || keyIdxPascal < keyIdxCamel))
+            {
+                keyIdx    = keyIdxPascal;
+                keyLength = contentKeyPascal.Length;
+            }
+            else
+            {
+                keyIdx    = keyIdxCamel;
+                keyLength = contentKeyCamel.Length;
+            }
+
+            if (keyIdx < 0) break;
+
+            int contentCharStart = keyIdx + keyLength;
+            searchFrom = contentCharStart + content.Length;  // advance past this segment
+
+            var tokenIndices = new List<int>();
+            int prevTi = -1;
+            for (int c = contentCharStart; c < searchFrom && c < charToToken.Length; c++)
+            {
+                int ti = charToToken[c];
+                if (ti != prevTi && ti >= 0 && ti < generated.Count)
+                {
+                    tokenIndices.Add(ti);
+                    prevTi = ti;
+                }
+            }
+
+            tokenIdsResult[si] = tokenIndices.Select(ti => checked((int)generated[ti])).ToArray();
+            tokenLogprobsResult[si] = tokenIndices
+                .Where(ti => ti >= 0 && ti < tokenLogprobs.Count)
+                .Select(ti => tokenLogprobs[ti])
+                .ToArray();
+
+            // Split into words and compute the mean logprob of tokens covering each word.
+            string[] words       = content.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var      wordLogprobs = new float[words.Length];
+            int      wordOffset  = 0;
+
+            for (int wi = 0; wi < words.Length; wi++)
+            {
+                int wordPosInContent = content.IndexOf(words[wi], wordOffset, StringComparison.Ordinal);
+                if (wordPosInContent < 0) { wordOffset += words[wi].Length; continue; }
+
+                int wcStart  = contentCharStart + wordPosInContent;
+                int wcEnd    = wcStart + words[wi].Length;
+                wordOffset   = wordPosInContent + words[wi].Length;
+
+                // Average logprobs of unique tokens covering chars [wcStart, wcEnd).
+                float sum   = 0f;
+                int   count = 0;
+                prevTi = -1;
+                for (int c = wcStart; c < wcEnd && c < charToToken.Length; c++)
+                {
+                    int ti = charToToken[c];
+                    if (ti != prevTi && ti < tokenLogprobs.Count)
+                    {
+                        sum  += tokenLogprobs[ti];
+                        count++;
+                        prevTi = ti;
+                    }
+                }
+                wordLogprobs[wi] = count > 0 ? sum / count : 0f;
+            }
+
+            wordLogprobsResult[si] = wordLogprobs;
+        }
+
+        return (tokenIdsResult, tokenLogprobsResult, wordLogprobsResult);
     }
 
     // ── Output parsing ────────────────────────────────────────────────────────
@@ -912,7 +1076,25 @@ public sealed class VibeVoiceAsr : IDisposable
 // ── Output types ─────────────────────────────────────────────────────────────
 
 /// <summary>A single diarized, timestamped transcription segment from VibeVoice-ASR.</summary>
-public sealed record VibeVoiceSegment(double Start, double End, int Speaker, string Content);
+public sealed record VibeVoiceSegment(double Start, double End, int Speaker, string Content)
+{
+    /// <summary>
+    /// Raw VibeVoice decoder token ids that contributed characters to this segment's Content.
+    /// </summary>
+    public IReadOnlyList<int> TokenIds { get; init; } = [];
+
+    /// <summary>
+    /// Per-token log-probabilities aligned 1:1 with <see cref="TokenIds"/>.
+    /// </summary>
+    public IReadOnlyList<float> TokenLogprobs { get; init; } = [];
+
+    /// <summary>
+     /// Per-word log-probabilities (one entry per whitespace-delimited word in Content).
+     /// Computed from the decoder logits at generation time using the same log-softmax
+    /// formula as Parakeet.  Empty when not yet computed (e.g. streaming callbacks).
+    /// </summary>
+    public IReadOnlyList<float> WordLogprobs { get; init; } = [];
+}
 
 /// <summary>Internal DTO matching the JSON schema VibeVoice generates.</summary>
 file sealed class VibeVoiceRawSegment

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -589,21 +589,38 @@ public sealed class VibeVoiceAsr : IDisposable
         return kvs;
     }
 
-    private static long ArgmaxOrtValue(OrtValue logits, int seqLen)
+    private long ArgmaxOrtValue(OrtValue logits, int seqLen)
     {
-        // logits: [1, seqLen, vocabSize] flattened row-major, CPU-resident
-        var span      = logits.GetTensorDataAsSpan<BFloat16>();
-        int vocabSize = span.Length / seqLen;      // batch = 1
-        int offset    = (seqLen - 1) * vocabSize;  // last token's logit row
-
-        long  best    = 0;
-        float bestVal = float.NegativeInfinity;
-        for (int v = 0; v < vocabSize; v++)
+        // logits: [1, seqLen, vocabSize] flattened row-major, CPU-resident.
+        // Static model outputs float16 logits; dynamic model outputs bfloat16.
+        if (_audioEmbeddingIsFloat16)
         {
-            float val = (float)span[offset + v];
-            if (val > bestVal) { bestVal = val; best = v; }
+            var span      = logits.GetTensorDataAsSpan<Float16>();
+            int vocabSize = span.Length / seqLen;
+            int offset    = (seqLen - 1) * vocabSize;
+            long  best    = 0;
+            float bestVal = float.NegativeInfinity;
+            for (int v = 0; v < vocabSize; v++)
+            {
+                float val = (float)span[offset + v];
+                if (val > bestVal) { bestVal = val; best = v; }
+            }
+            return best;
         }
-        return best;
+        else
+        {
+            var span      = logits.GetTensorDataAsSpan<BFloat16>();
+            int vocabSize = span.Length / seqLen;
+            int offset    = (seqLen - 1) * vocabSize;
+            long  best    = 0;
+            float bestVal = float.NegativeInfinity;
+            for (int v = 0; v < vocabSize; v++)
+            {
+                float val = (float)span[offset + v];
+                if (val > bestVal) { bestVal = val; best = v; }
+            }
+            return best;
+        }
     }
 
     // ── Token decoding ────────────────────────────────────────────────────────

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -195,6 +195,7 @@ public sealed class VibeVoiceAsr : IDisposable
         int channels,
         int prefillChunkTokens = 512,
         int maxNewTokens = 8_192,
+        Action<VibeVoiceSegment>? onSegment = null,
         CancellationToken ct = default)
     {
         // 1 — Resample to 24 kHz mono and pad to acoustic tokenizer stride
@@ -251,6 +252,7 @@ public sealed class VibeVoiceAsr : IDisposable
             suffixIds,
             prefillChunkTokens,
             maxNewTokens,
+            onSegment,
             ct);
 
         if (_profileOutputDir is not null)
@@ -398,6 +400,7 @@ public sealed class VibeVoiceAsr : IDisposable
         long[] suffixIds,
         int prefillChunkTokens,
         int maxNewTokens,
+        Action<VibeVoiceSegment>? onSegment,
         CancellationToken ct)
     {
         using var runOptions  = new RunOptions();
@@ -445,11 +448,38 @@ public sealed class VibeVoiceAsr : IDisposable
             long   nextToken  = lastToken;
             long[] tokenBuf   = new long[1]; // reused each step — avoids per-step allocation
 
+            // Streaming: accumulate decoded bytes and emit complete segments via callback.
+            List<byte>? streamBytes   = onSegment is not null ? new List<byte>(4096) : null;
+            int         streamEmitted = 0;
+
             for (int step = 0; step < maxNewTokens; step++)
             {
                 ct.ThrowIfCancellationRequested();
                 if (nextToken == _eosTokenId || nextToken == _imEndTokenId) break;
                 generated.Add(nextToken);
+
+                // Streaming: decode this token's bytes and check for newly closed segments.
+                if (streamBytes is not null)
+                {
+                    AppendTokenBytes(nextToken, streamBytes);
+
+                    // Only parse when a '}' appears in the last few appended bytes.
+                    bool mightClose = false;
+                    for (int bi = Math.Max(0, streamBytes.Count - 8); bi < streamBytes.Count; bi++)
+                        if (streamBytes[bi] == (byte)'}') { mightClose = true; break; }
+
+                    if (mightClose)
+                    {
+                        string current    = Encoding.UTF8.GetString(streamBytes.ToArray());
+                        int    arrayStart = current.IndexOf('[');
+                        if (arrayStart >= 0)
+                        {
+                            var partial = ParsePartialJson(current[arrayStart..]);
+                            while (streamEmitted < partial.Count)
+                                onSegment!(partial[streamEmitted++]);
+                        }
+                    }
+                }
 
                 tokenBuf[0] = nextToken;
                 var prevKvs = pastKvs;
@@ -653,6 +683,21 @@ public sealed class VibeVoiceAsr : IDisposable
     }
 
     // ── Token decoding ────────────────────────────────────────────────────────
+
+    private void AppendTokenBytes(long tokenId, List<byte> buffer)
+    {
+        int iid = (int)tokenId;
+        if (_addedTokenContent.TryGetValue(iid, out string? special))
+        {
+            buffer.AddRange(Encoding.UTF8.GetBytes(special));
+            return;
+        }
+        string? raw = iid >= 0 && iid < _idToToken.Length ? _idToToken[iid] : null;
+        if (raw is null) return;
+        foreach (char ch in raw)
+            if (_byteLevelDecode.TryGetValue(ch, out byte b))
+                buffer.Add(b);
+    }
 
     private string TokensToText(List<long> tokenIds)
     {

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -111,6 +111,7 @@ public sealed class VibeVoiceAsr : IDisposable
         string modelDir,
         ExecutionProvider ep = ExecutionProvider.Auto,
         bool persistEncoder = true,
+        bool allowStaticKvCache = true,
         string? profileOutputDir = null)
     {
         if (profileOutputDir is not null)
@@ -127,7 +128,8 @@ public sealed class VibeVoiceAsr : IDisposable
         _encoderChunkSamples = report.GetProperty("acoustic_tokenizer_chunk_size").GetInt32();
         _kvCacheIsFloat32    = report.TryGetProperty("f32_kv_cache", out var f32KvProp)
                                && f32KvProp.GetBoolean();
-        _staticKvCache       = report.TryGetProperty("static_kv_cache", out var staticKvProp)
+        _staticKvCache       = allowStaticKvCache
+                               && report.TryGetProperty("static_kv_cache", out var staticKvProp)
                                && staticKvProp.GetBoolean();
         _maxKvTokens         = _staticKvCache && report.TryGetProperty("static_kv_max_tokens", out var maxTokProp)
                                ? maxTokProp.GetInt32()
@@ -806,10 +808,12 @@ public sealed class VibeVoiceAsr : IDisposable
         }
 
         // Locate each segment's content value in the JSON and compute word-level logprobs.
+        // Match against the serialized JSON string, not the decoded content length, so
+        // escaped characters like \" and \\ stay aligned with the generated token span.
         // The JSON produced by VibeVoice has used PascalCase keys in practice, but we
         // accept either casing here because older comments/docs referred to lowercase.
-        const string contentKeyPascal = "\"Content\":\"";
-        const string contentKeyCamel  = "\"content\":\"";
+        const string contentKeyPascal = "\"Content\":";
+        const string contentKeyCamel  = "\"content\":";
         int searchFrom = 0;
 
         for (int si = 0; si < segments.Count; si++)
@@ -835,12 +839,24 @@ public sealed class VibeVoiceAsr : IDisposable
 
             if (keyIdx < 0) break;
 
-            int contentCharStart = keyIdx + keyLength;
-            searchFrom = contentCharStart + content.Length;  // advance past this segment
+            string serializedContent = JsonSerializer.Serialize(content);
+            int serializedContentIdx = fullJson.IndexOf(
+                serializedContent, keyIdx + keyLength, StringComparison.Ordinal);
+            if (serializedContentIdx < 0)
+            {
+                searchFrom = keyIdx + keyLength;
+                continue;
+            }
+
+            int contentCharStart = serializedContentIdx + 1; // skip opening quote
+            int contentCharEnd   = serializedContentIdx + serializedContent.Length - 1; // exclude closing quote
+            searchFrom = serializedContentIdx + serializedContent.Length;
+
+            var (decodedCharStarts, decodedCharEnds) = BuildSerializedJsonCharMap(serializedContent);
 
             var tokenIndices = new List<int>();
             int prevTi = -1;
-            for (int c = contentCharStart; c < searchFrom && c < charToToken.Length; c++)
+            for (int c = contentCharStart; c < contentCharEnd && c < charToToken.Length; c++)
             {
                 int ti = charToToken[c];
                 if (ti != prevTi && ti >= 0 && ti < generated.Count)
@@ -866,8 +882,15 @@ public sealed class VibeVoiceAsr : IDisposable
                 int wordPosInContent = content.IndexOf(words[wi], wordOffset, StringComparison.Ordinal);
                 if (wordPosInContent < 0) { wordOffset += words[wi].Length; continue; }
 
-                int wcStart  = contentCharStart + wordPosInContent;
-                int wcEnd    = wcStart + words[wi].Length;
+                int wordCharEnd = wordPosInContent + words[wi].Length;
+                if (wordPosInContent >= decodedCharStarts.Length || wordCharEnd > decodedCharEnds.Length)
+                {
+                    wordOffset = wordPosInContent + words[wi].Length;
+                    continue;
+                }
+
+                int wcStart  = contentCharStart + decodedCharStarts[wordPosInContent];
+                int wcEnd    = contentCharStart + decodedCharEnds[wordCharEnd - 1];
                 wordOffset   = wordPosInContent + words[wi].Length;
 
                 // Average logprobs of unique tokens covering chars [wcStart, wcEnd).
@@ -891,6 +914,36 @@ public sealed class VibeVoiceAsr : IDisposable
         }
 
         return (tokenIdsResult, tokenLogprobsResult, wordLogprobsResult);
+    }
+
+    private static (int[] starts, int[] ends) BuildSerializedJsonCharMap(string serializedContent)
+    {
+        if (serializedContent.Length < 2)
+            return ([], []);
+
+        var starts = new List<int>(serializedContent.Length);
+        var ends   = new List<int>(serializedContent.Length);
+
+        for (int i = 1; i < serializedContent.Length - 1;)
+        {
+            starts.Add(i - 1); // offsets relative to the first content character
+
+            if (serializedContent[i] == '\\' && i + 1 < serializedContent.Length - 1)
+            {
+                if (serializedContent[i + 1] == 'u' && i + 5 < serializedContent.Length)
+                    i += 6;
+                else
+                    i += 2;
+            }
+            else
+            {
+                i += 1;
+            }
+
+            ends.Add(i - 1); // exclusive offset relative to the first content character
+        }
+
+        return ([.. starts], [.. ends]);
     }
 
     // ── Output parsing ────────────────────────────────────────────────────────

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -55,10 +55,11 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── Model dimensions ──────────────────────────────────────────────────────
 
-    private readonly int _numLayers;   // 28
-    private readonly int _numKvHeads;  // 4
-    private readonly int _headDim;     // 128
-    private readonly int _hiddenSize;  // 3584
+    private readonly int _numLayers;          // 28
+    private readonly int _numKvHeads;         // 4
+    private readonly int _headDim;            // 128
+    private readonly int _hiddenSize;         // 3584
+    private readonly int _encoderChunkSamples; // from export-report.json acoustic_tokenizer_chunk_size
 
     // ── Tokenizer ─────────────────────────────────────────────────────────────
 
@@ -89,10 +90,11 @@ public sealed class VibeVoiceAsr : IDisposable
         using var reportDoc = JsonDocument.Parse(File.ReadAllText(reportPath));
         var report = reportDoc.RootElement;
 
-        _numLayers  = report.GetProperty("num_layers").GetInt32();
-        _numKvHeads = report.GetProperty("num_kv_heads").GetInt32();
-        _headDim    = report.GetProperty("head_dim").GetInt32();
-        _hiddenSize = report.GetProperty("hidden_size").GetInt32();
+        _numLayers           = report.GetProperty("num_layers").GetInt32();
+        _numKvHeads          = report.GetProperty("num_kv_heads").GetInt32();
+        _headDim             = report.GetProperty("head_dim").GetInt32();
+        _hiddenSize          = report.GetProperty("hidden_size").GetInt32();
+        _encoderChunkSamples = report.GetProperty("acoustic_tokenizer_chunk_size").GetInt32();
 
         var tok = report.GetProperty("tokenizer");
         _prefixTokenIds       = ReadLongArray(tok.GetProperty("prefix_token_ids"));
@@ -111,12 +113,11 @@ public sealed class VibeVoiceAsr : IDisposable
         _byteLevelDecode = BuildByteLevelDecode();
 
         // Create ORT sessions
-        var cpuOpts = new SessionOptions();
-        cpuOpts.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL;
-        _audioEncoder = new InferenceSession(Path.Combine(modelDir, AudioEncoderFile), cpuOpts);
-
+        // Both models need CUDA: audio_encoder.onnx contains BFloat16 MatMul nodes in
+        // the multimodal projector that CPU EP does not implement.
         var gpuOpts = MakeSessionOptions(ep);
-        _decoder = new InferenceSession(Path.Combine(modelDir, DecoderSingleFile), gpuOpts);
+        _audioEncoder = new InferenceSession(Path.Combine(modelDir, AudioEncoderFile), gpuOpts);
+        _decoder      = new InferenceSession(Path.Combine(modelDir, DecoderSingleFile), gpuOpts);
     }
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -154,8 +155,8 @@ public sealed class VibeVoiceAsr : IDisposable
         // 2 — Build suffix token IDs (contains the audio duration)
         long[] suffixIds = BuildSuffixTokenIds(durationSeconds);
 
-        // 3 — Run audio encoder → BF16 audio embeddings
-        BFloat16[] audioEmbeddings = RunAudioEncoder(audio24k);
+        // 3 — Run audio encoder in chunks → BF16 audio embeddings
+        BFloat16[] audioEmbeddings = RunAudioEncoderChunked(audio24k);
         int numAudioTokens = audioEmbeddings.Length / _hiddenSize;
 
         // 4 — Run decoder (chunked prefill + greedy decode) → raw JSON text
@@ -228,24 +229,54 @@ public sealed class VibeVoiceAsr : IDisposable
     // ── Audio encoder ─────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Runs audio_encoder.onnx and returns the BF16 audio embeddings as a flat array
-    /// in row-major order: [numTokens * hiddenSize].
+    /// Runs audio_encoder.onnx in chunks of _encoderChunkSamples and concatenates
+    /// the BF16 audio embeddings: [numTokens * hiddenSize] in row-major order.
     /// </summary>
-    private BFloat16[] RunAudioEncoder(float[] audio24kPadded)
+    private BFloat16[] RunAudioEncoderChunked(float[] audio24kPadded)
     {
-        int n = audio24kPadded.Length;
-        var inputValues = new DenseTensor<float>(audio24kPadded, new[] { 1, n });
-        var paddingMask = new DenseTensor<float>(Enumerable.Repeat(1f, n).ToArray(), new[] { 1, n });
+        var allEmbeddings = new List<BFloat16>();
+        int total = audio24kPadded.Length;
+        int chunkSize = _encoderChunkSamples; // must be a multiple of AudioStride
 
-        var inputs = new List<NamedOnnxValue>
+        for (int offset = 0; offset < total; offset += chunkSize)
         {
-            NamedOnnxValue.CreateFromTensor("input_values", inputValues),
-            NamedOnnxValue.CreateFromTensor("padding_mask", paddingMask),
-        };
+            int len = Math.Min(chunkSize, total - offset);
+            // Pad the final chunk if shorter than chunkSize so the model sees a
+            // consistent shape; the mask marks the valid region.
+            int paddedLen = ((len + AudioStride - 1) / AudioStride) * AudioStride;
 
-        using var results = _audioEncoder.Run(inputs);
-        var embTensor = results[0].AsTensor<BFloat16>();
-        return embTensor.ToArray();
+            var inputValuesBf16 = new BFloat16[paddedLen];
+            for (int i = 0; i < len; i++)
+                inputValuesBf16[i] = (BFloat16)audio24kPadded[offset + i];
+            // remaining elements stay 0 (default BFloat16 zero)
+
+            var maskBool = new bool[paddedLen];
+            for (int i = 0; i < len; i++) maskBool[i] = true;
+            // false for the padded tail
+
+            var inputValues = new DenseTensor<BFloat16>(inputValuesBf16, new[] { 1, paddedLen });
+            var paddingMask = new DenseTensor<bool>(maskBool,            new[] { 1, paddedLen });
+
+            var inputs = new List<NamedOnnxValue>
+            {
+                NamedOnnxValue.CreateFromTensor("input_values", inputValues),
+                NamedOnnxValue.CreateFromTensor("padding_mask", paddingMask),
+            };
+
+            using var results = _audioEncoder.Run(inputs);
+            var embTensor = results[0].AsTensor<BFloat16>();
+
+            // If we padded the last chunk, trim the extra tokens
+            int expectedTokens = len / AudioStride;
+            int gotTokens      = embTensor.Dimensions[0]; // [numTokens, hiddenSize]
+            int keepTokens     = Math.Min(gotTokens, expectedTokens);
+            int keepElements   = keepTokens * _hiddenSize;
+            var flat           = embTensor.ToArray();
+            for (int i = 0; i < keepElements; i++)
+                allEmbeddings.Add(flat[i]);
+        }
+
+        return [.. allEmbeddings];
     }
 
     // ── Tokenizer helpers ─────────────────────────────────────────────────────

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -50,7 +50,11 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── ORT sessions ─────────────────────────────────────────────────────────
 
-    private readonly InferenceSession _audioEncoder;
+    // The audio encoder is created on demand and disposed after each use so its
+    // GPU arena (dual float32 Conv towers) does not compete with the decoder's
+    // growing KV cache during the autoregressive decode loop.
+    private readonly string           _audioEncoderPath;
+    private readonly ExecutionProvider _ep;
     private readonly InferenceSession _decoder;
 
     // ── Model dimensions ──────────────────────────────────────────────────────
@@ -115,9 +119,13 @@ public sealed class VibeVoiceAsr : IDisposable
         // Create ORT sessions
         // Both models need CUDA: audio_encoder.onnx contains BFloat16 MatMul nodes in
         // the multimodal projector that CPU EP does not implement.
+        // The audio encoder is NOT loaded here — it is created and disposed within each
+        // Transcribe call so its GPU arena is freed before the autoregressive decode loop.
+        _audioEncoderPath = Path.Combine(modelDir, AudioEncoderFile);
+        _ep               = ep;
+
         var gpuOpts = MakeSessionOptions(ep);
-        _audioEncoder = new InferenceSession(Path.Combine(modelDir, AudioEncoderFile), gpuOpts);
-        _decoder      = new InferenceSession(Path.Combine(modelDir, DecoderSingleFile), gpuOpts);
+        _decoder = new InferenceSession(Path.Combine(modelDir, DecoderSingleFile), gpuOpts);
     }
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -155,8 +163,15 @@ public sealed class VibeVoiceAsr : IDisposable
         // 2 — Build suffix token IDs (contains the audio duration)
         long[] suffixIds = BuildSuffixTokenIds(durationSeconds);
 
-        // 3 — Run audio encoder in chunks → BF16 audio embeddings
-        BFloat16[] audioEmbeddings = RunAudioEncoderChunked(audio24k);
+        // 3 — Run audio encoder in chunks → BF16 audio embeddings.
+        //     The encoder session is created here and disposed immediately after so its
+        //     GPU arena (float32 Conv towers) is freed before the decoder KV cache grows.
+        BFloat16[] audioEmbeddings;
+        {
+            using var audioEncoder = new InferenceSession(
+                _audioEncoderPath, MakeSessionOptions(_ep));
+            audioEmbeddings = RunAudioEncoderChunked(audio24k, audioEncoder);
+        }
         int numAudioTokens = audioEmbeddings.Length / _hiddenSize;
 
         // 4 — Run decoder (chunked prefill + greedy decode) → raw JSON text
@@ -175,7 +190,6 @@ public sealed class VibeVoiceAsr : IDisposable
 
     public void Dispose()
     {
-        _audioEncoder.Dispose();
         _decoder.Dispose();
     }
 
@@ -232,7 +246,7 @@ public sealed class VibeVoiceAsr : IDisposable
     /// Runs audio_encoder.onnx in chunks of _encoderChunkSamples and concatenates
     /// the BF16 audio embeddings: [numTokens * hiddenSize] in row-major order.
     /// </summary>
-    private BFloat16[] RunAudioEncoderChunked(float[] audio24kPadded)
+    private BFloat16[] RunAudioEncoderChunked(float[] audio24kPadded, InferenceSession audioEncoder)
     {
         var allEmbeddings = new List<BFloat16>();
         int total = audio24kPadded.Length;
@@ -263,7 +277,7 @@ public sealed class VibeVoiceAsr : IDisposable
                 NamedOnnxValue.CreateFromTensor("padding_mask", paddingMask),
             };
 
-            using var results = _audioEncoder.Run(inputs);
+            using var results = audioEncoder.Run(inputs);
             var embTensor = results[0].AsTensor<BFloat16>();
 
             // If we padded the last chunk, trim the extra tokens
@@ -308,174 +322,174 @@ public sealed class VibeVoiceAsr : IDisposable
         int maxNewTokens,
         CancellationToken ct)
     {
-        // Initialise 56 empty float32 KV arrays: [1, numKvHeads, 0, headDim]
-        var pastKvs = new float[_numLayers * 2][];
-        for (int i = 0; i < pastKvs.Length; i++)
-            pastKvs[i] = [];
+        using var runOptions  = new RunOptions();
+        using var binding     = _decoder.CreateIoBinding();
+        using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.DeviceAllocator, 0, OrtMemType.Default);
 
-        // Prefill
-        long firstToken;
-        (firstToken, pastKvs) = RunPrefill(
-            prefixIds, audioEmbeddings, numAudioTokens, suffixIds,
-            pastKvs, prefillChunkTokens, ct);
-
-        // Greedy decode
-        var generated = new List<long>(256);
-        long nextToken = firstToken;
-
-        for (int step = 0; step < maxNewTokens; step++)
+        // Empty (cache_len = 0) CPU OrtValues for the initial KV inputs
+        OrtValue[] pastKvs = CreateEmptyKvOrtValues();
+        try
         {
-            ct.ThrowIfCancellationRequested();
-            if (nextToken == _eosTokenId || nextToken == _imEndTokenId)
-                break;
-            generated.Add(nextToken);
-            (nextToken, pastKvs) = RunDecoderStep(nextToken, pastKvs);
+            // ── Chunked prefill ───────────────────────────────────────────────
+
+            int    chunkSize = prefillChunkTokens > 0 ? prefillChunkTokens : numAudioTokens;
+            int    numChunks = (numAudioTokens + chunkSize - 1) / Math.Max(1, chunkSize);
+            long[] noIds     = [];
+            long   lastToken = 0;
+
+            for (int ci = 0; ci < numChunks; ci++)
+            {
+                ct.ThrowIfCancellationRequested();
+                int start = ci * chunkSize;
+                int count = Math.Min(chunkSize, numAudioTokens - start);
+
+                long[] pfx = ci == 0             ? prefixIds : noIds;
+                long[] sfx = ci == numChunks - 1 ? suffixIds : noIds;
+
+                var prevKvs = pastKvs;
+                (lastToken, pastKvs) = RunOnce(
+                    pfx, audioEmbeddings, start, count, sfx, pastKvs, binding, runOptions, cudaMemInfo);
+                foreach (var kv in prevKvs) kv.Dispose();
+            }
+
+            // ── Greedy decode ─────────────────────────────────────────────────
+
+            var    generated  = new List<long>(maxNewTokens);
+            long   nextToken  = lastToken;
+            long[] tokenBuf   = new long[1]; // reused each step — avoids per-step allocation
+
+            for (int step = 0; step < maxNewTokens; step++)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (nextToken == _eosTokenId || nextToken == _imEndTokenId) break;
+                generated.Add(nextToken);
+
+                tokenBuf[0] = nextToken;
+                var prevKvs = pastKvs;
+                (nextToken, pastKvs) = RunOnce(
+                    tokenBuf, audioEmbeddings, 0, 0, noIds, pastKvs, binding, runOptions, cudaMemInfo);
+                foreach (var kv in prevKvs) kv.Dispose();
+            }
+
+            return TokensToText(generated);
         }
-
-        return TokensToText(generated);
-    }
-
-    private (long firstToken, float[][] pastKvs) RunPrefill(
-        long[] prefixIds,
-        BFloat16[] audioEmbeddings,
-        int numAudioTokens,
-        long[] suffixIds,
-        float[][] pastKvs,
-        int prefillChunkTokens,
-        CancellationToken ct)
-    {
-        if (prefillChunkTokens <= 0 || numAudioTokens <= prefillChunkTokens)
+        finally
         {
-            // Full prefill in one shot
-            var audioTensor = MakeAudioTensor(audioEmbeddings, 0, numAudioTokens);
-            return RunSinglePrefillChunk(prefixIds, audioTensor, suffixIds, pastKvs);
+            foreach (var kv in pastKvs) kv.Dispose();
         }
-
-        // Chunked prefill
-        int numChunks = (numAudioTokens + prefillChunkTokens - 1) / prefillChunkTokens;
-        long lastToken = 0;
-        long[] emptyIds = [];
-
-        for (int ci = 0; ci < numChunks; ci++)
-        {
-            ct.ThrowIfCancellationRequested();
-            int start = ci * prefillChunkTokens;
-            int end   = Math.Min(start + prefillChunkTokens, numAudioTokens);
-
-            var pfx   = ci == 0             ? prefixIds : emptyIds;
-            var sfx   = ci == numChunks - 1 ? suffixIds : emptyIds;
-            var chunk = MakeAudioTensor(audioEmbeddings, start, end);
-
-            (lastToken, pastKvs) = RunSinglePrefillChunk(pfx, chunk, sfx, pastKvs);
-        }
-
-        return (lastToken, pastKvs);
     }
 
-    private (long firstToken, float[][] pastKvs) RunSinglePrefillChunk(
-        long[] prefixIds,
-        DenseTensor<BFloat16> audioChunk,
-        long[] suffixIds,
-        float[][] pastKvs)
+    /// <summary>
+    /// Runs the decoder once (one prefill chunk or one autoregressive step) using IO binding.
+    ///
+    /// KV cache inputs are OrtValues that may live on CPU (initial empty cache) or on CUDA
+    /// (every subsequent call). Because the outputs are also bound to CUDA, the KV data
+    /// never crosses the PCIe bus after the first step.
+    ///
+    /// Ownership note: GetOutputValues() returns a DisposableList which has no finalizer.
+    /// We extract the KV OrtValues by reference (they stay alive via their SafeHandles),
+    /// dispose the logits OrtValue immediately, and let the bare DisposableList be GC-collected
+    /// without calling Dispose — so the KV OrtValues it contained are not prematurely freed.
+    /// </summary>
+    private (long token, OrtValue[] presentKvs) RunOnce(
+        long[]       prefixIds,
+        BFloat16[]   audioData,
+        int          audioStart,
+        int          audioCount,
+        long[]       suffixIds,
+        OrtValue[]   pastKvs,
+        OrtIoBinding binding,
+        RunOptions   runOptions,
+        OrtMemoryInfo cudaMemInfo)
     {
-        var inputs = BuildDecoderInputs(
-            prefixIds:  prefixIds,
-            audioChunk: audioChunk,
-            suffixIds:  suffixIds,
-            stepToken:  null,
-            pastKvs:    pastKvs);
+        binding.ClearBoundInputs();
 
-        using var outputs = _decoder.Run(inputs);
-        long firstToken = ArgmaxLastRow(outputs[0].AsTensor<BFloat16>());
-        float[][] newKvs = ExtractKvs(outputs);
-        return (firstToken, newKvs);
-    }
-
-    private (long nextToken, float[][] pastKvs) RunDecoderStep(long token, float[][] pastKvs)
-    {
-        // Pass zero-length audio and empty prefix/suffix for pure autoregressive step
-        var emptyAudio = new DenseTensor<BFloat16>(new[] { 0, _hiddenSize });
-        var inputs = BuildDecoderInputs(
-            prefixIds:  [token],
-            audioChunk: emptyAudio,
-            suffixIds:  [],
-            stepToken:  null,
-            pastKvs:    pastKvs);
-
-        using var outputs = _decoder.Run(inputs);
-        long nextToken = ArgmaxLastRow(outputs[0].AsTensor<BFloat16>());
-        float[][] newKvs = ExtractKvs(outputs);
-        return (nextToken, newKvs);
-    }
-
-    // ── Decoder tensor helpers ────────────────────────────────────────────────
-
-    private List<NamedOnnxValue> BuildDecoderInputs(
-        long[]              prefixIds,
-        DenseTensor<BFloat16> audioChunk,
-        long[]              suffixIds,
-        long?               stepToken,
-        float[][]           pastKvs)
-    {
-        var inputs = new List<NamedOnnxValue>(_numLayers * 2 + 3);
-
-        inputs.Add(NamedOnnxValue.CreateFromTensor(
-            "prefix_input_ids",
-            new DenseTensor<long>(prefixIds, new[] { 1, prefixIds.Length })));
-
-        inputs.Add(NamedOnnxValue.CreateFromTensor("audio_embeddings", audioChunk));
-
-        inputs.Add(NamedOnnxValue.CreateFromTensor(
-            "suffix_input_ids",
-            new DenseTensor<long>(suffixIds, new[] { 1, suffixIds.Length })));
-
-        // 56 KV cache tensors
-        int cacheLen = pastKvs.Length > 0 ? pastKvs[0].Length / (_numKvHeads * _headDim) : 0;
+        // Re-register outputs every call: the KV cache grows each step, so the shape
+        // changes and ORT cannot reuse a previously allocated output buffer.
+        binding.ClearBoundOutputs();
+        binding.BindOutputToDevice("logits", OrtMemoryInfo.DefaultInstance);
         for (int i = 0; i < _numLayers; i++)
         {
-            inputs.Add(NamedOnnxValue.CreateFromTensor(
-                $"past_key_{i}",
-                new DenseTensor<float>(pastKvs[i * 2], new[] { 1, _numKvHeads, cacheLen, _headDim })));
-            inputs.Add(NamedOnnxValue.CreateFromTensor(
-                $"past_value_{i}",
-                new DenseTensor<float>(pastKvs[i * 2 + 1], new[] { 1, _numKvHeads, cacheLen, _headDim })));
+            binding.BindOutputToDevice($"present_key_{i}",   cudaMemInfo);
+            binding.BindOutputToDevice($"present_value_{i}", cudaMemInfo);
         }
 
-        return inputs;
+        // prefix_input_ids [1, P]
+        using var prefixOrtVal = OrtValue.CreateTensorValueFromMemory(
+            prefixIds, new long[] { 1, prefixIds.Length });
+        binding.BindInput("prefix_input_ids", prefixOrtVal);
+
+        // audio_embeddings [N, hiddenSize] — zero-length during decode steps
+        // Declared at method scope so it stays alive until after RunWithBinding.
+        int audioElems = audioCount * _hiddenSize;
+        using var audioOrtVal = audioElems > 0
+            ? OrtValue.CreateTensorValueFromMemory(
+                  OrtMemoryInfo.DefaultInstance,
+                  new Memory<BFloat16>(audioData, audioStart * _hiddenSize, audioElems),
+                  new long[] { audioCount, _hiddenSize })
+            : OrtValue.CreateTensorValueFromMemory(
+                  Array.Empty<BFloat16>(), new long[] { 0, _hiddenSize });
+        binding.BindInput("audio_embeddings", audioOrtVal);
+
+        // suffix_input_ids [1, S]
+        using var suffixOrtVal = OrtValue.CreateTensorValueFromMemory(
+            suffixIds, new long[] { 1, suffixIds.Length });
+        binding.BindInput("suffix_input_ids", suffixOrtVal);
+
+        // 56 KV cache inputs — GPU-resident after the first step, no copy
+        for (int i = 0; i < _numLayers; i++)
+        {
+            binding.BindInput($"past_key_{i}",   pastKvs[i * 2]);
+            binding.BindInput($"past_value_{i}", pastKvs[i * 2 + 1]);
+        }
+
+        _decoder.RunWithBinding(runOptions, binding);
+
+        // GetOutputValues() → IDisposableReadOnlyCollection<OrtValue> (a DisposableList).
+        // DisposableList has no finalizer, so skipping `using` is safe: GC collects the
+        // list shell without touching the OrtValues inside it.
+        var outputs = binding.GetOutputValues();
+
+        // outputs[0] = logits (CPU) — read argmax, then free immediately
+        int  seqLen = prefixIds.Length + audioCount + suffixIds.Length;
+        long token  = ArgmaxOrtValue(outputs[0], seqLen);
+        outputs[0].Dispose();
+
+        // outputs[1..56] = present_key/value (CUDA) — take ownership
+        var presentKvs = new OrtValue[_numLayers * 2];
+        for (int i = 0; i < _numLayers * 2; i++)
+            presentKvs[i] = outputs[i + 1];
+
+        return (token, presentKvs);
     }
 
-    private float[][] ExtractKvs(IDisposableReadOnlyCollection<DisposableNamedOnnxValue> outputs)
+    // ── Decoder helpers ───────────────────────────────────────────────────────
+
+    private OrtValue[] CreateEmptyKvOrtValues()
     {
-        // outputs[0] = logits, outputs[1..56] = present_key_0..27, present_value_0..27
-        var kvs = new float[_numLayers * 2][];
-        for (int i = 0; i < _numLayers * 2; i++)
-            kvs[i] = outputs[i + 1].AsTensor<float>().ToArray();
+        // shape [1, numKvHeads, 0, headDim] — zero total elements is valid
+        var    kvs   = new OrtValue[_numLayers * 2];
+        long[] shape = { 1, _numKvHeads, 0, _headDim };
+        for (int i = 0; i < kvs.Length; i++)
+            kvs[i] = OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(), shape);
         return kvs;
     }
 
-    private DenseTensor<BFloat16> MakeAudioTensor(BFloat16[] embeddings, int startToken, int endToken)
+    private static long ArgmaxOrtValue(OrtValue logits, int seqLen)
     {
-        int chunkLen = endToken - startToken;
-        var data = new BFloat16[chunkLen * _hiddenSize];
-        Array.Copy(embeddings, startToken * _hiddenSize, data, 0, data.Length);
-        return new DenseTensor<BFloat16>(data, new[] { chunkLen, _hiddenSize });
-    }
+        // logits: [1, seqLen, vocabSize] flattened row-major, CPU-resident
+        var span      = logits.GetTensorDataAsSpan<BFloat16>();
+        int vocabSize = span.Length / seqLen;      // batch = 1
+        int offset    = (seqLen - 1) * vocabSize;  // last token's logit row
 
-    private static long ArgmaxLastRow(Tensor<BFloat16> logits)
-    {
-        // logits shape: [1, seq_len, vocab_size]
-        int seqLen   = logits.Dimensions[1];
-        int vocabSize = logits.Dimensions[2];
-        int rowOffset = (seqLen - 1) * vocabSize;
-
-        long bestIdx = 0;
+        long  best    = 0;
         float bestVal = float.NegativeInfinity;
         for (int v = 0; v < vocabSize; v++)
         {
-            float val = (float)logits[0, seqLen - 1, v];
-            if (val > bestVal) { bestVal = val; bestIdx = v; }
+            float val = (float)span[offset + v];
+            if (val > bestVal) { bestVal = val; best = v; }
         }
-        return bestIdx;
+        return best;
     }
 
     // ── Token decoding ────────────────────────────────────────────────────────

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -124,7 +124,7 @@ public sealed class VibeVoiceAsr : IDisposable
         _audioEncoderPath = Path.Combine(modelDir, AudioEncoderFile);
         _ep               = ep;
 
-        var gpuOpts = MakeSessionOptions(ep);
+        var gpuOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED);
         _decoder = new InferenceSession(Path.Combine(modelDir, DecoderSingleFile), gpuOpts);
     }
 
@@ -657,10 +657,19 @@ public sealed class VibeVoiceAsr : IDisposable
 
     // ── Session options ───────────────────────────────────────────────────────
 
-    private static SessionOptions MakeSessionOptions(ExecutionProvider ep)
+    // The decoder must use ORT_ENABLE_EXTENDED, not ORT_ENABLE_ALL.
+    // ORT_ENABLE_ALL pattern-matches the Qwen2 BF16 softmax upcast (Cast→Softmax→Cast) and
+    // replaces it with a fused CUDA kernel that computes softmax in BF16 — different numerics
+    // from the original float32 upcast, causing content-word divergence after ~50 decode steps.
+    // ORT_ENABLE_EXTENDED skips attention fusion while still applying GeLU/LayerNorm fusions.
+    // The audio encoder keeps ORT_ENABLE_ALL because it needs memory-layout transforms to fit
+    // the float32 Conv towers within 24 GB VRAM.
+    private static SessionOptions MakeSessionOptions(
+        ExecutionProvider ep,
+        GraphOptimizationLevel optLevel = GraphOptimizationLevel.ORT_ENABLE_ALL)
     {
         var opts = new SessionOptions();
-        opts.GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL;
+        opts.GraphOptimizationLevel = optLevel;
 
         switch (ep)
         {

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -23,6 +23,8 @@ string  asrBackend      = "parakeet";   // parakeet, cohere, or vibevoice
 string? cohereModelDir  = null;         // defaults to <modelDir>/cohere_transcribe
 string? cohereLanguage  = null;         // ISO 639-1 forced language (e.g. "en")
 string? vibevoiceModelDir = null;       // defaults to <modelDir>/vibevoice_asr
+string? profileOutputDir  = null;       // ORT profiling output dir (vibevoice only)
+int     profileMaxTokens  = 200;        // cap maxNewTokens during profiling to stay under ORT 1M event limit
 ModelPrecision precision = ModelPrecision.Fp32;
 
 for (int i = 0; i < args.Length; i++)
@@ -65,6 +67,8 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--cohere-model":     cohereModelDir    = args[++i]; break;
         case "--vibevoice-model":  vibevoiceModelDir = args[++i]; break;
+        case "--profile":          profileOutputDir  = args[++i]; break;
+        case "--profile-steps":    profileMaxTokens  = int.Parse(args[++i]); break;
         case "--language":        cohereLanguage = args[++i]; break;
         case "--precision":
             precision = args[++i].ToLowerInvariant() switch {
@@ -313,8 +317,9 @@ try
         }
 
         Console.Write("Transcribing (VibeVoice-ASR)... ");
-        using var vibevoice = new VibeVoiceAsr(vibevoiceDir);
+        using var vibevoice = new VibeVoiceAsr(vibevoiceDir, profileOutputDir: profileOutputDir);
         var vibevoiceSegs = vibevoice.Transcribe(rawSamples, sampleRate, channels,
+            maxNewTokens: profileOutputDir is not null ? profileMaxTokens : 8_192,
             ct: cts.Token);
         swAsr.Stop();
 
@@ -512,6 +517,8 @@ static void PrintUsage()
     Console.WriteLine("  --asr <parakeet|cohere|vibevoice>  ASR backend (default: parakeet)");
     Console.WriteLine("  --cohere-model <dir>               Path to Cohere Transcribe model dir (default: <model>/cohere_transcribe)");
     Console.WriteLine("  --vibevoice-model <dir>            Path to VibeVoice-ASR model dir (default: <model>/vibevoice_asr)");
+    Console.WriteLine("  --profile <dir>                    Write ORT Chrome-trace JSON to <dir>/ (vibevoice only; for perf analysis)");
+    Console.WriteLine("  --profile-steps <n>                Cap decode tokens during --profile run (default: 200; ORT limit: ~1M events)");
     Console.WriteLine("  --language <code>                  Force language for Cohere ASR (ISO 639-1, e.g. en, fr, de)");
     Console.WriteLine("  --denoiser <none|dfn3>             Pre-processing denoiser (default: none)");
     Console.WriteLine("  --denoiser-models <dir>            Path to denoiser ONNX models (default: <model>/deepfilternet3)");

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -25,6 +25,8 @@ string? cohereLanguage  = null;         // ISO 639-1 forced language (e.g. "en")
 string? vibevoiceModelDir = null;       // defaults to <modelDir>/vibevoice_asr
 string? profileOutputDir  = null;       // ORT profiling output dir (vibevoice only)
 int     profileMaxTokens  = 200;        // cap maxNewTokens during profiling to stay under ORT 1M event limit
+double  minAsrSeconds     = 5.0;        // minimum group span (seconds) when using segmented VibeVoice ASR
+double  asrBufferSeconds  = 0.0;        // audio padding on each side of a group (seconds)
 ModelPrecision precision = ModelPrecision.Fp32;
 
 for (int i = 0; i < args.Length; i++)
@@ -67,6 +69,8 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--cohere-model":     cohereModelDir    = args[++i]; break;
         case "--vibevoice-model":  vibevoiceModelDir = args[++i]; break;
+        case "--min-asr-seconds":  minAsrSeconds     = double.Parse(args[++i]); break;
+        case "--asr-buffer":       asrBufferSeconds  = double.Parse(args[++i]); break;
         case "--profile":          profileOutputDir  = args[++i]; break;
         case "--profile-steps":    profileMaxTokens  = int.Parse(args[++i]); break;
         case "--language":        cohereLanguage = args[++i]; break;
@@ -316,17 +320,123 @@ try
             return 1;
         }
 
-        Console.Write("Transcribing (VibeVoice-ASR)... ");
-        using var vibevoice = new VibeVoiceAsr(vibevoiceDir, profileOutputDir: profileOutputDir);
-        var vibevoiceSegs = vibevoice.Transcribe(rawSamples, sampleRate, channels,
-            maxNewTokens: profileOutputDir is not null ? profileMaxTokens : 8_192,
-            ct: cts.Token);
-        swAsr.Stop();
+        // Persist the encoder across calls only in segmented mode (vad / diarizen).
+        // In built-in whole-recording mode the encoder is created and disposed
+        // inside each Transcribe() call so its VRAM is freed before the long decode.
+        bool persistEncoder = diarization != "vibevoice-asr-builtin";
+        using var vibevoice = new VibeVoiceAsr(vibevoiceDir, persistEncoder: persistEncoder,
+            profileOutputDir: profileOutputDir);
 
-        foreach (var seg in vibevoiceSegs)
-            results.Add((seg.Start, seg.End, $"speaker_{seg.Speaker}", seg.Content));
+        if (diarization == "vibevoice-asr-builtin")
+        {
+            // Whole-recording path: VibeVoice handles segmentation internally.
+            Console.Write("Transcribing (VibeVoice-ASR built-in diarization)... ");
+            var vibevoiceSegs = vibevoice.Transcribe(rawSamples, sampleRate, channels,
+                maxNewTokens: profileOutputDir is not null ? profileMaxTokens : 8_192,
+                ct: cts.Token);
+            swAsr.Stop();
 
-        Console.WriteLine($"{results.Count} segment(s) ({swAsr.ElapsedMilliseconds}ms)");
+            foreach (var seg in vibevoiceSegs)
+                results.Add((seg.Start, seg.End, $"speaker_{seg.Speaker}", seg.Content));
+
+            Console.WriteLine($"{results.Count} segment(s) ({swAsr.ElapsedMilliseconds}ms)");
+        }
+        else
+        {
+            // Segmented path: use VAD/diarizer segments from Phase 2, merge short
+            // groups, and run VibeVoice on each group independently.
+            var rawGroups = segs.Select(s => (s.start, s.end)).ToList();
+            var groups    = VadSegmenter.MergeShortGroups(rawGroups, minAsrSeconds);
+
+            Console.WriteLine($"Transcribing {groups.Count} group(s) from {segs.Count} segment(s) " +
+                              $"(VibeVoice-ASR, min {minAsrSeconds:F1}s)...");
+
+            // Collect VibeVoice sub-segments with absolute timestamps.
+            var vibeSegs = new List<(double start, double end, string spkId, string text)>();
+            int completed = 0;
+            foreach (var (grpStart, grpEnd) in groups)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+
+                // Slice raw audio at original sample rate (channel-frame-aligned).
+                // Pad each side by asrBufferSeconds to give VibeVoice context at
+                // group boundaries; the midpoint filter below discards any output
+                // segment whose midpoint falls outside [grpStart, grpEnd], so the
+                // same buffer audio in adjacent groups never produces duplicate text.
+                double sliceStart = Math.Max(0, grpStart - asrBufferSeconds);
+                double sliceEnd   = Math.Min(rawSamples.Length / (double)(sampleRate * channels),
+                                             grpEnd + asrBufferSeconds);
+                int startFrame = (int)(sliceStart * sampleRate);
+                int endFrame   = Math.Min((int)Math.Ceiling(sliceEnd * sampleRate),
+                                          rawSamples.Length / channels);
+                float[] slice  = rawSamples[(startFrame * channels)..(endFrame * channels)];
+                double sliceStartSec = (double)startFrame / sampleRate;
+
+                // Token cap: proportional to the full slice duration (including
+                // buffer) so hallucination loops are still bounded.
+                double sliceDuration = (double)(endFrame - startFrame) / sampleRate;
+                int groupMaxTokens = Math.Min(8_192, (int)(sliceDuration * 40) + 150);
+
+                var groupSegs = vibevoice.Transcribe(slice, sampleRate, channels,
+                    maxNewTokens: groupMaxTokens,
+                    ct: cts.Token);
+
+                // Convert to absolute timestamps and apply midpoint filter.
+                // Only keep segments whose midpoint lies within [grpStart, grpEnd]
+                // — this deduplicates the buffer overlap region between groups.
+                foreach (var seg in groupSegs)
+                {
+                    double absStart = sliceStartSec + seg.Start;
+                    double absEnd   = sliceStartSec + seg.End;
+                    double mid      = (absStart + absEnd) / 2.0;
+                    if (mid >= grpStart && mid <= grpEnd)
+                        vibeSegs.Add((absStart, absEnd, $"speaker_{seg.Speaker}", seg.Content));
+                }
+
+                completed++;
+                Console.Write($"\r  Group {completed}/{groups.Count} → {vibeSegs.Count} sub-segment(s)...");
+            }
+
+            swAsr.Stop();
+
+            // Use VibeVoice's segments directly — they carry accurate timestamps
+            // and meaningful speech boundaries.  Assign each VibeVoice segment the
+            // speaker ID from whichever diarizer segment overlaps it most.
+            //
+            // Attempting to redistribute text back onto the original diarizer
+            // segment boundaries causes blank segments and repeated text: when a
+            // VibeVoice sub-segment spans multiple diarizer segments, all of its
+            // text falls on one bucket and the others stay empty.
+            foreach (var vibe in vibeSegs.OrderBy(v => v.start))
+            {
+                if (string.IsNullOrWhiteSpace(vibe.text))
+                    continue;
+
+                // Find diarizer segment with maximum time overlap.
+                int    bestIdx     = -1;
+                double bestOverlap = 0;
+                for (int i = 0; i < segs.Count; i++)
+                {
+                    double ov = Math.Max(0,
+                        Math.Min(vibe.end, segs[i].end) - Math.Max(vibe.start, segs[i].start));
+                    if (ov > bestOverlap) { bestOverlap = ov; bestIdx = i; }
+                }
+                if (bestIdx < 0) // no overlap — fall back to nearest midpoint
+                {
+                    double vibeMid = (vibe.start + vibe.end) / 2;
+                    bestIdx = 0; double bestDist = double.MaxValue;
+                    for (int i = 0; i < segs.Count; i++)
+                    {
+                        double dist = Math.Abs((segs[i].start + segs[i].end) / 2 - vibeMid);
+                        if (dist < bestDist) { bestDist = dist; bestIdx = i; }
+                    }
+                }
+                results.Add((vibe.start, vibe.end, segs[bestIdx].spkId, vibe.text));
+            }
+
+            Console.WriteLine($"\r  {groups.Count} group(s) → {vibeSegs.Count} VibeVoice sub-segment(s) " +
+                              $"→ {results.Count} output segment(s) ({swAsr.ElapsedMilliseconds}ms)");
+        }
     }
     else if (asrBackend == "cohere")
     {
@@ -517,6 +627,8 @@ static void PrintUsage()
     Console.WriteLine("  --asr <parakeet|cohere|vibevoice>  ASR backend (default: parakeet)");
     Console.WriteLine("  --cohere-model <dir>               Path to Cohere Transcribe model dir (default: <model>/cohere_transcribe)");
     Console.WriteLine("  --vibevoice-model <dir>            Path to VibeVoice-ASR model dir (default: <model>/vibevoice_asr)");
+    Console.WriteLine("  --min-asr-seconds <n>              Minimum audio span (s) per ASR group when using segmented VibeVoice (default: 5.0)");
+    Console.WriteLine("  --asr-buffer <n>                   Seconds of audio padding on each side of a group (default: 0.0); helps boundary transitions");
     Console.WriteLine("  --profile <dir>                    Write ORT Chrome-trace JSON to <dir>/ (vibevoice only; for perf analysis)");
     Console.WriteLine("  --profile-steps <n>                Cap decode tokens during --profile run (default: 200; ORT limit: ~1M events)");
     Console.WriteLine("  --language <code>                  Force language for Cohere ASR (ISO 639-1, e.g. en, fr, de)");


### PR DESCRIPTION
## Summary
- add the VibeVoice-ASR backend and built-in segmentation flow in Avalonia
- persist VibeVoice tokens and logprobs into the results database and decode them in the transcript editor
- show an editor notice when VibeVoice token timing is approximate because token-level timings are synthetic

## Testing
- dotnet build public/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj