### PR TITLE
Qwen3-ASR integration: ONNX export, batched runtime, UI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj/
 *.suo
 .venv*/
 **/__pycache__/
+tmp/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -113,4 +113,5 @@ Exports `Qwen/Qwen3-ASR-0.6B` and `Qwen/Qwen3-ASR-1.7B` to the ONNX package we c
 - `export_qwen3_asr_to_onnx.py` — exports the Qwen3-ASR encoder, split KV-cache decoders, tokenizer assets, and config files
 - `optimize_qwen3_asr_graphs.py` — applies ORT transformer fusions to the exported encoder and decoders
 - `profile_qwen3_asr_pipeline.py` — profiles mel, encoder, decoder prefill, and decode-step timings for an exported ONNX package
+- `sweep_qwen3_asr_batching.py` — sweeps the experimental batched encoder / decoder-prefill graphs on CUDA to map safe VRAM-dependent batch sizes
 - `requirements.txt` — export dependencies

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,3 +103,14 @@ Exports `microsoft/VibeVoice-ASR-HF` to the ONNX package used by Vernacula. See 
 - `export_vibevoice_asr_to_onnx.py` — exports the VibeVoice audio encoder, decoder graph(s), configs, and export report
 - `test_static_kv_parity.py` — compares `decoder_single_static.onnx` against `decoder_single.onnx`
 - `requirements.txt` — export dependencies
+
+---
+
+## qwen3asr_export/
+
+Exports `Qwen/Qwen3-ASR-0.6B` and `Qwen/Qwen3-ASR-1.7B` to the ONNX package we can iterate on for Vernacula. This starts from the public `andrewleech/qwen3-asr-onnx` export flow, trimmed down to the core export path. See [qwen3asr_export/README.md](qwen3asr_export/README.md) for full documentation.
+
+- `export_qwen3_asr_to_onnx.py` — exports the Qwen3-ASR encoder, split KV-cache decoders, tokenizer assets, and config files
+- `optimize_qwen3_asr_graphs.py` — applies ORT transformer fusions to the exported encoder and decoders
+- `profile_qwen3_asr_pipeline.py` — profiles mel, encoder, decoder prefill, and decode-step timings for an exported ONNX package
+- `requirements.txt` — export dependencies

--- a/scripts/qwen3asr_export/README.md
+++ b/scripts/qwen3asr_export/README.md
@@ -9,7 +9,8 @@ This folder is intentionally the "start here" subset of [andrewleech/qwen3-asr-o
 - `export_qwen3_asr_to_onnx.py` - exports `encoder.onnx`, `decoder_init.onnx`, `decoder_step.onnx`, `embed_tokens.bin`, tokenizer assets, and config files
 - `optimize_qwen3_asr_graphs.py` - applies ORT transformer fusions to an exported package in place
 - `profile_qwen3_asr_pipeline.py` - profiles the exported ONNX package and reports which stages dominate runtime
-- `sweep_qwen3_asr_batching.py` - sweeps `encoder_batched.onnx` and `decoder_init_batched.onnx` on CUDA to map safe / unsafe batching regions and fit a first-pass VRAM heuristic
+- `sweep_qwen3_asr_batching.py` - sweeps `encoder_batched.onnx` and the available batched decoder prefill path (`decoder.onnx` preferred, `decoder_init_batched.onnx` legacy) on CUDA to map safe / unsafe batching regions and fit a first-pass VRAM heuristic
+- `verify_qwen3_asr_unified_batch_parity.py` - verifies mixed-length serial vs batched parity using `decoder.onnx` only
 - `src/` - helper modules vendored from the upstream exporter and kept local to this workflow
 - `requirements.txt` - Python dependencies for the export environment
 
@@ -117,6 +118,21 @@ This runs each sweep point in a fresh child process so CUDA allocator state does
 
 Use this to derive a conservative runtime heuristic for choosing Qwen batch counts from free VRAM and planned batch duration.
 
+## Unified Batch Parity
+
+Verify mixed-length parity with the single-decoder path:
+
+```bash
+python public/scripts/qwen3asr_export/verify_qwen3_asr_unified_batch_parity.py \
+  --onnx-dir ./models/qwen3-asr-1.7b \
+  --audio ./sample.wav \
+  --segments-json ./segments.json
+```
+
+The verifier uses `decoder.onnx` for both prefill and autoregressive decode, builds
+per-row prompts on the host, pads them on the right, and compacts the KV cache
+between decode steps so shorter rows do not keep fake padding positions alive.
+
 ## Graph Optimization
 
 Apply ORT transformer fusions to an exported package:
@@ -138,4 +154,4 @@ This applies the same style of offline fusions used upstream:
 - The helper modules stay local under `src/` so we can patch the export flow without depending on an external checkout.
 - In practice the current PyTorch exporter emits opset 18 kernels for this model family, so `--opset 18` is the recommended setting.
 - The main export now applies the proven offline ORT graph fusions by default after writing the ONNX files.
-- The experimental batching artifacts currently have exact ORT parity with the single-item graphs for duplicated-input batch tests.
+- The unified decoder path now has a dedicated mixed-length parity verifier; use that before changing the C# batching runtime.

--- a/scripts/qwen3asr_export/README.md
+++ b/scripts/qwen3asr_export/README.md
@@ -1,0 +1,106 @@
+# Qwen3-ASR Export
+
+Exports `Qwen/Qwen3-ASR-0.6B` and `Qwen/Qwen3-ASR-1.7B` into the ONNX package we can use as a baseline for Vernacula.
+
+This folder is intentionally the "start here" subset of [andrewleech/qwen3-asr-onnx](https://github.com/andrewleech/qwen3-asr-onnx): just the core export path and helper modules we need inside `public/`. Benchmarking, quantization sweeps, WER evaluation, and packaging scripts can stay separate while we get our own export landed and then iterate on performance.
+
+## Files
+
+- `export_qwen3_asr_to_onnx.py` - exports `encoder.onnx`, `decoder_init.onnx`, `decoder_step.onnx`, `embed_tokens.bin`, tokenizer assets, and config files
+- `optimize_qwen3_asr_graphs.py` - applies ORT transformer fusions to an exported package in place
+- `profile_qwen3_asr_pipeline.py` - profiles the exported ONNX package and reports which stages dominate runtime
+- `src/` - helper modules vendored from the upstream exporter and kept local to this workflow
+- `requirements.txt` - Python dependencies for the export environment
+
+## Environment
+
+Use Python `3.11` or `3.12`.
+
+Install dependencies:
+
+```bash
+python3 -m venv .venv-qwen3asr-export
+source .venv-qwen3asr-export/bin/activate
+pip install -r public/scripts/qwen3asr_export/requirements.txt
+```
+
+If the model or remote code is gated for your account, log in first:
+
+```bash
+huggingface-cli login
+```
+
+If Hugging Face downloads appear stuck at `0%`, disable the Xet transfer path for this workflow:
+
+```bash
+export HF_HUB_DISABLE_XET=1
+```
+
+## Main Export
+
+Export the 1.7B baseline package:
+
+```bash
+python public/scripts/qwen3asr_export/export_qwen3_asr_to_onnx.py \
+  --model Qwen/Qwen3-ASR-1.7B \
+  --output ./models/qwen3-asr-1.7b \
+  --opset 18
+```
+
+Useful options:
+
+- `--device cuda` to trace the export on GPU
+- `--dtype fp16` to shrink the exported ONNX weights after FP32 export
+- `--skip-graph-optimization` to keep the raw exported graphs instead of applying ORT offline fusions
+- `--skip-encoder` or `--skip-decoder` to rerun only one half of the package
+- `--no-share-weights` to keep separate decoder external-data files instead of renaming the init weights blob
+
+Default outputs:
+
+- `encoder.onnx`
+- `decoder_init.onnx`
+- `decoder_init.onnx.data`
+- `decoder_step.onnx` or `decoder_step.onnx.data` when too large to inline
+- `embed_tokens.bin`
+- `tokenizer.json`
+- `tokenizer_config.json`
+- `config.json`
+- `preprocessor_config.json`
+
+## Profiling
+
+Profile an exported package on a sample clip:
+
+```bash
+python public/scripts/qwen3asr_export/profile_qwen3_asr_pipeline.py \
+  --onnx-dir ./models/qwen3-asr-1.7b \
+  --audio ./sample.wav \
+  --max-tokens 128
+```
+
+Useful options:
+
+- `--execution-provider cpu|cuda` to force the ORT execution provider
+- `--enable-ort-profiling` to emit ORT JSON traces and print the hottest operators in each graph
+
+## Graph Optimization
+
+Apply ORT transformer fusions to an exported package:
+
+```bash
+python public/scripts/qwen3asr_export/optimize_qwen3_asr_graphs.py \
+  --input ./models/qwen3-asr-1.7b
+```
+
+This applies the same style of offline fusions used upstream:
+
+- decoder RMSNorm to `SimplifiedLayerNormalization`
+- encoder `SkipLayerNormalization` and `BiasGelu` where matched
+
+## Notes
+
+- This is the upstream split-decoder export adapted into Vernacula's `public/scripts` layout.
+- The current goal is a clean baseline export for Qwen3-ASR 1.7B; optimization and performance work comes next.
+- The helper modules stay local under `src/` so we can patch the export flow without depending on an external checkout.
+- In practice the current PyTorch exporter emits opset 18 kernels for this model family, so `--opset 18` is the recommended setting.
+- The main export now applies the proven offline ORT graph fusions by default after writing the ONNX files.

--- a/scripts/qwen3asr_export/README.md
+++ b/scripts/qwen3asr_export/README.md
@@ -9,6 +9,7 @@ This folder is intentionally the "start here" subset of [andrewleech/qwen3-asr-o
 - `export_qwen3_asr_to_onnx.py` - exports `encoder.onnx`, `decoder_init.onnx`, `decoder_step.onnx`, `embed_tokens.bin`, tokenizer assets, and config files
 - `optimize_qwen3_asr_graphs.py` - applies ORT transformer fusions to an exported package in place
 - `profile_qwen3_asr_pipeline.py` - profiles the exported ONNX package and reports which stages dominate runtime
+- `sweep_qwen3_asr_batching.py` - sweeps `encoder_batched.onnx` and `decoder_init_batched.onnx` on CUDA to map safe / unsafe batching regions and fit a first-pass VRAM heuristic
 - `src/` - helper modules vendored from the upstream exporter and kept local to this workflow
 - `requirements.txt` - Python dependencies for the export environment
 
@@ -51,6 +52,7 @@ Useful options:
 
 - `--device cuda` to trace the export on GPU
 - `--dtype fp16` to shrink the exported ONNX weights after FP32 export
+- `--export-batching-artifacts` to also emit experimental `encoder_batched.onnx` and `decoder_init_batched.onnx`
 - `--skip-graph-optimization` to keep the raw exported graphs instead of applying ORT offline fusions
 - `--skip-encoder` or `--skip-decoder` to rerun only one half of the package
 - `--no-share-weights` to keep separate decoder external-data files instead of renaming the init weights blob
@@ -67,6 +69,17 @@ Default outputs:
 - `config.json`
 - `preprocessor_config.json`
 
+Experimental batching artifacts:
+
+- `encoder_batched.onnx`
+  Inputs: `mel [batch, 128, time]`, `input_lengths [batch]`
+  Outputs: `audio_features [batch, audio_len_max, 2048]`, `audio_feature_lengths [batch]`
+- `decoder_init_batched.onnx`
+  Inputs: `input_ids [batch, seq_len]`, `position_ids [batch, seq_len]`, `audio_features [batch, audio_len, 2048]`, `audio_lengths [batch]`, `audio_offset [1]`
+  Outputs: `logits [batch, seq_len, vocab]`, `present_keys`, `present_values`
+
+The batched prefill graph keeps `<|audio_pad|>` embeddings in positions past each item's `audio_lengths`, so a batch can share one padded prompt length.
+
 ## Profiling
 
 Profile an exported package on a sample clip:
@@ -82,6 +95,27 @@ Useful options:
 
 - `--execution-provider cpu|cuda` to force the ORT execution provider
 - `--enable-ort-profiling` to emit ORT JSON traces and print the hottest operators in each graph
+
+## Batching Sweep
+
+Sweep the experimental batched encoder and batched decoder prefill on CUDA:
+
+```bash
+python public/scripts/qwen3asr_export/sweep_qwen3_asr_batching.py \
+  --onnx-dir ./models/qwen3-asr-1.7b \
+  --audio ./sample.wav \
+  --durations-seconds 16,20,24,28,32 \
+  --batch-sizes 6,8,10,12
+```
+
+This runs each sweep point in a fresh child process so CUDA allocator state does not pollute the VRAM readings. The output includes:
+
+- per-point success / OOM status
+- median encoder and decoder-prefill latency
+- rough encoder / decoder VRAM deltas from `nvidia-smi`
+- an observed safe / unsafe frontier by segment duration
+
+Use this to derive a conservative runtime heuristic for choosing Qwen batch counts from free VRAM and planned batch duration.
 
 ## Graph Optimization
 
@@ -104,3 +138,4 @@ This applies the same style of offline fusions used upstream:
 - The helper modules stay local under `src/` so we can patch the export flow without depending on an external checkout.
 - In practice the current PyTorch exporter emits opset 18 kernels for this model family, so `--opset 18` is the recommended setting.
 - The main export now applies the proven offline ORT graph fusions by default after writing the ONNX files.
+- The experimental batching artifacts currently have exact ORT parity with the single-item graphs for duplicated-input batch tests.

--- a/scripts/qwen3asr_export/export_qwen3_asr_to_onnx.py
+++ b/scripts/qwen3asr_export/export_qwen3_asr_to_onnx.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+Export Qwen3-ASR to ONNX format.
+
+Produces:
+    encoder.onnx         - Audio encoder (mel -> features), weights embedded in proto
+    decoder_init.onnx    - Decoder prefill (input_ids + audio -> logits + KV cache)
+    decoder_step.onnx    - Decoder step (token embed + KV cache -> logits + KV cache)
+    embed_tokens.bin     - Token embedding matrix for host-side decoder_step lookup
+    tokenizer.json       - HuggingFace tokenizer assets
+    config.json          - Architecture config + special tokens + mel params
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import onnx
+import torch
+from transformers import AutoModel, AutoTokenizer
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from src.decoder_wrapper import export_decoder_init, export_decoder_step, export_decoder_step_static
+from src.encoder_wrapper import export_encoder
+from optimize_qwen3_asr_graphs import optimize_exported_package
+from src.prompt import (
+    ASR_TEXT_TOKEN_ID,
+    AUDIO_END_TOKEN_ID,
+    AUDIO_PAD_TOKEN_ID,
+    AUDIO_START_TOKEN_ID,
+    ENDOFTEXT_TOKEN_ID,
+    EOS_TOKEN_IDS,
+    IM_END_TOKEN_ID,
+    IM_START_TOKEN_ID,
+)
+
+
+def load_model(model_id: str, device: str = "cpu", dtype: torch.dtype = torch.float32):
+    """
+    Load Qwen3-ASR.
+
+    We prefer `trust_remote_code=True` so the export works against the public
+    Hugging Face repo without requiring an extra local package install.
+    """
+    print(f"Loading model {model_id}...")
+
+    try:
+        model = AutoModel.from_pretrained(
+            model_id,
+            torch_dtype=dtype,
+            device_map=device,
+            trust_remote_code=True,
+        )
+    except Exception as exc:
+        print(f"AutoModel.from_pretrained failed: {exc}")
+        print("Trying explicit qwen_asr import...")
+        from qwen_asr.core.transformers_backend.modeling_qwen3_asr import (
+            Qwen3ASRForConditionalGeneration,
+        )
+
+        model = Qwen3ASRForConditionalGeneration.from_pretrained(
+            model_id,
+            torch_dtype=dtype,
+            device_map=device,
+        )
+
+    model.eval()
+    print(f"Model loaded. Device: {device}, dtype: {dtype}")
+    return model
+
+
+def copy_tokenizer(model_id: str, output_dir: str):
+    """Save the tokenizer assets we need beside the ONNX package."""
+    tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+    tokenizer.save_pretrained(output_dir)
+
+    keep_files = {"tokenizer.json", "tokenizer_config.json"}
+    remove_extensions = {".py", ".txt"}
+    for filename in os.listdir(output_dir):
+        if filename in keep_files:
+            continue
+        path = os.path.join(output_dir, filename)
+        if not os.path.isfile(path):
+            continue
+        _, ext = os.path.splitext(filename)
+        if ext in remove_extensions or filename == "special_tokens_map.json":
+            os.remove(path)
+
+    print(f"Tokenizer saved to {output_dir}")
+
+
+def verify_special_tokens(model_id: str):
+    """Make sure our hardcoded token IDs still match the upstream tokenizer."""
+    tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+
+    checks = {
+        "<|audio_start|>": AUDIO_START_TOKEN_ID,
+        "<|audio_end|>": AUDIO_END_TOKEN_ID,
+        "<|audio_pad|>": AUDIO_PAD_TOKEN_ID,
+        "<|im_start|>": IM_START_TOKEN_ID,
+        "<|im_end|>": IM_END_TOKEN_ID,
+        "<|endoftext|>": ENDOFTEXT_TOKEN_ID,
+    }
+
+    all_ok = True
+    for token_str, expected_id in checks.items():
+        actual_id = tokenizer.convert_tokens_to_ids(token_str)
+        if actual_id != expected_id:
+            print(f"  MISMATCH: {token_str} expected={expected_id} actual={actual_id}")
+            all_ok = False
+        else:
+            print(f"  OK: {token_str} = {actual_id}")
+
+    if not all_ok:
+        raise ValueError("Special token IDs do not match. Update src/prompt.py with the current tokenizer IDs.")
+    print("All special token IDs verified.")
+
+
+def write_preprocessor_config(output_dir: str):
+    """Write Whisper-style mel frontend metadata for downstream consumers."""
+    chunk_length = 30
+    sample_rate = 16000
+    hop_length = 160
+    n_fft = 400
+    n_mels = 128
+
+    config = {
+        "feature_extractor_type": "WhisperFeatureExtractor",
+        "feature_size": n_mels,
+        "sampling_rate": sample_rate,
+        "hop_length": hop_length,
+        "n_fft": n_fft,
+        "chunk_length": chunk_length,
+        "n_samples": chunk_length * sample_rate,
+        "nb_max_frames": chunk_length * sample_rate // hop_length,
+        "padding_side": "right",
+        "padding_value": 0.0,
+        "return_attention_mask": False,
+    }
+
+    output_path = os.path.join(output_dir, "preprocessor_config.json")
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(config, handle, indent=2)
+    print(f"Preprocessor config saved to {output_path}")
+
+
+def write_config(model, output_dir: str):
+    """Write the model metadata Vernacula will need to consume the export."""
+    thinker_config = model.config.thinker_config
+    audio_config = thinker_config.audio_config
+    text_config = thinker_config.text_config
+
+    config = {
+        "model_type": "qwen3_asr",
+        "encoder": {
+            "num_layers": audio_config.encoder_layers,
+            "hidden_size": audio_config.d_model,
+            "num_heads": audio_config.encoder_attention_heads,
+            "ffn_dim": audio_config.encoder_ffn_dim,
+            "conv_channels": audio_config.downsample_hidden_size,
+            "output_dim": audio_config.output_dim,
+            "downsample_factor": 8,
+            "num_mel_bins": audio_config.num_mel_bins,
+        },
+        "decoder": {
+            "num_layers": text_config.num_hidden_layers,
+            "hidden_size": text_config.hidden_size,
+            "num_attention_heads": text_config.num_attention_heads,
+            "num_key_value_heads": text_config.num_key_value_heads,
+            "head_dim": text_config.head_dim,
+            "intermediate_size": text_config.intermediate_size,
+            "vocab_size": text_config.vocab_size,
+            "rope_theta": text_config.rope_theta,
+            "rms_norm_eps": text_config.rms_norm_eps,
+            "tie_word_embeddings": text_config.tie_word_embeddings,
+            "rope_scaling": {
+                "mrope_section": text_config.rope_scaling.get("mrope_section", [24, 20, 20]),
+                "interleaved": text_config.rope_scaling.get("mrope_interleaved", True),
+            },
+        },
+        "embed_tokens_shape": list(model.thinker.model.embed_tokens.weight.shape),
+        "embed_tokens_dtype": "float32",
+        "mel": {
+            "sample_rate": 16000,
+            "n_fft": 400,
+            "hop_length": 160,
+            "n_mels": 128,
+            "fmin": 0,
+            "fmax": 8000,
+        },
+        "special_tokens": {
+            "eos_token_ids": EOS_TOKEN_IDS,
+            "pad_token_id": ENDOFTEXT_TOKEN_ID,
+            "im_start_token_id": IM_START_TOKEN_ID,
+            "im_end_token_id": IM_END_TOKEN_ID,
+            "audio_start_token_id": AUDIO_START_TOKEN_ID,
+            "audio_end_token_id": AUDIO_END_TOKEN_ID,
+            "audio_pad_token_id": AUDIO_PAD_TOKEN_ID,
+            "asr_text_token_id": ASR_TEXT_TOKEN_ID,
+        },
+    }
+
+    output_path = os.path.join(output_dir, "config.json")
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(config, handle, indent=2)
+    print(f"Config saved to {output_path}")
+
+
+def _convert_to_fp16(output_dir: str, filenames: list[str]):
+    """Convert exported ONNX files to FP16 while preserving FP32 I/O types."""
+    from onnxruntime.transformers.optimizer import optimize_model
+
+    for filename in filenames:
+        path = os.path.join(output_dir, filename)
+        if not os.path.exists(path):
+            print(f"  Skipping {filename} (not found)")
+            continue
+
+        size_before = os.path.getsize(path)
+        data_path = path + ".data"
+        if os.path.exists(data_path):
+            size_before += os.path.getsize(data_path)
+
+        print(f"  Converting {filename} to FP16...")
+        model = optimize_model(path, model_type="gpt2", opt_level=0)
+        model.convert_float_to_float16(keep_io_types=True)
+
+        if os.path.exists(data_path):
+            os.remove(data_path)
+        model.save_model_to_file(path)
+
+        size_after = os.path.getsize(path)
+        if os.path.exists(data_path):
+            size_after += os.path.getsize(data_path)
+        print(f"    {size_before / 1e6:.1f} MB -> {size_after / 1e6:.1f} MB")
+
+
+def _default_output_dir(model_id: str) -> str:
+    name = model_id.rstrip("/").rsplit("/", 1)[-1]
+    return os.path.join("output", name.lower())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export Qwen3-ASR to ONNX")
+    parser.add_argument("--model", default="Qwen/Qwen3-ASR-1.7B", help="Hugging Face model ID or local path")
+    parser.add_argument("--output", default=None, help="Output directory for ONNX files")
+    parser.add_argument("--device", default="cpu", help="Device for export tracing (cpu or cuda)")
+    parser.add_argument("--opset", type=int, default=18, help="ONNX opset version")
+    parser.add_argument("--skip-encoder", action="store_true", help="Skip encoder export")
+    parser.add_argument("--skip-decoder", action="store_true", help="Skip decoder export")
+    parser.add_argument(
+        "--skip-graph-optimization",
+        action="store_true",
+        help="Skip the offline ORT graph fusions normally applied after export",
+    )
+    parser.add_argument(
+        "--export-static-step",
+        action="store_true",
+        help="Also export decoder_step_static.onnx with pre-allocated KV buffers",
+    )
+    parser.add_argument(
+        "--static-kv-max-tokens",
+        type=int,
+        default=4096,
+        help="Pre-allocated token capacity for decoder_step_static.onnx",
+    )
+    parser.add_argument(
+        "--no-share-weights",
+        action="store_true",
+        help="Keep the default decoder_init external-data filename instead of renaming it",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="fp32",
+        choices=["fp32", "fp16"],
+        help="Weight storage dtype (fp16 halves model size after export)",
+    )
+    args = parser.parse_args()
+
+    if args.output is None:
+        args.output = _default_output_dir(args.model)
+
+    os.makedirs(args.output, exist_ok=True)
+
+    model = load_model(args.model, device=args.device, dtype=torch.float32)
+
+    print("\nVerifying special token IDs...")
+    verify_special_tokens(args.model)
+
+    if not args.skip_encoder:
+        print("\n=== Exporting encoder ===")
+        encoder_path = os.path.join(args.output, "encoder.onnx")
+        export_encoder(model, encoder_path, opset_version=args.opset, device=args.device)
+
+        encoder_data = encoder_path + ".data"
+        if os.path.exists(encoder_data):
+            print("  Embedding encoder weights into .onnx proto...")
+            encoder_model = onnx.load(encoder_path, load_external_data=True)
+            onnx.save(encoder_model, encoder_path)
+            os.remove(encoder_data)
+
+        if args.dtype == "fp16":
+            print("\n=== Converting encoder to FP16 ===")
+            _convert_to_fp16(args.output, ["encoder.onnx"])
+
+    export_any_decoder = (not args.skip_decoder) or args.export_static_step
+
+    if not args.skip_decoder:
+        print("\n=== Exporting decoder (init) ===")
+        export_decoder_init(
+            model,
+            os.path.join(args.output, "decoder_init.onnx"),
+            opset_version=args.opset,
+            device=args.device,
+        )
+
+        print("\n=== Exporting decoder (step) ===")
+        export_decoder_step(
+            model,
+            os.path.join(args.output, "decoder_step.onnx"),
+            opset_version=args.opset,
+            device=args.device,
+        )
+
+        if args.dtype == "fp16":
+            print("\n=== Converting decoders to FP16 ===")
+            _convert_to_fp16(args.output, ["decoder_init.onnx", "decoder_step.onnx"])
+
+        step_path = os.path.join(args.output, "decoder_step.onnx")
+        step_data = step_path + ".data"
+        if os.path.exists(step_data):
+            step_model = onnx.load(step_path, load_external_data=True)
+            proto_size = sum(len(tensor.raw_data) for tensor in step_model.graph.initializer)
+            if proto_size < 1_800_000_000:
+                print("  Inlining decoder_step weights into .onnx proto...")
+                onnx.save(step_model, step_path)
+                os.remove(step_data)
+                print(f"  decoder_step.onnx: {os.path.getsize(step_path) / 1e6:.1f} MB (self-contained)")
+            else:
+                print(f"  decoder_step too large to inline ({proto_size / 1e6:.0f} MB), keeping external data")
+
+        if not args.no_share_weights:
+            init_path = os.path.join(args.output, "decoder_init.onnx")
+            init_data = init_path + ".data"
+            if os.path.exists(init_data):
+                final_data = os.path.join(args.output, "decoder_init.onnx.data")
+                if init_data != final_data:
+                    os.rename(init_data, final_data)
+
+    if args.export_static_step:
+        print("\n=== Exporting decoder (static step) ===")
+        export_decoder_step_static(
+            model,
+            os.path.join(args.output, "decoder_step_static.onnx"),
+            static_kv_max_tokens=args.static_kv_max_tokens,
+            opset_version=args.opset,
+            device=args.device,
+        )
+
+    if export_any_decoder:
+        print("\n=== Saving embedding cache ===")
+        embed_weight = model.thinker.model.embed_tokens.weight.data
+        embed_np = embed_weight.cpu().float().numpy()
+        embed_path = os.path.join(args.output, "embed_tokens.bin")
+        embed_np.tofile(embed_path)
+        print(f"  {embed_np.shape} ({embed_np.nbytes / 1e6:.1f} MB)")
+
+    print("\n=== Copying tokenizer ===")
+    copy_tokenizer(args.model, args.output)
+
+    print("\n=== Writing config ===")
+    write_config(model, args.output)
+    write_preprocessor_config(args.output)
+
+    if not args.skip_graph_optimization:
+        print("\n=== Optimizing exported graphs ===")
+        optimize_exported_package(
+            args.output,
+            skip_encoder=args.skip_encoder,
+            skip_decoders=args.skip_decoder,
+        )
+
+    print(f"\nExport complete. Output directory: {args.output}")
+    print("Files:")
+    for filename in sorted(os.listdir(args.output)):
+        path = os.path.join(args.output, filename)
+        if not os.path.isfile(path):
+            continue
+        size = os.path.getsize(path)
+        if size > 1e6:
+            print(f"  {filename}: {size / 1e6:.1f} MB")
+        else:
+            print(f"  {filename}: {size / 1e3:.1f} KB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qwen3asr_export/export_qwen3_asr_to_onnx.py
+++ b/scripts/qwen3asr_export/export_qwen3_asr_to_onnx.py
@@ -27,8 +27,13 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from src.decoder_wrapper import export_decoder_init, export_decoder_step, export_decoder_step_static
-from src.encoder_wrapper import export_encoder
+from src.decoder_wrapper import (
+    export_decoder_init,
+    export_decoder_init_batched,
+    export_decoder_step,
+    export_decoder_step_static,
+)
+from src.encoder_wrapper import export_encoder, export_encoder_batched
 from optimize_qwen3_asr_graphs import optimize_exported_package
 from src.prompt import (
     ASR_TEXT_TOKEN_ID,
@@ -256,6 +261,11 @@ def main():
     parser.add_argument("--skip-encoder", action="store_true", help="Skip encoder export")
     parser.add_argument("--skip-decoder", action="store_true", help="Skip decoder export")
     parser.add_argument(
+        "--export-batching-artifacts",
+        action="store_true",
+        help="Also export experimental encoder_batched.onnx and decoder_init_batched.onnx",
+    )
+    parser.add_argument(
         "--skip-graph-optimization",
         action="store_true",
         help="Skip the offline ORT graph fusions normally applied after export",
@@ -294,65 +304,91 @@ def main():
     print("\nVerifying special token IDs...")
     verify_special_tokens(args.model)
 
-    if not args.skip_encoder:
-        print("\n=== Exporting encoder ===")
-        encoder_path = os.path.join(args.output, "encoder.onnx")
-        export_encoder(model, encoder_path, opset_version=args.opset, device=args.device)
+    export_any_encoder = (not args.skip_encoder) or args.export_batching_artifacts
+    if export_any_encoder:
+        if args.skip_encoder:
+            print("\n=== Skipping standard encoder export; emitting requested experimental encoder artifacts ===")
+        else:
+            print("\n=== Exporting encoder ===")
+            encoder_path = os.path.join(args.output, "encoder.onnx")
+            export_encoder(model, encoder_path, opset_version=args.opset, device=args.device)
 
-        encoder_data = encoder_path + ".data"
-        if os.path.exists(encoder_data):
-            print("  Embedding encoder weights into .onnx proto...")
-            encoder_model = onnx.load(encoder_path, load_external_data=True)
-            onnx.save(encoder_model, encoder_path)
-            os.remove(encoder_data)
+            encoder_data = encoder_path + ".data"
+            if os.path.exists(encoder_data):
+                print("  Embedding encoder weights into .onnx proto...")
+                encoder_model = onnx.load(encoder_path, load_external_data=True)
+                onnx.save(encoder_model, encoder_path)
+                os.remove(encoder_data)
 
-        if args.dtype == "fp16":
-            print("\n=== Converting encoder to FP16 ===")
-            _convert_to_fp16(args.output, ["encoder.onnx"])
+            if args.dtype == "fp16":
+                print("\n=== Converting encoder to FP16 ===")
+                _convert_to_fp16(args.output, ["encoder.onnx"])
 
-    export_any_decoder = (not args.skip_decoder) or args.export_static_step
+        if args.export_batching_artifacts:
+            print("\n=== Exporting batched encoder (experimental) ===")
+            export_encoder_batched(
+                model,
+                os.path.join(args.output, "encoder_batched.onnx"),
+                opset_version=args.opset,
+                device=args.device,
+            )
 
-    if not args.skip_decoder:
-        print("\n=== Exporting decoder (init) ===")
-        export_decoder_init(
-            model,
-            os.path.join(args.output, "decoder_init.onnx"),
-            opset_version=args.opset,
-            device=args.device,
-        )
+    export_any_decoder = (not args.skip_decoder) or args.export_static_step or args.export_batching_artifacts
 
-        print("\n=== Exporting decoder (step) ===")
-        export_decoder_step(
-            model,
-            os.path.join(args.output, "decoder_step.onnx"),
-            opset_version=args.opset,
-            device=args.device,
-        )
+    if export_any_decoder:
+        if args.skip_decoder:
+            print("\n=== Skipping standard decoder export; emitting requested experimental decoder artifacts ===")
+        else:
+            print("\n=== Exporting decoder (init) ===")
+            export_decoder_init(
+                model,
+                os.path.join(args.output, "decoder_init.onnx"),
+                opset_version=args.opset,
+                device=args.device,
+            )
 
-        if args.dtype == "fp16":
-            print("\n=== Converting decoders to FP16 ===")
-            _convert_to_fp16(args.output, ["decoder_init.onnx", "decoder_step.onnx"])
+        if args.export_batching_artifacts:
+            print("\n=== Exporting decoder (init, batched experimental) ===")
+            export_decoder_init_batched(
+                model,
+                os.path.join(args.output, "decoder_init_batched.onnx"),
+                opset_version=args.opset,
+                device=args.device,
+            )
 
-        step_path = os.path.join(args.output, "decoder_step.onnx")
-        step_data = step_path + ".data"
-        if os.path.exists(step_data):
-            step_model = onnx.load(step_path, load_external_data=True)
-            proto_size = sum(len(tensor.raw_data) for tensor in step_model.graph.initializer)
-            if proto_size < 1_800_000_000:
-                print("  Inlining decoder_step weights into .onnx proto...")
-                onnx.save(step_model, step_path)
-                os.remove(step_data)
-                print(f"  decoder_step.onnx: {os.path.getsize(step_path) / 1e6:.1f} MB (self-contained)")
-            else:
-                print(f"  decoder_step too large to inline ({proto_size / 1e6:.0f} MB), keeping external data")
+        if not args.skip_decoder:
+            print("\n=== Exporting decoder (step) ===")
+            export_decoder_step(
+                model,
+                os.path.join(args.output, "decoder_step.onnx"),
+                opset_version=args.opset,
+                device=args.device,
+            )
 
-        if not args.no_share_weights:
-            init_path = os.path.join(args.output, "decoder_init.onnx")
-            init_data = init_path + ".data"
-            if os.path.exists(init_data):
-                final_data = os.path.join(args.output, "decoder_init.onnx.data")
-                if init_data != final_data:
-                    os.rename(init_data, final_data)
+            if args.dtype == "fp16":
+                print("\n=== Converting decoders to FP16 ===")
+                _convert_to_fp16(args.output, ["decoder_init.onnx", "decoder_step.onnx"])
+
+            step_path = os.path.join(args.output, "decoder_step.onnx")
+            step_data = step_path + ".data"
+            if os.path.exists(step_data):
+                step_model = onnx.load(step_path, load_external_data=True)
+                proto_size = sum(len(tensor.raw_data) for tensor in step_model.graph.initializer)
+                if proto_size < 1_800_000_000:
+                    print("  Inlining decoder_step weights into .onnx proto...")
+                    onnx.save(step_model, step_path)
+                    os.remove(step_data)
+                    print(f"  decoder_step.onnx: {os.path.getsize(step_path) / 1e6:.1f} MB (self-contained)")
+                else:
+                    print(f"  decoder_step too large to inline ({proto_size / 1e6:.0f} MB), keeping external data")
+
+            if not args.no_share_weights:
+                init_path = os.path.join(args.output, "decoder_init.onnx")
+                init_data = init_path + ".data"
+                if os.path.exists(init_data):
+                    final_data = os.path.join(args.output, "decoder_init.onnx.data")
+                    if init_data != final_data:
+                        os.rename(init_data, final_data)
 
     if args.export_static_step:
         print("\n=== Exporting decoder (static step) ===")

--- a/scripts/qwen3asr_export/export_qwen3_asr_to_onnx.py
+++ b/scripts/qwen3asr_export/export_qwen3_asr_to_onnx.py
@@ -32,6 +32,7 @@ from src.decoder_wrapper import (
     export_decoder_init_batched,
     export_decoder_step,
     export_decoder_step_static,
+    export_decoder_unified,
 )
 from src.encoder_wrapper import export_encoder, export_encoder_batched
 from optimize_qwen3_asr_graphs import optimize_exported_package
@@ -282,6 +283,11 @@ def main():
         help="Pre-allocated token capacity for decoder_step_static.onnx",
     )
     parser.add_argument(
+        "--export-unified-decoder",
+        action="store_true",
+        help="Export decoder.onnx — a single graph for both prefill and step (replaces decoder_init + decoder_step)",
+    )
+    parser.add_argument(
         "--no-share-weights",
         action="store_true",
         help="Keep the default decoder_init external-data filename instead of renaming it",
@@ -389,6 +395,27 @@ def main():
                     final_data = os.path.join(args.output, "decoder_init.onnx.data")
                     if init_data != final_data:
                         os.rename(init_data, final_data)
+
+    if args.export_unified_decoder:
+        print("\n=== Exporting unified decoder ===")
+        unified_path = os.path.join(args.output, "decoder.onnx")
+        export_decoder_unified(model, unified_path, opset_version=args.opset, device=args.device)
+
+        if args.dtype == "fp16":
+            print("\n=== Converting unified decoder to FP16 ===")
+            _convert_to_fp16(args.output, ["decoder.onnx"])
+
+        unified_data = unified_path + ".data"
+        if os.path.exists(unified_data):
+            unified_model = onnx.load(unified_path, load_external_data=True)
+            proto_size = sum(len(tensor.raw_data) for tensor in unified_model.graph.initializer)
+            if proto_size < 1_800_000_000:
+                print("  Inlining unified decoder weights into .onnx proto...")
+                onnx.save(unified_model, unified_path)
+                os.remove(unified_data)
+                print(f"  decoder.onnx: {os.path.getsize(unified_path) / 1e6:.1f} MB (self-contained)")
+            else:
+                print(f"  decoder.onnx too large to inline ({proto_size / 1e6:.0f} MB), keeping external data")
 
     if args.export_static_step:
         print("\n=== Exporting decoder (static step) ===")

--- a/scripts/qwen3asr_export/optimize_qwen3_asr_graphs.py
+++ b/scripts/qwen3asr_export/optimize_qwen3_asr_graphs.py
@@ -76,17 +76,20 @@ def optimize_exported_package(model_dir: str, *, skip_encoder: bool = False, ski
     if not skip_encoder:
         encoder_cfg = config.get("encoder")
         if encoder_cfg is not None:
-            optimize_graph(
-                os.path.join(model_dir, "encoder.onnx"),
-                encoder_cfg["num_heads"],
-                encoder_cfg["hidden_size"],
-                use_external_data=False,
-            )
+            for encoder_name in ("encoder", "encoder_batched"):
+                path = os.path.join(model_dir, f"{encoder_name}.onnx")
+                if os.path.exists(path):
+                    optimize_graph(
+                        path,
+                        encoder_cfg["num_heads"],
+                        encoder_cfg["hidden_size"],
+                        use_external_data=False,
+                    )
 
     if not skip_decoders:
         decoder_cfg = config.get("decoder")
         if decoder_cfg is not None:
-            for decoder_name in ("decoder_init", "decoder_step"):
+            for decoder_name in ("decoder_init", "decoder_init_batched", "decoder_step"):
                 path = os.path.join(model_dir, f"{decoder_name}.onnx")
                 if os.path.exists(path):
                     optimize_graph(

--- a/scripts/qwen3asr_export/optimize_qwen3_asr_graphs.py
+++ b/scripts/qwen3asr_export/optimize_qwen3_asr_graphs.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Apply ORT transformer optimizer fusions to Qwen3-ASR ONNX graphs.
+
+This mirrors the upstream graph optimization flow:
+  - encoder: SkipLayerNormalization / BiasGelu fusions
+  - decoders: SimplifiedLayerNormalization fusion for decomposed RMSNorm
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import onnx
+from onnxruntime.transformers.optimizer import optimize_model
+
+
+PROTOBUF_LIMIT = 2 * 1024**3
+
+
+def load_config(model_dir: str) -> dict:
+    config_path = os.path.join(model_dir, "config.json")
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"config.json not found in {model_dir}")
+    with open(config_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def optimize_graph(onnx_path: str, num_heads: int, hidden_size: int, *, use_external_data: bool) -> None:
+    basename = os.path.basename(onnx_path)
+    print(f"\nOptimizing {basename}...")
+
+    model_proto = onnx.load(onnx_path, load_external_data=False)
+    nodes_before = len(model_proto.graph.node)
+    del model_proto
+
+    model = optimize_model(
+        onnx_path,
+        model_type="gpt2",
+        num_heads=num_heads,
+        hidden_size=hidden_size,
+        opt_level=1,
+    )
+
+    fusions = model.get_fused_operator_statistics() or {}
+    applied = {op: count for op, count in fusions.items() if count > 0}
+    if not applied:
+        print("  No fusions applied, skipping save")
+        return
+
+    print("  Fusions applied:")
+    for op_type, count in sorted(applied.items()):
+        print(f"    {op_type}: {count}")
+
+    if not use_external_data:
+        estimated_size = model.model.ByteSize()
+        if estimated_size > PROTOBUF_LIMIT * 0.85:
+            print(
+                f"  WARNING: estimated model size {estimated_size / 1024**3:.2f} GB "
+                "is close to the protobuf size limit"
+            )
+
+    model.save_model_to_file(onnx_path, use_external_data_format=use_external_data)
+
+    nodes_after = len(model.model.graph.node)
+    reduction = nodes_before - nodes_after
+    pct = (reduction / nodes_before * 100.0) if nodes_before else 0.0
+    print(f"  Nodes: {nodes_before} -> {nodes_after} ({reduction} removed, {pct:.1f}% reduction)")
+
+
+def optimize_exported_package(model_dir: str, *, skip_encoder: bool = False, skip_decoders: bool = False) -> None:
+    config = load_config(model_dir)
+
+    if not skip_encoder:
+        encoder_cfg = config.get("encoder")
+        if encoder_cfg is not None:
+            optimize_graph(
+                os.path.join(model_dir, "encoder.onnx"),
+                encoder_cfg["num_heads"],
+                encoder_cfg["hidden_size"],
+                use_external_data=False,
+            )
+
+    if not skip_decoders:
+        decoder_cfg = config.get("decoder")
+        if decoder_cfg is not None:
+            for decoder_name in ("decoder_init", "decoder_step"):
+                path = os.path.join(model_dir, f"{decoder_name}.onnx")
+                if os.path.exists(path):
+                    optimize_graph(
+                        path,
+                        decoder_cfg["num_attention_heads"],
+                        decoder_cfg["hidden_size"],
+                        use_external_data=True,
+                    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply ORT transformer optimizer to Qwen3-ASR ONNX graphs")
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Model directory containing encoder.onnx, decoder_init.onnx, decoder_step.onnx",
+    )
+    parser.add_argument("--skip-encoder", action="store_true", help="Skip encoder optimization")
+    parser.add_argument("--skip-decoders", action="store_true", help="Skip decoder optimization")
+    args = parser.parse_args()
+
+    optimize_exported_package(
+        args.input,
+        skip_encoder=args.skip_encoder,
+        skip_decoders=args.skip_decoders,
+    )
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qwen3asr_export/profile_qwen3_asr_pipeline.py
+++ b/scripts/qwen3asr_export/profile_qwen3_asr_pipeline.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""
+Profile a Qwen3-ASR ONNX package and identify the main runtime hotspots.
+
+The profiler reports coarse stage timings first:
+  - audio load / resample
+  - log-mel frontend
+  - encoder
+  - prompt build
+  - decoder prefill
+  - autoregressive decode loop
+
+With --enable-ort-profiling it also aggregates the hottest ONNX Runtime ops
+for encoder / decoder_init / decoder_step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+import soundfile as sf
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from src.mel import log_mel_spectrogram
+from src.prompt import EOS_TOKEN_IDS, build_prompt_ids, get_audio_pad_range
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Profile Qwen3-ASR ONNX pipeline timing.")
+    parser.add_argument("--onnx-dir", required=True, help="Directory containing encoder/decoder ONNX files")
+    parser.add_argument("--audio", required=True, help="Audio file to profile")
+    parser.add_argument("--max-tokens", type=int, default=128, help="Maximum decode tokens")
+    parser.add_argument(
+        "--decoder-mode",
+        choices=("auto", "dynamic", "static-step"),
+        default="auto",
+        help="Which decoder path to profile",
+    )
+    parser.add_argument(
+        "--static-kv-max-tokens",
+        type=int,
+        default=4096,
+        help="Token capacity for decoder_step_static.onnx",
+    )
+    parser.add_argument(
+        "--execution-provider",
+        choices=("auto", "cpu", "cuda"),
+        default="auto",
+        help="Which ORT execution provider to use",
+    )
+    parser.add_argument(
+        "--enable-ort-profiling",
+        action="store_true",
+        help="Enable ORT session profiling and print the hottest operators",
+    )
+    return parser.parse_args()
+
+
+def load_audio(path: str) -> tuple[np.ndarray, float]:
+    start = time.perf_counter()
+    audio, sample_rate = sf.read(path, dtype="float32")
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if sample_rate != 16000:
+        import librosa
+
+        audio = librosa.resample(audio, orig_sr=sample_rate, target_sr=16000)
+    return audio, time.perf_counter() - start
+
+
+def get_providers(choice: str) -> list[str]:
+    available = ort.get_available_providers()
+    if choice == "cpu":
+        return ["CPUExecutionProvider"]
+    if choice == "cuda":
+        if "CUDAExecutionProvider" not in available:
+            raise RuntimeError("CUDAExecutionProvider is not available in this environment")
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if "CUDAExecutionProvider" in available:
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    return ["CPUExecutionProvider"]
+
+
+def make_session(path: str, providers: list[str], enable_profiling: bool) -> ort.InferenceSession:
+    session_options = ort.SessionOptions()
+    if enable_profiling:
+        session_options.enable_profiling = True
+    return ort.InferenceSession(path, sess_options=session_options, providers=providers)
+
+
+def load_sessions(
+    onnx_dir: str,
+    providers: list[str],
+    enable_profiling: bool,
+    decoder_mode: str,
+) -> dict[str, ort.InferenceSession]:
+    sessions = {}
+    required_names = ["encoder", "decoder_init"]
+    if decoder_mode == "dynamic":
+        required_names.append("decoder_step")
+    elif decoder_mode == "static-step":
+        required_names.append("decoder_step_static")
+    else:
+        static_step_path = os.path.join(onnx_dir, "decoder_step_static.onnx")
+        required_names.append("decoder_step_static" if os.path.exists(static_step_path) else "decoder_step")
+
+    for name in required_names:
+        path = os.path.join(onnx_dir, f"{name}.onnx")
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+        sessions[name] = make_session(path, providers, enable_profiling)
+    return sessions
+
+
+def load_embed_tokens(onnx_dir: str) -> np.ndarray:
+    config_path = os.path.join(onnx_dir, "config.json")
+    with open(config_path, "r", encoding="utf-8") as handle:
+        config = json.load(handle)
+    shape = tuple(config["embed_tokens_shape"])
+    dtype_name = config.get("embed_tokens_dtype", "float32")
+    dtype = np.float32 if dtype_name == "float32" else np.float16
+    return np.fromfile(os.path.join(onnx_dir, "embed_tokens.bin"), dtype=dtype).reshape(shape)
+
+
+def summarize_stage_times(stage_times: list[tuple[str, float]], total: float):
+    print("\nStage breakdown")
+    for label, seconds in stage_times:
+        share = (seconds / total * 100.0) if total > 0 else 0.0
+        print(f"  {label:22s} {seconds:8.3f}s  {share:6.1f}%")
+    print(f"  {'total_pipeline':22s} {total:8.3f}s")
+
+
+def summarize_decode_steps(step_times: list[float]):
+    print("\nDecode-step stats")
+    if not step_times:
+        print("  No autoregressive steps were needed; EOS was emitted from prefill.")
+        return
+    step_ms = np.array(step_times, dtype=np.float64) * 1000.0
+    print(f"  steps:               {len(step_times)}")
+    print(f"  mean step time:      {step_ms.mean():8.2f} ms")
+    print(f"  median step time:    {np.median(step_ms):8.2f} ms")
+    print(f"  p95 step time:       {np.percentile(step_ms, 95):8.2f} ms")
+    print(f"  max step time:       {step_ms.max():8.2f} ms")
+
+
+def summarize_ort_profile(name: str, session: ort.InferenceSession, limit: int = 10):
+    profile_path = session.end_profiling()
+    if not profile_path:
+        return
+
+    with open(profile_path, "r", encoding="utf-8") as handle:
+        events = json.load(handle)
+
+    op_totals_us: dict[str, float] = defaultdict(float)
+    op_counts: dict[str, int] = defaultdict(int)
+
+    for event in events:
+        args = event.get("args", {})
+        op_name = args.get("op_name")
+        dur_us = event.get("dur")
+        if not op_name or dur_us is None:
+            continue
+        op_totals_us[op_name] += float(dur_us)
+        op_counts[op_name] += 1
+
+    top_ops = sorted(op_totals_us.items(), key=lambda item: item[1], reverse=True)[:limit]
+    print(f"\n{name} hottest ORT ops")
+    for op_name, total_us in top_ops:
+        total_ms = total_us / 1000.0
+        count = op_counts[op_name]
+        mean_ms = total_ms / count
+        print(f"  {op_name:28s} total={total_ms:9.2f}ms  calls={count:5d}  mean={mean_ms:8.3f}ms")
+
+
+def main():
+    args = parse_args()
+    providers = get_providers(args.execution_provider)
+    sessions = load_sessions(args.onnx_dir, providers, args.enable_ort_profiling, args.decoder_mode)
+    embed_tokens = load_embed_tokens(args.onnx_dir)
+
+    audio, audio_load_s = load_audio(args.audio)
+
+    pipeline_start = time.perf_counter()
+
+    start = time.perf_counter()
+    mel = log_mel_spectrogram(audio).cpu().numpy()
+    mel_s = time.perf_counter() - start
+
+    start = time.perf_counter()
+    audio_features = sessions["encoder"].run(["audio_features"], {"mel": mel})[0]
+    encoder_s = time.perf_counter() - start
+
+    start = time.perf_counter()
+    prompt_ids = build_prompt_ids(audio_features.shape[1])
+    position_ids = np.arange(len(prompt_ids), dtype=np.int64)[np.newaxis, :]
+    audio_start, _ = get_audio_pad_range(prompt_ids)
+    input_ids = np.array(prompt_ids, dtype=np.int64)[np.newaxis, :]
+    audio_offset = np.array([audio_start], dtype=np.int64)
+    prompt_build_s = time.perf_counter() - start
+
+    start = time.perf_counter()
+    logits, present_keys, present_values = sessions["decoder_init"].run(
+        ["logits", "present_keys", "present_values"],
+        {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "audio_features": audio_features,
+            "audio_offset": audio_offset,
+        },
+    )
+    prefill_s = time.perf_counter() - start
+
+    next_token = int(np.argmax(logits[0, -1, :]))
+    tokens = [next_token]
+    decode_step_times: list[float] = []
+    use_static_step = args.decoder_mode == "static-step" or (
+        args.decoder_mode == "auto" and "decoder_step_static" in sessions
+    )
+
+    if next_token not in EOS_TOKEN_IDS:
+        pos = len(prompt_ids)
+        static_keys = None
+        static_values = None
+        if use_static_step:
+            num_layers, batch, kv_heads, prompt_len, head_dim = present_keys.shape
+            static_keys = np.zeros(
+                (num_layers, batch, kv_heads, args.static_kv_max_tokens, head_dim),
+                dtype=present_keys.dtype,
+            )
+            static_values = np.zeros(
+                (num_layers, batch, kv_heads, args.static_kv_max_tokens, head_dim),
+                dtype=present_values.dtype,
+            )
+            static_keys[:, :, :, :prompt_len, :] = present_keys
+            static_values[:, :, :, :prompt_len, :] = present_values
+
+        for _ in range(args.max_tokens - 1):
+            token_embed = embed_tokens[next_token][np.newaxis, np.newaxis, :]
+            step_pos = np.array([[pos]], dtype=np.int64)
+
+            start = time.perf_counter()
+            if use_static_step:
+                logits, static_keys, static_values = sessions["decoder_step_static"].run(
+                    ["logits", "present_keys", "present_values"],
+                    {
+                        "input_embeds": token_embed,
+                        "position_ids": step_pos,
+                        "kv_pos": np.array(pos, dtype=np.int64),
+                        "past_keys": static_keys,
+                        "past_values": static_values,
+                    },
+                )
+            else:
+                logits, present_keys, present_values = sessions["decoder_step"].run(
+                    ["logits", "present_keys", "present_values"],
+                    {
+                        "input_embeds": token_embed,
+                        "position_ids": step_pos,
+                        "past_keys": present_keys,
+                        "past_values": present_values,
+                    },
+                )
+            decode_step_times.append(time.perf_counter() - start)
+
+            next_token = int(np.argmax(logits[0, -1, :]))
+            tokens.append(next_token)
+            pos += 1
+
+            if next_token in EOS_TOKEN_IDS:
+                break
+
+    total_pipeline_s = time.perf_counter() - pipeline_start
+    decode_total_s = float(sum(decode_step_times))
+
+    stage_times = [
+        ("audio_load", audio_load_s),
+        ("mel", mel_s),
+        ("encoder", encoder_s),
+        ("prompt_build", prompt_build_s),
+        ("decoder_prefill", prefill_s),
+        ("decoder_steps_total", decode_total_s),
+    ]
+
+    print(f"Providers: {providers}")
+    print(f"Audio samples: {audio.shape[0]}")
+    print(f"Mel shape: {mel.shape}")
+    print(f"Audio token count: {audio_features.shape[1]}")
+    print(f"Generated tokens: {len(tokens)}")
+    print(f"Decoder mode: {'static-step' if use_static_step else 'dynamic'}")
+
+    summarize_stage_times(stage_times, audio_load_s + total_pipeline_s)
+    summarize_decode_steps(decode_step_times)
+
+    sorted_stages = sorted(stage_times, key=lambda item: item[1], reverse=True)
+    print("\nTop bottlenecks")
+    for label, seconds in sorted_stages[:3]:
+        print(f"  {label:22s} {seconds:8.3f}s")
+
+    if args.enable_ort_profiling:
+        summarize_ort_profile("encoder", sessions["encoder"])
+        summarize_ort_profile("decoder_init", sessions["decoder_init"])
+        if use_static_step:
+            summarize_ort_profile("decoder_step_static", sessions["decoder_step_static"])
+        else:
+            summarize_ort_profile("decoder_step", sessions["decoder_step"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qwen3asr_export/requirements.txt
+++ b/scripts/qwen3asr_export/requirements.txt
@@ -1,0 +1,10 @@
+torch>=2.2
+transformers>=4.48
+onnx>=1.16
+onnxruntime>=1.17
+onnxscript
+numpy
+soundfile
+librosa
+huggingface_hub
+qwen-asr==0.0.6

--- a/scripts/qwen3asr_export/src/__init__.py
+++ b/scripts/qwen3asr_export/src/__init__.py
@@ -1,0 +1,1 @@
+"""Qwen3-ASR export helpers."""

--- a/scripts/qwen3asr_export/src/decoder_wrapper.py
+++ b/scripts/qwen3asr_export/src/decoder_wrapper.py
@@ -200,6 +200,74 @@ class DecoderInitWrapper(nn.Module):
         return logits, present_keys, present_values
 
 
+class DecoderInitBatchedWrapper(nn.Module):
+    def __init__(self, text_model, lm_head, text_config):
+        super().__init__()
+        self.embed_tokens = text_model.embed_tokens
+        self.layers = text_model.layers
+        self.norm = text_model.norm
+        self.rotary_emb = text_model.rotary_emb
+        self.lm_head = lm_head
+        self.num_kv_groups = text_config.num_attention_heads // text_config.num_key_value_heads
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        audio_features: torch.Tensor,
+        audio_lengths: torch.Tensor,
+        audio_offset: torch.Tensor,
+    ):
+        input_embeds = self.embed_tokens(input_ids)
+
+        batch_size, audio_len, hidden_size = audio_features.shape
+        start_index = audio_offset[0]
+        audio_positions = torch.arange(audio_len, device=input_ids.device).unsqueeze(0).expand(batch_size, -1)
+        valid_mask = (audio_positions < audio_lengths.unsqueeze(1)).unsqueeze(-1)
+        indices = audio_positions.unsqueeze(-1).expand(batch_size, audio_len, hidden_size) + start_index
+        target_slice = torch.gather(input_embeds, 1, indices)
+        scatter_values = torch.where(valid_mask, audio_features, target_slice)
+        input_embeds = input_embeds.scatter(1, indices, scatter_values)
+
+        _, seq_len = input_embeds.shape[:2]
+
+        pos_3d = position_ids.unsqueeze(0).expand(3, -1, -1)
+        cos, sin = self.rotary_emb(input_embeds, pos_3d)
+
+        causal_mask = torch.full(
+            (seq_len, seq_len),
+            torch.finfo(input_embeds.dtype).min,
+            device=input_embeds.device,
+            dtype=input_embeds.dtype,
+        )
+        causal_mask = torch.triu(causal_mask, diagonal=1).unsqueeze(0).unsqueeze(0)
+
+        hidden_states = input_embeds
+        all_keys = []
+        all_values = []
+
+        for layer in self.layers:
+            hidden_states, key_states, value_states = _decoder_layer_forward(
+                layer,
+                hidden_states,
+                cos,
+                sin,
+                causal_mask,
+                past_key=None,
+                past_value=None,
+                num_kv_groups=self.num_kv_groups,
+            )
+            all_keys.append(key_states)
+            all_values.append(value_states)
+
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+
+        present_keys = torch.stack(all_keys, dim=0)
+        present_values = torch.stack(all_values, dim=0)
+        return logits, present_keys, present_values
+
+
 class DecoderStepWrapper(nn.Module):
     def __init__(self, text_model, lm_head, text_config):
         super().__init__()
@@ -333,6 +401,51 @@ def export_decoder_init(model, output_path: str, opset_version: int = 17, device
 
     fixed = fix_reshape_allowzero(output_path)
     print(f"Decoder init exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")
+
+
+def export_decoder_init_batched(model, output_path: str, opset_version: int = 18, device: str = "cpu"):
+    """Export an experimental decoder prefill graph that accepts per-item audio lengths."""
+    text_config = model.config.thinker_config.text_config
+    hidden_size = text_config.hidden_size
+
+    text_model = model.thinker.model
+    lm_head = model.thinker.lm_head
+    wrapper = DecoderInitBatchedWrapper(text_model, lm_head, text_config).eval().to(device)
+
+    batch_size = 2
+    seq_len = 120
+    audio_len = 96
+    audio_offset_value = 9
+    dummy_ids = torch.zeros(batch_size, seq_len, device=device, dtype=torch.long)
+    dummy_pos = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0).expand(batch_size, -1)
+    dummy_audio = torch.randn(batch_size, audio_len, hidden_size, device=device, dtype=torch.float32)
+    dummy_audio_lengths = torch.tensor([96, 61], device=device, dtype=torch.long)
+    dummy_offset = torch.tensor([audio_offset_value], device=device, dtype=torch.long)
+
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (dummy_ids, dummy_pos, dummy_audio, dummy_audio_lengths, dummy_offset),
+            output_path,
+            input_names=["input_ids", "position_ids", "audio_features", "audio_lengths", "audio_offset"],
+            output_names=["logits", "present_keys", "present_values"],
+            dynamic_axes={
+                "input_ids": {0: "batch", 1: "seq_len"},
+                "position_ids": {0: "batch", 1: "seq_len"},
+                "audio_features": {0: "batch", 1: "audio_len"},
+                "audio_lengths": {0: "batch"},
+                "logits": {0: "batch", 1: "seq_len"},
+                "present_keys": {1: "batch", 3: "seq_len"},
+                "present_values": {1: "batch", 3: "seq_len"},
+            },
+            opset_version=opset_version,
+            do_constant_folding=True,
+        )
+
+    from .onnx_fixup import fix_reshape_allowzero
+
+    fixed = fix_reshape_allowzero(output_path)
+    print(f"Batched decoder init exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")
 
 
 def export_decoder_step(model, output_path: str, opset_version: int = 17, device: str = "cpu"):

--- a/scripts/qwen3asr_export/src/decoder_wrapper.py
+++ b/scripts/qwen3asr_export/src/decoder_wrapper.py
@@ -1,0 +1,429 @@
+"""
+Wrapper modules for Qwen3-ASR decoder export to ONNX.
+
+The export uses split decoder graphs:
+- `decoder_init.onnx` for prompt prefill
+- `decoder_step.onnx` for autoregressive decoding with explicit KV cache I/O
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary_pos_emb(query, key, cos, sin):
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    query_embed = (query * cos) + (_rotate_half(query) * sin)
+    key_embed = (key * cos) + (_rotate_half(key) * sin)
+    return query_embed, key_embed
+
+
+def _repeat_kv(hidden_states, n_rep):
+    if n_rep == 1:
+        return hidden_states
+    batch, num_kv_heads, seq_len, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_kv_heads, n_rep, seq_len, head_dim)
+    return hidden_states.reshape(batch, num_kv_heads * n_rep, seq_len, head_dim)
+
+
+def _attention(query, key, value, mask, scaling, num_kv_groups):
+    key = _repeat_kv(key, num_kv_groups)
+    value = _repeat_kv(value, num_kv_groups)
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) * scaling
+    if mask is not None:
+        attn_weights = attn_weights + mask[:, :, :, : key.shape[-2]]
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = torch.matmul(attn_weights, value)
+    return attn_output.transpose(1, 2).contiguous()
+
+
+def _scatter_static_kv(
+    *,
+    buffer: torch.Tensor,
+    update: torch.Tensor,
+    kv_pos: torch.Tensor,
+) -> torch.Tensor:
+    seq_len = update.shape[2]
+    kv_heads = update.shape[1]
+    head_dim = update.shape[3]
+    positions = torch.arange(seq_len, device=update.device, dtype=torch.int64) + kv_pos
+    indices = positions.view(1, 1, seq_len, 1).expand(1, kv_heads, seq_len, head_dim)
+    return torch.scatter(buffer, 2, indices, update)
+
+
+def _decoder_layer_forward(layer, hidden_states, cos, sin, mask, past_key, past_value, num_kv_groups):
+    attn = layer.self_attn
+
+    residual = hidden_states
+    normed = layer.input_layernorm(hidden_states)
+
+    input_shape = normed.shape[:-1]
+    hidden_shape = (*input_shape, -1, attn.head_dim)
+
+    query_states = attn.q_norm(attn.q_proj(normed).view(hidden_shape)).transpose(1, 2)
+    key_states = attn.k_norm(attn.k_proj(normed).view(hidden_shape)).transpose(1, 2)
+    value_states = attn.v_proj(normed).view(hidden_shape).transpose(1, 2)
+
+    query_states, key_states = _apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+    if past_key is not None:
+        key_states = torch.cat([past_key, key_states], dim=2)
+        value_states = torch.cat([past_value, value_states], dim=2)
+
+    attn_output = _attention(query_states, key_states, value_states, mask, attn.scaling, num_kv_groups)
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    attn_output = attn.o_proj(attn_output)
+
+    hidden_states = residual + attn_output
+
+    residual = hidden_states
+    normed = layer.post_attention_layernorm(hidden_states)
+    hidden_states = residual + layer.mlp(normed)
+
+    return hidden_states, key_states, value_states
+
+
+def _decoder_layer_forward_static(
+    layer,
+    hidden_states,
+    cos,
+    sin,
+    key_buffer,
+    value_buffer,
+    kv_pos,
+    num_kv_groups,
+):
+    attn = layer.self_attn
+
+    residual = hidden_states
+    normed = layer.input_layernorm(hidden_states)
+
+    input_shape = normed.shape[:-1]
+    hidden_shape = (*input_shape, -1, attn.head_dim)
+
+    query_states = attn.q_norm(attn.q_proj(normed).view(hidden_shape)).transpose(1, 2)
+    key_states = attn.k_norm(attn.k_proj(normed).view(hidden_shape)).transpose(1, 2)
+    value_states = attn.v_proj(normed).view(hidden_shape).transpose(1, 2)
+
+    query_states, key_states = _apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+    updated_keys = _scatter_static_kv(buffer=key_buffer, update=key_states, kv_pos=kv_pos)
+    updated_values = _scatter_static_kv(buffer=value_buffer, update=value_states, kv_pos=kv_pos)
+
+    active_length = kv_pos + key_states.shape[2]
+    active_positions = torch.arange(active_length, device=updated_keys.device, dtype=torch.int64)
+    active_keys = torch.index_select(updated_keys, 2, active_positions)
+    active_values = torch.index_select(updated_values, 2, active_positions)
+
+    attn_output = _attention(query_states, active_keys, active_values, None, attn.scaling, num_kv_groups)
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    attn_output = attn.o_proj(attn_output)
+
+    hidden_states = residual + attn_output
+
+    residual = hidden_states
+    normed = layer.post_attention_layernorm(hidden_states)
+    hidden_states = residual + layer.mlp(normed)
+
+    return hidden_states, updated_keys, updated_values
+
+
+class DecoderInitWrapper(nn.Module):
+    def __init__(self, text_model, lm_head, text_config):
+        super().__init__()
+        self.embed_tokens = text_model.embed_tokens
+        self.layers = text_model.layers
+        self.norm = text_model.norm
+        self.rotary_emb = text_model.rotary_emb
+        self.lm_head = lm_head
+        self.num_kv_groups = text_config.num_attention_heads // text_config.num_key_value_heads
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        audio_features: torch.Tensor,
+        audio_offset: torch.Tensor,
+    ):
+        input_embeds = self.embed_tokens(input_ids)
+
+        audio_len = audio_features.shape[1]
+        indices = torch.arange(audio_len, device=input_ids.device) + audio_offset[0]
+        indices = indices.unsqueeze(0).unsqueeze(-1).expand_as(audio_features)
+        input_embeds = input_embeds.scatter(1, indices, audio_features)
+
+        _, seq_len = input_embeds.shape[:2]
+
+        pos_3d = position_ids.unsqueeze(0).expand(3, -1, -1)
+        cos, sin = self.rotary_emb(input_embeds, pos_3d)
+
+        causal_mask = torch.full(
+            (seq_len, seq_len),
+            torch.finfo(input_embeds.dtype).min,
+            device=input_embeds.device,
+            dtype=input_embeds.dtype,
+        )
+        causal_mask = torch.triu(causal_mask, diagonal=1).unsqueeze(0).unsqueeze(0)
+
+        hidden_states = input_embeds
+        all_keys = []
+        all_values = []
+
+        for layer in self.layers:
+            hidden_states, key_states, value_states = _decoder_layer_forward(
+                layer,
+                hidden_states,
+                cos,
+                sin,
+                causal_mask,
+                past_key=None,
+                past_value=None,
+                num_kv_groups=self.num_kv_groups,
+            )
+            all_keys.append(key_states)
+            all_values.append(value_states)
+
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+
+        present_keys = torch.stack(all_keys, dim=0)
+        present_values = torch.stack(all_values, dim=0)
+        return logits, present_keys, present_values
+
+
+class DecoderStepWrapper(nn.Module):
+    def __init__(self, text_model, lm_head, text_config):
+        super().__init__()
+        self.layers = text_model.layers
+        self.norm = text_model.norm
+        self.rotary_emb = text_model.rotary_emb
+        self.lm_head = lm_head
+        self.num_kv_groups = text_config.num_attention_heads // text_config.num_key_value_heads
+
+    def forward(
+        self,
+        input_embeds: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_keys: torch.Tensor,
+        past_values: torch.Tensor,
+    ):
+        pos_3d = position_ids.unsqueeze(0).expand(3, -1, -1)
+        cos, sin = self.rotary_emb(input_embeds, pos_3d)
+
+        hidden_states = input_embeds
+        all_keys = []
+        all_values = []
+
+        for index, layer in enumerate(self.layers):
+            hidden_states, key_states, value_states = _decoder_layer_forward(
+                layer,
+                hidden_states,
+                cos,
+                sin,
+                None,
+                past_key=past_keys[index],
+                past_value=past_values[index],
+                num_kv_groups=self.num_kv_groups,
+            )
+            all_keys.append(key_states)
+            all_values.append(value_states)
+
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+
+        present_keys = torch.stack(all_keys, dim=0)
+        present_values = torch.stack(all_values, dim=0)
+        return logits, present_keys, present_values
+
+
+class DecoderStepStaticWrapper(nn.Module):
+    def __init__(self, text_model, lm_head, text_config):
+        super().__init__()
+        self.layers = text_model.layers
+        self.norm = text_model.norm
+        self.rotary_emb = text_model.rotary_emb
+        self.lm_head = lm_head
+        self.num_kv_groups = text_config.num_attention_heads // text_config.num_key_value_heads
+
+    def forward(
+        self,
+        input_embeds: torch.Tensor,
+        position_ids: torch.Tensor,
+        kv_pos: torch.Tensor,
+        past_keys: torch.Tensor,
+        past_values: torch.Tensor,
+    ):
+        pos_3d = position_ids.unsqueeze(0).expand(3, -1, -1)
+        cos, sin = self.rotary_emb(input_embeds, pos_3d)
+
+        hidden_states = input_embeds
+        all_keys = []
+        all_values = []
+
+        flat_kv_pos = kv_pos.reshape(())
+
+        for index, layer in enumerate(self.layers):
+            hidden_states, key_states, value_states = _decoder_layer_forward_static(
+                layer,
+                hidden_states,
+                cos,
+                sin,
+                past_keys[index],
+                past_values[index],
+                flat_kv_pos,
+                self.num_kv_groups,
+            )
+            all_keys.append(key_states)
+            all_values.append(value_states)
+
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+
+        present_keys = torch.stack(all_keys, dim=0)
+        present_values = torch.stack(all_values, dim=0)
+        return logits, present_keys, present_values
+
+
+def export_decoder_init(model, output_path: str, opset_version: int = 17, device: str = "cpu"):
+    """Export the decoder prefill graph to ONNX."""
+    text_config = model.config.thinker_config.text_config
+    hidden_size = text_config.hidden_size
+
+    text_model = model.thinker.model
+    lm_head = model.thinker.lm_head
+    wrapper = DecoderInitWrapper(text_model, lm_head, text_config).eval().to(device)
+
+    seq_len = 100
+    audio_len = 80
+    audio_offset_value = 9
+    dummy_ids = torch.zeros(1, seq_len, device=device, dtype=torch.long)
+    dummy_pos = torch.arange(seq_len, device=device, dtype=torch.long).unsqueeze(0)
+    dummy_audio = torch.randn(1, audio_len, hidden_size, device=device, dtype=torch.float32)
+    dummy_offset = torch.tensor([audio_offset_value], device=device, dtype=torch.long)
+
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (dummy_ids, dummy_pos, dummy_audio, dummy_offset),
+            output_path,
+            input_names=["input_ids", "position_ids", "audio_features", "audio_offset"],
+            output_names=["logits", "present_keys", "present_values"],
+            dynamic_axes={
+                "input_ids": {0: "batch", 1: "seq_len"},
+                "position_ids": {0: "batch", 1: "seq_len"},
+                "audio_features": {0: "batch", 1: "audio_len"},
+                "logits": {0: "batch", 1: "seq_len"},
+                "present_keys": {1: "batch", 3: "seq_len"},
+                "present_values": {1: "batch", 3: "seq_len"},
+            },
+            opset_version=opset_version,
+            do_constant_folding=True,
+        )
+
+    from .onnx_fixup import fix_reshape_allowzero
+
+    fixed = fix_reshape_allowzero(output_path)
+    print(f"Decoder init exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")
+
+
+def export_decoder_step(model, output_path: str, opset_version: int = 17, device: str = "cpu"):
+    """Export the autoregressive decoder step graph to ONNX."""
+    text_config = model.config.thinker_config.text_config
+    hidden_size = text_config.hidden_size
+    num_layers = text_config.num_hidden_layers
+    num_kv_heads = text_config.num_key_value_heads
+    head_dim = text_config.head_dim
+
+    text_model = model.thinker.model
+    lm_head = model.thinker.lm_head
+    wrapper = DecoderStepWrapper(text_model, lm_head, text_config).eval().to(device)
+
+    past_seq_len = 100
+    dummy_embeds = torch.randn(1, 1, hidden_size, device=device, dtype=torch.float32)
+    dummy_pos = torch.tensor([[past_seq_len]], device=device, dtype=torch.long)
+    dummy_past_keys = torch.randn(
+        num_layers, 1, num_kv_heads, past_seq_len, head_dim, device=device, dtype=torch.float32
+    )
+    dummy_past_values = torch.randn(
+        num_layers, 1, num_kv_heads, past_seq_len, head_dim, device=device, dtype=torch.float32
+    )
+
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (dummy_embeds, dummy_pos, dummy_past_keys, dummy_past_values),
+            output_path,
+            input_names=["input_embeds", "position_ids", "past_keys", "past_values"],
+            output_names=["logits", "present_keys", "present_values"],
+            dynamic_axes={
+                "input_embeds": {0: "batch"},
+                "position_ids": {0: "batch"},
+                "past_keys": {1: "batch", 3: "past_seq_len"},
+                "past_values": {1: "batch", 3: "past_seq_len"},
+                "logits": {0: "batch"},
+                "present_keys": {1: "batch", 3: "total_seq_len"},
+                "present_values": {1: "batch", 3: "total_seq_len"},
+            },
+            opset_version=opset_version,
+            do_constant_folding=True,
+        )
+
+    from .onnx_fixup import fix_reshape_allowzero
+
+    fixed = fix_reshape_allowzero(output_path)
+    print(f"Decoder step exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")
+
+
+def export_decoder_step_static(
+    model,
+    output_path: str,
+    *,
+    static_kv_max_tokens: int,
+    opset_version: int = 18,
+    device: str = "cpu",
+):
+    """Export a decoder step graph with pre-allocated static KV buffers."""
+    text_config = model.config.thinker_config.text_config
+    hidden_size = text_config.hidden_size
+    num_layers = text_config.num_hidden_layers
+    num_kv_heads = text_config.num_key_value_heads
+    head_dim = text_config.head_dim
+
+    text_model = model.thinker.model
+    lm_head = model.thinker.lm_head
+    wrapper = DecoderStepStaticWrapper(text_model, lm_head, text_config).eval().to(device)
+
+    dummy_embeds = torch.randn(1, 1, hidden_size, device=device, dtype=torch.float32)
+    dummy_pos = torch.tensor([[100]], device=device, dtype=torch.long)
+    dummy_kv_pos = torch.tensor(100, device=device, dtype=torch.long)
+    dummy_past_keys = torch.zeros(
+        num_layers, 1, num_kv_heads, static_kv_max_tokens, head_dim, device=device, dtype=torch.float32
+    )
+    dummy_past_values = torch.zeros(
+        num_layers, 1, num_kv_heads, static_kv_max_tokens, head_dim, device=device, dtype=torch.float32
+    )
+
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (dummy_embeds, dummy_pos, dummy_kv_pos, dummy_past_keys, dummy_past_values),
+            output_path,
+            input_names=["input_embeds", "position_ids", "kv_pos", "past_keys", "past_values"],
+            output_names=["logits", "present_keys", "present_values"],
+            opset_version=opset_version,
+            do_constant_folding=True,
+        )
+
+    from .onnx_fixup import fix_reshape_allowzero
+
+    fixed = fix_reshape_allowzero(output_path)
+    print(f"Decoder step static exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")

--- a/scripts/qwen3asr_export/src/decoder_wrapper.py
+++ b/scripts/qwen3asr_export/src/decoder_wrapper.py
@@ -1,9 +1,17 @@
 """
 Wrapper modules for Qwen3-ASR decoder export to ONNX.
 
-The export uses split decoder graphs:
-- `decoder_init.onnx` for prompt prefill
-- `decoder_step.onnx` for autoregressive decoding with explicit KV cache I/O
+Two decoder export strategies are available:
+
+Split (legacy):
+- `decoder_init.onnx` — prompt prefill (input_ids + audio_features → logits + KV cache)
+- `decoder_step.onnx` — autoregressive step (token embed + KV cache → logits + KV cache)
+
+Unified (preferred):
+- `decoder.onnx` — single graph for both prefill and step.
+  The caller builds `input_embeds` on the host (embedding lookup + audio scatter)
+  and passes a zero-length KV cache on the first (prefill) call.
+  Subsequent calls pass the growing KV cache exactly like the split `decoder_step`.
 """
 
 from __future__ import annotations
@@ -494,6 +502,157 @@ def export_decoder_step(model, output_path: str, opset_version: int = 17, device
 
     fixed = fix_reshape_allowzero(output_path)
     print(f"Decoder step exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")
+
+
+class DecoderUnifiedWrapper(nn.Module):
+    """
+    Single decoder graph covering both prompt prefill and autoregressive decode.
+
+    The caller is responsible for building ``input_embeds`` on the host:
+    embed all ``input_ids`` via the ``embed_tokens`` matrix, then scatter the
+    encoder's ``audio_features`` into the audio-pad positions.  A zero-length
+    KV cache (``past_seq_len = 0``) is passed on the first (prefill) call;
+    the returned ``present_keys / present_values`` are fed back on every
+    subsequent step call.
+
+    Inputs
+    ------
+    input_embeds : [batch, seq_len, hidden_size]
+    position_ids : [batch, seq_len]
+    past_keys    : [nlayers, batch, nkvheads, past_seq_len, head_dim]
+    past_values  : [nlayers, batch, nkvheads, past_seq_len, head_dim]
+
+    Outputs
+    -------
+    logits         : [batch, seq_len, vocab_size]
+    present_keys   : [nlayers, batch, nkvheads, past_seq_len+seq_len, head_dim]
+    present_values : [nlayers, batch, nkvheads, past_seq_len+seq_len, head_dim]
+    """
+
+    def __init__(self, text_model, lm_head, text_config):
+        super().__init__()
+        self.layers = text_model.layers
+        self.norm = text_model.norm
+        self.rotary_emb = text_model.rotary_emb
+        self.lm_head = lm_head
+        self.num_kv_groups = text_config.num_attention_heads // text_config.num_key_value_heads
+
+    def forward(
+        self,
+        input_embeds: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        past_keys: torch.Tensor,
+        past_values: torch.Tensor,
+    ):
+        pos_3d = position_ids.unsqueeze(0).expand(3, -1, -1)
+        cos, sin = self.rotary_emb(input_embeds, pos_3d)
+
+        hidden_states = input_embeds
+        all_keys = []
+        all_values = []
+
+        for index, layer in enumerate(self.layers):
+            hidden_states, key_states, value_states = _decoder_layer_forward(
+                layer,
+                hidden_states,
+                cos,
+                sin,
+                attention_mask,
+                past_key=past_keys[index],
+                past_value=past_values[index],
+                num_kv_groups=self.num_kv_groups,
+            )
+            all_keys.append(key_states)
+            all_values.append(value_states)
+
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+
+        present_keys = torch.stack(all_keys, dim=0)
+        present_values = torch.stack(all_values, dim=0)
+        return logits, present_keys, present_values
+
+
+def export_decoder_unified(model, output_path: str, opset_version: int = 18, device: str = "cpu"):
+    """Export a single decoder graph that handles both prefill (past_seq_len=0) and autoregressive decode."""
+    text_config = model.config.thinker_config.text_config
+    hidden_size = text_config.hidden_size
+    num_layers = text_config.num_hidden_layers
+    num_kv_heads = text_config.num_key_value_heads
+    head_dim = text_config.head_dim
+
+    text_model = model.thinker.model
+    lm_head = model.thinker.lm_head
+    wrapper = DecoderUnifiedWrapper(text_model, lm_head, text_config).eval().to(device)
+
+    # Trace with a step-shaped dummy (past_seq_len=100, seq_len=1).
+    # The attention_mask is passed in from the caller so the graph contains no
+    # dynamic shape computations — the mask is built on the host before each call:
+    #   prefill  → upper-triangular [1, 1, seq_len, seq_len]
+    #   step     → all-zeros        [1, 1, 1, past_seq_len+1]
+    past_seq_len = 100
+    dummy_embeds = torch.randn(1, 1, hidden_size, device=device, dtype=torch.float32)
+    dummy_pos = torch.tensor([[past_seq_len]], device=device, dtype=torch.long)
+    dummy_mask = torch.zeros(1, 1, 1, past_seq_len + 1, device=device, dtype=torch.float32)
+    dummy_past_keys = torch.randn(
+        num_layers, 1, num_kv_heads, past_seq_len, head_dim, device=device, dtype=torch.float32
+    )
+    dummy_past_values = torch.randn(
+        num_layers, 1, num_kv_heads, past_seq_len, head_dim, device=device, dtype=torch.float32
+    )
+
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (dummy_embeds, dummy_pos, dummy_mask, dummy_past_keys, dummy_past_values),
+            output_path,
+            input_names=["input_embeds", "position_ids", "attention_mask", "past_keys", "past_values"],
+            output_names=["logits", "present_keys", "present_values"],
+            dynamic_axes={
+                "input_embeds":    {0: "batch", 1: "seq_len"},
+                "position_ids":    {0: "batch", 1: "seq_len"},
+                "attention_mask":  {0: "batch", 2: "seq_len", 3: "total_seq_len"},
+                "past_keys":       {1: "batch", 3: "past_seq_len"},
+                "past_values":     {1: "batch", 3: "past_seq_len"},
+                "logits":          {0: "batch", 1: "seq_len"},
+                "present_keys":    {1: "batch", 3: "total_seq_len"},
+                "present_values":  {1: "batch", 3: "total_seq_len"},
+            },
+            opset_version=opset_version,
+            do_constant_folding=True,
+            dynamo=False,
+        )
+
+    import glob
+    import os
+    import onnx
+    from .onnx_fixup import fix_reshape_allowzero
+
+    fixed = fix_reshape_allowzero(output_path)
+
+    # The legacy tracer may scatter weights into many individual sidecar files.
+    # Consolidate everything into a single <output>.data file so the package stays tidy.
+    loaded = onnx.load(output_path, load_external_data=True)
+    data_path = output_path + ".data"
+    if os.path.exists(data_path):
+        os.remove(data_path)
+    onnx.save_model(
+        loaded,
+        output_path,
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=os.path.basename(data_path),
+        size_threshold=1024,
+    )
+    # Remove stale individual weight sidecar files left by the legacy tracer
+    model_dir = os.path.dirname(output_path)
+    sidecar_patterns = ["layers.*.weight", "norm.weight", "onnx__MatMul_*"]
+    for pattern in sidecar_patterns:
+        for f in glob.glob(os.path.join(model_dir, pattern)):
+            os.remove(f)
+
+    print(f"Unified decoder exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")
 
 
 def export_decoder_step_static(

--- a/scripts/qwen3asr_export/src/encoder_wrapper.py
+++ b/scripts/qwen3asr_export/src/encoder_wrapper.py
@@ -28,6 +28,10 @@ def _get_feat_extract_output_lengths(input_lengths):
     return value + (input_lengths // CONV_WINDOW) * TOKENS_PER_WINDOW
 
 
+def _get_feat_extract_output_lengths_scalar(input_lengths: int) -> int:
+    return int(_get_feat_extract_output_lengths(torch.tensor(input_lengths)).item())
+
+
 def _encoder_attention(query, key, value, mask, scaling):
     attn_weights = torch.matmul(query, key.transpose(2, 3)) * scaling
     attn_weights = attn_weights + mask
@@ -127,6 +131,74 @@ class EncoderWrapper(nn.Module):
         return x
 
 
+class EncoderBatchedWrapper(nn.Module):
+    def __init__(self, audio_tower):
+        super().__init__()
+        self.conv2d1 = audio_tower.conv2d1
+        self.conv2d2 = audio_tower.conv2d2
+        self.conv2d3 = audio_tower.conv2d3
+        self.conv_out = audio_tower.conv_out
+        self.positional_embedding = audio_tower.positional_embedding
+        self.layers = audio_tower.layers
+        self.ln_post = audio_tower.ln_post
+        self.proj1 = audio_tower.proj1
+        self.proj2 = audio_tower.proj2
+        self.act = audio_tower.act
+        self.scaling = self.layers[0].self_attn.scaling
+
+        self.d_model = audio_tower.config.d_model
+        self.num_heads = audio_tower.config.encoder_attention_heads
+        self.head_dim = self.d_model // self.num_heads
+        self.output_dim = audio_tower.config.output_dim
+
+    def forward(self, mel: torch.Tensor, input_lengths: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size = mel.shape[0]
+        time_steps = mel.shape[2]
+
+        pad_amount = (CONV_WINDOW - time_steps % CONV_WINDOW) % CONV_WINDOW
+        mel = F.pad(mel, (0, pad_amount))
+        padded_time = mel.shape[2]
+        num_conv_windows = padded_time // CONV_WINDOW
+
+        x = mel.reshape(batch_size, 128, num_conv_windows, CONV_WINDOW)
+        x = x.permute(0, 2, 1, 3).reshape(batch_size * num_conv_windows, 1, 128, CONV_WINDOW)
+
+        x = F.gelu(self.conv2d1(x))
+        x = F.gelu(self.conv2d2(x))
+        x = F.gelu(self.conv2d3(x))
+
+        _, channels, freq_bins, tokens_per_window = x.shape
+        x = x.permute(0, 3, 1, 2).reshape(batch_size, num_conv_windows, tokens_per_window, channels * freq_bins)
+        x = self.conv_out(x)
+
+        pos_embed = self.positional_embedding(tokens_per_window)
+        x = x + pos_embed.view(1, 1, tokens_per_window, self.d_model)
+        x = x.reshape(batch_size, num_conv_windows * tokens_per_window, self.d_model)
+
+        total_tokens = x.shape[1]
+
+        valid_counts = _get_feat_extract_output_lengths(input_lengths)
+
+        attn_pad = (ATTN_WINDOW_SIZE - total_tokens % ATTN_WINDOW_SIZE) % ATTN_WINDOW_SIZE
+        x = F.pad(x, (0, 0, 0, attn_pad))
+        total_padded = total_tokens + attn_pad
+        num_attn_windows = total_padded // ATTN_WINDOW_SIZE
+        x = x.reshape(batch_size * num_attn_windows, ATTN_WINDOW_SIZE, self.d_model)
+
+        positions = torch.arange(total_padded, device=mel.device).unsqueeze(0).expand(batch_size, -1)
+        pad_mask = (positions >= valid_counts.unsqueeze(1)).to(mel.dtype) * torch.finfo(mel.dtype).min
+        attn_mask = pad_mask.reshape(batch_size * num_attn_windows, ATTN_WINDOW_SIZE).unsqueeze(1).unsqueeze(1)
+
+        for layer in self.layers:
+            x = _encoder_layer_forward(layer, x, attn_mask, self.scaling, self.num_heads, self.head_dim)
+
+        x = x.reshape(batch_size, total_padded, self.d_model)[:, :total_tokens, :]
+        x = self.ln_post(x)
+        x = self.act(self.proj1(x))
+        x = self.proj2(x)
+        return x, valid_counts
+
+
 def export_encoder(model, output_path: str, opset_version: int = 17, device: str = "cpu"):
     """Export the audio encoder to ONNX."""
     audio_tower = model.thinker.audio_tower
@@ -137,7 +209,7 @@ def export_encoder(model, output_path: str, opset_version: int = 17, device: str
 
     with torch.no_grad():
         test_output = wrapper(dummy_mel)
-        expected_tokens = _get_feat_extract_output_lengths(997)
+        expected_tokens = _get_feat_extract_output_lengths_scalar(997)
         assert test_output.shape == (1, expected_tokens, output_dim)
 
     with torch.no_grad():
@@ -156,3 +228,40 @@ def export_encoder(model, output_path: str, opset_version: int = 17, device: str
 
     fixed = fix_reshape_allowzero(output_path)
     print(f"Encoder exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")
+
+
+def export_encoder_batched(model, output_path: str, opset_version: int = 18, device: str = "cpu"):
+    """Export an experimental batch-dynamic encoder graph with explicit input lengths."""
+    audio_tower = model.thinker.audio_tower
+    output_dim = audio_tower.config.output_dim
+    wrapper = EncoderBatchedWrapper(audio_tower).eval().to(device)
+
+    dummy_mel = torch.randn(2, 128, 997, device=device, dtype=torch.float32)
+    dummy_lengths = torch.tensor([997, 840], device=device, dtype=torch.long)
+
+    with torch.no_grad():
+        test_output, test_lengths = wrapper(dummy_mel, dummy_lengths)
+        assert test_output.shape == (2, 130, output_dim)
+        assert test_lengths.shape == (2,)
+
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (dummy_mel, dummy_lengths),
+            output_path,
+            input_names=["mel", "input_lengths"],
+            output_names=["audio_features", "audio_feature_lengths"],
+            dynamic_axes={
+                "mel": {0: "batch", 2: "time"},
+                "input_lengths": {0: "batch"},
+                "audio_features": {0: "batch", 1: "enc_time"},
+                "audio_feature_lengths": {0: "batch"},
+            },
+            opset_version=opset_version,
+            do_constant_folding=True,
+        )
+
+    from .onnx_fixup import fix_reshape_allowzero
+
+    fixed = fix_reshape_allowzero(output_path)
+    print(f"Batched encoder exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")

--- a/scripts/qwen3asr_export/src/encoder_wrapper.py
+++ b/scripts/qwen3asr_export/src/encoder_wrapper.py
@@ -1,0 +1,158 @@
+"""
+Wrapper module for Qwen3-ASR audio encoder export to ONNX.
+
+This reimplements the native encoder with trace-friendly tensor operations so
+the exported graph avoids runtime-only structures that do not serialize well.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+CONV_WINDOW = 100
+TOKENS_PER_WINDOW = 13
+ATTN_WINDOW_SIZE = 104
+
+
+def _conv_out_len(value):
+    return (value + 1) // 2
+
+
+def _get_feat_extract_output_lengths(input_lengths):
+    leave = input_lengths % CONV_WINDOW
+    value = _conv_out_len(leave)
+    value = _conv_out_len(value)
+    value = _conv_out_len(value)
+    return value + (input_lengths // CONV_WINDOW) * TOKENS_PER_WINDOW
+
+
+def _encoder_attention(query, key, value, mask, scaling):
+    attn_weights = torch.matmul(query, key.transpose(2, 3)) * scaling
+    attn_weights = attn_weights + mask
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    out = torch.matmul(attn_weights, value)
+    return out.transpose(1, 2).reshape(query.shape[0], query.shape[2], -1)
+
+
+def _encoder_layer_forward(layer, x, attn_mask, scaling, num_heads, head_dim):
+    sa = layer.self_attn
+    batch, seq, _ = x.shape
+
+    residual = x
+    normed = layer.self_attn_layer_norm(x)
+
+    query = sa.q_proj(normed).view(batch, seq, num_heads, head_dim).transpose(1, 2)
+    key = sa.k_proj(normed).view(batch, seq, num_heads, head_dim).transpose(1, 2)
+    value = sa.v_proj(normed).view(batch, seq, num_heads, head_dim).transpose(1, 2)
+
+    attn_out = _encoder_attention(query, key, value, attn_mask, scaling)
+    attn_out = sa.out_proj(attn_out)
+    x = residual + attn_out
+
+    residual = x
+    normed = layer.final_layer_norm(x)
+    x = residual + layer.fc2(F.gelu(layer.fc1(normed)))
+
+    return x
+
+
+class EncoderWrapper(nn.Module):
+    def __init__(self, audio_tower):
+        super().__init__()
+        self.conv2d1 = audio_tower.conv2d1
+        self.conv2d2 = audio_tower.conv2d2
+        self.conv2d3 = audio_tower.conv2d3
+        self.conv_out = audio_tower.conv_out
+        self.positional_embedding = audio_tower.positional_embedding
+        self.layers = audio_tower.layers
+        self.ln_post = audio_tower.ln_post
+        self.proj1 = audio_tower.proj1
+        self.proj2 = audio_tower.proj2
+        self.act = audio_tower.act
+        self.scaling = self.layers[0].self_attn.scaling
+
+        self.d_model = audio_tower.config.d_model
+        self.num_heads = audio_tower.config.encoder_attention_heads
+        self.head_dim = self.d_model // self.num_heads
+        self.output_dim = audio_tower.config.output_dim
+
+    def forward(self, mel: torch.Tensor) -> torch.Tensor:
+        time_steps = mel.shape[2]
+
+        pad_amount = (CONV_WINDOW - time_steps % CONV_WINDOW) % CONV_WINDOW
+        mel = F.pad(mel, (0, pad_amount))
+        padded_time = mel.shape[2]
+        num_conv_windows = padded_time // CONV_WINDOW
+
+        if mel.shape[0] != 1:
+            raise ValueError(f"Expected batch=1, got {mel.shape[0]}")
+
+        x = mel.squeeze(0)
+        x = x.reshape(128, num_conv_windows, CONV_WINDOW)
+        x = x.permute(1, 0, 2).unsqueeze(1)
+
+        x = F.gelu(self.conv2d1(x))
+        x = F.gelu(self.conv2d2(x))
+        x = F.gelu(self.conv2d3(x))
+
+        batch, channels, freq_bins, tokens = x.shape
+        x = x.permute(0, 3, 1, 2).reshape(batch, tokens, channels * freq_bins)
+        x = self.conv_out(x)
+
+        pos_embed = self.positional_embedding(tokens)
+        x = x + pos_embed.unsqueeze(0)
+
+        valid_count = _get_feat_extract_output_lengths(time_steps)
+        flat = x.reshape(-1, self.d_model)[:valid_count]
+
+        attn_pad = (ATTN_WINDOW_SIZE - valid_count % ATTN_WINDOW_SIZE) % ATTN_WINDOW_SIZE
+        flat = F.pad(flat, (0, 0, 0, attn_pad))
+        total_padded = valid_count + attn_pad
+        num_attn_windows = total_padded // ATTN_WINDOW_SIZE
+        x = flat.reshape(num_attn_windows, ATTN_WINDOW_SIZE, self.d_model)
+
+        positions = torch.arange(total_padded, device=mel.device).reshape(num_attn_windows, ATTN_WINDOW_SIZE)
+        pad_mask = (positions >= valid_count).to(mel.dtype) * torch.finfo(mel.dtype).min
+        attn_mask = pad_mask.unsqueeze(1).unsqueeze(1)
+
+        for layer in self.layers:
+            x = _encoder_layer_forward(layer, x, attn_mask, self.scaling, self.num_heads, self.head_dim)
+
+        x = x.reshape(-1, self.d_model)[:valid_count].unsqueeze(0)
+        x = self.ln_post(x)
+        x = self.act(self.proj1(x))
+        x = self.proj2(x)
+        return x
+
+
+def export_encoder(model, output_path: str, opset_version: int = 17, device: str = "cpu"):
+    """Export the audio encoder to ONNX."""
+    audio_tower = model.thinker.audio_tower
+    output_dim = audio_tower.config.output_dim
+    wrapper = EncoderWrapper(audio_tower).eval().to(device)
+
+    dummy_mel = torch.randn(1, 128, 997, device=device, dtype=torch.float32)
+
+    with torch.no_grad():
+        test_output = wrapper(dummy_mel)
+        expected_tokens = _get_feat_extract_output_lengths(997)
+        assert test_output.shape == (1, expected_tokens, output_dim)
+
+    with torch.no_grad():
+        torch.onnx.export(
+            wrapper,
+            (dummy_mel,),
+            output_path,
+            input_names=["mel"],
+            output_names=["audio_features"],
+            dynamic_axes={"mel": {2: "time"}, "audio_features": {1: "enc_time"}},
+            opset_version=opset_version,
+            do_constant_folding=True,
+        )
+
+    from .onnx_fixup import fix_reshape_allowzero
+
+    fixed = fix_reshape_allowzero(output_path)
+    print(f"Encoder exported to {output_path} (fixed {fixed} Reshape allowzero attrs)")

--- a/scripts/qwen3asr_export/src/mel.py
+++ b/scripts/qwen3asr_export/src/mel.py
@@ -1,0 +1,63 @@
+"""
+Whisper-compatible mel spectrogram computation for Qwen3-ASR profiling.
+
+This runs on the host side and mirrors the upstream validation helper.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+SAMPLE_RATE = 16000
+N_FFT = 400
+HOP_LENGTH = 160
+N_MELS = 128
+FMIN = 0.0
+FMAX = 8000.0
+
+
+def _mel_filterbank(sr: int, n_fft: int, n_mels: int, fmin: float, fmax: float) -> np.ndarray:
+    import librosa
+
+    return librosa.filters.mel(sr=sr, n_fft=n_fft, n_mels=n_mels, fmin=fmin, fmax=fmax, norm="slaney")
+
+
+def log_mel_spectrogram(
+    audio: np.ndarray,
+    *,
+    sample_rate: int = SAMPLE_RATE,
+    n_fft: int = N_FFT,
+    hop_length: int = HOP_LENGTH,
+    n_mels: int = N_MELS,
+    fmin: float = FMIN,
+    fmax: float = FMAX,
+    device: str = "cpu",
+) -> torch.Tensor:
+    if sample_rate != 16000:
+        raise ValueError(f"Expected 16kHz audio, got {sample_rate}Hz")
+
+    if audio.dtype != np.float32:
+        audio = audio.astype(np.float32)
+
+    mel_filters = _mel_filterbank(sample_rate, n_fft, n_mels, fmin, fmax)
+    mel_filters_t = torch.from_numpy(mel_filters).float().to(device)
+
+    window = torch.hann_window(n_fft).to(device)
+    audio_tensor = torch.from_numpy(audio).float().to(device)
+
+    stft = torch.stft(
+        audio_tensor,
+        n_fft=n_fft,
+        hop_length=hop_length,
+        window=window,
+        return_complex=True,
+    )
+    magnitudes = stft.abs() ** 2
+
+    mel_spec = mel_filters_t @ magnitudes
+    log_spec = torch.clamp(mel_spec, min=1e-10).log10()
+    log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
+    log_spec = (log_spec + 4.0) / 4.0
+    log_spec = log_spec[:, :-1]
+    return log_spec.unsqueeze(0)

--- a/scripts/qwen3asr_export/src/onnx_fixup.py
+++ b/scripts/qwen3asr_export/src/onnx_fixup.py
@@ -1,0 +1,21 @@
+"""Post-export ONNX graph fixups for runtime compatibility."""
+
+from __future__ import annotations
+
+import onnx
+
+
+def fix_reshape_allowzero(onnx_path: str) -> int:
+    """Remove allowzero=1 from Reshape nodes for DirectML compatibility."""
+    model = onnx.load(onnx_path, load_external_data=False)
+    count = 0
+    for node in model.graph.node:
+        if node.op_type != "Reshape":
+            continue
+        for attr in list(node.attribute):
+            if attr.name == "allowzero" and attr.i == 1:
+                node.attribute.remove(attr)
+                count += 1
+    if count > 0:
+        onnx.save(model, onnx_path)
+    return count

--- a/scripts/qwen3asr_export/src/prompt.py
+++ b/scripts/qwen3asr_export/src/prompt.py
@@ -1,0 +1,74 @@
+"""
+Prompt helpers and token IDs for Qwen3-ASR.
+
+The export uses these token IDs to build config metadata and verify the
+upstream tokenizer still matches what the runtime expects.
+"""
+
+from __future__ import annotations
+
+ENDOFTEXT_TOKEN_ID = 151643
+IM_START_TOKEN_ID = 151644
+IM_END_TOKEN_ID = 151645
+AUDIO_START_TOKEN_ID = 151669
+AUDIO_END_TOKEN_ID = 151670
+AUDIO_PAD_TOKEN_ID = 151676
+ASR_TEXT_TOKEN_ID = 151704
+
+EOS_TOKEN_IDS = [ENDOFTEXT_TOKEN_ID, IM_END_TOKEN_ID]
+NEWLINE_TOKEN_ID = 198
+
+
+def get_feat_extract_output_lengths(input_lengths: int) -> int:
+    """Compute the encoder output token count from a mel frame count."""
+    from src.encoder_wrapper import _get_feat_extract_output_lengths
+
+    return _get_feat_extract_output_lengths(input_lengths)
+
+
+def build_prompt_ids(audio_token_count: int, language: str | None = None) -> list[int]:
+    """Build the standard ASR chat-template prompt IDs."""
+    ids = [
+        IM_START_TOKEN_ID,
+        9125,
+        NEWLINE_TOKEN_ID,
+        IM_END_TOKEN_ID,
+        NEWLINE_TOKEN_ID,
+        IM_START_TOKEN_ID,
+        882,
+        NEWLINE_TOKEN_ID,
+        AUDIO_START_TOKEN_ID,
+    ]
+
+    ids.extend([AUDIO_PAD_TOKEN_ID] * audio_token_count)
+    ids.extend(
+        [
+            AUDIO_END_TOKEN_ID,
+            IM_END_TOKEN_ID,
+            NEWLINE_TOKEN_ID,
+            IM_START_TOKEN_ID,
+            77091,
+            NEWLINE_TOKEN_ID,
+        ]
+    )
+
+    if language is not None:
+        raise NotImplementedError(
+            "Language forcing requires tokenizer access. Use the processor chat template when we wire that in."
+        )
+
+    return ids
+
+
+def get_audio_pad_range(prompt_ids: list[int]) -> tuple[int, int]:
+    """Return the [start, end) indices covered by audio pad tokens."""
+    start = None
+    end = None
+    for index, token_id in enumerate(prompt_ids):
+        if token_id == AUDIO_PAD_TOKEN_ID:
+            if start is None:
+                start = index
+            end = index + 1
+    if start is None or end is None:
+        raise ValueError("No <|audio_pad|> tokens found in prompt")
+    return start, end

--- a/scripts/qwen3asr_export/src/unified_batch.py
+++ b/scripts/qwen3asr_export/src/unified_batch.py
@@ -1,0 +1,180 @@
+"""
+Helpers for mixed-length batching with the unified Qwen3-ASR decoder export.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+
+from .prompt import build_prompt_ids, get_audio_pad_range
+
+
+class DecoderConfig(NamedTuple):
+    hidden_size: int
+    num_layers: int
+    num_kv_heads: int
+    head_dim: int
+
+
+def build_empty_kv(batch_size: int, cfg: DecoderConfig) -> tuple[np.ndarray, np.ndarray]:
+    empty = np.zeros((cfg.num_layers, batch_size, cfg.num_kv_heads, 0, cfg.head_dim), dtype=np.float32)
+    return empty, empty.copy()
+
+
+def build_prefill_attention_mask(seq_lengths: np.ndarray) -> np.ndarray:
+    batch_size = int(seq_lengths.shape[0])
+    max_seq_len = int(seq_lengths.max())
+    mask = np.full((batch_size, 1, max_seq_len, max_seq_len), np.finfo(np.float32).min, dtype=np.float32)
+
+    for batch_index, seq_len in enumerate(seq_lengths.astype(np.int64, copy=False)):
+        valid_len = int(seq_len)
+        for query_index in range(valid_len):
+            mask[batch_index, 0, query_index, : query_index + 1] = 0.0
+
+        if valid_len < max_seq_len:
+            # Keep padded query rows numerically stable; their logits are ignored.
+            mask[batch_index, 0, valid_len:, 0] = 0.0
+
+    return mask
+
+
+def build_prefill_inputs(
+    audio_features: np.ndarray,
+    audio_feature_lengths: np.ndarray,
+    embed_table: np.ndarray,
+    cfg: DecoderConfig,
+) -> tuple[dict[str, np.ndarray], np.ndarray]:
+    batch_size = int(audio_features.shape[0])
+    hidden_size = int(cfg.hidden_size)
+
+    prompt_embeds: list[np.ndarray] = []
+    seq_lengths: list[int] = []
+
+    for batch_index in range(batch_size):
+        audio_len = int(audio_feature_lengths[batch_index])
+        prompt_ids = build_prompt_ids(audio_len)
+        prompt_embed = embed_table[prompt_ids].astype(np.float32, copy=True)
+        audio_start, _ = get_audio_pad_range(prompt_ids)
+        prompt_embed[audio_start : audio_start + audio_len] = audio_features[batch_index, :audio_len]
+        prompt_embeds.append(prompt_embed)
+        seq_lengths.append(prompt_embed.shape[0])
+
+    seq_lengths_array = np.array(seq_lengths, dtype=np.int64)
+    max_seq_len = int(seq_lengths_array.max())
+    input_embeds = np.zeros((batch_size, max_seq_len, hidden_size), dtype=np.float32)
+    position_ids = np.zeros((batch_size, max_seq_len), dtype=np.int64)
+
+    for batch_index, prompt_embed in enumerate(prompt_embeds):
+        seq_len = prompt_embed.shape[0]
+        input_embeds[batch_index, :seq_len] = prompt_embed
+        position_ids[batch_index, :seq_len] = np.arange(seq_len, dtype=np.int64)
+
+    attention_mask = build_prefill_attention_mask(seq_lengths_array)
+    past_keys, past_values = build_empty_kv(batch_size, cfg)
+
+    return {
+        "input_embeds": input_embeds,
+        "position_ids": position_ids,
+        "attention_mask": attention_mask,
+        "past_keys": past_keys,
+        "past_values": past_values,
+    }, seq_lengths_array
+
+
+def gather_last_valid_logits(logits: np.ndarray, seq_lengths: np.ndarray) -> np.ndarray:
+    batch_size = int(logits.shape[0])
+    vocab_size = int(logits.shape[2])
+    gathered = np.empty((batch_size, vocab_size), dtype=logits.dtype)
+
+    for batch_index, seq_len in enumerate(seq_lengths.astype(np.int64, copy=False)):
+        gathered[batch_index] = logits[batch_index, int(seq_len) - 1]
+
+    return gathered
+
+
+def compact_prefill_kv(
+    present_keys: np.ndarray,
+    present_values: np.ndarray,
+    seq_lengths: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    max_seq_len = int(seq_lengths.max())
+    compact_keys = np.zeros(
+        (present_keys.shape[0], present_keys.shape[1], present_keys.shape[2], max_seq_len, present_keys.shape[4]),
+        dtype=present_keys.dtype,
+    )
+    compact_values = np.zeros(
+        (present_values.shape[0], present_values.shape[1], present_values.shape[2], max_seq_len, present_values.shape[4]),
+        dtype=present_values.dtype,
+    )
+
+    for batch_index, seq_len in enumerate(seq_lengths.astype(np.int64, copy=False)):
+        valid_len = int(seq_len)
+        compact_keys[:, batch_index, :, :valid_len, :] = present_keys[:, batch_index, :, :valid_len, :]
+        compact_values[:, batch_index, :, :valid_len, :] = present_values[:, batch_index, :, :valid_len, :]
+
+    return compact_keys, compact_values
+
+
+def build_step_attention_mask(past_lengths: np.ndarray) -> np.ndarray:
+    batch_size = int(past_lengths.shape[0])
+    max_past_len = int(past_lengths.max())
+    total_len = max_past_len + 1
+    mask = np.full((batch_size, 1, 1, total_len), np.finfo(np.float32).min, dtype=np.float32)
+
+    for batch_index, past_len in enumerate(past_lengths.astype(np.int64, copy=False)):
+        valid_past_len = int(past_len)
+        mask[batch_index, 0, 0, :valid_past_len] = 0.0
+        mask[batch_index, 0, 0, max_past_len] = 0.0
+
+    return mask
+
+
+def build_step_inputs(
+    next_tokens: np.ndarray,
+    embed_table: np.ndarray,
+    past_keys: np.ndarray,
+    past_values: np.ndarray,
+    past_lengths: np.ndarray,
+) -> dict[str, np.ndarray]:
+    return {
+        "input_embeds": embed_table[next_tokens][:, np.newaxis, :].astype(np.float32, copy=False),
+        "position_ids": past_lengths.astype(np.int64, copy=False)[:, np.newaxis],
+        "attention_mask": build_step_attention_mask(past_lengths),
+        "past_keys": past_keys,
+        "past_values": past_values,
+    }
+
+
+def compact_step_kv(
+    present_keys: np.ndarray,
+    present_values: np.ndarray,
+    past_lengths: np.ndarray,
+    advance_mask: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    append_index = int(present_keys.shape[3] - 1)
+    next_lengths = past_lengths.astype(np.int64, copy=True)
+    next_lengths[advance_mask] += 1
+    max_next_len = int(next_lengths.max())
+
+    compact_keys = np.zeros(
+        (present_keys.shape[0], present_keys.shape[1], present_keys.shape[2], max_next_len, present_keys.shape[4]),
+        dtype=present_keys.dtype,
+    )
+    compact_values = np.zeros(
+        (present_values.shape[0], present_values.shape[1], present_values.shape[2], max_next_len, present_values.shape[4]),
+        dtype=present_values.dtype,
+    )
+
+    for batch_index, past_len in enumerate(past_lengths.astype(np.int64, copy=False)):
+        valid_past_len = int(past_len)
+        if valid_past_len > 0:
+            compact_keys[:, batch_index, :, :valid_past_len, :] = present_keys[:, batch_index, :, :valid_past_len, :]
+            compact_values[:, batch_index, :, :valid_past_len, :] = present_values[:, batch_index, :, :valid_past_len, :]
+
+        if bool(advance_mask[batch_index]):
+            compact_keys[:, batch_index, :, valid_past_len, :] = present_keys[:, batch_index, :, append_index, :]
+            compact_values[:, batch_index, :, valid_past_len, :] = present_values[:, batch_index, :, append_index, :]
+
+    return compact_keys, compact_values, next_lengths

--- a/scripts/qwen3asr_export/sweep_qwen3_asr_batching.py
+++ b/scripts/qwen3asr_export/sweep_qwen3_asr_batching.py
@@ -29,8 +29,6 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple
-
 import numpy as np
 import onnxruntime as ort
 
@@ -41,6 +39,7 @@ if str(SCRIPT_DIR) not in sys.path:
 from profile_qwen3_asr_pipeline import load_audio, make_session  # noqa: E402
 from src.mel import log_mel_spectrogram  # noqa: E402
 from src.prompt import build_prompt_ids, get_audio_pad_range  # noqa: E402
+from src.unified_batch import DecoderConfig, build_prefill_inputs  # noqa: E402
 
 
 def parse_csv_ints(raw: str) -> list[int]:
@@ -169,13 +168,6 @@ def attach_decoder_inputs(batch: BatchInputs, audio_feature_lengths: np.ndarray)
     )
 
 
-class DecoderConfig(NamedTuple):
-    hidden_size: int
-    num_layers: int
-    num_kv_heads: int
-    head_dim: int
-
-
 def load_decoder_config(onnx_dir: str) -> DecoderConfig:
     config_path = Path(onnx_dir) / "config.json"
     config = json.loads(config_path.read_text())
@@ -196,15 +188,6 @@ def load_embed_tokens(onnx_dir: str) -> np.ndarray:
     return np.fromfile(embed_path, dtype=np.float32).reshape(vocab_size, hidden_size)
 
 
-def build_causal_mask(seq_len: int, past_seq_len: int) -> np.ndarray:
-    total_len = past_seq_len + seq_len
-    mask = np.zeros((1, 1, seq_len, total_len), dtype=np.float32)
-    for q in range(seq_len):
-        mask[0, 0, q, past_seq_len + q + 1:] = float("-inf")
-    return mask
-
-
-
 def build_unified_decoder_inputs_with_kv(
     base_batch: BatchInputs,
     audio_features: np.ndarray,
@@ -213,29 +196,8 @@ def build_unified_decoder_inputs_with_kv(
     cfg: DecoderConfig,
 ) -> tuple[dict[str, np.ndarray], int]:
     """Build inputs for decoder.onnx (unified prefill call with zero-size past KV)."""
-    batch_size = base_batch.batch_size
-    max_audio_tokens = int(audio_feature_lengths.max())
-    prompt_ids = build_prompt_ids(max_audio_tokens)
-    audio_start, _ = get_audio_pad_range(prompt_ids)
-    seq_len = len(prompt_ids)
-
-    base_embeds = embed_table[prompt_ids]
-    input_embeds = np.tile(base_embeds[np.newaxis], (batch_size, 1, 1)).copy()
-    for b in range(batch_size):
-        audio_len = int(audio_feature_lengths[b])
-        input_embeds[b, audio_start:audio_start + audio_len] = audio_features[b, :audio_len]
-
-    position_ids = np.tile(np.arange(seq_len, dtype=np.int64)[np.newaxis], (batch_size, 1))
-    attention_mask = build_causal_mask(seq_len, 0)
-    empty_kv = np.zeros((cfg.num_layers, batch_size, cfg.num_kv_heads, 0, cfg.head_dim), dtype=np.float32)
-
-    return {
-        "input_embeds": input_embeds,
-        "position_ids": position_ids,
-        "attention_mask": attention_mask,
-        "past_keys": empty_kv,
-        "past_values": empty_kv.copy(),
-    }, max_audio_tokens
+    decoder_inputs, _ = build_prefill_inputs(audio_features, audio_feature_lengths, embed_table, cfg)
+    return decoder_inputs, int(audio_feature_lengths.max())
 
 
 def timed_run(session: ort.InferenceSession, outputs: list[str], inputs: dict[str, np.ndarray]) -> tuple[list[np.ndarray], float]:

--- a/scripts/qwen3asr_export/sweep_qwen3_asr_batching.py
+++ b/scripts/qwen3asr_export/sweep_qwen3_asr_batching.py
@@ -5,11 +5,15 @@ VRAM heuristic for batch sizing.
 
 The current export only batches the encoder and decoder prefill. This tool:
   1. builds synthetic segment batches by trimming/repeating one reference clip
-  2. runs encoder_batched.onnx and decoder_init_batched.onnx
+  2. runs encoder_batched.onnx and decoder.onnx (unified) or decoder_init_batched.onnx (legacy)
   3. records success / failure, latency, and rough VRAM deltas
   4. fits a simple linear model over successful runs
 
 The fitted model is intended as a sizing heuristic, not a guarantee.
+
+Decoder selection (auto-detected from --onnx-dir):
+  decoder.onnx             unified decoder — takes input_embeds + attention_mask + past KV
+  decoder_init_batched.onnx  legacy split decoder — takes input_ids + audio_features
 """
 
 from __future__ import annotations
@@ -25,6 +29,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 import onnxruntime as ort
@@ -33,9 +38,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from profile_qwen3_asr_pipeline import load_audio, make_session
-from src.mel import log_mel_spectrogram
-from src.prompt import build_prompt_ids, get_audio_pad_range
+from profile_qwen3_asr_pipeline import load_audio, make_session  # noqa: E402
+from src.mel import log_mel_spectrogram  # noqa: E402
+from src.prompt import build_prompt_ids, get_audio_pad_range  # noqa: E402
 
 
 def parse_csv_ints(raw: str) -> list[int]:
@@ -110,7 +115,6 @@ class BatchInputs:
 def build_batch_inputs(audio: np.ndarray, durations_s: list[float]) -> BatchInputs:
     mel_items: list[np.ndarray] = []
     mel_lengths: list[int] = []
-    audio_token_lengths: list[int] = []
 
     for seconds in durations_s:
         target_samples = max(1, int(round(seconds * 16000.0)))
@@ -163,6 +167,75 @@ def attach_decoder_inputs(batch: BatchInputs, audio_feature_lengths: np.ndarray)
         max_audio_seconds=batch.max_audio_seconds,
         batch_size=batch.batch_size,
     )
+
+
+class DecoderConfig(NamedTuple):
+    hidden_size: int
+    num_layers: int
+    num_kv_heads: int
+    head_dim: int
+
+
+def load_decoder_config(onnx_dir: str) -> DecoderConfig:
+    config_path = Path(onnx_dir) / "config.json"
+    config = json.loads(config_path.read_text())
+    dec = config["decoder"]
+    return DecoderConfig(
+        hidden_size=dec["hidden_size"],
+        num_layers=dec["num_layers"],
+        num_kv_heads=dec["num_key_value_heads"],
+        head_dim=dec["head_dim"],
+    )
+
+
+def load_embed_tokens(onnx_dir: str) -> np.ndarray:
+    config_path = Path(onnx_dir) / "config.json"
+    config = json.loads(config_path.read_text())
+    vocab_size, hidden_size = config["embed_tokens_shape"]
+    embed_path = Path(onnx_dir) / "embed_tokens.bin"
+    return np.fromfile(embed_path, dtype=np.float32).reshape(vocab_size, hidden_size)
+
+
+def build_causal_mask(seq_len: int, past_seq_len: int) -> np.ndarray:
+    total_len = past_seq_len + seq_len
+    mask = np.zeros((1, 1, seq_len, total_len), dtype=np.float32)
+    for q in range(seq_len):
+        mask[0, 0, q, past_seq_len + q + 1:] = float("-inf")
+    return mask
+
+
+
+def build_unified_decoder_inputs_with_kv(
+    base_batch: BatchInputs,
+    audio_features: np.ndarray,
+    audio_feature_lengths: np.ndarray,
+    embed_table: np.ndarray,
+    cfg: DecoderConfig,
+) -> tuple[dict[str, np.ndarray], int]:
+    """Build inputs for decoder.onnx (unified prefill call with zero-size past KV)."""
+    batch_size = base_batch.batch_size
+    max_audio_tokens = int(audio_feature_lengths.max())
+    prompt_ids = build_prompt_ids(max_audio_tokens)
+    audio_start, _ = get_audio_pad_range(prompt_ids)
+    seq_len = len(prompt_ids)
+
+    base_embeds = embed_table[prompt_ids]
+    input_embeds = np.tile(base_embeds[np.newaxis], (batch_size, 1, 1)).copy()
+    for b in range(batch_size):
+        audio_len = int(audio_feature_lengths[b])
+        input_embeds[b, audio_start:audio_start + audio_len] = audio_features[b, :audio_len]
+
+    position_ids = np.tile(np.arange(seq_len, dtype=np.int64)[np.newaxis], (batch_size, 1))
+    attention_mask = build_causal_mask(seq_len, 0)
+    empty_kv = np.zeros((cfg.num_layers, batch_size, cfg.num_kv_heads, 0, cfg.head_dim), dtype=np.float32)
+
+    return {
+        "input_embeds": input_embeds,
+        "position_ids": position_ids,
+        "attention_mask": attention_mask,
+        "past_keys": empty_kv,
+        "past_values": empty_kv.copy(),
+    }, max_audio_tokens
 
 
 def timed_run(session: ort.InferenceSession, outputs: list[str], inputs: dict[str, np.ndarray]) -> tuple[list[np.ndarray], float]:
@@ -299,8 +372,17 @@ def run_single_point(
     settle_s: float,
 ) -> dict[str, object]:
     providers = get_cuda_providers()
+
+    unified_path = Path(onnx_dir) / "decoder.onnx"
+    split_path = Path(onnx_dir) / "decoder_init_batched.onnx"
+    use_unified = unified_path.exists()
+    decoder_file = unified_path if use_unified else split_path
+
     encoder = make_session(str(Path(onnx_dir) / "encoder_batched.onnx"), providers, enable_profiling=False)
-    decoder = make_session(str(Path(onnx_dir) / "decoder_init_batched.onnx"), providers, enable_profiling=False)
+    decoder = make_session(str(decoder_file), providers, enable_profiling=False)
+
+    cfg = load_decoder_config(onnx_dir) if use_unified else None
+    embed_table = load_embed_tokens(onnx_dir) if use_unified else None
 
     audio, _ = load_audio(audio_path)
     durations_s = [duration_s] * batch_size
@@ -332,20 +414,26 @@ def run_single_point(
             free_after_encoder = force_gpu_settle(settle_s)
             free_after_encoder_values.append(-1 if free_after_encoder is None else free_after_encoder)
 
-            batch = attach_decoder_inputs(base_batch, audio_feature_lengths)
-            max_audio_tokens = batch.max_audio_tokens
-            padded_audio_features = audio_features[:, : batch.max_audio_tokens, :]
-
-            _, decoder_s = timed_run(
-                decoder,
-                ["logits", "present_keys", "present_values"],
-                {
+            if use_unified:
+                decoder_inputs, max_audio_tokens = build_unified_decoder_inputs_with_kv(
+                    base_batch, audio_features, audio_feature_lengths, embed_table, cfg
+                )
+            else:
+                batch = attach_decoder_inputs(base_batch, audio_feature_lengths)
+                max_audio_tokens = batch.max_audio_tokens
+                padded_audio_features = audio_features[:, : batch.max_audio_tokens, :]
+                decoder_inputs = {
                     "input_ids": batch.input_ids,
                     "position_ids": batch.position_ids,
                     "audio_features": padded_audio_features,
                     "audio_lengths": batch.audio_lengths,
                     "audio_offset": batch.audio_offset,
-                },
+                }
+
+            _, decoder_s = timed_run(
+                decoder,
+                ["logits", "present_keys", "present_values"],
+                decoder_inputs,
             )
 
             free_after_decoder = force_gpu_settle(settle_s)
@@ -379,6 +467,7 @@ def run_single_point(
         "total_audio_seconds": duration_s * batch_size,
         "max_audio_seconds": duration_s,
         "status": status,
+        "decoder_mode": "unified" if use_unified else "split",
         "max_audio_tokens": max_audio_tokens,
         "encoder_ms_median": statistics.median(encoder_ms_values) if encoder_ms_values else None,
         "decoder_init_ms_median": statistics.median(decoder_ms_values) if decoder_ms_values else None,
@@ -432,7 +521,7 @@ def run_single_point_subprocess(args: argparse.Namespace, duration_s: float, bat
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sweep Qwen3-ASR batching artifacts and fit a VRAM heuristic.")
-    parser.add_argument("--onnx-dir", required=True, help="Directory containing encoder_batched.onnx and decoder_init_batched.onnx")
+    parser.add_argument("--onnx-dir", required=True, help="Directory containing encoder_batched.onnx and decoder.onnx (unified) or decoder_init_batched.onnx (legacy)")
     parser.add_argument("--audio", required=True, help="Reference audio file used to synthesize sweep batches")
     parser.add_argument("--durations-seconds", default="2,4,8,12,16,24,32", help="Comma-separated segment durations to test")
     parser.add_argument("--batch-sizes", default="1,2,4,6,8,10,12", help="Comma-separated batch sizes to test")
@@ -463,11 +552,13 @@ def main() -> None:
 
     onnx_dir = Path(args.onnx_dir)
     encoder_path = onnx_dir / "encoder_batched.onnx"
-    decoder_path = onnx_dir / "decoder_init_batched.onnx"
+    unified_decoder_path = onnx_dir / "decoder.onnx"
+    split_decoder_path = onnx_dir / "decoder_init_batched.onnx"
     if not encoder_path.exists():
         raise FileNotFoundError(encoder_path)
-    if not decoder_path.exists():
-        raise FileNotFoundError(decoder_path)
+    if not unified_decoder_path.exists() and not split_decoder_path.exists():
+        raise FileNotFoundError(f"Neither {unified_decoder_path} nor {split_decoder_path} found")
+    decoder_mode = "unified" if unified_decoder_path.exists() else "split"
     durations = parse_csv_floats(args.durations_seconds)
     batch_sizes = parse_csv_ints(args.batch_sizes)
 
@@ -477,6 +568,7 @@ def main() -> None:
 
     total_mb, initial_free_mb = initial_gpu
     print(f"GPU memory at start: total={total_mb} MB free={initial_free_mb} MB")
+    print(f"Decoder mode: {decoder_mode}")
     print(f"Testing durations={durations} seconds batch_sizes={batch_sizes}")
 
     rows: list[dict[str, object]] = []

--- a/scripts/qwen3asr_export/sweep_qwen3_asr_batching.py
+++ b/scripts/qwen3asr_export/sweep_qwen3_asr_batching.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""
+Sweep experimental Qwen3-ASR batching artifacts on CUDA and fit a first-pass
+VRAM heuristic for batch sizing.
+
+The current export only batches the encoder and decoder prefill. This tool:
+  1. builds synthetic segment batches by trimming/repeating one reference clip
+  2. runs encoder_batched.onnx and decoder_init_batched.onnx
+  3. records success / failure, latency, and rough VRAM deltas
+  4. fits a simple linear model over successful runs
+
+The fitted model is intended as a sizing heuristic, not a guarantee.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import gc
+import json
+import math
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from profile_qwen3_asr_pipeline import load_audio, make_session
+from src.mel import log_mel_spectrogram
+from src.prompt import build_prompt_ids, get_audio_pad_range
+
+
+def parse_csv_ints(raw: str) -> list[int]:
+    return [int(part.strip()) for part in raw.split(",") if part.strip()]
+
+
+def parse_csv_floats(raw: str) -> list[float]:
+    return [float(part.strip()) for part in raw.split(",") if part.strip()]
+
+
+def get_cuda_providers() -> list[str]:
+    available = ort.get_available_providers()
+    if "CUDAExecutionProvider" not in available:
+        raise RuntimeError(f"CUDAExecutionProvider not available. Providers: {available}")
+    return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+
+def query_gpu_memory_mb() -> tuple[int, int] | None:
+    try:
+        completed = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.total,memory.free",
+                "--format=csv,noheader,nounits",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    first_line = completed.stdout.strip().splitlines()[0]
+    total_mb, free_mb = [int(part.strip()) for part in first_line.split(",")]
+    return total_mb, free_mb
+
+
+def sample_free_mb() -> int | None:
+    stats = query_gpu_memory_mb()
+    return None if stats is None else stats[1]
+
+
+def force_gpu_settle(delay_s: float) -> int | None:
+    gc.collect()
+    time.sleep(delay_s)
+    return sample_free_mb()
+
+
+def loop_audio_to_duration(audio: np.ndarray, target_samples: int) -> np.ndarray:
+    if target_samples <= audio.shape[0]:
+        return audio[:target_samples].copy()
+
+    reps = math.ceil(target_samples / audio.shape[0])
+    tiled = np.tile(audio, reps)
+    return tiled[:target_samples].copy()
+
+
+@dataclass
+class BatchInputs:
+    mel: np.ndarray
+    input_lengths: np.ndarray
+    input_ids: np.ndarray
+    position_ids: np.ndarray
+    audio_offset: np.ndarray
+    audio_lengths: np.ndarray
+    max_audio_tokens: int
+    total_audio_seconds: float
+    max_audio_seconds: float
+    batch_size: int
+
+
+def build_batch_inputs(audio: np.ndarray, durations_s: list[float]) -> BatchInputs:
+    mel_items: list[np.ndarray] = []
+    mel_lengths: list[int] = []
+    audio_token_lengths: list[int] = []
+
+    for seconds in durations_s:
+        target_samples = max(1, int(round(seconds * 16000.0)))
+        segment_audio = loop_audio_to_duration(audio, target_samples)
+        mel = log_mel_spectrogram(segment_audio).cpu().numpy().astype(np.float32)
+        mel_items.append(mel[0])
+        mel_lengths.append(int(mel.shape[2]))
+
+        # Match the batched encoder contract by deriving output lengths from real mel lengths later.
+        # The decoder prompt is sized from the batched encoder output length.
+
+    max_mel_frames = max(mel_lengths)
+    batch_size = len(mel_items)
+    mel_batch = np.zeros((batch_size, 128, max_mel_frames), dtype=np.float32)
+    for index, mel in enumerate(mel_items):
+        mel_batch[index, :, : mel.shape[1]] = mel
+
+    return BatchInputs(
+        mel=mel_batch,
+        input_lengths=np.array(mel_lengths, dtype=np.int64),
+        input_ids=np.empty((0, 0), dtype=np.int64),
+        position_ids=np.empty((0, 0), dtype=np.int64),
+        audio_offset=np.empty((0,), dtype=np.int64),
+        audio_lengths=np.empty((0,), dtype=np.int64),
+        max_audio_tokens=0,
+        total_audio_seconds=float(sum(durations_s)),
+        max_audio_seconds=float(max(durations_s)),
+        batch_size=batch_size,
+    )
+
+
+def attach_decoder_inputs(batch: BatchInputs, audio_feature_lengths: np.ndarray) -> BatchInputs:
+    max_audio_tokens = int(audio_feature_lengths.max())
+    prompt_ids = build_prompt_ids(max_audio_tokens)
+    audio_start, _ = get_audio_pad_range(prompt_ids)
+    seq_len = len(prompt_ids)
+    batch_size = batch.batch_size
+    input_ids = np.repeat(np.array(prompt_ids, dtype=np.int64)[np.newaxis, :], batch_size, axis=0)
+    position_ids = np.repeat(np.arange(seq_len, dtype=np.int64)[np.newaxis, :], batch_size, axis=0)
+
+    return BatchInputs(
+        mel=batch.mel,
+        input_lengths=batch.input_lengths,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        audio_offset=np.array([audio_start], dtype=np.int64),
+        audio_lengths=audio_feature_lengths.astype(np.int64, copy=False),
+        max_audio_tokens=max_audio_tokens,
+        total_audio_seconds=batch.total_audio_seconds,
+        max_audio_seconds=batch.max_audio_seconds,
+        batch_size=batch.batch_size,
+    )
+
+
+def timed_run(session: ort.InferenceSession, outputs: list[str], inputs: dict[str, np.ndarray]) -> tuple[list[np.ndarray], float]:
+    start = time.perf_counter()
+    result = session.run(outputs, inputs)
+    return result, time.perf_counter() - start
+
+
+def is_oom(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return (
+        "out of memory" in message
+        or "failed to allocate memory" in message
+        or "cuda failure 2" in message
+        or "cuda error 2" in message
+        or "cudnn status alloc failed" in message
+    )
+
+
+def fit_linear_model(rows: list[dict[str, object]]) -> dict[str, float] | None:
+    success_rows = [row for row in rows if row["status"] == "ok" and row["peak_vram_delta_mb"] is not None]
+    if len(success_rows) < 4:
+        return None
+
+    x = np.array(
+        [
+            [
+                1.0,
+                float(row["batch_size"]),
+                float(row["total_audio_seconds"]),
+                float(row["max_audio_seconds"]),
+                float(row["max_audio_tokens"]),
+            ]
+            for row in success_rows
+        ],
+        dtype=np.float64,
+    )
+    y = np.array([float(row["peak_vram_delta_mb"]) for row in success_rows], dtype=np.float64)
+    coeffs, _, _, _ = np.linalg.lstsq(x, y, rcond=None)
+
+    predictions = x @ coeffs
+    residual_rmse = float(np.sqrt(np.mean((predictions - y) ** 2)))
+
+    return {
+        "intercept_mb": float(coeffs[0]),
+        "per_batch_item_mb": float(coeffs[1]),
+        "per_total_audio_second_mb": float(coeffs[2]),
+        "per_max_audio_second_mb": float(coeffs[3]),
+        "per_max_audio_token_mb": float(coeffs[4]),
+        "rmse_mb": residual_rmse,
+    }
+
+
+def summarize_frontier(rows: list[dict[str, object]], reference_free_mb: float) -> dict[str, object]:
+    by_duration: dict[float, dict[str, list[int]]] = {}
+    for row in rows:
+        duration = float(row["duration_seconds"])
+        stats = by_duration.setdefault(duration, {"ok": [], "oom": []})
+        stats["ok" if row["status"] == "ok" else "oom" if row["status"] == "oom" else "other"] = stats.get(
+            "ok" if row["status"] == "ok" else "oom" if row["status"] == "oom" else "other",
+            [],
+        )
+        if row["status"] == "ok":
+            stats["ok"].append(int(row["batch_size"]))
+        elif row["status"] == "oom":
+            stats["oom"].append(int(row["batch_size"]))
+
+    duration_rows = []
+    frontier_totals: list[float] = []
+    for duration in sorted(by_duration):
+        ok_batches = sorted(by_duration[duration]["ok"])
+        oom_batches = sorted(by_duration[duration]["oom"])
+        max_safe = max(ok_batches) if ok_batches else None
+        min_fail = min(oom_batches) if oom_batches else None
+        safe_total_seconds = (max_safe * duration) if max_safe is not None else None
+        if max_safe is not None and min_fail is not None and min_fail > max_safe:
+            frontier_totals.append(safe_total_seconds)
+        duration_rows.append(
+            {
+                "duration_seconds": duration,
+                "max_safe_batch": max_safe,
+                "min_oom_batch": min_fail,
+                "safe_total_seconds": safe_total_seconds,
+            }
+        )
+
+    conservative_total_seconds = min(frontier_totals) if frontier_totals else None
+    return {
+        "reference_free_mb": reference_free_mb,
+        "duration_rows": duration_rows,
+        "conservative_total_seconds": conservative_total_seconds,
+    }
+
+
+def estimate_capacity_seconds(
+    free_mb: float,
+    batch_size: int,
+    average_seconds: float,
+    fit: dict[str, float],
+    safety_mb: float,
+) -> float | None:
+    per_total_sec = fit["per_total_audio_second_mb"]
+    if per_total_sec <= 0:
+        return None
+
+    constant_mb = (
+        fit["intercept_mb"]
+        + fit["per_batch_item_mb"] * batch_size
+        + fit["per_max_audio_second_mb"] * average_seconds
+    )
+    available_mb = free_mb - safety_mb - constant_mb
+    if available_mb <= 0:
+        return 0.0
+
+    return available_mb / per_total_sec
+
+
+def write_csv(path: str, rows: list[dict[str, object]]) -> None:
+    if not rows:
+        return
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def run_single_point(
+    onnx_dir: str,
+    audio_path: str,
+    duration_s: float,
+    batch_size: int,
+    warmup_runs: int,
+    repeat_runs: int,
+    settle_s: float,
+) -> dict[str, object]:
+    providers = get_cuda_providers()
+    encoder = make_session(str(Path(onnx_dir) / "encoder_batched.onnx"), providers, enable_profiling=False)
+    decoder = make_session(str(Path(onnx_dir) / "decoder_init_batched.onnx"), providers, enable_profiling=False)
+
+    audio, _ = load_audio(audio_path)
+    durations_s = [duration_s] * batch_size
+    base_batch = build_batch_inputs(audio, durations_s)
+
+    status = "ok"
+    error_message = None
+    encoder_ms_values: list[float] = []
+    decoder_ms_values: list[float] = []
+    free_before_values: list[int] = []
+    free_after_encoder_values: list[int] = []
+    free_after_decoder_values: list[int] = []
+    max_audio_tokens = None
+
+    try:
+        for run_index in range(warmup_runs + repeat_runs):
+            free_before = force_gpu_settle(settle_s)
+            free_before_values.append(-1 if free_before is None else free_before)
+
+            (audio_features, audio_feature_lengths), encoder_s = timed_run(
+                encoder,
+                ["audio_features", "audio_feature_lengths"],
+                {
+                    "mel": base_batch.mel,
+                    "input_lengths": base_batch.input_lengths,
+                },
+            )
+
+            free_after_encoder = force_gpu_settle(settle_s)
+            free_after_encoder_values.append(-1 if free_after_encoder is None else free_after_encoder)
+
+            batch = attach_decoder_inputs(base_batch, audio_feature_lengths)
+            max_audio_tokens = batch.max_audio_tokens
+            padded_audio_features = audio_features[:, : batch.max_audio_tokens, :]
+
+            _, decoder_s = timed_run(
+                decoder,
+                ["logits", "present_keys", "present_values"],
+                {
+                    "input_ids": batch.input_ids,
+                    "position_ids": batch.position_ids,
+                    "audio_features": padded_audio_features,
+                    "audio_lengths": batch.audio_lengths,
+                    "audio_offset": batch.audio_offset,
+                },
+            )
+
+            free_after_decoder = force_gpu_settle(settle_s)
+            free_after_decoder_values.append(-1 if free_after_decoder is None else free_after_decoder)
+
+            if run_index >= warmup_runs:
+                encoder_ms_values.append(encoder_s * 1000.0)
+                decoder_ms_values.append(decoder_s * 1000.0)
+    except Exception as exc:  # noqa: BLE001
+        status = "oom" if is_oom(exc) else "error"
+        error_message = str(exc)
+
+    valid_before = [value for value in free_before_values if value >= 0]
+    valid_after_encoder = [value for value in free_after_encoder_values if value >= 0]
+    valid_after_decoder = [value for value in free_after_decoder_values if value >= 0]
+
+    peak_vram_delta_mb = None
+    encoder_vram_delta_mb = None
+    decoder_vram_delta_mb = None
+    if valid_before and valid_after_encoder and valid_after_decoder:
+        baseline_free = max(valid_before)
+        encoder_low = min(valid_after_encoder)
+        decoder_low = min(valid_after_decoder)
+        encoder_vram_delta_mb = float(baseline_free - encoder_low)
+        decoder_vram_delta_mb = float(baseline_free - decoder_low)
+        peak_vram_delta_mb = max(encoder_vram_delta_mb, decoder_vram_delta_mb)
+
+    return {
+        "duration_seconds": duration_s,
+        "batch_size": batch_size,
+        "total_audio_seconds": duration_s * batch_size,
+        "max_audio_seconds": duration_s,
+        "status": status,
+        "max_audio_tokens": max_audio_tokens,
+        "encoder_ms_median": statistics.median(encoder_ms_values) if encoder_ms_values else None,
+        "decoder_init_ms_median": statistics.median(decoder_ms_values) if decoder_ms_values else None,
+        "encoder_vram_delta_mb": encoder_vram_delta_mb,
+        "decoder_init_vram_delta_mb": decoder_vram_delta_mb,
+        "peak_vram_delta_mb": peak_vram_delta_mb,
+        "error": error_message,
+    }
+
+
+def run_single_point_subprocess(args: argparse.Namespace, duration_s: float, batch_size: int) -> dict[str, object]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--onnx-dir",
+        args.onnx_dir,
+        "--audio",
+        args.audio,
+        "--warmup-runs",
+        str(args.warmup_runs),
+        "--repeat-runs",
+        str(args.repeat_runs),
+        "--gpu-settle-ms",
+        str(args.gpu_settle_ms),
+        "--child-duration-seconds",
+        str(duration_s),
+        "--child-batch-size",
+        str(batch_size),
+    ]
+    completed = subprocess.run(command, capture_output=True, text=True)
+    if completed.returncode == 0:
+        return json.loads(completed.stdout.strip().splitlines()[-1])
+
+    error = completed.stderr.strip() or completed.stdout.strip() or f"Child sweep failed with exit code {completed.returncode}"
+    status = "oom" if "out of memory" in error.lower() else "error"
+    return {
+        "duration_seconds": duration_s,
+        "batch_size": batch_size,
+        "total_audio_seconds": duration_s * batch_size,
+        "max_audio_seconds": duration_s,
+        "status": status,
+        "max_audio_tokens": None,
+        "encoder_ms_median": None,
+        "decoder_init_ms_median": None,
+        "encoder_vram_delta_mb": None,
+        "decoder_init_vram_delta_mb": None,
+        "peak_vram_delta_mb": None,
+        "error": error,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sweep Qwen3-ASR batching artifacts and fit a VRAM heuristic.")
+    parser.add_argument("--onnx-dir", required=True, help="Directory containing encoder_batched.onnx and decoder_init_batched.onnx")
+    parser.add_argument("--audio", required=True, help="Reference audio file used to synthesize sweep batches")
+    parser.add_argument("--durations-seconds", default="2,4,8,12,16,24,32", help="Comma-separated segment durations to test")
+    parser.add_argument("--batch-sizes", default="1,2,4,6,8,10,12", help="Comma-separated batch sizes to test")
+    parser.add_argument("--warmup-runs", type=int, default=1, help="Warmup runs before timing")
+    parser.add_argument("--repeat-runs", type=int, default=2, help="Measured runs per sweep point")
+    parser.add_argument("--gpu-settle-ms", type=int, default=750, help="Delay between VRAM samples")
+    parser.add_argument("--output-json", default=None, help="Optional path to write structured JSON results")
+    parser.add_argument("--output-csv", default=None, help="Optional path to write CSV results")
+    parser.add_argument("--safety-mb", type=float, default=1024.0, help="Extra safety margin to subtract when turning fit into a heuristic")
+    parser.add_argument("--child-duration-seconds", type=float, default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--child-batch-size", type=int, default=None, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.child_duration_seconds is not None or args.child_batch_size is not None:
+        if args.child_duration_seconds is None or args.child_batch_size is None:
+            raise ValueError("Both child sweep arguments are required together")
+        row = run_single_point(
+            onnx_dir=args.onnx_dir,
+            audio_path=args.audio,
+            duration_s=args.child_duration_seconds,
+            batch_size=args.child_batch_size,
+            warmup_runs=args.warmup_runs,
+            repeat_runs=args.repeat_runs,
+            settle_s=args.gpu_settle_ms / 1000.0,
+        )
+        print(json.dumps(row))
+        return
+
+    onnx_dir = Path(args.onnx_dir)
+    encoder_path = onnx_dir / "encoder_batched.onnx"
+    decoder_path = onnx_dir / "decoder_init_batched.onnx"
+    if not encoder_path.exists():
+        raise FileNotFoundError(encoder_path)
+    if not decoder_path.exists():
+        raise FileNotFoundError(decoder_path)
+    durations = parse_csv_floats(args.durations_seconds)
+    batch_sizes = parse_csv_ints(args.batch_sizes)
+
+    initial_gpu = query_gpu_memory_mb()
+    if initial_gpu is None:
+        raise RuntimeError("Could not query GPU memory via nvidia-smi")
+
+    total_mb, initial_free_mb = initial_gpu
+    print(f"GPU memory at start: total={total_mb} MB free={initial_free_mb} MB")
+    print(f"Testing durations={durations} seconds batch_sizes={batch_sizes}")
+
+    rows: list[dict[str, object]] = []
+
+    for duration_s in durations:
+        for batch_size in batch_sizes:
+            print(f"\n=== Sweep point: duration={duration_s:.1f}s batch={batch_size} total={duration_s * batch_size:.1f}s ===")
+            row = run_single_point_subprocess(args, duration_s, batch_size)
+            rows.append(row)
+
+            print(json.dumps(row, indent=2))
+
+    fit = fit_linear_model(rows)
+    summary = {
+        "gpu_total_mb": total_mb,
+        "gpu_free_mb_at_start": initial_free_mb,
+        "fit": fit,
+        "frontier": summarize_frontier(rows, initial_free_mb),
+    }
+
+    print("\nObserved frontier")
+    for frontier_row in summary["frontier"]["duration_rows"]:
+        print(
+            "  "
+            f"duration={frontier_row['duration_seconds']:>4.1f}s "
+            f"max_safe_batch={frontier_row['max_safe_batch']} "
+            f"min_oom_batch={frontier_row['min_oom_batch']} "
+            f"safe_total_seconds={frontier_row['safe_total_seconds']}"
+        )
+    if summary["frontier"]["conservative_total_seconds"] is not None:
+        print(
+            "  "
+            f"conservative_total_seconds_at_{initial_free_mb:.0f}MB_free="
+            f"{summary['frontier']['conservative_total_seconds']:.1f}s"
+        )
+
+    if fit is not None:
+        print("\nFitted VRAM model (MB)")
+        print(json.dumps(fit, indent=2))
+        print("\nExample capacity estimates")
+        for average_seconds in (2.0, 4.0, 8.0, 16.0):
+            for batch_size in (1, 2, 4, 8):
+                estimate = estimate_capacity_seconds(initial_free_mb, batch_size, average_seconds, fit, args.safety_mb)
+                if estimate is None:
+                    continue
+                print(
+                    f"  avg_seg={average_seconds:4.1f}s batch={batch_size:2d} "
+                    f"=> estimated total_seconds_ceiling={estimate:6.1f}s"
+                )
+    else:
+        print("\nNot enough successful points with VRAM samples to fit a heuristic.")
+
+    payload = {
+        "summary": summary,
+        "rows": rows,
+    }
+
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        print(f"\nWrote {args.output_json}")
+
+    if args.output_csv:
+        write_csv(args.output_csv, rows)
+        print(f"Wrote {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qwen3asr_export/verify_qwen3_asr_unified_batch_parity.py
+++ b/scripts/qwen3asr_export/verify_qwen3_asr_unified_batch_parity.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Verify mixed-length batched parity for the unified Qwen3-ASR decoder export.
+
+This compares:
+  - serial unified decoding (one segment at a time)
+  - mixed-length unified batched decoding
+
+The batched path uses per-row prompt padding, explicit attention masks, and
+KV compaction between decode steps so shorter rows do not keep fake padding
+positions alive in the cache.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+from transformers import AutoTokenizer
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from profile_qwen3_asr_pipeline import load_audio, make_session  # noqa: E402
+from src.mel import log_mel_spectrogram  # noqa: E402
+from src.prompt import EOS_TOKEN_IDS  # noqa: E402
+from src.unified_batch import (  # noqa: E402
+    DecoderConfig,
+    build_prefill_inputs,
+    build_step_inputs,
+    compact_prefill_kv,
+    compact_step_kv,
+    gather_last_valid_logits,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify unified mixed-length batch parity for Qwen3-ASR ONNX exports.")
+    parser.add_argument("--onnx-dir", required=True, help="Directory containing encoder/decoder ONNX files")
+    parser.add_argument("--audio", required=True, help="Audio file containing the test segments")
+    parser.add_argument("--segments-json", required=True, help="JSON file with [{segId,start,end,...}, ...]")
+    parser.add_argument(
+        "--execution-provider",
+        choices=("auto", "cpu", "cuda"),
+        default="auto",
+        help="Which ORT execution provider to use",
+    )
+    parser.add_argument("--max-tokens", type=int, default=128, help="Maximum decode tokens")
+    parser.add_argument(
+        "--show-tokens",
+        action="store_true",
+        help="Include token IDs in the output",
+    )
+    return parser.parse_args()
+
+
+def get_providers(choice: str) -> list[str]:
+    available = ort.get_available_providers()
+    if choice == "cpu":
+        return ["CPUExecutionProvider"]
+    if choice == "cuda":
+        if "CUDAExecutionProvider" not in available:
+            raise RuntimeError("CUDAExecutionProvider is not available in this environment")
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if "CUDAExecutionProvider" in available:
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    return ["CPUExecutionProvider"]
+
+
+def load_decoder_config(onnx_dir: str) -> DecoderConfig:
+    config_path = Path(onnx_dir) / "config.json"
+    config = json.loads(config_path.read_text())
+    dec = config["decoder"]
+    return DecoderConfig(
+        hidden_size=dec["hidden_size"],
+        num_layers=dec["num_layers"],
+        num_kv_heads=dec["num_key_value_heads"],
+        head_dim=dec["head_dim"],
+    )
+
+
+def load_embed_tokens(onnx_dir: str) -> np.ndarray:
+    config_path = Path(onnx_dir) / "config.json"
+    config = json.loads(config_path.read_text())
+    vocab_size, hidden_size = config["embed_tokens_shape"]
+    embed_path = Path(onnx_dir) / "embed_tokens.bin"
+    return np.fromfile(embed_path, dtype=np.float32).reshape(vocab_size, hidden_size)
+
+
+def extract_segment(audio: np.ndarray, start_s: float, end_s: float) -> np.ndarray:
+    start = max(0, int(round(start_s * 16000.0)))
+    end = max(start + 1, int(round(end_s * 16000.0)))
+    return audio[start:end].copy()
+
+
+def decode_batch(
+    decoder: ort.InferenceSession,
+    embed_table: np.ndarray,
+    first_logits: np.ndarray,
+    past_keys: np.ndarray,
+    past_values: np.ndarray,
+    past_lengths: np.ndarray,
+    max_tokens: int,
+) -> list[list[int]]:
+    next_tokens = np.argmax(first_logits, axis=1).astype(np.int64)
+    sequences = [[int(token)] for token in next_tokens.tolist()]
+    done = np.isin(next_tokens, np.array(EOS_TOKEN_IDS, dtype=np.int64))
+
+    for _ in range(max_tokens - 1):
+        if np.all(done):
+            break
+
+        decoder_inputs = build_step_inputs(next_tokens, embed_table, past_keys, past_values, past_lengths)
+        logits, present_keys, present_values = decoder.run(
+            ["logits", "present_keys", "present_values"],
+            decoder_inputs,
+        )
+        step_tokens = np.argmax(logits[:, 0, :], axis=1).astype(np.int64)
+        active_mask = ~done
+
+        for batch_index, token in enumerate(step_tokens.tolist()):
+            if active_mask[batch_index]:
+                sequences[batch_index].append(int(token))
+
+        emitted_eos = np.isin(step_tokens, np.array(EOS_TOKEN_IDS, dtype=np.int64))
+        past_keys, past_values, past_lengths = compact_step_kv(present_keys, present_values, past_lengths, active_mask)
+        done = done | (active_mask & emitted_eos)
+
+        for batch_index, token in enumerate(step_tokens.tolist()):
+            if active_mask[batch_index]:
+                next_tokens[batch_index] = int(token)
+
+    return sequences
+
+
+def run_serial_unified(
+    encoder: ort.InferenceSession,
+    decoder: ort.InferenceSession,
+    audio: np.ndarray,
+    segments: list[dict[str, object]],
+    embed_table: np.ndarray,
+    cfg: DecoderConfig,
+    max_tokens: int,
+) -> dict[int, list[int]]:
+    results: dict[int, list[int]] = {}
+
+    for segment in segments:
+        segment_audio = extract_segment(audio, float(segment["start"]), float(segment["end"]))
+        mel = log_mel_spectrogram(segment_audio).cpu().numpy()
+        audio_features = encoder.run(["audio_features"], {"mel": mel})[0].astype(np.float32, copy=False)
+        audio_lengths = np.array([audio_features.shape[1]], dtype=np.int64)
+
+        decoder_inputs, seq_lengths = build_prefill_inputs(audio_features, audio_lengths, embed_table, cfg)
+        logits, present_keys, present_values = decoder.run(
+            ["logits", "present_keys", "present_values"],
+            decoder_inputs,
+        )
+        first_logits = gather_last_valid_logits(logits, seq_lengths)
+        compact_keys, compact_values = compact_prefill_kv(present_keys, present_values, seq_lengths)
+        results[int(segment["segId"])] = decode_batch(
+            decoder,
+            embed_table,
+            first_logits,
+            compact_keys,
+            compact_values,
+            seq_lengths,
+            max_tokens=max_tokens,
+        )[0]
+
+    return results
+
+
+def run_batched_unified(
+    encoder: ort.InferenceSession,
+    decoder: ort.InferenceSession,
+    audio: np.ndarray,
+    segments: list[dict[str, object]],
+    embed_table: np.ndarray,
+    cfg: DecoderConfig,
+    max_tokens: int,
+) -> dict[int, list[int]]:
+    mel_items: list[np.ndarray] = []
+    mel_lengths: list[int] = []
+
+    for segment in segments:
+        segment_audio = extract_segment(audio, float(segment["start"]), float(segment["end"]))
+        mel = log_mel_spectrogram(segment_audio).cpu().numpy().astype(np.float32)
+        mel_items.append(mel[0])
+        mel_lengths.append(int(mel.shape[2]))
+
+    max_mel_len = max(mel_lengths)
+    mel_batch = np.zeros((len(segments), 128, max_mel_len), dtype=np.float32)
+    for batch_index, mel in enumerate(mel_items):
+        mel_batch[batch_index, :, : mel.shape[1]] = mel
+
+    audio_features, audio_lengths = encoder.run(
+        ["audio_features", "audio_feature_lengths"],
+        {
+            "mel": mel_batch,
+            "input_lengths": np.array(mel_lengths, dtype=np.int64),
+        },
+    )
+    audio_features = audio_features.astype(np.float32, copy=False)
+    audio_lengths = audio_lengths.astype(np.int64, copy=False)
+
+    decoder_inputs, seq_lengths = build_prefill_inputs(audio_features, audio_lengths, embed_table, cfg)
+    logits, present_keys, present_values = decoder.run(
+        ["logits", "present_keys", "present_values"],
+        decoder_inputs,
+    )
+    first_logits = gather_last_valid_logits(logits, seq_lengths)
+    compact_keys, compact_values = compact_prefill_kv(present_keys, present_values, seq_lengths)
+    sequences = decode_batch(
+        decoder,
+        embed_table,
+        first_logits,
+        compact_keys,
+        compact_values,
+        seq_lengths,
+        max_tokens=max_tokens,
+    )
+
+    return {
+        int(segment["segId"]): sequences[batch_index]
+        for batch_index, segment in enumerate(segments)
+    }
+
+
+def decode_text(tokenizer: AutoTokenizer, tokens: list[int]) -> str:
+    filtered = [token for token in tokens if token not in EOS_TOKEN_IDS]
+    return tokenizer.decode(filtered, skip_special_tokens=True, clean_up_tokenization_spaces=False)
+
+
+def main() -> int:
+    args = parse_args()
+    providers = get_providers(args.execution_provider)
+    cfg = load_decoder_config(args.onnx_dir)
+    embed_table = load_embed_tokens(args.onnx_dir)
+    tokenizer = AutoTokenizer.from_pretrained(args.onnx_dir, trust_remote_code=False, fix_mistral_regex=True)
+
+    segments = json.loads(Path(args.segments_json).read_text())
+    if not segments:
+        raise ValueError("segments-json must contain at least one segment")
+
+    serial_encoder = make_session(str(Path(args.onnx_dir) / "encoder.onnx"), providers, enable_profiling=False)
+    batched_encoder = make_session(str(Path(args.onnx_dir) / "encoder_batched.onnx"), providers, enable_profiling=False)
+    decoder = make_session(str(Path(args.onnx_dir) / "decoder.onnx"), providers, enable_profiling=False)
+
+    audio, _ = load_audio(args.audio)
+    serial = run_serial_unified(serial_encoder, decoder, audio, segments, embed_table, cfg, args.max_tokens)
+    batched = run_batched_unified(batched_encoder, decoder, audio, segments, embed_table, cfg, args.max_tokens)
+
+    mismatch_count = 0
+    print(f"Providers: {providers}")
+    for segment in segments:
+        seg_id = int(segment["segId"])
+        serial_tokens = serial[seg_id]
+        batched_tokens = batched[seg_id]
+        serial_text = decode_text(tokenizer, serial_tokens)
+        batched_text = decode_text(tokenizer, batched_tokens)
+        same = serial_tokens == batched_tokens
+        if not same:
+            mismatch_count += 1
+
+        row = {
+            "segId": seg_id,
+            "start": float(segment["start"]),
+            "end": float(segment["end"]),
+            "match": same,
+            "serial_text": serial_text,
+            "batched_text": batched_text,
+        }
+        if args.show_tokens or not same:
+            row["serial_tokens"] = serial_tokens
+            row["batched_tokens"] = batched_tokens
+        print(json.dumps(row, ensure_ascii=True))
+
+    if mismatch_count:
+        print(f"Parity failed: {mismatch_count} segment(s) diverged.")
+        return 1
+
+    print("Parity passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/Vernacula.Avalonia/Locales/en.json
+++ b/src/Vernacula.Avalonia/Locales/en.json
@@ -93,6 +93,7 @@
   "editor_merge_next_tooltip": "Merge this segment with the next one",
   "editor_split_tooltip": "Split this segment at a token boundary",
   "editor_redo_asr": "Redo ASR",
+  "editor_redo_asr_language": "Language for redo ASR",
   "editor_redo_asr_running": "Running…",
   "editor_redo_asr_tooltip": "Re-run speech recognition on this segment's audio to get a clean, single-source transcription (enables splitting)",
   "editor_add_speaker": "+ Add Speaker…",

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -12,6 +12,7 @@ public class AppSettings
     public SegmentationMode   Segmentation        { get; set; } = SegmentationMode.SileroVad;
     public AsrBackend         AsrBackend          { get; set; } = AsrBackend.Parakeet;
     public string             CohereLanguage      { get; set; } = "";
+    public string             Qwen3AsrLanguage    { get; set; } = "";
     public DenoiserMode       Denoiser            { get; set; } = DenoiserMode.None;
     public PlaybackMode       EditorPlaybackMode  { get; set; } = PlaybackMode.Continuous;
     public string             ModelsDir           { get; set; } = "";

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -4,7 +4,7 @@ namespace Vernacula.App.Models;
 
 public enum AppTheme    { Dark, Light }
 public enum PlaybackMode { Single, AutoAdvance, Continuous }
-public enum AsrBackend { Parakeet, Cohere, VibeVoice }
+public enum AsrBackend { Parakeet, Cohere, Qwen3Asr, VibeVoice }
 
 public class AppSettings
 {

--- a/src/Vernacula.Avalonia/Models/AsrLanguageOption.cs
+++ b/src/Vernacula.Avalonia/Models/AsrLanguageOption.cs
@@ -1,0 +1,11 @@
+namespace Vernacula.App.Models;
+
+/// <summary>
+/// A user-selectable language for ASR backends that support forced language
+/// (e.g. Cohere, Qwen3-ASR). <see cref="Code"/> is an ISO 639-1 code ("en", "fr"),
+/// or empty string to mean "auto-detect". <see cref="DisplayName"/> is the UI label.
+/// </summary>
+public record AsrLanguageOption(string Code, string DisplayName)
+{
+    public override string ToString() => DisplayName;
+}

--- a/src/Vernacula.Avalonia/Models/EditorSegment.cs
+++ b/src/Vernacula.Avalonia/Models/EditorSegment.cs
@@ -18,6 +18,7 @@ internal partial class EditorSegment : ObservableObject
     private double _playEnd;
 
     public string AsrContent { get; set; } = "";
+    public string? Language  { get; set; }
 
     [ObservableProperty]
     private string _content = "";

--- a/src/Vernacula.Avalonia/Models/TranscriptEditorCardState.cs
+++ b/src/Vernacula.Avalonia/Models/TranscriptEditorCardState.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Vernacula.App.ViewModels;
 
 namespace Vernacula.App.Models;
 
@@ -13,21 +14,7 @@ internal sealed partial class TranscriptEditorCardState : ObservableObject
         public override string ToString() => Name;
     }
 
-    public static readonly IReadOnlyList<string> Qwen3AsrLanguageNames =
-        (new[] {
-            "Auto",
-            "Afrikaans", "Arabic", "Armenian", "Azerbaijani", "Belarusian",
-            "Bosnian", "Bulgarian", "Catalan", "Chinese", "Croatian",
-            "Czech", "Danish", "Dutch", "English", "Estonian",
-            "Finnish", "French", "Galician", "German", "Greek",
-            "Hebrew", "Hindi", "Hungarian", "Icelandic", "Indonesian",
-            "Italian", "Japanese", "Kannada", "Kazakh", "Korean",
-            "Latvian", "Lithuanian", "Macedonian", "Malay", "Marathi",
-            "Nepali", "Norwegian", "Persian", "Polish", "Portuguese",
-            "Romanian", "Russian", "Serbian", "Slovak", "Slovenian",
-            "Spanish", "Swahili", "Swedish", "Tagalog", "Tamil",
-            "Thai", "Turkish", "Ukrainian", "Urdu", "Vietnamese", "Welsh",
-        }).ToList().AsReadOnly();
+    public static IReadOnlyList<AsrLanguageOption> Qwen3AsrLanguages => SettingsViewModel.Qwen3AsrLanguages;
 
     public TranscriptEditorCardState(EditorSegment segment, int index)
     {
@@ -37,7 +24,16 @@ internal sealed partial class TranscriptEditorCardState : ObservableObject
         _draftContent = segment.Content;
         _timeRangeText = FormatTimeRange(segment.PlayStart, segment.PlayEnd);
         _suppressButtonText = "Suppress";
-        _selectedRedoLanguage = segment.Language ?? "Auto";
+        _selectedRedoLanguage = MatchLanguageOption(segment.Language);
+    }
+
+    internal static AsrLanguageOption MatchLanguageOption(string? language)
+    {
+        if (string.IsNullOrEmpty(language)) return Qwen3AsrLanguages[0];
+        return Qwen3AsrLanguages.FirstOrDefault(l =>
+                   string.Equals(l.DisplayName, language, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(l.Code,        language, StringComparison.OrdinalIgnoreCase))
+               ?? Qwen3AsrLanguages[0];
     }
 
     internal EditorSegment Segment { get; }
@@ -52,7 +48,7 @@ internal sealed partial class TranscriptEditorCardState : ObservableObject
     public ObservableCollection<TranscriptEditorTextRunState> AdjacentRuns { get; } = [];
 
     [ObservableProperty] private bool _isFocused;
-    [ObservableProperty] private string? _selectedRedoLanguage;
+    [ObservableProperty] private AsrLanguageOption? _selectedRedoLanguage;
     public bool ShowLanguageChip { get; set; }
     [ObservableProperty] private string _draftSpeakerName;
     [ObservableProperty] private string _draftContent;

--- a/src/Vernacula.Avalonia/Models/TranscriptEditorCardState.cs
+++ b/src/Vernacula.Avalonia/Models/TranscriptEditorCardState.cs
@@ -13,6 +13,22 @@ internal sealed partial class TranscriptEditorCardState : ObservableObject
         public override string ToString() => Name;
     }
 
+    public static readonly IReadOnlyList<string> Qwen3AsrLanguageNames =
+        (new[] {
+            "Auto",
+            "Afrikaans", "Arabic", "Armenian", "Azerbaijani", "Belarusian",
+            "Bosnian", "Bulgarian", "Catalan", "Chinese", "Croatian",
+            "Czech", "Danish", "Dutch", "English", "Estonian",
+            "Finnish", "French", "Galician", "German", "Greek",
+            "Hebrew", "Hindi", "Hungarian", "Icelandic", "Indonesian",
+            "Italian", "Japanese", "Kannada", "Kazakh", "Korean",
+            "Latvian", "Lithuanian", "Macedonian", "Malay", "Marathi",
+            "Nepali", "Norwegian", "Persian", "Polish", "Portuguese",
+            "Romanian", "Russian", "Serbian", "Slovak", "Slovenian",
+            "Spanish", "Swahili", "Swedish", "Tagalog", "Tamil",
+            "Thai", "Turkish", "Ukrainian", "Urdu", "Vietnamese", "Welsh",
+        }).ToList().AsReadOnly();
+
     public TranscriptEditorCardState(EditorSegment segment, int index)
     {
         Segment = segment;
@@ -21,6 +37,7 @@ internal sealed partial class TranscriptEditorCardState : ObservableObject
         _draftContent = segment.Content;
         _timeRangeText = FormatTimeRange(segment.PlayStart, segment.PlayEnd);
         _suppressButtonText = "Suppress";
+        _selectedRedoLanguage = segment.Language ?? "Auto";
     }
 
     internal EditorSegment Segment { get; }
@@ -35,6 +52,8 @@ internal sealed partial class TranscriptEditorCardState : ObservableObject
     public ObservableCollection<TranscriptEditorTextRunState> AdjacentRuns { get; } = [];
 
     [ObservableProperty] private bool _isFocused;
+    [ObservableProperty] private string? _selectedRedoLanguage;
+    public bool ShowLanguageChip { get; set; }
     [ObservableProperty] private string _draftSpeakerName;
     [ObservableProperty] private string _draftContent;
     [ObservableProperty] private SpeakerChoice? _selectedSpeaker;

--- a/src/Vernacula.Avalonia/Services/JobQueueService.cs
+++ b/src/Vernacula.Avalonia/Services/JobQueueService.cs
@@ -316,12 +316,14 @@ internal sealed class JobQueueService
 
     private string GetJobAsrLanguageCode()
     {
-        if (_settings.Current.AsrBackend != AsrBackend.Cohere)
-            return "auto";
-
-        return string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
-            ? "auto"
-            : _settings.Current.CohereLanguage;
+        return _settings.Current.AsrBackend switch
+        {
+            AsrBackend.Cohere   => string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
+                                       ? "auto" : _settings.Current.CohereLanguage,
+            AsrBackend.Qwen3Asr => string.IsNullOrWhiteSpace(_settings.Current.Qwen3AsrLanguage)
+                                       ? "auto" : _settings.Current.Qwen3AsrLanguage,
+            _                   => "auto",
+        };
     }
 
     private record QueueEntry(

--- a/src/Vernacula.Avalonia/Services/JobQueueService.cs
+++ b/src/Vernacula.Avalonia/Services/JobQueueService.cs
@@ -309,6 +309,7 @@ internal sealed class JobQueueService
     private string GetJobAsrModelName() => _settings.Current.AsrBackend switch
     {
         AsrBackend.Cohere     => "CohereLabs/cohere-transcribe-03-2026",
+        AsrBackend.Qwen3Asr   => "Qwen/Qwen3-ASR-1.7B",
         AsrBackend.VibeVoice  => "vibevoice/vibevoice-asr",
         _                     => "nvidia/parakeet-tdt-0.6b-v3",
     };

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -75,6 +75,20 @@ internal class ModelManagerService
             new(Path.Combine("cohere_transcribe", CohereTranscribe.ConfigFile), CohereTranscribe.ConfigFile),
         ];
 
+    private static readonly ModelAsset[] Qwen3AsrFiles =
+        [
+            new(Path.Combine(Config.Qwen3AsrSubDir, Qwen3Asr.EncoderFile), Qwen3Asr.EncoderFile),
+            new(Path.Combine(Config.Qwen3AsrSubDir, Qwen3Asr.DecoderInitFile), Qwen3Asr.DecoderInitFile),
+            new(Path.Combine(Config.Qwen3AsrSubDir, $"{Qwen3Asr.DecoderInitFile}.data"), $"{Qwen3Asr.DecoderInitFile}.data"),
+            new(Path.Combine(Config.Qwen3AsrSubDir, Qwen3Asr.DecoderStepFile), Qwen3Asr.DecoderStepFile),
+            new(Path.Combine(Config.Qwen3AsrSubDir, $"{Qwen3Asr.DecoderStepFile}.data"), $"{Qwen3Asr.DecoderStepFile}.data"),
+            new(Path.Combine(Config.Qwen3AsrSubDir, Qwen3Asr.EmbedTokensFile), Qwen3Asr.EmbedTokensFile),
+            new(Path.Combine(Config.Qwen3AsrSubDir, Qwen3Asr.TokenizerFile), Qwen3Asr.TokenizerFile),
+            new(Path.Combine(Config.Qwen3AsrSubDir, "tokenizer_config.json"), "tokenizer_config.json"),
+            new(Path.Combine(Config.Qwen3AsrSubDir, Qwen3Asr.ConfigFile), Qwen3Asr.ConfigFile),
+            new(Path.Combine(Config.Qwen3AsrSubDir, "preprocessor_config.json"), "preprocessor_config.json"),
+        ];
+
     private static readonly ModelAsset[] VibeVoiceFiles =
         [
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.AudioEncoderFile),                       VibeVoiceAsr.AudioEncoderFile),
@@ -108,6 +122,11 @@ internal class ModelManagerService
             [
                 new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
                 new AssetRepo(CohereRepoBase, CohereManifestUrl, CohereFiles),
+            ],
+            AsrBackend.Qwen3Asr =>
+            [
+                new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
+                new AssetRepo("", "", Qwen3AsrFiles),
             ],
             _ =>
             [
@@ -193,6 +212,9 @@ internal class ModelManagerService
 
         foreach (var repo in ActiveRepos())
         {
+            if (string.IsNullOrWhiteSpace(repo.ManifestUrl))
+                continue;
+
             string json;
             try
             {

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -95,6 +95,9 @@ internal class SettingsService
     public string GetCohereModelsDir() =>
         Path.Combine(GetModelsDir(), "cohere_transcribe");
 
+    public string GetQwen3AsrModelsDir() =>
+        Path.Combine(GetModelsDir(), Config.Qwen3AsrSubDir);
+
     public string GetVibeVoiceModelsDir() =>
         Path.Combine(GetModelsDir(), "vibevoice_asr");
 

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -74,6 +74,7 @@ internal class TranscriptionService
     {
         Console.WriteLine($"[Transcription] RunPipelineAsync starting for '{audioPath}'");
         string parakeetModelsDir = _settings.GetParakeetModelsDir();
+        string qwen3AsrModelsDir = _settings.GetQwen3AsrModelsDir();
         string sortformerModelsDir = _settings.GetSortformerModelsDir();
         string sileroModelsDir = _settings.GetSileroModelsDir();
 
@@ -87,6 +88,7 @@ internal class TranscriptionService
         // ── ASR backend / segmentation flags ─────────────────────────────────
         bool useVibeVoiceAsr  = string.Equals(asrModelName, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
         bool useCohereAsr     = string.Equals(asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+        bool useQwen3Asr      = string.Equals(asrModelName, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
         var  segmentationMode = _settings.Current.Segmentation;
         bool runVibeVoice     = useVibeVoiceAsr || segmentationMode == SegmentationMode.VibeVoiceBuiltin;
 
@@ -574,6 +576,47 @@ internal class TranscriptionService
                             storedTextTokens: result.TextTokens,
                             syntheticTimestamps: true,
                             timestampMode: CohereSyntheticTimestampMode));
+
+                    onSegmentText(absId, result.Text);
+
+                    string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
+                        ["i"]     = completed.ToString(),
+                        ["count"] = totalSegs.ToString() });
+                    double? overridePercent = segmentationMode == SegmentationMode.DiariZen
+                        ? ScaleOverallProgress(
+                            DiariZenDiarizationPercentWeight,
+                            100,
+                            totalSegs > 0 ? completed / (double)totalSegs : 1)
+                        : null;
+                    progress.Report(new TranscriptionProgress(
+                        TranscriptionPhase.Recognizing,
+                        completed,
+                        totalSegs,
+                        asrText,
+                        absId,
+                        result.Text,
+                        overridePercent));
+                }
+            }
+            else if (useQwen3Asr)
+            {
+                using var qwen3Asr = new Qwen3Asr(qwen3AsrModelsDir);
+                foreach (var result in qwen3Asr.RecognizeDetailed(segsSubset, audio))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    int absId = startSeg + result.SegmentId;
+                    completed++;
+                    var syntheticTimestamps = BuildSyntheticTokenTimestamps(
+                        segsSubset[result.SegmentId].end - segsSubset[result.SegmentId].start,
+                        result.TextTokens.Count);
+
+                    db.UpdateResult(
+                        resultId:   absId + 1,
+                        asrContent: result.Text,
+                        content:    result.Text,
+                        tokens:     JsonSerializer.Serialize(result.TextTokens),
+                        timestamps: JsonSerializer.Serialize(syntheticTimestamps),
+                        logprobs:   JsonSerializer.Serialize(result.TextLogprobs));
 
                     onSegmentText(absId, result.Text);
 

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -600,8 +600,14 @@ internal class TranscriptionService
             }
             else if (useQwen3Asr)
             {
-                using var qwen3Asr = new Qwen3Asr(qwen3AsrModelsDir);
-                foreach (var result in qwen3Asr.RecognizeDetailed(segsSubset, audio))
+                bool hasBatchedFiles = File.Exists(Path.Combine(qwen3AsrModelsDir, Qwen3Asr.EncoderBatchedFile)) &&
+                                       (File.Exists(Path.Combine(qwen3AsrModelsDir, Qwen3Asr.DecoderFile)) ||
+                                        File.Exists(Path.Combine(qwen3AsrModelsDir, Qwen3Asr.DecoderInitBatchedFile)));
+                using var qwen3Asr = new Qwen3Asr(qwen3AsrModelsDir, preferBatched: hasBatchedFiles);
+                var recognitionResults = hasBatchedFiles
+                    ? qwen3Asr.RecognizeBatchedDetailed(segsSubset, audio)
+                    : qwen3Asr.RecognizeDetailed(segsSubset, audio);
+                foreach (var result in recognitionResults)
                 {
                     ct.ThrowIfCancellationRequested();
                     int absId = startSeg + result.SegmentId;

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -616,7 +616,13 @@ internal class TranscriptionService
                         content:    result.Text,
                         tokens:     JsonSerializer.Serialize(result.TextTokens),
                         timestamps: JsonSerializer.Serialize(syntheticTimestamps),
-                        logprobs:   JsonSerializer.Serialize(result.TextLogprobs));
+                        logprobs:   JsonSerializer.Serialize(result.TextLogprobs),
+                        language:   result.Language,
+                        asrMeta:    JsonSerializer.Serialize(new
+                        {
+                            raw_decoder_text = result.RawText,
+                            parsed_language = result.Language,
+                        }));
 
                     onSegmentText(absId, result.Text);
 

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -600,13 +600,18 @@ internal class TranscriptionService
             }
             else if (useQwen3Asr)
             {
+                string? qwenForceLanguage =
+                    string.Equals(asrLanguageCode, "auto", StringComparison.OrdinalIgnoreCase) ||
+                    string.IsNullOrWhiteSpace(asrLanguageCode)
+                        ? null
+                        : asrLanguageCode;
                 bool hasBatchedFiles = File.Exists(Path.Combine(qwen3AsrModelsDir, Qwen3Asr.EncoderBatchedFile)) &&
                                        (File.Exists(Path.Combine(qwen3AsrModelsDir, Qwen3Asr.DecoderFile)) ||
                                         File.Exists(Path.Combine(qwen3AsrModelsDir, Qwen3Asr.DecoderInitBatchedFile)));
                 using var qwen3Asr = new Qwen3Asr(qwen3AsrModelsDir, preferBatched: hasBatchedFiles);
                 var recognitionResults = hasBatchedFiles
-                    ? qwen3Asr.RecognizeBatchedDetailed(segsSubset, audio)
-                    : qwen3Asr.RecognizeDetailed(segsSubset, audio);
+                    ? qwen3Asr.RecognizeBatchedDetailed(segsSubset, audio, forceLanguage: qwenForceLanguage)
+                    : qwen3Asr.RecognizeDetailed(segsSubset, audio, forceLanguage: qwenForceLanguage);
                 foreach (var result in recognitionResults)
                 {
                     ct.ThrowIfCancellationRequested();

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -13,7 +13,7 @@ namespace Vernacula.App.Services;
 /// </summary>
 internal class VocabService
 {
-    private enum VocabKind { Parakeet, Cohere, VibeVoice }
+    private enum VocabKind { Parakeet, Cohere, Qwen3Asr, VibeVoice }
 
     private readonly Dictionary<int, string> _vocab;
     private readonly VocabKind _kind;
@@ -31,6 +31,12 @@ internal class VocabService
         {
             _kind = VocabKind.VibeVoice;
             (_vocab, _addedContent) = LoadVibeVoiceVocab(Path.Combine(modelsDir, Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile));
+            _byteLevelDecode = BuildByteLevelDecode();
+        }
+        else if (string.Equals(asrModel, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal))
+        {
+            _kind = VocabKind.Qwen3Asr;
+            (_vocab, _addedContent) = LoadVibeVoiceVocab(Path.Combine(modelsDir, Config.Qwen3AsrSubDir, Qwen3Asr.TokenizerFile));
             _byteLevelDecode = BuildByteLevelDecode();
         }
         else
@@ -101,6 +107,7 @@ internal class VocabService
         return _kind switch
         {
             VocabKind.Cohere   => DecodeCohereTokens(tokens),
+            VocabKind.Qwen3Asr => DecodeQwen3AsrTokens(tokens),
             VocabKind.VibeVoice => DecodeVibeVoiceTokens(tokens),
             _                  => DecodeParakeetTokens(tokens),
         };
@@ -112,6 +119,8 @@ internal class VocabService
     {
         if (_kind == VocabKind.Cohere)
             return GetCohereTokenRuns(tokens, logprobs);
+        if (_kind == VocabKind.Qwen3Asr)
+            return GetQwen3AsrTokenRuns(tokens, logprobs);
         if (_kind == VocabKind.VibeVoice)
             return GetVibeVoiceTokenRuns(tokens, logprobs, targetText);
 
@@ -181,6 +190,15 @@ internal class VocabService
         return TrimVibeVoiceBoundaryQuotes(Encoding.UTF8.GetString(bytes.ToArray()));
     }
 
+    private string DecodeQwen3AsrTokens(IReadOnlyList<int> tokens)
+    {
+        var bytes = new List<byte>(tokens.Count * 4);
+        foreach (int token in tokens)
+            bytes.AddRange(GetQwen3AsrTokenBytes(token));
+        string text = Encoding.UTF8.GetString(bytes.ToArray());
+        return text.Length > 0 && text[0] == ' ' ? text[1..] : text;
+    }
+
     private string DecodeToken(int token)
     {
         if (!_vocab.TryGetValue(token, out var value))
@@ -191,6 +209,8 @@ internal class VocabService
 
         if (_kind == VocabKind.VibeVoice)
             return Encoding.UTF8.GetString(GetVibeVoiceTokenBytes(token));
+        if (_kind == VocabKind.Qwen3Asr)
+            return Encoding.UTF8.GetString(GetQwen3AsrTokenBytes(token));
 
         if (value.Length == 6 && value[0] == '<' && value[1] == '0' && value[2] == 'x' && value[5] == '>')
         {
@@ -268,10 +288,61 @@ internal class VocabService
         return ClipRunsToTargetText(runs, targetText);
     }
 
+    private IReadOnlyList<(string text, float logprob)> GetQwen3AsrTokenRuns(
+        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
+    {
+        var runs = new List<(string, float)>(tokens.Count);
+        Decoder decoder = Encoding.UTF8.GetDecoder();
+        bool stripLeadingSpace = true;
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            byte[] tokenBytes = GetQwen3AsrTokenBytes(tokens[i]);
+            string runText;
+            if (tokenBytes.Length == 0)
+            {
+                runText = "";
+            }
+            else
+            {
+                int charCount = decoder.GetCharCount(tokenBytes, 0, tokenBytes.Length, flush: false);
+                char[] chars = new char[charCount];
+                decoder.GetChars(tokenBytes, 0, tokenBytes.Length, chars, 0, flush: false);
+                runText = new string(chars);
+                if (stripLeadingSpace && runText.Length > 0)
+                {
+                    stripLeadingSpace = false;
+                    if (runText[0] == ' ')
+                        runText = runText[1..];
+                }
+            }
+
+            float lp = i < logprobs.Count ? logprobs[i] : 0f;
+            runs.Add((runText, lp));
+        }
+
+        return runs;
+    }
+
     private byte[] GetVibeVoiceTokenBytes(int token)
     {
         if (_addedContent.TryGetValue(token, out var special))
             return Encoding.UTF8.GetBytes(special);
+
+        if (!_vocab.TryGetValue(token, out var raw))
+            return [];
+
+        var bytes = new List<byte>(raw.Length);
+        foreach (char ch in raw)
+            if (_byteLevelDecode.TryGetValue(ch, out byte b))
+                bytes.Add(b);
+        return bytes.ToArray();
+    }
+
+    private byte[] GetQwen3AsrTokenBytes(int token)
+    {
+        if (_addedContent.TryGetValue(token, out _))
+            return [];
 
         if (!_vocab.TryGetValue(token, out var raw))
             return [];

--- a/src/Vernacula.Avalonia/TranscriptionDb.cs
+++ b/src/Vernacula.Avalonia/TranscriptionDb.cs
@@ -471,7 +471,8 @@ internal sealed class TranscriptionDb : IDisposable
             int cardId, double sortOrder, int speakerId, string speakerName,
             double playStart, double playEnd, string? content, bool verified, bool suppressed,
             int resultId, int tokenStart, int? tokenEnd, int tsFrameOffset, int sourceOrder,
-            string? tokensJson, string? timestampsJson, string? logprobsJson, string asrContent)>();
+            string? tokensJson, string? timestampsJson, string? logprobsJson, string asrContent,
+            string? language)>();
 
         using var cmd = CreateCmd();
         cmd.CommandText = """
@@ -479,7 +480,8 @@ internal sealed class TranscriptionDb : IDisposable
                    c.play_start, c.play_end, c.content, c.verified, c.suppressed,
                    cs.result_id, cs.token_start, cs.token_end, cs.ts_frame_offset, cs.source_order,
                    r.tokens, r.timestamps, r.logprobs,
-                   coalesce(r.asr_content, coalesce(r.content, ''))
+                   coalesce(r.asr_content, coalesce(r.content, '')),
+                   r.language
             FROM segment_cards c
             JOIN speakers s  ON c.speaker_id  = s.speaker_id
             JOIN card_sources cs ON cs.card_id = c.card_id
@@ -509,7 +511,8 @@ internal sealed class TranscriptionDb : IDisposable
                     reader.IsDBNull(14) ? null : reader.GetString(14),
                     reader.IsDBNull(15) ? null : reader.GetString(15),
                     reader.IsDBNull(16) ? null : reader.GetString(16),
-                    reader.GetString(17)));
+                    reader.GetString(17),
+                    reader.IsDBNull(18) ? null : reader.GetString(18)));
             }
         }
 
@@ -527,10 +530,12 @@ internal sealed class TranscriptionDb : IDisposable
             var timestamps = new List<int>();
             var logprobs   = new List<float>();
             var asrParts   = new List<string>();
+            string? cardLanguage = null;
 
             while (i < raw.Count && raw[i].cardId == cardId)
             {
                 var row = raw[i++];
+                cardLanguage ??= row.language;
                 resultIds.Add(row.resultId);
                 sources.Add(new CardSource(row.resultId, row.tokenStart, row.tokenEnd,
                                            row.tsFrameOffset, row.sourceOrder));
@@ -573,7 +578,8 @@ internal sealed class TranscriptionDb : IDisposable
                 Tokens:      tokens,
                 Timestamps:  timestamps,
                 Logprobs:    logprobs,
-                AsrContent:  asrContent));
+                AsrContent:  asrContent,
+                Language:    cardLanguage));
         }
 
         return cards;
@@ -826,4 +832,5 @@ internal record CardQueryRow(
     IReadOnlyList<int>        Tokens,
     IReadOnlyList<int>        Timestamps,
     IReadOnlyList<float>      Logprobs,
-    string  AsrContent);
+    string  AsrContent,
+    string? Language);

--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -84,12 +84,12 @@
 
   <ItemGroup>
     <!-- Platform-specific ONNX Runtime, selected by EP build property -->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.2" Condition="'$(EP)' == 'Cuda' AND '$(UseDirectML)' != 'true' AND ($([MSBuild]::IsOSPlatform('Windows')) OR $([MSBuild]::IsOSPlatform('Linux')))" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.4" Condition="'$(EP)' == 'Cuda' AND '$(UseDirectML)' != 'true' AND ($([MSBuild]::IsOSPlatform('Windows')) OR $([MSBuild]::IsOSPlatform('Linux')))" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.21.1" Condition="'$(UseDirectML)' == 'true' AND $([MSBuild]::IsOSPlatform('Windows'))" />
     <!-- macOS x64 (Intel): 1.24.x dropped osx-x64 native support; 1.19.2 is the last version that includes it -->
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.19.2" Condition="$([MSBuild]::IsOSPlatform('OSX')) AND $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'X64'" />
     <!-- CPU runtime for all other platforms: EP=Cpu override, or macOS arm64 -->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" Condition="!($([MSBuild]::IsOSPlatform('OSX')) AND $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'X64') AND ('$(EP)' == 'Cpu' OR ('$(UseDirectML)' != 'true' AND !$([MSBuild]::IsOSPlatform('Windows')) AND !$([MSBuild]::IsOSPlatform('Linux'))))" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" Condition="!($([MSBuild]::IsOSPlatform('OSX')) AND $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'X64') AND ('$(EP)' == 'Cpu' OR ('$(UseDirectML)' != 'true' AND !$([MSBuild]::IsOSPlatform('Windows')) AND !$([MSBuild]::IsOSPlatform('Linux'))))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
@@ -77,6 +77,8 @@ internal partial class HomeViewModel : ObservableObject
 
         if (_settings.Current.AsrBackend == AsrBackend.Cohere)
             ModelStatusText = $"Cohere Transcribe weights are missing. Place them in {_settings.GetCohereModelsDir()}.";
+        else if (_settings.Current.AsrBackend == AsrBackend.Qwen3Asr)
+            ModelStatusText = $"Qwen3-ASR weights are missing. Place them in {_settings.GetQwen3AsrModelsDir()}.";
         else if (_settings.Current.AsrBackend == AsrBackend.VibeVoice ||
                  _settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.VibeVoiceBuiltin)
             ModelStatusText = $"VibeVoice-ASR weights are missing. Use Download Missing Models, or place them in {_settings.GetVibeVoiceModelsDir()}.";

--- a/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
@@ -347,6 +347,7 @@ internal partial class ProgressViewModel : ObservableObject
     private string GetJobAsrModelName() => _settings.Current.AsrBackend switch
     {
         AsrBackend.Cohere => "CohereLabs/cohere-transcribe-03-2026",
+        AsrBackend.Qwen3Asr => "Qwen/Qwen3-ASR-1.7B",
         _                 => "nvidia/parakeet-tdt-0.6b-v3",
     };
 

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -30,14 +30,16 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
     private CohereLanguageOption? _selectedCohereLanguage;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(ShowCohereLanguagePicker))]
+    private CohereLanguageOption? _selectedQwen3AsrLanguage;
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDenoiserNone), nameof(IsDenoiserDfn3))]
     private DenoiserMode _selectedDenoiser;
 
@@ -72,7 +74,8 @@ internal partial class SettingsViewModel : ObservableObject
     public string VibeVoiceAsrDescription => CanUseVibeVoiceAsr
         ? "Whole-recording ASR with built-in diarization. Downloads into the vibevoice_asr models folder."
         : "Unavailable because the CUDA execution provider check did not pass.";
-    public bool ShowCohereLanguagePicker => SelectedAsrBackend == AsrBackend.Cohere;
+    public bool ShowCohereLanguagePicker   => SelectedAsrBackend == AsrBackend.Cohere;
+    public bool ShowQwen3AsrLanguagePicker => SelectedAsrBackend == AsrBackend.Qwen3Asr;
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
     public bool ShowStandardSegmentationOptions => SelectedAsrBackend != AsrBackend.VibeVoice;
@@ -105,6 +108,67 @@ internal partial class SettingsViewModel : ObservableObject
         new("pt", "Portuguese"),
         new("vi", "Vietnamese"),
         new("zh", "Chinese"),
+    ];
+
+    public static readonly IReadOnlyList<CohereLanguageOption> Qwen3AsrLanguages =
+    [
+        new("",   "Auto-detect"),
+        new("af", "Afrikaans"),
+        new("ar", "Arabic"),
+        new("hy", "Armenian"),
+        new("az", "Azerbaijani"),
+        new("be", "Belarusian"),
+        new("bs", "Bosnian"),
+        new("bg", "Bulgarian"),
+        new("ca", "Catalan"),
+        new("zh", "Chinese"),
+        new("hr", "Croatian"),
+        new("cs", "Czech"),
+        new("da", "Danish"),
+        new("nl", "Dutch"),
+        new("en", "English"),
+        new("et", "Estonian"),
+        new("fi", "Finnish"),
+        new("fr", "French"),
+        new("gl", "Galician"),
+        new("de", "German"),
+        new("el", "Greek"),
+        new("he", "Hebrew"),
+        new("hi", "Hindi"),
+        new("hu", "Hungarian"),
+        new("is", "Icelandic"),
+        new("id", "Indonesian"),
+        new("it", "Italian"),
+        new("ja", "Japanese"),
+        new("kn", "Kannada"),
+        new("kk", "Kazakh"),
+        new("ko", "Korean"),
+        new("lv", "Latvian"),
+        new("lt", "Lithuanian"),
+        new("mk", "Macedonian"),
+        new("ms", "Malay"),
+        new("mr", "Marathi"),
+        new("ne", "Nepali"),
+        new("no", "Norwegian"),
+        new("fa", "Persian"),
+        new("pl", "Polish"),
+        new("pt", "Portuguese"),
+        new("ro", "Romanian"),
+        new("ru", "Russian"),
+        new("sr", "Serbian"),
+        new("sk", "Slovak"),
+        new("sl", "Slovenian"),
+        new("es", "Spanish"),
+        new("sw", "Swahili"),
+        new("sv", "Swedish"),
+        new("tl", "Tagalog"),
+        new("ta", "Tamil"),
+        new("th", "Thai"),
+        new("tr", "Turkish"),
+        new("uk", "Ukrainian"),
+        new("ur", "Urdu"),
+        new("vi", "Vietnamese"),
+        new("cy", "Welsh"),
     ];
 
     // ── Hardware check state ─────────────────────────────────────────────────
@@ -166,6 +230,8 @@ internal partial class SettingsViewModel : ObservableObject
             _lastNonVibeSegmentation = _selectedSegmentation;
         _selectedCohereLanguage       = CohereLanguages.FirstOrDefault(l => l.Code == svc.Current.CohereLanguage)
                                         ?? CohereLanguages[0];
+        _selectedQwen3AsrLanguage     = Qwen3AsrLanguages.FirstOrDefault(l => l.Code == svc.Current.Qwen3AsrLanguage)
+                                        ?? Qwen3AsrLanguages[0];
         _selectedDenoiser             = svc.Current.Denoiser;
         _selectedEditorPlaybackMode   = svc.Current.EditorPlaybackMode;
         _selectedLanguage             = svc.Current.Language;
@@ -252,6 +318,12 @@ internal partial class SettingsViewModel : ObservableObject
     partial void OnSelectedCohereLanguageChanged(CohereLanguageOption? value)
     {
         _svc.Current.CohereLanguage = value?.Code ?? "";
+        _svc.Save();
+    }
+
+    partial void OnSelectedQwen3AsrLanguageChanged(CohereLanguageOption? value)
+    {
+        _svc.Current.Qwen3AsrLanguage = value?.Code ?? "";
         _svc.Save();
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -34,10 +34,10 @@ internal partial class SettingsViewModel : ObservableObject
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
-    private CohereLanguageOption? _selectedCohereLanguage;
+    private AsrLanguageOption? _selectedCohereLanguage;
 
     [ObservableProperty]
-    private CohereLanguageOption? _selectedQwen3AsrLanguage;
+    private AsrLanguageOption? _selectedQwen3AsrLanguage;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDenoiserNone), nameof(IsDenoiserDfn3))]
@@ -90,8 +90,7 @@ internal partial class SettingsViewModel : ObservableObject
         ? "Unlocked gated models: DiariZen"
         : "Some optional models require accepting their own license terms before they appear in settings.";
 
-    public record CohereLanguageOption(string Code, string DisplayName);
-    public static readonly IReadOnlyList<CohereLanguageOption> CohereLanguages =
+    public static readonly IReadOnlyList<AsrLanguageOption> CohereLanguages =
     [
         new("",   "Auto-detect"),
         new("ar", "Arabic"),
@@ -110,7 +109,7 @@ internal partial class SettingsViewModel : ObservableObject
         new("zh", "Chinese"),
     ];
 
-    public static readonly IReadOnlyList<CohereLanguageOption> Qwen3AsrLanguages =
+    public static readonly IReadOnlyList<AsrLanguageOption> Qwen3AsrLanguages =
     [
         new("",   "Auto-detect"),
         new("af", "Afrikaans"),
@@ -315,13 +314,13 @@ internal partial class SettingsViewModel : ObservableObject
         _ = CheckModelsAsync();
     }
 
-    partial void OnSelectedCohereLanguageChanged(CohereLanguageOption? value)
+    partial void OnSelectedCohereLanguageChanged(AsrLanguageOption? value)
     {
         _svc.Current.CohereLanguage = value?.Code ?? "";
         _svc.Save();
     }
 
-    partial void OnSelectedQwen3AsrLanguageChanged(CohereLanguageOption? value)
+    partial void OnSelectedQwen3AsrLanguageChanged(AsrLanguageOption? value)
     {
         _svc.Current.Qwen3AsrLanguage = value?.Code ?? "";
         _svc.Save();

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -30,7 +30,7 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -65,6 +65,7 @@ internal partial class SettingsViewModel : ObservableObject
     public bool IsVibeVoiceBuiltin  => SelectedSegmentation == SegmentationMode.VibeVoiceBuiltin;
     public bool IsAsrParakeet       => SelectedAsrBackend == AsrBackend.Parakeet;
     public bool IsAsrCohere         => SelectedAsrBackend == AsrBackend.Cohere;
+    public bool IsAsrQwen3Asr       => SelectedAsrBackend == AsrBackend.Qwen3Asr;
     public bool IsAsrVibeVoice      => SelectedAsrBackend == AsrBackend.VibeVoice;
     public bool CanUseVibeVoiceAsr  => CudaEpWorking;
     public string VibeVoiceAsrLabel => CanUseVibeVoiceAsr ? "VibeVoice-ASR" : "VibeVoice-ASR (Unavailable - CUDA Missing)";
@@ -404,6 +405,13 @@ internal partial class SettingsViewModel : ObservableObject
             {
                 ModelStatusText = $"Missing {_lastMissing.Count} required model file(s): {string.Join(", ", _lastMissing)}. " +
                                   $"Place Cohere weights under {_svc.GetCohereModelsDir()}.";
+                return;
+            }
+
+            if (SelectedAsrBackend == AsrBackend.Qwen3Asr)
+            {
+                ModelStatusText = $"Missing {_lastMissing.Count} required model file(s): {string.Join(", ", _lastMissing)}. " +
+                                  $"Place Qwen3-ASR weights under {_svc.GetQwen3AsrModelsDir()}.";
                 return;
             }
 

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -82,6 +82,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
                 Sources            = row.Sources,
                 Verified           = row.Verified,
                 IsSuppressed       = row.IsSuppressed,
+                Language           = row.Language,
             });
         }
 
@@ -1017,7 +1018,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     /// <para>MUST be called from a background thread — loads and runs the ONNX model.</para>
     /// Returns (newResultId, asrContent, tokens, timestamps, logprobs) on success, or null.
     /// </summary>
-    public (int newResultId, string asrContent, List<int> tokens, List<int> timestamps, List<float> logprobs)?
+    public (int newResultId, string asrContent, List<int> tokens, List<int> timestamps, List<float> logprobs, string? language)?
         PerformRedoAsr(
             int index,
             string asrModel,
@@ -1027,7 +1028,8 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             string? cohereModelsDir = null,
             string? cohereLanguageCode = null,
             string? qwen3AsrModelsDir = null,
-            string? vibeVoiceModelsDir = null)
+            string? vibeVoiceModelsDir = null,
+            string? qwen3AsrLanguageCode = null)
     {
         if (index < 0 || index >= Segments.Count || _dbPath is null || _fullAudio is null)
             return null;
@@ -1103,8 +1105,11 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             if (string.IsNullOrWhiteSpace(qwen3AsrModelsDir))
                 return null;
 
+            string? qwenForceLanguage = string.IsNullOrEmpty(qwen3AsrLanguageCode) || string.Equals(qwen3AsrLanguageCode, "Auto", StringComparison.OrdinalIgnoreCase)
+                ? null : qwen3AsrLanguageCode;
+
             using var qwen3Asr = new Qwen3Asr(qwen3AsrModelsDir);
-            foreach (var result in qwen3Asr.RecognizeDetailed(asrSeg, mono16k))
+            foreach (var result in qwen3Asr.RecognizeDetailed(asrSeg, mono16k, forceLanguage: qwenForceLanguage))
             {
                 text = result.Text;
                 tokens = result.TextTokens.ToList();
@@ -1149,7 +1154,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             db.DeleteOrphanedResults(oldResultIds);
         }
 
-        return (newResultId, text, tokens, timestamps, logprobs);
+        return (newResultId, text, tokens, timestamps, logprobs, language);
     }
 
     private const string CohereSyntheticTimestampMode = "uniform_segment_frames_v1";
@@ -1182,7 +1187,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     /// <see cref="PerformRedoAsr"/> completes.
     /// </summary>
     public void ApplyRedoAsr(int index, int newResultId, string asrContent,
-        List<int> tokens, List<int> timestamps, List<float> logprobs)
+        List<int> tokens, List<int> timestamps, List<float> logprobs, string? language = null)
     {
         if (index < 0 || index >= Segments.Count) return;
         var seg = Segments[index];
@@ -1191,6 +1196,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         seg.Tokens     = tokens;
         seg.Timestamps = timestamps;
         seg.Logprobs   = logprobs;
+        seg.Language   = language;
         seg.Sources    = new List<CardSource>
         {
             new CardSource(newResultId, 0, null, 0, 0)

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1026,6 +1026,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             string decoderJointFile,
             string? cohereModelsDir = null,
             string? cohereLanguageCode = null,
+            string? qwen3AsrModelsDir = null,
             string? vibeVoiceModelsDir = null)
     {
         if (index < 0 || index >= Segments.Count || _dbPath is null || _fullAudio is null)
@@ -1096,6 +1097,20 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             logprobs       = vibeSegs.SelectMany(s => s.TokenLogprobs).ToList();
             int tokenCount = Math.Max(tokens.Count, logprobs.Count);
             timestamps = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, tokenCount);
+        }
+        else if (string.Equals(asrModel, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal))
+        {
+            if (string.IsNullOrWhiteSpace(qwen3AsrModelsDir))
+                return null;
+
+            using var qwen3Asr = new Qwen3Asr(qwen3AsrModelsDir);
+            foreach (var result in qwen3Asr.RecognizeDetailed(asrSeg, mono16k))
+            {
+                text = result.Text;
+                tokens = result.TextTokens.ToList();
+                timestamps = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, result.TextTokens.Count);
+                logprobs = result.TextLogprobs.ToList();
+            }
         }
         else
         {

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1110,6 +1110,12 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
                 tokens = result.TextTokens.ToList();
                 timestamps = BuildSyntheticTokenTimestamps(seg.PlayEnd - seg.PlayStart, result.TextTokens.Count);
                 logprobs = result.TextLogprobs.ToList();
+                language = result.Language;
+                asrMeta = JsonSerializer.Serialize(new
+                {
+                    raw_decoder_text = result.RawText,
+                    parsed_language = result.Language,
+                });
             }
         }
         else

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -454,6 +454,24 @@
                         <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
 
                         <RadioButton GroupName="AsrBackend"
+                                     IsChecked="{Binding IsAsrQwen3Asr, Mode=OneWay}"
+                                     Command="{Binding SetAsrBackendCommand}"
+                                     CommandParameter="Qwen3Asr"
+                                     Foreground="{DynamicResource TextBrush}">
+                            <StackPanel>
+                                <TextBlock Text="Qwen3-ASR 1.7B"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextBrush}" />
+                                <TextBlock Text="Optimized dynamic-decoder path. Place the exported package in the qwen3asr models folder."
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+
+                        <RadioButton GroupName="AsrBackend"
                                      IsChecked="{Binding IsAsrVibeVoice, Mode=OneWay}"
                                      Command="{Binding SetAsrBackendCommand}"
                                      CommandParameter="VibeVoice"

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -514,6 +514,32 @@
                             </ComboBox>
                         </StackPanel>
 
+                        <StackPanel Margin="24,10,0,0"
+                                    IsVisible="{Binding ShowQwen3AsrLanguagePicker}">
+                            <TextBlock Text="Forced Language"
+                                       Foreground="{DynamicResource TextBrush}"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,0,6" />
+                            <TextBlock Text="Optional. Use this when auto language detection is unstable."
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <ComboBox ItemsSource="{x:Static vm:SettingsViewModel.Qwen3AsrLanguages}"
+                                      SelectedItem="{Binding SelectedQwen3AsrLanguage}"
+                                      Background="{DynamicResource OverlayBrush}"
+                                      Foreground="{DynamicResource TextBrush}"
+                                      BorderBrush="{DynamicResource OverlayBrush}"
+                                      HorizontalAlignment="Left"
+                                      MinWidth="220">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+
                     </StackPanel>
                 </Border>
 

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:conv="using:Vernacula.App.Converters"
         xmlns:local="using:Vernacula.App"
+        xmlns:models="using:Vernacula.App.Models"
         Title="{local:Loc editor_heading}"
         Width="1040" Height="820"
         MinWidth="820" MinHeight="560"
@@ -499,6 +500,14 @@
                                                 </Canvas>
                                             </Grid>
                                         </Button>
+                                        <ComboBox Margin="0,0,8,8"
+                                                  Height="26"
+                                                  MinWidth="100"
+                                                  VerticalAlignment="Center"
+                                                  IsVisible="{Binding ShowLanguageChip}"
+                                                  ItemsSource="{x:Static models:TranscriptEditorCardState.Qwen3AsrLanguageNames}"
+                                                  SelectedItem="{Binding SelectedRedoLanguage, Mode=TwoWay}"
+                                                  ToolTip.Tip="Language for redo ASR" />
                                     </WrapPanel>
 
                                     <Grid ColumnDefinitions="*,*"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
@@ -505,9 +505,15 @@
                                                   MinWidth="100"
                                                   VerticalAlignment="Center"
                                                   IsVisible="{Binding ShowLanguageChip}"
-                                                  ItemsSource="{x:Static models:TranscriptEditorCardState.Qwen3AsrLanguageNames}"
+                                                  ItemsSource="{x:Static models:TranscriptEditorCardState.Qwen3AsrLanguages}"
                                                   SelectedItem="{Binding SelectedRedoLanguage, Mode=TwoWay}"
-                                                  ToolTip.Tip="Language for redo ASR" />
+                                                  ToolTip.Tip="{local:Loc editor_redo_asr_language}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding DisplayName}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
                                     </WrapPanel>
 
                                     <Grid ColumnDefinitions="*,*"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -48,6 +48,7 @@ public partial class TranscriptEditorWindow : Window
     private readonly string _jobAsrModel = "nvidia/parakeet-tdt-0.6b-v3";
     private readonly string _jobAsrLanguageCode = "auto";
     private readonly bool _asrModelsAvailable;
+    private readonly bool _isQwen3Asr;
     private readonly bool _showApproximateTimingNotice;
     private readonly string _approximateTimingNoticeText = "";
     private bool _isUpdatingUi;
@@ -100,6 +101,7 @@ public partial class TranscriptEditorWindow : Window
         bool isCohere    = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
         bool isQwen3Asr  = string.Equals(_jobAsrModel, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
         bool isVibeVoice = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+        _isQwen3Asr = isQwen3Asr;
         _showApproximateTimingNotice = isCohere || isQwen3Asr || isVibeVoice;
         _approximateTimingNoticeText = isCohere
             ? "Cohere Transcribe: no word-level timing; token sync is approximate."
@@ -321,6 +323,7 @@ public partial class TranscriptEditorWindow : Window
         for (int i = 0; i < _vm.Segments.Count; i++)
         {
             var state = new TranscriptEditorCardState(_vm.Segments[i], i);
+            state.ShowLanguageChip = _isQwen3Asr;
             AssignActionButtonImages(state);
             state.RedoAsrSpinnerImage = GetRedoAsrSpinnerImage();
             RefreshCardState(state, preserveDrafts: false);
@@ -1290,7 +1293,8 @@ public partial class TranscriptEditorWindow : Window
                 cohereModelsDir,
                 _jobAsrLanguageCode,
                 qwen3AsrModelsDir: App.Current.Settings.GetQwen3AsrModelsDir(),
-                vibeVoiceModelsDir: App.Current.Settings.GetVibeVoiceModelsDir()));
+                vibeVoiceModelsDir: App.Current.Settings.GetVibeVoiceModelsDir(),
+                qwen3AsrLanguageCode: _isQwen3Asr ? card.SelectedRedoLanguage : null));
             if (result is null)
             {
                 SetCardStatus(card, "Redo ASR did not produce a result.");
@@ -1298,7 +1302,10 @@ public partial class TranscriptEditorWindow : Window
             }
 
             _vm.ApplyRedoAsr(card.Index, result.Value.newResultId, result.Value.asrContent,
-                result.Value.tokens, result.Value.timestamps, result.Value.logprobs);
+                result.Value.tokens, result.Value.timestamps, result.Value.logprobs, result.Value.language);
+
+            if (_isQwen3Asr)
+                card.SelectedRedoLanguage = result.Value.language ?? "Auto";
 
             card.DraftContent = card.Segment.Content;
             DataChanged?.Invoke();

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -98,23 +98,28 @@ public partial class TranscriptEditorWindow : Window
             ? "auto"
             : asrLanguageCode;
         bool isCohere    = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+        bool isQwen3Asr  = string.Equals(_jobAsrModel, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
         bool isVibeVoice = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
-        _showApproximateTimingNotice = isCohere || isVibeVoice;
+        _showApproximateTimingNotice = isCohere || isQwen3Asr || isVibeVoice;
         _approximateTimingNoticeText = isCohere
             ? "Cohere Transcribe: no word-level timing; token sync is approximate."
+            : isQwen3Asr
+                ? "Qwen3-ASR: no word-level timing; token sync is approximate."
             : isVibeVoice
                 ? "VibeVoice-ASR: no token-level timing; token sync is approximate."
                 : "";
 
         string? vocabPath = isCohere
             ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)
+            : isQwen3Asr
+                ? Path.Combine(modelsDir, Config.Qwen3AsrSubDir, Qwen3Asr.TokenizerFile)
             : isVibeVoice
                 ? Path.Combine(modelsDir, Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile)
                 : Path.Combine(parakeetModelsDir, Config.VocabFile);
         if (vocabPath is not null && File.Exists(vocabPath))
         {
             _vocab = new VocabService(
-                isCohere || isVibeVoice ? App.Current.Settings.GetModelsDir() : parakeetModelsDir,
+                isCohere || isQwen3Asr || isVibeVoice ? App.Current.Settings.GetModelsDir() : parakeetModelsDir,
                 _jobAsrModel);
         }
 
@@ -138,6 +143,19 @@ public partial class TranscriptEditorWindow : Window
             _asrModelsAvailable =
                 File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.AudioEncoderFile)) &&
                 File.Exists(Path.Combine(vibeVoiceDir, VibeVoiceAsr.DecoderSingleFile));
+        }
+        else if (isQwen3Asr)
+        {
+            string qwenDir = App.Current.Settings.GetQwen3AsrModelsDir();
+            _asrModelsAvailable =
+                File.Exists(Path.Combine(qwenDir, Qwen3Asr.EncoderFile)) &&
+                File.Exists(Path.Combine(qwenDir, Qwen3Asr.DecoderInitFile)) &&
+                File.Exists(Path.Combine(qwenDir, $"{Qwen3Asr.DecoderInitFile}.data")) &&
+                File.Exists(Path.Combine(qwenDir, Qwen3Asr.DecoderStepFile)) &&
+                File.Exists(Path.Combine(qwenDir, $"{Qwen3Asr.DecoderStepFile}.data")) &&
+                File.Exists(Path.Combine(qwenDir, Qwen3Asr.EmbedTokensFile)) &&
+                File.Exists(Path.Combine(qwenDir, Qwen3Asr.TokenizerFile)) &&
+                File.Exists(Path.Combine(qwenDir, Qwen3Asr.ConfigFile));
         }
         else
         {
@@ -1271,6 +1289,7 @@ public partial class TranscriptEditorWindow : Window
                 decoderJointFile,
                 cohereModelsDir,
                 _jobAsrLanguageCode,
+                qwen3AsrModelsDir: App.Current.Settings.GetQwen3AsrModelsDir(),
                 vibeVoiceModelsDir: App.Current.Settings.GetVibeVoiceModelsDir()));
             if (result is null)
             {

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -1294,7 +1294,7 @@ public partial class TranscriptEditorWindow : Window
                 _jobAsrLanguageCode,
                 qwen3AsrModelsDir: App.Current.Settings.GetQwen3AsrModelsDir(),
                 vibeVoiceModelsDir: App.Current.Settings.GetVibeVoiceModelsDir(),
-                qwen3AsrLanguageCode: _isQwen3Asr ? card.SelectedRedoLanguage : null));
+                qwen3AsrLanguageCode: _isQwen3Asr ? card.SelectedRedoLanguage?.Code : null));
             if (result is null)
             {
                 SetCardStatus(card, "Redo ASR did not produce a result.");
@@ -1305,7 +1305,7 @@ public partial class TranscriptEditorWindow : Window
                 result.Value.tokens, result.Value.timestamps, result.Value.logprobs, result.Value.language);
 
             if (_isQwen3Asr)
-                card.SelectedRedoLanguage = result.Value.language ?? "Auto";
+                card.SelectedRedoLanguage = TranscriptEditorCardState.MatchLanguageOption(result.Value.language);
 
             card.DraftContent = card.Segment.Content;
             DataChanged?.Invoke();

--- a/src/Vernacula.Base/AudioUtils.cs
+++ b/src/Vernacula.Base/AudioUtils.cs
@@ -221,6 +221,23 @@ public static class AudioUtils
     /// </summary>
     public static (float[] samples, int sampleRate, int channels) ReadAudio(string path)
     {
+        if (!OperatingSystem.IsWindows() &&
+            string.Equals(Path.GetExtension(path), ".wav", StringComparison.OrdinalIgnoreCase))
+        {
+            using var wavReader = new WaveFileReader(path);
+            ISampleProvider sampleProvider = wavReader.ToSampleProvider();
+            int wavSampleRate = sampleProvider.WaveFormat.SampleRate;
+            int wavChannels = sampleProvider.WaveFormat.Channels;
+
+            var wavSamples = new List<float>(wavSampleRate * wavChannels * 10);
+            var wavBuffer = new float[8192];
+            int wavRead;
+            while ((wavRead = sampleProvider.Read(wavBuffer, 0, wavBuffer.Length)) > 0)
+                for (int i = 0; i < wavRead; i++) wavSamples.Add(wavBuffer[i]);
+
+            return (wavSamples.ToArray(), wavSampleRate, wavChannels);
+        }
+
         using var reader = new AudioFileReader(path);
         int sampleRate = reader.WaveFormat.SampleRate;
         int channels   = reader.WaveFormat.Channels;

--- a/src/Vernacula.Base/Config.cs
+++ b/src/Vernacula.Base/Config.cs
@@ -213,12 +213,17 @@ public static class Config
     public static string GetSortformerModelPath(string modelDir)
     {
         string? overridePath = Environment.GetEnvironmentVariable(SortformerModelOverrideEnvVar);
-        if (string.IsNullOrWhiteSpace(overridePath))
-            return Path.Combine(modelDir, SortformerFile);
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            return Path.IsPathRooted(overridePath)
+                ? overridePath
+                : Path.Combine(modelDir, overridePath);
+        }
 
-        return Path.IsPathRooted(overridePath)
-            ? overridePath
-            : Path.Combine(modelDir, overridePath);
+        string subDirPath = Path.Combine(modelDir, SortformerSubDir, SortformerFile);
+        return File.Exists(subDirPath)
+            ? subDirPath
+            : Path.Combine(modelDir, SortformerFile);
     }
 
     public static int GetDiariZenSegmentationIntraOpThreads()

--- a/src/Vernacula.Base/Config.cs
+++ b/src/Vernacula.Base/Config.cs
@@ -183,6 +183,9 @@ public static class Config
     /// </summary>
     public const string VibeVoiceSubDir = "vibevoice_asr";
 
+    // ── ASR (Qwen3-ASR) ──────────────────────────────────────────────────────
+    public const string Qwen3AsrSubDir = "qwen3asr";
+
     // ── ASR (Parakeet) ───────────────────────────────────────────────────────
     public const string ParakeetSubDir       = "parakeet";
     public const string PreprocessorFile     = "nemo128.onnx";

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -58,6 +58,7 @@ public sealed class Qwen3Asr : IDisposable
     private readonly int _vocabSize;
     private readonly int _baseVocabSize;
     private readonly int[] _eosTokenIds;
+    private readonly HashSet<int> _eosTokenIdSet;
     private readonly MemoryMappedFile _embedMmf;
     private readonly MemoryMappedViewAccessor _embedAccessor;
     private readonly string?[] _idToToken;
@@ -76,6 +77,7 @@ public sealed class Qwen3Asr : IDisposable
         _vocabSize = decoderConfig.GetProperty("vocab_size").GetInt32();
         _baseVocabSize = root.GetProperty("embed_tokens_shape")[0].GetInt32();
         _eosTokenIds = specialTokens.GetProperty("eos_token_ids").EnumerateArray().Select(e => e.GetInt32()).ToArray();
+        _eosTokenIdSet = [.. _eosTokenIds];
 
         var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool encoderUsesCuda);
         var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool decoderUsesCuda);
@@ -119,10 +121,7 @@ public sealed class Qwen3Asr : IDisposable
             }
 
             int length = endSample - startSample;
-            var waveform = new float[length];
-            Array.Copy(audio, startSample, waveform, 0, length);
-
-            float[] mel = ComputeLogMelSpectrogram(waveform, out int melFrames);
+            float[] mel = ComputeLogMelSpectrogram(audio, startSample, length, out int melFrames);
             float[] audioFeatures = RunEncoder(mel, melFrames, out int audioTokenCount);
 
             List<int> promptIds = BuildPromptIds(audioTokenCount);
@@ -210,6 +209,8 @@ public sealed class Qwen3Asr : IDisposable
         float[] pastKeys = ExtractTensor(initOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
         float[] pastValues = ExtractTensor(initOutputs.First(r => r.Name == "present_values").AsTensor<float>());
         int pastSeqLen = promptIds.Count;
+        var tokenEmbed = new float[_hiddenSize];
+        long[] stepPos = [0L];
 
         var rawTokens = new List<int>(maxNewTokens);
         var rawLogprobs = new List<float>(maxNewTokens);
@@ -221,8 +222,8 @@ public sealed class Qwen3Asr : IDisposable
 
         while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
         {
-            float[] tokenEmbed = ReadTokenEmbedding(nextToken);
-            long[] stepPos = [promptIds.Count + rawTokens.Count - 1L];
+            ReadTokenEmbedding(nextToken, tokenEmbed);
+            stepPos[0] = promptIds.Count + rawTokens.Count - 1L;
 
             using var stepOutputs = _decoderStep.Run(
             [
@@ -278,6 +279,8 @@ public sealed class Qwen3Asr : IDisposable
         var initOutputs = initBinding.GetOutputValues();
         var rawTokens = new List<int>(maxNewTokens);
         var rawLogprobs = new List<float>(maxNewTokens);
+        var tokenEmbed = new float[_hiddenSize];
+        long[] stepPos = [0L];
 
         int nextToken = ArgMaxLastLogits(initOutputs[0], promptIds.Count, out float nextLogprob);
         rawTokens.Add(nextToken);
@@ -288,8 +291,8 @@ public sealed class Qwen3Asr : IDisposable
 
         while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
         {
-            float[] tokenEmbed = ReadTokenEmbedding(nextToken);
-            long[] stepPos = [promptIds.Count + rawTokens.Count - 1L];
+            ReadTokenEmbedding(nextToken, tokenEmbed);
+            stepPos[0] = promptIds.Count + rawTokens.Count - 1L;
 
             using var tokenEmbedValue = OrtValue.CreateTensorValueFromMemory(tokenEmbed, [1, 1, _hiddenSize]);
             using var stepPosValue = OrtValue.CreateTensorValueFromMemory(stepPos, [1, 1]);
@@ -366,12 +369,10 @@ public sealed class Qwen3Asr : IDisposable
         return best;
     }
 
-    private float[] ReadTokenEmbedding(int tokenId)
+    private void ReadTokenEmbedding(int tokenId, float[] destination)
     {
-        var embedding = new float[_hiddenSize];
         long byteOffset = (long)tokenId * _hiddenSize * sizeof(float);
-        _embedAccessor.ReadArray(byteOffset, embedding, 0, _hiddenSize);
-        return embedding;
+        _embedAccessor.ReadArray(byteOffset, destination, 0, _hiddenSize);
     }
 
     private static (List<int> textTokens, List<float> textLogprobs) ExtractTextTokens(
@@ -414,7 +415,7 @@ public sealed class Qwen3Asr : IDisposable
         return text.Length > 0 && text[0] == ' ' ? text[1..] : text;
     }
 
-    private bool IsEos(int token) => _eosTokenIds.Contains(token);
+    private bool IsEos(int token) => _eosTokenIdSet.Contains(token);
 
     private static List<int> BuildPromptIds(int audioTokenCount)
     {
@@ -451,44 +452,52 @@ public sealed class Qwen3Asr : IDisposable
         throw new InvalidOperationException("Prompt does not contain <|audio_pad|> tokens.");
     }
 
-    private static float[] ComputeLogMelSpectrogram(float[] signal, out int framesOut)
+    private static float[] ComputeLogMelSpectrogram(float[] signal, int start, int length, out int framesOut)
     {
         int pad = NFft / 2;
-        float[] padded = ReflectPad(signal, pad);
+        float[] padded = ReflectPad(signal, start, length, pad);
         int frameCount = ((padded.Length - NFft) / HopLength) + 1;
         int keptFrames = Math.Max(frameCount - 1, 1);
         int freqBins = (NFft / 2) + 1;
         var mel = new float[NMels * keptFrames];
-        var fft = new Complex32[NFft];
-
-        float maxLog = float.NegativeInfinity;
-        for (int frame = 0; frame < frameCount; frame++)
-        {
-            int start = frame * HopLength;
-            Array.Clear(fft, 0, fft.Length);
-            for (int i = 0; i < NFft; i++)
-                fft[i] = new Complex32((float)(padded[start + i] * HannWindow[i]), 0f);
-
-            Fourier.Forward(fft, FourierOptions.NoScaling);
-
-            if (frame >= keptFrames)
-                continue;
-
-            for (int m = 0; m < NMels; m++)
+        Parallel.For(
+            0,
+            frameCount,
+            () => new Complex32[NFft],
+            (frame, _, fft) =>
             {
-                double sum = 0;
-                for (int k = 0; k < freqBins; k++)
+                int startIndex = frame * HopLength;
+                Array.Clear(fft, 0, fft.Length);
+                for (int i = 0; i < NFft; i++)
+                    fft[i] = new Complex32((float)(padded[startIndex + i] * HannWindow[i]), 0f);
+
+                Fourier.Forward(fft, FourierOptions.NoScaling);
+
+                if (frame < keptFrames)
                 {
-                    float re = fft[k].Real;
-                    float im = fft[k].Imaginary;
-                    sum += MelFilterbank[m, k] * (re * re + im * im);
+                    for (int m = 0; m < NMels; m++)
+                    {
+                        double sum = 0;
+                        for (int k = 0; k < freqBins; k++)
+                        {
+                            float re = fft[k].Real;
+                            float im = fft[k].Imaginary;
+                            sum += MelFilterbank[m, k] * (re * re + im * im);
+                        }
+
+                        mel[m * keptFrames + frame] = MathF.Log10(MathF.Max((float)sum, 1e-10f));
+                    }
                 }
 
-                float log = MathF.Log10(MathF.Max((float)sum, 1e-10f));
-                mel[m * keptFrames + frame] = log;
-                if (log > maxLog)
-                    maxLog = log;
-            }
+                return fft;
+            },
+            _ => { });
+
+        float maxLog = float.NegativeInfinity;
+        for (int i = 0; i < mel.Length; i++)
+        {
+            if (mel[i] > maxLog)
+                maxLog = mel[i];
         }
 
         float floor = MathF.Max(maxLog - LogClampSpan, LogFloor);
@@ -499,20 +508,20 @@ public sealed class Qwen3Asr : IDisposable
         return mel;
     }
 
-    private static float[] ReflectPad(float[] signal, int pad)
+    private static float[] ReflectPad(float[] signal, int start, int length, int pad)
     {
-        if (signal.Length == 0)
+        if (length == 0)
             return new float[pad * 2];
 
-        var padded = new float[signal.Length + (pad * 2)];
-        Array.Copy(signal, 0, padded, pad, signal.Length);
+        var padded = new float[length + (pad * 2)];
+        Array.Copy(signal, start, padded, pad, length);
 
         for (int i = 0; i < pad; i++)
         {
-            int leftSrc = Math.Min(signal.Length - 1, pad - i);
-            int rightSrc = Math.Max(0, signal.Length - 2 - i);
-            padded[i] = signal[leftSrc];
-            padded[pad + signal.Length + i] = signal[rightSrc];
+            int leftSrc = Math.Min(length - 1, pad - i);
+            int rightSrc = Math.Max(0, length - 2 - i);
+            padded[i] = signal[start + leftSrc];
+            padded[pad + length + i] = signal[start + rightSrc];
         }
 
         return padded;

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -1604,8 +1604,8 @@ public sealed class Qwen3Asr : IDisposable
             [
                 NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(tokenEmbed, [1, 1, _hiddenSize])),
                 NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(stepPos, [1, 1])),
-                NamedOnnxValue.CreateFromTensor("past_keys", new DenseTensor<float>(pastKeys, [28, 1, 8, pastSeqLen, 128])),
-                NamedOnnxValue.CreateFromTensor("past_values", new DenseTensor<float>(pastValues, [28, 1, 8, pastSeqLen, 128])),
+                NamedOnnxValue.CreateFromTensor("past_keys", new DenseTensor<float>(pastKeys, [_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
+                NamedOnnxValue.CreateFromTensor("past_values", new DenseTensor<float>(pastValues, [_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
             ]);
 
             logits     = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
@@ -1836,7 +1836,6 @@ public sealed class Qwen3Asr : IDisposable
         rawLogprobs.Add(nextLogprob);
 
         IDisposableReadOnlyCollection<OrtValue>? prevOutputs = initOutputs;
-        int pastSeqLen = seqLen;
 
         while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
         {
@@ -1859,7 +1858,6 @@ public sealed class Qwen3Asr : IDisposable
             nextToken = ArgMaxLastLogits(curOutputs[0], 1, out nextLogprob);
             rawTokens.Add(nextToken);
             rawLogprobs.Add(nextLogprob);
-            pastSeqLen++;
 
             prevOutputs.Dispose();
             prevOutputs = curOutputs;

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -27,6 +27,7 @@ public sealed class Qwen3Asr : IDisposable
 {
     public const string EncoderFile = "encoder.onnx";
     public const string EncoderBatchedFile = "encoder_batched.onnx";
+    public const string DecoderFile = "decoder.onnx";
     public const string DecoderInitFile = "decoder_init.onnx";
     public const string DecoderInitBatchedFile = "decoder_init_batched.onnx";
     public const string DecoderStepFile = "decoder_step.onnx";
@@ -126,7 +127,8 @@ public sealed class Qwen3Asr : IDisposable
 
     private readonly InferenceSession _encoder;
     private readonly InferenceSession _decoderInit;
-    private readonly InferenceSession _decoderStep;
+    private readonly InferenceSession? _decoderStep;
+    private readonly InferenceSession? _decoder;
     private readonly InferenceSession? _encoderBatched;
     private readonly InferenceSession? _decoderInitBatched;
     private readonly bool _useCudaIoBinding;
@@ -134,6 +136,9 @@ public sealed class Qwen3Asr : IDisposable
     private readonly string _modelPath;
     private readonly ExecutionProvider _executionProvider;
     private readonly int _hiddenSize;
+    private readonly int _nLayers;
+    private readonly int _nKvHeads;
+    private readonly int _headDim;
     private readonly int _vocabSize;
     private readonly int _baseVocabSize;
     private readonly int[] _eosTokenIds;
@@ -155,6 +160,9 @@ public sealed class Qwen3Asr : IDisposable
         var specialTokens = root.GetProperty("special_tokens");
 
         _hiddenSize = decoderConfig.GetProperty("hidden_size").GetInt32();
+        _nLayers    = decoderConfig.GetProperty("num_layers").GetInt32();
+        _nKvHeads   = decoderConfig.GetProperty("num_key_value_heads").GetInt32();
+        _headDim    = decoderConfig.GetProperty("head_dim").GetInt32();
         _vocabSize = decoderConfig.GetProperty("vocab_size").GetInt32();
         _baseVocabSize = root.GetProperty("embed_tokens_shape")[0].GetInt32();
         _eosTokenIds = specialTokens.GetProperty("eos_token_ids").EnumerateArray().Select(e => e.GetInt32()).ToArray();
@@ -163,28 +171,53 @@ public sealed class Qwen3Asr : IDisposable
         var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool encoderUsesCuda);
         var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool decoderUsesCuda);
 
-        bool hasBatchedFiles = File.Exists(Path.Combine(modelPath, EncoderBatchedFile)) &&
-                               File.Exists(Path.Combine(modelPath, DecoderInitBatchedFile));
-        _preferBatched = preferBatched && hasBatchedFiles;
+        bool hasUnified       = File.Exists(Path.Combine(modelPath, DecoderFile));
+        bool hasBatchedEncoder = File.Exists(Path.Combine(modelPath, EncoderBatchedFile));
+        bool hasBatchedInit   = File.Exists(Path.Combine(modelPath, DecoderInitBatchedFile));
+        _preferBatched = preferBatched && hasBatchedEncoder && (hasBatchedInit || hasUnified);
 
-        if (_preferBatched)
+        if (hasUnified)
         {
-            // Load only batched encoder + decoder_init + shared decoder_step.
-            // Skipping serial encoder/decoder_init avoids peak VRAM from 5 → 3 sessions.
-            _encoder      = null!;
-            _decoderInit  = null!;
-            _encoderBatched      = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile),      encoderOpts);
-            _decoderInitBatched  = new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile),  decoderOpts);
+            // Unified decoder.onnx replaces decoder_init + decoder_step — only one session.
+            _decoder          = new InferenceSession(Path.Combine(modelPath, DecoderFile), decoderOpts);
+            _decoderInit      = null!;
+            _decoderStep      = null;
+            _decoderInitBatched = null;
+            _useCudaIoBinding = false;
+
+            if (_preferBatched)
+            {
+                _encoder        = null!;
+                _encoderBatched = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile), encoderOpts);
+            }
+            else
+            {
+                _encoder        = new InferenceSession(Path.Combine(modelPath, EncoderFile), encoderOpts);
+                _encoderBatched = null;
+            }
+        }
+        else if (_preferBatched)
+        {
+            // Batched split path: encoder_batched + decoder_init_batched + decoder_step.
+            _decoder             = null;
+            _encoder             = null!;
+            _decoderInit         = null!;
+            _encoderBatched      = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile),     encoderOpts);
+            _decoderInitBatched  = new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile), decoderOpts);
+            _decoderStep         = new InferenceSession(Path.Combine(modelPath, DecoderStepFile),        decoderOpts);
             _useCudaIoBinding    = false;
         }
         else
         {
-            _encoder     = new InferenceSession(Path.Combine(modelPath, EncoderFile),     encoderOpts);
-            _decoderInit = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), decoderOpts);
-            _useCudaIoBinding = encoderUsesCuda && decoderUsesCuda;
+            // Serial split path: encoder + decoder_init + decoder_step.
+            _decoder         = null;
+            _encoder         = new InferenceSession(Path.Combine(modelPath, EncoderFile),     encoderOpts);
+            _decoderInit     = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), decoderOpts);
+            _decoderStep     = new InferenceSession(Path.Combine(modelPath, DecoderStepFile), decoderOpts);
+            _encoderBatched     = null;
+            _decoderInitBatched = null;
+            _useCudaIoBinding   = encoderUsesCuda && decoderUsesCuda;
         }
-
-        _decoderStep = new InferenceSession(Path.Combine(modelPath, DecoderStepFile), decoderOpts);
 
         string embedPath = Path.Combine(modelPath, EmbedTokensFile);
         _embedMmf = MemoryMappedFile.CreateFromFile(embedPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
@@ -321,9 +354,11 @@ public sealed class Qwen3Asr : IDisposable
             List<int> promptIds = BuildPromptIds(audioTokenCount);
             int audioOffset = GetAudioPadStart(promptIds);
 
-            var (rawTokens, rawLogprobs) = _useCudaIoBinding
-                ? DecodeWithIoBinding(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens)
-                : DecodeOnCpu(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens);
+            var (rawTokens, rawLogprobs) = _decoder is not null
+                ? DecodeOnCpuUnified(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens)
+                : _useCudaIoBinding
+                    ? DecodeWithIoBinding(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens)
+                    : DecodeOnCpu(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens);
 
             var (textTokens, textLogprobs) = ExtractTextTokens(rawTokens, rawLogprobs);
             string rawText = DecodeTokens(textTokens);
@@ -452,7 +487,7 @@ public sealed class Qwen3Asr : IDisposable
         float[] audio,
         int maxNewTokens = 256)
     {
-        if (_encoderBatched is null || _decoderInitBatched is null)
+        if (_encoderBatched is null || (_decoderInitBatched is null && _decoder is null))
         {
             foreach (var r in RecognizeDetailed(segs, audio, maxNewTokens))
                 yield return r;
@@ -536,37 +571,73 @@ public sealed class Qwen3Asr : IDisposable
                 Array.Copy(audioFeaturesSource, srcBase, audioFeatures, dstBase, _hiddenSize);
             }
 
-            // ── Batched decoder_init ─────────────────────────────────────────
-            List<int> prompt   = BuildPromptIds(maxAudioTokens);
+            // ── Batched prefill ──────────────────────────────────────────────
+            List<int> prompt    = BuildPromptIds(maxAudioTokens);
             int       audioOffset = GetAudioPadStart(prompt);
-            int       seqLen   = prompt.Count;
+            int       seqLen    = prompt.Count;
 
-            var inputIds    = new long[take * seqLen];
             var positionIds = new long[take * seqLen];
             for (int b = 0; b < take; b++)
             for (int t = 0; t < seqLen; t++)
-            {
-                inputIds   [b * seqLen + t] = prompt[t];
                 positionIds[b * seqLen + t] = t;
+
+            float[] batchedLogits;
+            float[] batchedKeys;
+            float[] batchedValues;
+
+            if (_decoder is not null)
+            {
+                // Unified decoder: build input_embeds from embedding lookup + per-item audio scatter.
+                float[] inputEmbeds = new float[take * seqLen * _hiddenSize];
+                var tmpEmbed = new float[_hiddenSize];
+                for (int b = 0; b < take; b++)
+                {
+                    for (int t = 0; t < seqLen; t++)
+                    {
+                        ReadTokenEmbedding(prompt[t], tmpEmbed);
+                        Array.Copy(tmpEmbed, 0, inputEmbeds, (b * seqLen + t) * _hiddenSize, _hiddenSize);
+                    }
+                    int audioLen = (int)audioLengths[b];
+                    for (int t = 0; t < audioLen; t++)
+                        Array.Copy(audioFeatures, (b * maxAudioTokens + t) * _hiddenSize,
+                                   inputEmbeds,   (b * seqLen + audioOffset + t) * _hiddenSize, _hiddenSize);
+                }
+
+                float[] emptyKv = [];
+                float[] prefillMask = BuildCausalMask(seqLen, 0);
+                using var initResults = _decoder.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(inputEmbeds, [take, seqLen, _hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(positionIds,  [take, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(prefillMask, [1, 1, seqLen, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
+                    NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
+                ]);
+                batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
+                batchedKeys   = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
+                batchedValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
+            }
+            else
+            {
+                var inputIds = new long[take * seqLen];
+                for (int b = 0; b < take; b++)
+                for (int t = 0; t < seqLen; t++)
+                    inputIds[b * seqLen + t] = prompt[t];
+
+                using var initResults = _decoderInitBatched!.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_ids",      new DenseTensor<long> (inputIds,     [take, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long> (positionIds,  [take, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures,[take, maxAudioTokens, _hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("audio_lengths",  new DenseTensor<long> (audioLengths, [take])),
+                    NamedOnnxValue.CreateFromTensor("audio_offset",   new DenseTensor<long> (new long[] { audioOffset }, [1])),
+                ]);
+                batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
+                batchedKeys   = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
+                batchedValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
             }
 
-            using var initResults = _decoderInitBatched.Run(
-            [
-                NamedOnnxValue.CreateFromTensor("input_ids",      new DenseTensor<long> (inputIds,     [take, seqLen])),
-                NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long> (positionIds,  [take, seqLen])),
-                NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures,[take, maxAudioTokens, _hiddenSize])),
-                NamedOnnxValue.CreateFromTensor("audio_lengths",  new DenseTensor<long> (audioLengths, [take])),
-                NamedOnnxValue.CreateFromTensor("audio_offset",   new DenseTensor<long> (new long[] { audioOffset }, [1])),
-            ]);
-
-            float[] batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
-            float[] batchedKeys   = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
-            float[] batchedValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
-
-            int vocabSize      = batchedLogits.Length / (take * seqLen);
-            const int NLayers  = 28;
-            const int NKvHeads = 8;
-            const int HdDim    = 128;
+            int vocabSize = batchedLogits.Length / (take * seqLen);
 
             // Extract first token per sequence from batched prefill logits
             var seqTokens    = new List<int>  [take];
@@ -593,9 +664,10 @@ public sealed class Qwen3Asr : IDisposable
             float[] pastValues = batchedValues;
             int pastSeqLen     = seqLen;
 
-            var batchEmbeds = new float[take * _hiddenSize];
-            var stepPosArr  = new long[take];
-            var tmpEmbed    = new float[_hiddenSize];
+            var batchEmbeds  = new float[take * _hiddenSize];
+            var stepPosArr   = new long[take];
+            var tmpStepEmbed = new float[_hiddenSize];
+            var stepSession  = _decoder ?? _decoderStep!;
 
             for (int step = 0; step < maxNewTokens - 1; step++)
             {
@@ -604,18 +676,26 @@ public sealed class Qwen3Asr : IDisposable
                 long pos = seqLen + step;
                 for (int b = 0; b < take; b++)
                 {
-                    ReadTokenEmbedding(seqNextToken[b], tmpEmbed);
-                    Array.Copy(tmpEmbed, 0, batchEmbeds, b * _hiddenSize, _hiddenSize);
+                    ReadTokenEmbedding(seqNextToken[b], tmpStepEmbed);
+                    Array.Copy(tmpStepEmbed, 0, batchEmbeds, b * _hiddenSize, _hiddenSize);
                     stepPosArr[b] = pos;
                 }
 
-                using var stepOutputs = _decoderStep.Run(
-                [
-                    NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(batchEmbeds, [take, 1, _hiddenSize])),
-                    NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long> (stepPosArr,  [take, 1])),
-                    NamedOnnxValue.CreateFromTensor("past_keys",    new DenseTensor<float>(pastKeys,    [NLayers, take, NKvHeads, pastSeqLen, HdDim])),
-                    NamedOnnxValue.CreateFromTensor("past_values",  new DenseTensor<float>(pastValues,  [NLayers, take, NKvHeads, pastSeqLen, HdDim])),
-                ]);
+                IEnumerable<NamedOnnxValue> stepInputs = _decoder is not null
+                    ? [
+                        NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(batchEmbeds,              [take, 1, _hiddenSize])),
+                        NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long> (stepPosArr,               [take, 1])),
+                        NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(new float[pastSeqLen + 1],[1, 1, 1, pastSeqLen + 1])),
+                        NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys,                 [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
+                        NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues,               [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
+                      ]
+                    : [
+                        NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(batchEmbeds, [take, 1, _hiddenSize])),
+                        NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long> (stepPosArr,  [take, 1])),
+                        NamedOnnxValue.CreateFromTensor("past_keys",    new DenseTensor<float>(pastKeys,    [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
+                        NamedOnnxValue.CreateFromTensor("past_values",  new DenseTensor<float>(pastValues,  [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
+                      ];
+                using var stepOutputs = stepSession.Run(stepInputs.ToList());
 
                 float[] stepLogits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
                 pastKeys   = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
@@ -646,6 +726,17 @@ public sealed class Qwen3Asr : IDisposable
         }
     }
 
+    // Build a [1,1,seqLen,pastSeqLen+seqLen] causal mask (upper-tri -inf; past positions zero).
+    private static float[] BuildCausalMask(int seqLen, int pastSeqLen)
+    {
+        int totalLen = pastSeqLen + seqLen;
+        float[] mask = new float[seqLen * totalLen]; // broadcast batch dim from C# side
+        for (int q = 0; q < seqLen; q++)
+            for (int k = pastSeqLen + q + 1; k < totalLen; k++)
+                mask[q * totalLen + k] = float.NegativeInfinity;
+        return mask;
+    }
+
     private int ArgMaxSpan(Span<float> logits, out float logprob)
     {
         int   best    = 0;
@@ -661,7 +752,7 @@ public sealed class Qwen3Asr : IDisposable
     }
 
     public bool HasExperimentalBatchingArtifacts()
-        => _encoderBatched is not null && _decoderInitBatched is not null;
+        => _encoderBatched is not null && (_decoderInitBatched is not null || _decoder is not null);
 
     public QwenExperimentalBatchBenchmark BenchmarkExperimentalBatching(
         IReadOnlyList<(double start, double end, string spk)> segs,
@@ -870,7 +961,7 @@ public sealed class Qwen3Asr : IDisposable
             ReadTokenEmbedding(nextToken, tokenEmbed);
             stepPos[0] = promptIds.Count + rawTokens.Count - 1L;
 
-            using var stepOutputs = _decoderStep.Run(
+            using var stepOutputs = _decoderStep!.Run(
             [
                 NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(tokenEmbed, [1, 1, _hiddenSize])),
                 NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(stepPos, [1, 1])),
@@ -880,6 +971,82 @@ public sealed class Qwen3Asr : IDisposable
 
             logits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
             pastKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+            pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+            pastSeqLen++;
+
+            nextToken = ArgMaxLastLogits(logits, 1, out nextLogprob);
+            rawTokens.Add(nextToken);
+            rawLogprobs.Add(nextLogprob);
+        }
+
+        return (rawTokens, rawLogprobs);
+    }
+
+    private (List<int> rawTokens, List<float> rawLogprobs) DecodeOnCpuUnified(
+        IReadOnlyList<int> promptIds,
+        int audioOffset,
+        float[] audioFeatures,
+        int audioTokenCount,
+        int maxNewTokens)
+    {
+        int seqLen = promptIds.Count;
+
+        // Build input_embeds: embedding lookup for all prompt tokens, then scatter audio features.
+        float[] inputEmbeds = new float[seqLen * _hiddenSize];
+        var tmpEmbed = new float[_hiddenSize];
+        for (int t = 0; t < seqLen; t++)
+        {
+            ReadTokenEmbedding(promptIds[t], tmpEmbed);
+            Array.Copy(tmpEmbed, 0, inputEmbeds, t * _hiddenSize, _hiddenSize);
+        }
+        Array.Copy(audioFeatures, 0, inputEmbeds, audioOffset * _hiddenSize, audioTokenCount * _hiddenSize);
+
+        long[] positionIds = Enumerable.Range(0, seqLen).Select(i => (long)i).ToArray();
+        float[] emptyKv = [];
+
+        // Prefill causal mask: upper-triangular -inf [1, 1, seqLen, seqLen]
+        float[] prefillMask = BuildCausalMask(seqLen, 0);
+
+        using var initOutputs = _decoder!.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(inputEmbeds,  [1, seqLen, _hiddenSize])),
+            NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(positionIds,   [1, seqLen])),
+            NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(prefillMask,  [1, 1, seqLen, seqLen])),
+            NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(emptyKv,      [_nLayers, 1, _nKvHeads, 0, _headDim])),
+            NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(emptyKv,      [_nLayers, 1, _nKvHeads, 0, _headDim])),
+        ]);
+
+        float[] logits     = ExtractTensor(initOutputs.First(r => r.Name == "logits").AsTensor<float>());
+        float[] pastKeys   = ExtractTensor(initOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+        float[] pastValues = ExtractTensor(initOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+        int pastSeqLen     = seqLen;
+
+        var rawTokens   = new List<int>(maxNewTokens);
+        var rawLogprobs = new List<float>(maxNewTokens);
+        long[] stepPos  = [0L];
+
+        int nextToken = ArgMaxLastLogits(logits, seqLen, out float nextLogprob);
+        rawTokens.Add(nextToken);
+        rawLogprobs.Add(nextLogprob);
+
+        while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
+        {
+            ReadTokenEmbedding(nextToken, tmpEmbed);
+            stepPos[0] = seqLen + rawTokens.Count - 1L;
+            // Step mask: all-zeros [1, 1, 1, pastSeqLen+1] — single query attends to all past
+            float[] stepMask = new float[pastSeqLen + 1];
+
+            using var stepOutputs = _decoder.Run(
+            [
+                NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(tmpEmbed,  [1, 1, _hiddenSize])),
+                NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(stepPos,    [1, 1])),
+                NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(stepMask,  [1, 1, 1, pastSeqLen + 1])),
+                NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys,  [_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
+                NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues,[_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
+            ]);
+
+            logits     = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
+            pastKeys   = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
             pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
             pastSeqLen++;
 
@@ -941,7 +1108,7 @@ public sealed class Qwen3Asr : IDisposable
 
             using var tokenEmbedValue = OrtValue.CreateTensorValueFromMemory(tokenEmbed, [1, 1, _hiddenSize]);
             using var stepPosValue = OrtValue.CreateTensorValueFromMemory(stepPos, [1, 1]);
-            using var stepBinding = _decoderStep.CreateIoBinding();
+            using var stepBinding = _decoderStep!.CreateIoBinding();
             stepBinding.BindInput("input_embeds", tokenEmbedValue);
             stepBinding.BindInput("position_ids", stepPosValue);
             stepBinding.BindInput("past_keys", prevOutputs![1]);
@@ -1305,7 +1472,8 @@ public sealed class Qwen3Asr : IDisposable
     {
         _embedAccessor.Dispose();
         _embedMmf.Dispose();
-        _decoderStep.Dispose();
+        _decoder?.Dispose();
+        _decoderStep?.Dispose();
         _decoderInitBatched?.Dispose();
         _encoderBatched?.Dispose();
         _decoderInit?.Dispose();

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -52,17 +52,18 @@ public sealed class Qwen3Asr : IDisposable
     private const int UserTokenId = 882;
     private const int AssistantTokenId = 77091;
     private const string LanguagePrefix = "language ";
-    private const long BatchSizingReferenceFreeVramMb = 22_800;
-    private const double BatchSizingReferenceTotalSecondsCeiling = 192.0;
+    private const long BatchSizingReferenceFreeVramMb = 22_673;
+    private const double BatchSizingReferenceTotalSecondsCeiling = 224.0;
 
     private static readonly float[,] MelFilterbank = CreateMelFilterbank();
     private static readonly double[] HannWindow = Window.HannPeriodic(NFft);
+    // Frontier calibrated for decoder.onnx (unified) on RTX 3090 with 22,673 MB free.
+    // Sweep: 2–32s segments × 1–16 batch. OOM boundaries: >14 at 16s, >10 at 24s, >8 at 32s.
     private static readonly (double MaxSegmentSeconds, int ReferenceBatchCap)[] ExperimentalBatchFrontier =
     [
-        (20.0, 10),
-        (24.0, 9),
-        (28.0, 8),
-        (32.0, 7),
+        (16.0, 14),
+        (24.0, 10),
+        (32.0,  8),
         (double.PositiveInfinity, 6),
     ];
     private static readonly string[] SpokenLanguageNames =

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -136,6 +136,7 @@ public sealed class Qwen3Asr : IDisposable
     private readonly bool _preferBatched;
     private readonly string _modelPath;
     private readonly ExecutionProvider _executionProvider;
+    private readonly GraphOptimizationLevel _optimizationLevel;
     private readonly int _hiddenSize;
     private readonly int _nLayers;
     private readonly int _nKvHeads;
@@ -150,10 +151,15 @@ public sealed class Qwen3Asr : IDisposable
     private readonly Dictionary<int, string> _addedTokenContent;
     private readonly Dictionary<char, byte> _byteLevelDecode;
 
-    public Qwen3Asr(string modelPath, ExecutionProvider ep = ExecutionProvider.Auto, bool preferBatched = false)
+    public Qwen3Asr(
+        string modelPath,
+        ExecutionProvider ep = ExecutionProvider.Auto,
+        bool preferBatched = false,
+        GraphOptimizationLevel optimizationLevel = GraphOptimizationLevel.ORT_ENABLE_EXTENDED)
     {
         _modelPath = modelPath;
         _executionProvider = ep;
+        _optimizationLevel = optimizationLevel;
         string configJson = File.ReadAllText(Path.Combine(modelPath, ConfigFile));
         using var configDoc = JsonDocument.Parse(configJson);
         var root = configDoc.RootElement;
@@ -169,8 +175,8 @@ public sealed class Qwen3Asr : IDisposable
         _eosTokenIds = specialTokens.GetProperty("eos_token_ids").EnumerateArray().Select(e => e.GetInt32()).ToArray();
         _eosTokenIdSet = [.. _eosTokenIds];
 
-        var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool encoderUsesCuda);
-        var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool decoderUsesCuda);
+        var encoderOpts = MakeSessionOptions(ep, optimizationLevel, out bool encoderUsesCuda);
+        var decoderOpts = MakeSessionOptions(ep, optimizationLevel, out bool decoderUsesCuda);
 
         bool hasUnified       = File.Exists(Path.Combine(modelPath, DecoderFile));
         bool hasBatchedEncoder = File.Exists(Path.Combine(modelPath, EncoderBatchedFile));
@@ -184,15 +190,13 @@ public sealed class Qwen3Asr : IDisposable
 
             if (_preferBatched)
             {
-                // Batched path keeps a single unified decoder session for
-                // autoregressive continuation and uses the dedicated batched
-                // prefill export only for the initial prompt pass.
+                // Unified batched path: encoder_batched + decoder.onnx only.
+                // Do not load decoder_init_batched here; we want the runtime
+                // contract to be unambiguously single-decoder.
                 _decoder = new InferenceSession(Path.Combine(modelPath, DecoderFile), decoderOpts);
                 _encoder        = null!;
                 _encoderBatched = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile), encoderOpts);
-                _decoderInitBatched = hasBatchedInit
-                    ? new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile), decoderOpts)
-                    : null;
+                _decoderInitBatched = null;
                 _decoderStep = null;
             }
             else
@@ -553,7 +557,15 @@ public sealed class Qwen3Asr : IDisposable
             for (int b = 0; b < take; b++)
             {
                 inputLengths[b] = batch[b].MelFrames;
-                Array.Copy(batch[b].Mel!, 0, melBatch, b * NMels * maxMelFrames, batch[b].Mel!.Length);
+                for (int melBin = 0; melBin < NMels; melBin++)
+                {
+                    Array.Copy(
+                        batch[b].Mel!,
+                        melBin * batch[b].MelFrames,
+                        melBatch,
+                        (b * NMels + melBin) * maxMelFrames,
+                        batch[b].MelFrames);
+                }
             }
 
             using var encoderResults = _encoderBatched.Run(
@@ -568,18 +580,114 @@ public sealed class Qwen3Asr : IDisposable
             long[] audioLengths     = [.. audioLengthsTensor];
 
             // Rearrange: [take, sourceTokens, hidden] → [take, maxAudioTokens, hidden]
-            float[] audioFeaturesSource     = ExtractTensor(audioFeaturesTensor);
-            int     sourceTokensPerBatch    = audioFeaturesTensor.Dimensions[1];
             float[] audioFeatures           = new float[take * maxAudioTokens * _hiddenSize];
             for (int b = 0; b < take; b++)
             for (int t = 0; t < (int)audioLengths[b]; t++)
-            {
-                int srcBase = (b * sourceTokensPerBatch + t) * _hiddenSize;
-                int dstBase = (b * maxAudioTokens      + t) * _hiddenSize;
-                Array.Copy(audioFeaturesSource, srcBase, audioFeatures, dstBase, _hiddenSize);
-            }
+                for (int h = 0; h < _hiddenSize; h++)
+                    audioFeatures[(b * maxAudioTokens + t) * _hiddenSize + h] = audioFeaturesTensor[b, t, h];
 
             // ── Batched prefill ──────────────────────────────────────────────
+            if (_decoder is not null)
+            {
+                var (unifiedInputEmbeds, unifiedPositionIds, unifiedPrefillMask, unifiedSeqLengths) =
+                    BuildUnifiedBatchPrefillInputs(audioFeatures, audioLengths, take, maxAudioTokens);
+
+                float[] emptyKv = [];
+                using var initResults = _decoder.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(unifiedInputEmbeds, [take, unifiedSeqLengths.Max(), _hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(unifiedPositionIds,  [take, unifiedSeqLengths.Max()])),
+                    NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(unifiedPrefillMask, [take, 1, unifiedSeqLengths.Max(), unifiedSeqLengths.Max()])),
+                    NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
+                    NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
+                ]);
+
+                float[] unifiedBatchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
+                float[] presentKeys = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
+                float[] presentValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
+                float[] pastKeys = CompactPrefillKv(presentKeys, unifiedSeqLengths, take);
+                float[] pastValues = CompactPrefillKv(presentValues, unifiedSeqLengths, take);
+                int[] pastLengths = [.. unifiedSeqLengths];
+
+                int unifiedVocabSize = unifiedBatchedLogits.Length / (take * unifiedSeqLengths.Max());
+                var unifiedSeqTokens = new List<int>[take];
+                var unifiedSeqLogprobs = new List<float>[take];
+                var unifiedSeqDone = new bool[take];
+                var nextTokens = new int[take];
+
+                for (int b = 0; b < take; b++)
+                {
+                    unifiedSeqTokens[b] = new List<int>(maxNewTokens);
+                    unifiedSeqLogprobs[b] = new List<float>(maxNewTokens);
+                    int logitOffset = b * unifiedSeqLengths.Max() * unifiedVocabSize + (unifiedSeqLengths[b] - 1) * unifiedVocabSize;
+                    int firstToken = ArgMaxSpan(unifiedBatchedLogits.AsSpan(logitOffset, unifiedVocabSize), out float firstLogprob);
+                    nextTokens[b] = firstToken;
+                    unifiedSeqTokens[b].Add(firstToken);
+                    unifiedSeqLogprobs[b].Add(firstLogprob);
+                    unifiedSeqDone[b] = IsEos(firstToken);
+                }
+
+                for (int step = 1; step < maxNewTokens && unifiedSeqDone.Any(done => !done); step++)
+                {
+                    float[] stepEmbeds = new float[take * _hiddenSize];
+                    var tokenEmbed = new float[_hiddenSize];
+                    for (int b = 0; b < take; b++)
+                    {
+                        ReadTokenEmbedding(nextTokens[b], tokenEmbed);
+                        Array.Copy(tokenEmbed, 0, stepEmbeds, b * _hiddenSize, _hiddenSize);
+                    }
+
+                    long[] stepPos = new long[take];
+                    for (int b = 0; b < take; b++)
+                        stepPos[b] = pastLengths[b];
+
+                    int maxPastLen = pastLengths.Max();
+                    float[] stepMask = BuildBatchStepAttentionMask(pastLengths, maxPastLen);
+
+                    using var stepOutputs = _decoder.Run(
+                    [
+                        NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(stepEmbeds, [take, 1, _hiddenSize])),
+                        NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(stepPos,     [take, 1])),
+                        NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(stepMask,   [take, 1, 1, maxPastLen + 1])),
+                        NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys,   [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
+                        NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues, [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
+                    ]);
+
+                    float[] stepLogits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
+                    float[] stepPresentKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+                    float[] stepPresentValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+                    bool[] activeMask = new bool[take];
+                    for (int b = 0; b < take; b++)
+                        activeMask[b] = !unifiedSeqDone[b];
+
+                    for (int b = 0; b < take; b++)
+                    {
+                        int token = ArgMaxSpan(stepLogits.AsSpan(b * unifiedVocabSize, unifiedVocabSize), out float logprob);
+                        if (!activeMask[b])
+                            continue;
+
+                        nextTokens[b] = token;
+                        unifiedSeqTokens[b].Add(token);
+                        unifiedSeqLogprobs[b].Add(logprob);
+                        if (IsEos(token))
+                            unifiedSeqDone[b] = true;
+                    }
+
+                    CompactStepKv(stepPresentKeys, stepPresentValues, pastLengths, activeMask, take, out pastKeys, out pastValues, out pastLengths);
+                }
+
+                for (int b = 0; b < take; b++)
+                {
+                    var (textTokens, textLogprobs2) = ExtractTextTokens(unifiedSeqTokens[b], unifiedSeqLogprobs[b]);
+                    string rawText = DecodeTokens(textTokens);
+                    var parsed = ParseMetadataPrefix(rawText);
+                    yield return new QwenRecognitionResult(
+                        batch[b].SegId, parsed.Text, unifiedSeqTokens[b], textTokens, textLogprobs2, parsed.Language, rawText);
+                }
+
+                continue;
+            }
+
             List<int> prompt    = BuildPromptIds(maxAudioTokens);
             int       audioOffset = GetAudioPadStart(prompt);
             int       seqLen    = prompt.Count;
@@ -610,38 +718,6 @@ public sealed class Qwen3Asr : IDisposable
                     NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures,[take, maxAudioTokens, _hiddenSize])),
                     NamedOnnxValue.CreateFromTensor("audio_lengths",  new DenseTensor<long> (audioLengths, [take])),
                     NamedOnnxValue.CreateFromTensor("audio_offset",   new DenseTensor<long> (new long[] { audioOffset }, [1])),
-                ]);
-                batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
-                batchedKeys   = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
-                batchedValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
-            }
-            else if (_decoder is not null)
-            {
-                // Unified decoder: build input_embeds from embedding lookup + per-item audio scatter.
-                float[] inputEmbeds = new float[take * seqLen * _hiddenSize];
-                var tmpEmbed = new float[_hiddenSize];
-                for (int b = 0; b < take; b++)
-                {
-                    for (int t = 0; t < seqLen; t++)
-                    {
-                        ReadTokenEmbedding(prompt[t], tmpEmbed);
-                        Array.Copy(tmpEmbed, 0, inputEmbeds, (b * seqLen + t) * _hiddenSize, _hiddenSize);
-                    }
-                    int audioLen = (int)audioLengths[b];
-                    for (int t = 0; t < audioLen; t++)
-                        Array.Copy(audioFeatures, (b * maxAudioTokens + t) * _hiddenSize,
-                                   inputEmbeds,   (b * seqLen + audioOffset + t) * _hiddenSize, _hiddenSize);
-                }
-
-                float[] emptyKv = [];
-                float[] prefillMask = BuildCausalMask(seqLen, 0);
-                using var initResults = _decoder.Run(
-                [
-                    NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(inputEmbeds, [take, seqLen, _hiddenSize])),
-                    NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(positionIds,  [take, seqLen])),
-                    NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(prefillMask, [1, 1, seqLen, seqLen])),
-                    NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
-                    NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
                 ]);
                 batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
                 batchedKeys   = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
@@ -747,6 +823,213 @@ public sealed class Qwen3Asr : IDisposable
         return mask;
     }
 
+    private (float[] inputEmbeds, long[] positionIds, float[] attentionMask, int[] seqLengths) BuildUnifiedBatchPrefillInputs(
+        float[] audioFeatures,
+        long[] audioLengths,
+        int batchSize,
+        int maxAudioTokens)
+    {
+        var prompts = new List<int>[batchSize];
+        var seqLengths = new int[batchSize];
+        int maxSeqLen = 0;
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            prompts[b] = BuildPromptIds((int)audioLengths[b]);
+            seqLengths[b] = prompts[b].Count;
+            maxSeqLen = Math.Max(maxSeqLen, seqLengths[b]);
+        }
+
+        float[] inputEmbeds = new float[batchSize * maxSeqLen * _hiddenSize];
+        long[] positionIds = new long[batchSize * maxSeqLen];
+        var tokenEmbed = new float[_hiddenSize];
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            List<int> prompt = prompts[b];
+            int audioOffset = GetAudioPadStart(prompt);
+            for (int t = 0; t < prompt.Count; t++)
+            {
+                ReadTokenEmbedding(prompt[t], tokenEmbed);
+                Array.Copy(tokenEmbed, 0, inputEmbeds, (b * maxSeqLen + t) * _hiddenSize, _hiddenSize);
+                positionIds[b * maxSeqLen + t] = t;
+            }
+
+            for (int t = 0; t < (int)audioLengths[b]; t++)
+            {
+                Array.Copy(
+                    audioFeatures,
+                    (b * maxAudioTokens + t) * _hiddenSize,
+                    inputEmbeds,
+                    (b * maxSeqLen + audioOffset + t) * _hiddenSize,
+                    _hiddenSize);
+            }
+        }
+
+        float[] attentionMask = BuildBatchPrefillAttentionMask(seqLengths, maxSeqLen);
+        return (inputEmbeds, positionIds, attentionMask, seqLengths);
+    }
+
+    private static (float[] inputEmbeds, long[] positionIds, float[] attentionMask, int[] seqLengths) BuildUnifiedBatchPrefillInputsForBenchmark(
+        string modelPath,
+        float[] audioFeatures,
+        long[] audioLengths,
+        int batchSize,
+        int maxAudioTokens,
+        int hiddenSize)
+    {
+        using var mmf = MemoryMappedFile.CreateFromFile(Path.Combine(modelPath, EmbedTokensFile), FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+        using var accessor = mmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+        var prompts = new List<int>[batchSize];
+        var seqLengths = new int[batchSize];
+        int maxSeqLen = 0;
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            prompts[b] = BuildPromptIds((int)audioLengths[b]);
+            seqLengths[b] = prompts[b].Count;
+            maxSeqLen = Math.Max(maxSeqLen, seqLengths[b]);
+        }
+
+        float[] inputEmbeds = new float[batchSize * maxSeqLen * hiddenSize];
+        long[] positionIds = new long[batchSize * maxSeqLen];
+        var tokenEmbed = new float[hiddenSize];
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            List<int> prompt = prompts[b];
+            int audioOffset = GetAudioPadStart(prompt);
+            for (int t = 0; t < prompt.Count; t++)
+            {
+                long byteOffset = (long)prompt[t] * hiddenSize * sizeof(float);
+                accessor.ReadArray(byteOffset, tokenEmbed, 0, hiddenSize);
+                Array.Copy(tokenEmbed, 0, inputEmbeds, (b * maxSeqLen + t) * hiddenSize, hiddenSize);
+                positionIds[b * maxSeqLen + t] = t;
+            }
+
+            for (int t = 0; t < (int)audioLengths[b]; t++)
+            {
+                Array.Copy(
+                    audioFeatures,
+                    (b * maxAudioTokens + t) * hiddenSize,
+                    inputEmbeds,
+                    (b * maxSeqLen + audioOffset + t) * hiddenSize,
+                    hiddenSize);
+            }
+        }
+
+        float[] attentionMask = BuildBatchPrefillAttentionMask(seqLengths, maxSeqLen);
+        return (inputEmbeds, positionIds, attentionMask, seqLengths);
+    }
+
+    private static float[] BuildBatchPrefillAttentionMask(int[] seqLengths, int maxSeqLen)
+    {
+        float[] mask = new float[seqLengths.Length * maxSeqLen * maxSeqLen];
+        Array.Fill(mask, float.MinValue);
+
+        for (int b = 0; b < seqLengths.Length; b++)
+        {
+            int batchOffset = b * maxSeqLen * maxSeqLen;
+            int validLen = seqLengths[b];
+            for (int q = 0; q < validLen; q++)
+                for (int k = 0; k <= q; k++)
+                    mask[batchOffset + q * maxSeqLen + k] = 0f;
+
+            for (int q = validLen; q < maxSeqLen; q++)
+                mask[batchOffset + q * maxSeqLen] = 0f;
+        }
+
+        return mask;
+    }
+
+    private static float[] BuildBatchStepAttentionMask(int[] pastLengths, int maxPastLen)
+    {
+        float[] mask = new float[pastLengths.Length * (maxPastLen + 1)];
+        Array.Fill(mask, float.MinValue);
+
+        for (int b = 0; b < pastLengths.Length; b++)
+        {
+            int offset = b * (maxPastLen + 1);
+            for (int k = 0; k < pastLengths[b]; k++)
+                mask[offset + k] = 0f;
+            mask[offset + maxPastLen] = 0f;
+        }
+
+        return mask;
+    }
+
+    private float[] CompactPrefillKv(float[] present, int[] seqLengths, int batchSize)
+    {
+        int maxSeqLen = seqLengths.Max();
+        float[] compact = new float[_nLayers * batchSize * _nKvHeads * maxSeqLen * _headDim];
+
+        for (int layer = 0; layer < _nLayers; layer++)
+        for (int b = 0; b < batchSize; b++)
+        for (int head = 0; head < _nKvHeads; head++)
+        {
+            int validLen = seqLengths[b];
+            int sourceBase = (((layer * batchSize + b) * _nKvHeads + head) * maxSeqLen) * _headDim;
+            int destBase = sourceBase;
+            Array.Copy(present, sourceBase, compact, destBase, validLen * _headDim);
+        }
+
+        return compact;
+    }
+
+    private void CompactStepKv(
+        float[] presentKeys,
+        float[] presentValues,
+        int[] pastLengths,
+        bool[] activeMask,
+        int batchSize,
+        out float[] nextKeys,
+        out float[] nextValues,
+        out int[] nextLengths)
+    {
+        int appendIndex = pastLengths.Max();
+        nextLengths = (int[])pastLengths.Clone();
+        for (int b = 0; b < batchSize; b++)
+            if (activeMask[b])
+                nextLengths[b]++;
+
+        int maxNextLen = nextLengths.Max();
+        nextKeys = new float[_nLayers * batchSize * _nKvHeads * maxNextLen * _headDim];
+        nextValues = new float[_nLayers * batchSize * _nKvHeads * maxNextLen * _headDim];
+
+        for (int layer = 0; layer < _nLayers; layer++)
+        for (int b = 0; b < batchSize; b++)
+        for (int head = 0; head < _nKvHeads; head++)
+        {
+            int sourceStride = appendIndex + 1;
+            int sourceBase = (((layer * batchSize + b) * _nKvHeads + head) * sourceStride) * _headDim;
+            int destBase = (((layer * batchSize + b) * _nKvHeads + head) * maxNextLen) * _headDim;
+            int validPastLen = pastLengths[b];
+
+            if (validPastLen > 0)
+            {
+                Array.Copy(presentKeys, sourceBase, nextKeys, destBase, validPastLen * _headDim);
+                Array.Copy(presentValues, sourceBase, nextValues, destBase, validPastLen * _headDim);
+            }
+
+            if (activeMask[b])
+            {
+                Array.Copy(
+                    presentKeys,
+                    sourceBase + appendIndex * _headDim,
+                    nextKeys,
+                    destBase + validPastLen * _headDim,
+                    _headDim);
+                Array.Copy(
+                    presentValues,
+                    sourceBase + appendIndex * _headDim,
+                    nextValues,
+                    destBase + validPastLen * _headDim,
+                    _headDim);
+            }
+        }
+    }
+
     private int ArgMaxSpan(Span<float> logits, out float logprob)
     {
         int   best    = 0;
@@ -767,21 +1050,34 @@ public sealed class Qwen3Asr : IDisposable
     public QwenExperimentalBatchBenchmark BenchmarkExperimentalBatching(
         IReadOnlyList<(double start, double end, string spk)> segs,
         float[] audio)
-        => BenchmarkExperimentalBatching(_modelPath, _executionProvider, segs, audio);
+        => BenchmarkExperimentalBatching(
+            _modelPath,
+            _executionProvider,
+            segs,
+            audio,
+            _optimizationLevel);
 
     public static QwenExperimentalBatchBenchmark BenchmarkExperimentalBatching(
         string modelPath,
         ExecutionProvider ep,
         IReadOnlyList<(double start, double end, string spk)> segs,
-        float[] audio)
+        float[] audio,
+        GraphOptimizationLevel optimizationLevel = GraphOptimizationLevel.ORT_ENABLE_EXTENDED)
     {
-        if (!File.Exists(Path.Combine(modelPath, EncoderBatchedFile)) ||
-            !File.Exists(Path.Combine(modelPath, DecoderInitBatchedFile)))
+        bool hasEncoderBatched = File.Exists(Path.Combine(modelPath, EncoderBatchedFile));
+        bool hasUnifiedDecoder = File.Exists(Path.Combine(modelPath, DecoderFile));
+        bool hasDecoderInitBatched = File.Exists(Path.Combine(modelPath, DecoderInitBatchedFile));
+
+        if (!hasEncoderBatched || (!hasUnifiedDecoder && !hasDecoderInitBatched))
             throw new FileNotFoundException("Experimental batching artifacts are missing.");
 
         string configJson = File.ReadAllText(Path.Combine(modelPath, ConfigFile));
         using var configDoc = JsonDocument.Parse(configJson);
-        int hiddenSize = configDoc.RootElement.GetProperty("decoder").GetProperty("hidden_size").GetInt32();
+        var decoderConfig = configDoc.RootElement.GetProperty("decoder");
+        int hiddenSize = decoderConfig.GetProperty("hidden_size").GetInt32();
+        int nLayers = decoderConfig.GetProperty("num_layers").GetInt32();
+        int nKvHeads = decoderConfig.GetProperty("num_key_value_heads").GetInt32();
+        int headDim = decoderConfig.GetProperty("head_dim").GetInt32();
 
         var prepared = new List<QwenPreparedSegment>(segs.Count);
         foreach (var (start, end, _) in segs)
@@ -802,8 +1098,8 @@ public sealed class Qwen3Asr : IDisposable
         double serialEncoderMs = 0;
         double serialPrefillMs = 0;
         {
-            var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
-            var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
+            var encoderOpts = MakeSessionOptions(ep, optimizationLevel, out _);
+            var decoderOpts = MakeSessionOptions(ep, optimizationLevel, out _);
             using var encoder = new InferenceSession(Path.Combine(modelPath, EncoderFile), encoderOpts);
             using var decoderInit = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), decoderOpts);
             foreach (var segment in prepared)
@@ -827,10 +1123,15 @@ public sealed class Qwen3Asr : IDisposable
         double batchedEncoderMs = 0;
         double batchedPrefillMs = 0;
         {
-            var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
-            var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
+            var encoderOpts = MakeSessionOptions(ep, optimizationLevel, out _);
+            var decoderOpts = MakeSessionOptions(ep, optimizationLevel, out _);
             using var encoderBatched = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile), encoderOpts);
-            using var decoderInitBatched = new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile), decoderOpts);
+            using var decoder = hasUnifiedDecoder
+                ? new InferenceSession(Path.Combine(modelPath, DecoderFile), decoderOpts)
+                : null;
+            using var decoderInitBatched = !hasUnifiedDecoder && hasDecoderInitBatched
+                ? new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile), decoderOpts)
+                : null;
             long freeGpuMemoryMb = HardwareInfo.GetGpuMemoryMb().FreeMb;
 
             int index = 0;
@@ -849,7 +1150,15 @@ public sealed class Qwen3Asr : IDisposable
                 {
                     var segment = batch[batchIndex];
                     inputLengths[batchIndex] = segment.MelFrames;
-                    Array.Copy(segment.Mel, 0, mel, batchIndex * NMels * maxMelFrames, segment.Mel.Length);
+                    for (int melBin = 0; melBin < NMels; melBin++)
+                    {
+                        Array.Copy(
+                            segment.Mel,
+                            melBin * segment.MelFrames,
+                            mel,
+                            (batchIndex * NMels + melBin) * maxMelFrames,
+                            segment.MelFrames);
+                    }
                 }
 
                 var sw = Stopwatch.StartNew();
@@ -865,46 +1174,58 @@ public sealed class Qwen3Asr : IDisposable
                 var audioFeaturesTensor = encoderResults.First(r => r.Name == "audio_features").AsTensor<float>();
                 var audioLengthsTensor = encoderResults.First(r => r.Name == "audio_feature_lengths").AsTensor<long>();
                 int maxAudioTokens = (int)audioLengthsTensor.Max();
-                int seqLen = BuildPromptIds(maxAudioTokens).Count;
-                List<int> prompt = BuildPromptIds(maxAudioTokens);
-                int audioOffset = GetAudioPadStart(prompt);
-
-                long[] inputIds = new long[take * seqLen];
-                long[] positionIds = new long[take * seqLen];
-                for (int batchIndex = 0; batchIndex < take; batchIndex++)
-                {
-                    for (int tokenIndex = 0; tokenIndex < seqLen; tokenIndex++)
-                    {
-                        inputIds[batchIndex * seqLen + tokenIndex] = prompt[tokenIndex];
-                        positionIds[batchIndex * seqLen + tokenIndex] = tokenIndex;
-                    }
-                }
-
-                float[] audioFeaturesSource = ExtractTensor(audioFeaturesTensor);
                 float[] audioFeatures = new float[take * maxAudioTokens * hiddenSize];
-                int sourceTokensPerBatch = audioFeaturesTensor.Dimensions[1];
                 for (int batchIndex = 0; batchIndex < take; batchIndex++)
                 {
-                    for (int tokenIndex = 0; tokenIndex < maxAudioTokens; tokenIndex++)
-                    {
-                        int srcBase = ((batchIndex * sourceTokensPerBatch) + tokenIndex) * hiddenSize;
-                        int dstBase = ((batchIndex * maxAudioTokens) + tokenIndex) * hiddenSize;
-                        Array.Copy(audioFeaturesSource, srcBase, audioFeatures, dstBase, hiddenSize);
-                    }
+                    for (int tokenIndex = 0; tokenIndex < (int)audioLengthsTensor[batchIndex]; tokenIndex++)
+                        for (int hiddenIndex = 0; hiddenIndex < hiddenSize; hiddenIndex++)
+                            audioFeatures[(batchIndex * maxAudioTokens + tokenIndex) * hiddenSize + hiddenIndex]
+                                = audioFeaturesTensor[batchIndex, tokenIndex, hiddenIndex];
                 }
 
                 long[] audioLengths = [.. audioLengthsTensor];
-                long[] audioOffsetTensor = [audioOffset];
 
                 sw.Restart();
-                using var decoderResults = decoderInitBatched.Run(
-                [
-                    NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(inputIds, [take, seqLen])),
-                    NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(positionIds, [take, seqLen])),
-                    NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures, [take, maxAudioTokens, hiddenSize])),
-                    NamedOnnxValue.CreateFromTensor("audio_lengths", new DenseTensor<long>(audioLengths, [take])),
-                    NamedOnnxValue.CreateFromTensor("audio_offset", new DenseTensor<long>(audioOffsetTensor, [1])),
-                ]);
+                if (decoder is not null)
+                {
+                    var (inputEmbeds, positionIds, attentionMask, seqLengths) =
+                        BuildUnifiedBatchPrefillInputsForBenchmark(modelPath, audioFeatures, audioLengths, take, maxAudioTokens, hiddenSize);
+                    float[] emptyKv = [];
+                    using var decoderResults = decoder.Run(
+                    [
+                        NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(inputEmbeds, [take, seqLengths.Max(), hiddenSize])),
+                        NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(positionIds, [take, seqLengths.Max()])),
+                        NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(attentionMask, [take, 1, seqLengths.Max(), seqLengths.Max()])),
+                        NamedOnnxValue.CreateFromTensor("past_keys", new DenseTensor<float>(emptyKv, [nLayers, take, nKvHeads, 0, headDim])),
+                        NamedOnnxValue.CreateFromTensor("past_values", new DenseTensor<float>(emptyKv, [nLayers, take, nKvHeads, 0, headDim])),
+                    ]);
+                }
+                else
+                {
+                    int seqLen = BuildPromptIds(maxAudioTokens).Count;
+                    List<int> prompt = BuildPromptIds(maxAudioTokens);
+                    int audioOffset = GetAudioPadStart(prompt);
+                    long[] inputIds = new long[take * seqLen];
+                    long[] positionIds = new long[take * seqLen];
+                    for (int batchIndex = 0; batchIndex < take; batchIndex++)
+                    {
+                        for (int tokenIndex = 0; tokenIndex < seqLen; tokenIndex++)
+                        {
+                            inputIds[batchIndex * seqLen + tokenIndex] = prompt[tokenIndex];
+                            positionIds[batchIndex * seqLen + tokenIndex] = tokenIndex;
+                        }
+                    }
+
+                    long[] audioOffsetTensor = [audioOffset];
+                    using var decoderResults = decoderInitBatched!.Run(
+                    [
+                        NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(inputIds, [take, seqLen])),
+                        NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(positionIds, [take, seqLen])),
+                        NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures, [take, maxAudioTokens, hiddenSize])),
+                        NamedOnnxValue.CreateFromTensor("audio_lengths", new DenseTensor<long>(audioLengths, [take])),
+                        NamedOnnxValue.CreateFromTensor("audio_offset", new DenseTensor<long>(audioOffsetTensor, [1])),
+                    ]);
+                }
                 sw.Stop();
                 double prefillMs = sw.Elapsed.TotalMilliseconds;
                 batchedPrefillMs += prefillMs;

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -179,22 +179,29 @@ public sealed class Qwen3Asr : IDisposable
 
         if (hasUnified)
         {
-            // Unified decoder.onnx replaces decoder_init + decoder_step — only one session.
-            _decoder          = new InferenceSession(Path.Combine(modelPath, DecoderFile), decoderOpts);
             _decoderInit      = null!;
-            _decoderStep      = null;
-            _decoderInitBatched = null;
             _useCudaIoBinding = false;
 
             if (_preferBatched)
             {
+                // Batched path keeps a single unified decoder session for
+                // autoregressive continuation and uses the dedicated batched
+                // prefill export only for the initial prompt pass.
+                _decoder = new InferenceSession(Path.Combine(modelPath, DecoderFile), decoderOpts);
                 _encoder        = null!;
                 _encoderBatched = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile), encoderOpts);
+                _decoderInitBatched = hasBatchedInit
+                    ? new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile), decoderOpts)
+                    : null;
+                _decoderStep = null;
             }
             else
             {
+                _decoder        = new InferenceSession(Path.Combine(modelPath, DecoderFile), decoderOpts);
                 _encoder        = new InferenceSession(Path.Combine(modelPath, EncoderFile), encoderOpts);
                 _encoderBatched = null;
+                _decoderInitBatched = null;
+                _decoderStep = null;
             }
         }
         else if (_preferBatched)
@@ -565,7 +572,7 @@ public sealed class Qwen3Asr : IDisposable
             int     sourceTokensPerBatch    = audioFeaturesTensor.Dimensions[1];
             float[] audioFeatures           = new float[take * maxAudioTokens * _hiddenSize];
             for (int b = 0; b < take; b++)
-            for (int t = 0; t < maxAudioTokens; t++)
+            for (int t = 0; t < (int)audioLengths[b]; t++)
             {
                 int srcBase = (b * sourceTokensPerBatch + t) * _hiddenSize;
                 int dstBase = (b * maxAudioTokens      + t) * _hiddenSize;
@@ -586,7 +593,29 @@ public sealed class Qwen3Asr : IDisposable
             float[] batchedKeys;
             float[] batchedValues;
 
-            if (_decoder is not null)
+            if (_decoderInitBatched is not null)
+            {
+                var inputIds = new long[take * seqLen];
+                for (int b = 0; b < take; b++)
+                {
+                    List<int> perItemPrompt = BuildPromptIds((int)audioLengths[b]);
+                    for (int t = 0; t < perItemPrompt.Count; t++)
+                        inputIds[b * seqLen + t] = perItemPrompt[t];
+                }
+
+                using var initResults = _decoderInitBatched.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_ids",      new DenseTensor<long> (inputIds,     [take, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long> (positionIds,  [take, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures,[take, maxAudioTokens, _hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("audio_lengths",  new DenseTensor<long> (audioLengths, [take])),
+                    NamedOnnxValue.CreateFromTensor("audio_offset",   new DenseTensor<long> (new long[] { audioOffset }, [1])),
+                ]);
+                batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
+                batchedKeys   = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
+                batchedValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
+            }
+            else if (_decoder is not null)
             {
                 // Unified decoder: build input_embeds from embedding lookup + per-item audio scatter.
                 float[] inputEmbeds = new float[take * seqLen * _hiddenSize];
@@ -622,8 +651,11 @@ public sealed class Qwen3Asr : IDisposable
             {
                 var inputIds = new long[take * seqLen];
                 for (int b = 0; b < take; b++)
-                for (int t = 0; t < seqLen; t++)
-                    inputIds[b * seqLen + t] = prompt[t];
+                {
+                    List<int> perItemPrompt = BuildPromptIds((int)audioLengths[b]);
+                    for (int t = 0; t < perItemPrompt.Count; t++)
+                        inputIds[b * seqLen + t] = perItemPrompt[t];
+                }
 
                 using var initResults = _decoderInitBatched!.Run(
                 [
@@ -644,74 +676,51 @@ public sealed class Qwen3Asr : IDisposable
             var seqTokens    = new List<int>  [take];
             var seqLogprobs  = new List<float>[take];
             var seqDone      = new bool[take];
-            var seqNextToken = new int[take];
+            var seqPromptLens = new int[take];
 
             for (int b = 0; b < take; b++)
             {
+                int promptLen = BuildPromptIds((int)audioLengths[b]).Count;
+                seqPromptLens[b] = promptLen;
                 seqTokens[b]   = new List<int>  (maxNewTokens);
                 seqLogprobs[b] = new List<float>(maxNewTokens);
-                int logitOffset = b * seqLen * vocabSize + (seqLen - 1) * vocabSize;
+                int logitOffset = b * seqLen * vocabSize + (promptLen - 1) * vocabSize;
                 int firstToken  = ArgMaxSpan(batchedLogits.AsSpan(logitOffset, vocabSize), out float firstLogprob);
                 seqTokens[b].Add(firstToken);
                 seqLogprobs[b].Add(firstLogprob);
-                seqNextToken[b] = firstToken;
                 seqDone[b]      = IsEos(firstToken);
             }
 
-            // ── Joint batched autoregressive decode ──────────────────────────
-            // All sequences share the same pastSeqLen (same prefill prompt length),
-            // so their KV caches stay in lockstep — no slicing needed.
-            float[] pastKeys   = batchedKeys;
-            float[] pastValues = batchedValues;
-            int pastSeqLen     = seqLen;
-
-            var batchEmbeds  = new float[take * _hiddenSize];
-            var stepPosArr   = new long[take];
-            var tmpStepEmbed = new float[_hiddenSize];
-            var stepSession  = _decoder ?? _decoderStep!;
-
-            for (int step = 0; step < maxNewTokens - 1; step++)
+            // ── Serial autoregressive continuation from batched prefill ──────
+            // The encoder + prefill passes batch cleanly and provide the useful
+            // throughput win. Continue decoding each sequence independently from
+            // its own sliced KV cache so the generated text exactly follows the
+            // known-good serial decoder path.
+            for (int b = 0; b < take; b++)
             {
-                if (Array.TrueForAll(seqDone, d => d)) break;
-
-                long pos = seqLen + step;
-                for (int b = 0; b < take; b++)
+                if (!seqDone[b] && seqTokens[b].Count < maxNewTokens)
                 {
-                    ReadTokenEmbedding(seqNextToken[b], tmpStepEmbed);
-                    Array.Copy(tmpStepEmbed, 0, batchEmbeds, b * _hiddenSize, _hiddenSize);
-                    stepPosArr[b] = pos;
-                }
-
-                IEnumerable<NamedOnnxValue> stepInputs = _decoder is not null
-                    ? [
-                        NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(batchEmbeds,              [take, 1, _hiddenSize])),
-                        NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long> (stepPosArr,               [take, 1])),
-                        NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(new float[pastSeqLen + 1],[1, 1, 1, pastSeqLen + 1])),
-                        NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys,                 [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
-                        NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues,               [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
-                      ]
-                    : [
-                        NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(batchEmbeds, [take, 1, _hiddenSize])),
-                        NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long> (stepPosArr,  [take, 1])),
-                        NamedOnnxValue.CreateFromTensor("past_keys",    new DenseTensor<float>(pastKeys,    [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
-                        NamedOnnxValue.CreateFromTensor("past_values",  new DenseTensor<float>(pastValues,  [_nLayers, take, _nKvHeads, pastSeqLen, _headDim])),
-                      ];
-                using var stepOutputs = stepSession.Run(stepInputs.ToList());
-
-                float[] stepLogits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
-                pastKeys   = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
-                pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
-                pastSeqLen++;
-
-                int stepVocabSize = stepLogits.Length / take; // [take, 1, vocab] flat
-                for (int b = 0; b < take; b++)
-                {
-                    if (seqDone[b]) continue;
-                    int nextToken = ArgMaxSpan(stepLogits.AsSpan(b * stepVocabSize, stepVocabSize), out float logprob);
-                    seqNextToken[b] = nextToken;
-                    seqTokens[b].Add(nextToken);
-                    seqLogprobs[b].Add(logprob);
-                    seqDone[b] = IsEos(nextToken) || seqTokens[b].Count >= maxNewTokens;
+                    int promptLen = seqPromptLens[b];
+                    float[] seqPastKeys = SliceBatchKv(
+                        past: batchedKeys,
+                        batchSize: take,
+                        batchIndex: b,
+                        sourceSeqLen: seqLen,
+                        targetSeqLen: promptLen);
+                    float[] seqPastValues = SliceBatchKv(
+                        past: batchedValues,
+                        batchSize: take,
+                        batchIndex: b,
+                        sourceSeqLen: seqLen,
+                        targetSeqLen: promptLen);
+                    ContinueDecodeFromPrefill(
+                        seqTokens[b],
+                        seqLogprobs[b],
+                        seqTokens[b][^1],
+                        seqPastKeys,
+                        seqPastValues,
+                        promptLen,
+                        maxNewTokens);
                 }
             }
 
@@ -1057,6 +1066,88 @@ public sealed class Qwen3Asr : IDisposable
         }
 
         return (rawTokens, rawLogprobs);
+    }
+
+    private void ContinueDecodeFromPrefill(
+        List<int> rawTokens,
+        List<float> rawLogprobs,
+        int nextToken,
+        float[] pastKeys,
+        float[] pastValues,
+        int promptSeqLen,
+        int maxNewTokens)
+    {
+        if (rawTokens.Count == 0 || rawTokens.Count >= maxNewTokens || IsEos(nextToken))
+            return;
+
+        int pastSeqLen = promptSeqLen;
+        var tokenEmbed = new float[_hiddenSize];
+        long[] stepPos = [0L];
+
+        while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
+        {
+            ReadTokenEmbedding(nextToken, tokenEmbed);
+            stepPos[0] = promptSeqLen + rawTokens.Count - 1L;
+
+            if (_decoder is not null)
+            {
+                float[] stepMask = new float[pastSeqLen + 1];
+                using var stepOutputs = _decoder.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(tokenEmbed,  [1, 1, _hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(stepPos,     [1, 1])),
+                    NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(stepMask,   [1, 1, 1, pastSeqLen + 1])),
+                    NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys,   [_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
+                    NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues, [_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
+                ]);
+
+                float[] logits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
+                pastKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+                pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+                pastSeqLen++;
+
+                nextToken = ArgMaxLastLogits(logits, 1, out float nextLogprob);
+                rawTokens.Add(nextToken);
+                rawLogprobs.Add(nextLogprob);
+            }
+            else
+            {
+                using var stepOutputs = _decoderStep!.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(tokenEmbed, [1, 1, _hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(stepPos, [1, 1])),
+                    NamedOnnxValue.CreateFromTensor("past_keys", new DenseTensor<float>(pastKeys, [_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
+                    NamedOnnxValue.CreateFromTensor("past_values", new DenseTensor<float>(pastValues, [_nLayers, 1, _nKvHeads, pastSeqLen, _headDim])),
+                ]);
+
+                float[] logits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
+                pastKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+                pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+                pastSeqLen++;
+
+                nextToken = ArgMaxLastLogits(logits, 1, out float nextLogprob);
+                rawTokens.Add(nextToken);
+                rawLogprobs.Add(nextLogprob);
+            }
+        }
+    }
+
+    private float[] SliceBatchKv(float[] past, int batchSize, int batchIndex, int sourceSeqLen, int targetSeqLen)
+    {
+        int sourcePerSequenceSize = _nKvHeads * sourceSeqLen * _headDim;
+        int targetPerSequenceSize = _nKvHeads * targetSeqLen * _headDim;
+        float[] sliced = new float[_nLayers * targetPerSequenceSize];
+        int destinationOffset = 0;
+
+        for (int layer = 0; layer < _nLayers; layer++)
+        {
+            int layerOffset = layer * batchSize * sourcePerSequenceSize;
+            int sourceOffset = layerOffset + batchIndex * sourcePerSequenceSize;
+            Array.Copy(past, sourceOffset, sliced, destinationOffset, targetPerSequenceSize);
+            destinationOffset += targetPerSequenceSize;
+        }
+
+        return sliced;
     }
 
     private (List<int> rawTokens, List<float> rawLogprobs) DecodeWithIoBinding(

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -402,150 +402,204 @@ public sealed class Qwen3Asr : IDisposable
         if (encodedItems.Count == 0)
             yield break;
 
-        double maxSegmentSeconds = encodedItems.Max(it => it.DurationSamples / (double)SampleRate);
-        int slotCapacity = Math.Min(encodedItems.Count, EstimateExperimentalBatchCap(maxSegmentSeconds, freeGpuMemoryMb));
-        int maxPromptSeqLen = encodedItems.Max(it => BuildPromptIds(it.AudioTokenCount).Count);
-        int maxKvSeqCapacity = maxPromptSeqLen + maxNewTokens - 1;
-        int kvCapacity = _nLayers * slotCapacity * _nKvHeads * maxKvSeqCapacity * _headDim;
+        // Capacity is bounded by the LARGER of two peak allocations:
+        //   prefill:  [groupSize, maxPromptLen, vocabSize] logits  (lm_head output, temporary but large)
+        //   decode KV: [nLayers, groupSize, nKvHeads, maxKvSeqLen, headDim] × 2 (persistent throughout decode)
+        // Budget 25% of free VRAM; remainder for model weights, activations, ORT arena overhead.
+        int  maxPromptSeqLen       = encodedItems.Max(it => BuildPromptIds(it.AudioTokenCount).Count);
+        int  maxKvSeqLen           = maxPromptSeqLen + maxNewTokens;
+        long prefillLogitsPerSlot  = (long)maxPromptSeqLen * _vocabSize * 4;
+        long decodeKvPerSlot       = (long)_nLayers * _nKvHeads * maxKvSeqLen * _headDim * 4 * 2;
+        long peakBytesPerSlot      = Math.Max(prefillLogitsPerSlot, decodeKvPerSlot);
+        int  decodeCap             = (int)Math.Max(1, freeGpuMemoryMb * 1024L * 1024 / 4 / peakBytesPerSlot);
+        int  slotCapacity          = Math.Min(encodedItems.Count, decodeCap);
+        Console.Error.WriteLine($"[Qwen3Asr] static-batch decode: {encodedItems.Count} segments, slotCapacity={slotCapacity}");
 
-        // Stable per-slot KV: [nLayers, slotCapacity, nKvHeads, maxKvSeqCapacity, headDim]
-        float[] slotKeys    = new float[kvCapacity];
-        float[] slotValues  = new float[kvCapacity];
-        // Temporary packed batch buffers for decoder: [nLayers, activeCount, nKvHeads, maxPastLen, headDim]
-        float[] batchKeys   = new float[kvCapacity];
-        float[] batchValues = new float[kvCapacity];
+        using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var runOpts     = new RunOptions();
 
-        int[]          slotPastLengths  = new int[slotCapacity];
-        int[]          slotSegIds       = new int[slotCapacity];
-        int[]          slotNextTokens   = new int[slotCapacity];
-        bool[]         slotDone         = new bool[slotCapacity];
-        List<int>?[]   slotRawTokens    = new List<int>?[slotCapacity];
-        List<float>?[] slotRawLogprobs  = new List<float>?[slotCapacity];
+        float[] emptyKv    = [];
+        float[] tokenEmbed = new float[_hiddenSize];
 
-        int[]   activeToSlot   = new int[slotCapacity];
-        int[]   batchPastLens  = new int[slotCapacity];
-        int[]   freeSlots      = new int[slotCapacity];
-        float[] stepEmbeds     = new float[slotCapacity * _hiddenSize];
-        var     tokenEmbed     = new float[_hiddenSize];
-        long[]  stepPos        = new long[slotCapacity];
-        float[] stepMaskBuffer = new float[slotCapacity * (maxKvSeqCapacity + 1)];
-
-        using var cpuMemInfo = new OrtMemoryInfo("Cpu",  OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
-        using var runOpts    = new RunOptions();
-
-        int occupiedCount = 0;
-        int pendingIndex  = 0;
-
-        while (occupiedCount > 0 || pendingIndex < encodedItems.Count)
+        int pendingIndex = 0;
+        while (pendingIndex < encodedItems.Count)
         {
-            // Yield finished slots and release them
-            for (int slot = 0; slot < slotCapacity; slot++)
-            {
-                if (slotRawTokens[slot] is null || !slotDone[slot]) continue;
+            int groupSize = Math.Min(slotCapacity, encodedItems.Count - pendingIndex);
 
-                var (textTokens, textLogprobs) = ExtractTextTokens(slotRawTokens[slot]!, slotRawLogprobs[slot]!);
+            // --- Build batched prefill inputs for this group ---
+            int maxAudioTokens = 0;
+            for (int i = 0; i < groupSize; i++)
+                maxAudioTokens = Math.Max(maxAudioTokens, encodedItems[pendingIndex + i].AudioTokenCount);
+
+            float[] audioFeatures = new float[groupSize * maxAudioTokens * _hiddenSize];
+            long[]  audioLengths  = new long[groupSize];
+            for (int i = 0; i < groupSize; i++)
+            {
+                var item = encodedItems[pendingIndex + i];
+                audioLengths[i] = item.AudioTokenCount;
+                for (int t = 0; t < item.AudioTokenCount; t++)
+                    Array.Copy(item.AudioFeatures, t * _hiddenSize,
+                               audioFeatures, (i * maxAudioTokens + t) * _hiddenSize, _hiddenSize);
+            }
+
+            var (inputEmbeds, positionIds, prefillMask, seqLengths) =
+                BuildUnifiedBatchPrefillInputs(audioFeatures, audioLengths, groupSize, maxAudioTokens);
+            int maxPromptLen = seqLengths.Max();
+
+            // --- Prefill: use Run() — avoids GetTensorDataAsSpan failing on _decoder with mixed CPU/CUDA IO binding ---
+            using var prefillResults = _decoder!.Run([
+                NamedOnnxValue.CreateFromTensor("input_embeds",
+                    new DenseTensor<float>(inputEmbeds,  new[] { groupSize, maxPromptLen, _hiddenSize })),
+                NamedOnnxValue.CreateFromTensor("position_ids",
+                    new DenseTensor<long>(positionIds,   new[] { groupSize, maxPromptLen })),
+                NamedOnnxValue.CreateFromTensor("attention_mask",
+                    new DenseTensor<float>(prefillMask,  new[] { groupSize, 1, maxPromptLen, maxPromptLen })),
+                NamedOnnxValue.CreateFromTensor("past_keys",
+                    new DenseTensor<float>(Memory<float>.Empty, new[] { _nLayers, groupSize, _nKvHeads, 0, _headDim })),
+                NamedOnnxValue.CreateFromTensor("past_values",
+                    new DenseTensor<float>(Memory<float>.Empty, new[] { _nLayers, groupSize, _nKvHeads, 0, _headDim })),
+            ]);
+
+            // Extract last-position logits per slot (groupSize×vocabSize, ~8MB vs ~3.5GB full tensor)
+            float[] lastPosLogits = new float[groupSize * _vocabSize];
+            var prefillLogitTensor = prefillResults.First(r => r.Name == "logits").AsTensor<float>();
+            if (prefillLogitTensor is DenseTensor<float> densePrefillLogits)
+            {
+                var span = densePrefillLogits.Buffer.Span;
+                for (int b = 0; b < groupSize; b++)
+                {
+                    int srcOffset = (b * maxPromptLen + seqLengths[b] - 1) * _vocabSize;
+                    span.Slice(srcOffset, _vocabSize).CopyTo(lastPosLogits.AsSpan(b * _vocabSize));
+                }
+            }
+
+            // Extract KV for step-1 H2D bootstrap (one-time per group)
+            float[] prefillKeysBuf   = ExtractTensor(prefillResults.First(r => r.Name == "present_keys").AsTensor<float>());
+            float[] prefillValuesBuf = ExtractTensor(prefillResults.First(r => r.Name == "present_values").AsTensor<float>());
+
+            // --- Init per-slot state from prefill logits ---
+            int[]  nextTokens  = new int[groupSize];
+            bool[] done        = new bool[groupSize];
+            var    rawTokens   = new List<int>[groupSize];
+            var    rawLogprobs = new List<float>[groupSize];
+
+            for (int b = 0; b < groupSize; b++)
+            {
+                rawTokens[b]   = new List<int>(maxNewTokens);
+                rawLogprobs[b] = new List<float>(maxNewTokens);
+                int firstToken = ArgMaxSpan(lastPosLogits.AsSpan(b * _vocabSize, _vocabSize), out float firstLogprob);
+                nextTokens[b] = firstToken;
+                rawTokens[b].Add(firstToken);
+                rawLogprobs[b].Add(firstLogprob);
+                done[b] = IsEos(firstToken) || maxNewTokens <= 1;
+            }
+
+            // --- Decode: GPU KV chains step-to-step; only logits (~vocabSize×groupSize×4B) cross PCIe ---
+            // Pre-allocate decode logits buffer; bind as output so ORT writes directly — no GetTensorDataAsSpan.
+            float[] decodeLogBuf = new float[groupSize * _vocabSize];
+            float[] stepEmbeds   = new float[groupSize * _hiddenSize];
+            long[]  stepPos      = new long[groupSize];
+            float[] stepMask     = new float[groupSize * (maxPromptLen + maxNewTokens)];
+
+            bool firstStep = true;
+            IDisposableReadOnlyCollection<OrtValue>? prevKv = null;
+            int stepCount = 1;
+            while (!Array.TrueForAll(done, d => d))
+            {
+                // totalPastLen = tokens already in KV: maxPromptLen positions from prefill + stepCount decode tokens
+                int totalPastLen = maxPromptLen + stepCount;
+
+                for (int b = 0; b < groupSize; b++)
+                {
+                    ReadTokenEmbedding(nextTokens[b], tokenEmbed);
+                    Array.Copy(tokenEmbed, 0, stepEmbeds, b * _hiddenSize, _hiddenSize);
+                    // actual sequence position for each slot (differs when prompt lengths differ)
+                    stepPos[b] = seqLengths[b] + stepCount - 1;
+                }
+
+                // Attend to valid prefill [0, seqLengths[b]) and all decode tokens [maxPromptLen, totalPastLen).
+                // Mask padding gap [seqLengths[b], maxPromptLen) which holds garbage from padded prefill.
+                BuildStaticBatchStepMask(stepMask, seqLengths, groupSize, maxPromptLen, stepCount, totalPastLen);
+
+                using var embVal       = OrtValue.CreateTensorValueFromMemory(stepEmbeds,  [groupSize, 1, _hiddenSize]);
+                using var posVal       = OrtValue.CreateTensorValueFromMemory(stepPos,     [groupSize, 1]);
+                using var maskVal      = OrtValue.CreateTensorValueFromMemory(stepMask,    [groupSize, 1, 1, totalPastLen]);
+                using var logitsOutVal = OrtValue.CreateTensorValueFromMemory(decodeLogBuf, [groupSize, 1, _vocabSize]);
+
+                using var stepBinding = _decoder!.CreateIoBinding();
+                stepBinding.BindInput("input_embeds",   embVal);
+                stepBinding.BindInput("position_ids",   posVal);
+                stepBinding.BindInput("attention_mask", maskVal);
+                if (firstStep)
+                {
+                    // H2D bootstrap: CPU prefill KV → GPU for step 1 (one-time per group)
+                    using var pkv = OrtValue.CreateTensorValueFromMemory(prefillKeysBuf,   [_nLayers, groupSize, _nKvHeads, maxPromptLen, _headDim]);
+                    using var pvv = OrtValue.CreateTensorValueFromMemory(prefillValuesBuf, [_nLayers, groupSize, _nKvHeads, maxPromptLen, _headDim]);
+                    stepBinding.BindInput("past_keys",   pkv);
+                    stepBinding.BindInput("past_values", pvv);
+                    firstStep = false;
+                }
+                else
+                {
+                    stepBinding.BindInput("past_keys",   prevKv![1]); // GPU → GPU: no PCIe
+                    stepBinding.BindInput("past_values", prevKv![2]); // GPU → GPU: no PCIe
+                }
+                stepBinding.BindOutput("logits",                   logitsOutVal); // writes to decodeLogBuf
+                stepBinding.BindOutputToDevice("present_keys",   cudaMemInfo);
+                stepBinding.BindOutputToDevice("present_values", cudaMemInfo);
+                _decoder!.RunWithBinding(runOpts, stepBinding);
+
+                var curKv = stepBinding.GetOutputValues();
+
+                // Read logits from decodeLogBuf (float[]) — no GetTensorDataAsSpan needed
+                for (int b = 0; b < groupSize; b++)
+                {
+                    if (done[b]) continue;
+                    int token = ArgMaxSpan(decodeLogBuf.AsSpan(b * _vocabSize, _vocabSize), out float logprob);
+                    nextTokens[b] = token;
+                    rawTokens[b].Add(token);
+                    rawLogprobs[b].Add(logprob);
+                    if (IsEos(token) || rawTokens[b].Count >= maxNewTokens)
+                        done[b] = true;
+                }
+
+                prevKv?.Dispose();
+                prevKv = curKv;
+                stepCount++;
+            }
+
+            prevKv?.Dispose();
+
+            // --- Yield results for this group ---
+            for (int i = 0; i < groupSize; i++)
+            {
+                var item = encodedItems[pendingIndex + i];
+                var (textTokens, textLogprobs) = ExtractTextTokens(rawTokens[i], rawLogprobs[i]);
                 string rawText = DecodeTokens(textTokens);
                 var parsed = ParseMetadataPrefix(rawText);
                 yield return new QwenRecognitionResult(
-                    slotSegIds[slot], parsed.Text, slotRawTokens[slot]!, textTokens, textLogprobs, parsed.Language, rawText);
-
-                slotRawTokens[slot]   = null;
-                slotRawLogprobs[slot] = null;
-                slotDone[slot]        = false;
-                slotPastLengths[slot] = 0;
-                occupiedCount--;
+                    item.SegId, parsed.Text, rawTokens[i], textTokens, textLogprobs, parsed.Language, rawText);
             }
 
-            // Fill free slots with pending segments
-            if (pendingIndex < encodedItems.Count)
-            {
-                int freeCount = 0;
-                for (int slot = 0; slot < slotCapacity && pendingIndex + freeCount < encodedItems.Count; slot++)
-                    if (slotRawTokens[slot] is null)
-                        freeSlots[freeCount++] = slot;
+            pendingIndex += groupSize;
+        }
+    }
 
-                if (freeCount > 0)
-                {
-                    AdmitUnifiedDecodeSlots(
-                        encodedItems, pendingIndex, freeCount, freeSlots,
-                        slotCapacity, maxKvSeqCapacity, maxNewTokens,
-                        slotKeys, slotValues, slotPastLengths, slotSegIds,
-                        slotNextTokens, slotDone, slotRawTokens, slotRawLogprobs);
-                    pendingIndex  += freeCount;
-                    occupiedCount += freeCount;
-                }
-            }
-
-            // Build active set: occupied and not-done slots
-            int activeCount = 0;
-            for (int slot = 0; slot < slotCapacity; slot++)
-            {
-                if (slotRawTokens[slot] is not null && !slotDone[slot])
-                {
-                    activeToSlot[activeCount]  = slot;
-                    batchPastLens[activeCount] = slotPastLengths[slot];
-                    activeCount++;
-                }
-            }
-
-            if (activeCount == 0) continue;
-
-            for (int b = 0; b < activeCount; b++)
-            {
-                ReadTokenEmbedding(slotNextTokens[activeToSlot[b]], tokenEmbed);
-                Array.Copy(tokenEmbed, 0, stepEmbeds, b * _hiddenSize, _hiddenSize);
-                stepPos[b] = batchPastLens[b];
-            }
-
-            int maxPastLen     = MaxPrefix(batchPastLens, activeCount);
-            int stepMaskLength = activeCount * (maxPastLen + 1);
-            BuildBatchStepAttentionMaskInto(stepMaskBuffer, stepMaskLength, batchPastLens, activeCount, maxPastLen);
-
-            // Pack stable slot KV into a contiguous batch buffer with correct strides for the decoder
-            PackKvForDecode(slotKeys,   slotCapacity, maxKvSeqCapacity, activeToSlot, batchPastLens, activeCount, maxPastLen, batchKeys);
-            PackKvForDecode(slotValues, slotCapacity, maxKvSeqCapacity, activeToSlot, batchPastLens, activeCount, maxPastLen, batchValues);
-
-            // ORT reads exactly product(shape) elements from offset 0; arrays may be larger (pre-allocated for max capacity)
-            using var embVal      = OrtValue.CreateTensorValueFromMemory(stepEmbeds,     [activeCount, 1, _hiddenSize]);
-            using var posVal      = OrtValue.CreateTensorValueFromMemory(stepPos,         [activeCount, 1]);
-            using var maskVal     = OrtValue.CreateTensorValueFromMemory(stepMaskBuffer,  [activeCount, 1, 1, maxPastLen + 1]);
-            using var pastKeysVal = OrtValue.CreateTensorValueFromMemory(batchKeys,       [_nLayers, activeCount, _nKvHeads, maxPastLen, _headDim]);
-            using var pastValsVal = OrtValue.CreateTensorValueFromMemory(batchValues,     [_nLayers, activeCount, _nKvHeads, maxPastLen, _headDim]);
-
-            using var stepBinding = _decoder!.CreateIoBinding();
-            stepBinding.BindInput("input_embeds",   embVal);
-            stepBinding.BindInput("position_ids",   posVal);
-            stepBinding.BindInput("attention_mask", maskVal);
-            stepBinding.BindInput("past_keys",      pastKeysVal);
-            stepBinding.BindInput("past_values",    pastValsVal);
-            stepBinding.BindOutputToDevice("logits",         cpuMemInfo);
-            stepBinding.BindOutputToDevice("present_keys",   cpuMemInfo);
-            stepBinding.BindOutputToDevice("present_values", cpuMemInfo);
-            _decoder!.RunWithBinding(runOpts, stepBinding);
-
-            using var stepOutVals   = stepBinding.GetOutputValues();
-            var logitsSpan          = stepOutVals[0].GetTensorDataAsSpan<float>();
-            var presentKeysSpan     = stepOutVals[1].GetTensorDataAsSpan<float>();
-            var presentValsSpan     = stepOutVals[2].GetTensorDataAsSpan<float>();
-            int vocabSize           = logitsSpan.Length / activeCount;
-
-            for (int b = 0; b < activeCount; b++)
-            {
-                int slot  = activeToSlot[b];
-                int token = ArgMaxSpan(logitsSpan.Slice(b * vocabSize, vocabSize), out float logprob);
-                slotNextTokens[slot] = token;
-                slotRawTokens[slot]!.Add(token);
-                slotRawLogprobs[slot]!.Add(logprob);
-                if (IsEos(token) || slotRawTokens[slot]!.Count >= maxNewTokens)
-                    slotDone[slot] = true;
-            }
-
-            // Append the new token's KV from decoder output into stable slot storage
-            AppendTokenKvToSlots(presentKeysSpan, activeCount, maxPastLen, activeToSlot, batchPastLens, slotKeys,   slotCapacity, maxKvSeqCapacity);
-            AppendTokenKvToSlots(presentValsSpan, activeCount, maxPastLen, activeToSlot, batchPastLens, slotValues, slotCapacity, maxKvSeqCapacity);
-
-            for (int b = 0; b < activeCount; b++)
-                slotPastLengths[activeToSlot[b]]++;
+    // Attention mask for one decode step in a static-batch group.
+    // Valid positions: prefill tokens [0, seqLengths[b]) and new tokens [maxPromptLen, maxPromptLen+stepCount).
+    // Masked:          padding gap [seqLengths[b], maxPromptLen) — garbage KV from padded prefill.
+    private static void BuildStaticBatchStepMask(
+        float[] buffer, int[] seqLengths, int batchSize,
+        int maxPromptLen, int stepCount, int totalPastLen)
+    {
+        Array.Fill(buffer, float.MinValue, 0, batchSize * totalPastLen);
+        for (int b = 0; b < batchSize; b++)
+        {
+            int offset = b * totalPastLen;
+            for (int k = 0; k < seqLengths[b]; k++)
+                buffer[offset + k] = 0f;
+            for (int k = 0; k < stepCount; k++)
+                buffer[offset + maxPromptLen + k] = 0f;
         }
     }
 
@@ -1129,172 +1183,6 @@ public sealed class Qwen3Asr : IDisposable
                 Array.Copy(presentKeys,   sourceBase + appendIndex * _headDim, nextKeys,   destBase + validPastLen * _headDim, _headDim);
                 Array.Copy(presentValues, sourceBase + appendIndex * _headDim, nextValues, destBase + validPastLen * _headDim, _headDim);
             }
-        }
-    }
-
-    // Copies active-slot KV from stable slot storage into a contiguous batch buffer for the decoder.
-    // slotKv:  [nLayers, slotCapacity, nKvHeads, maxKvSeqCapacity, headDim]
-    // batchKv: [nLayers, activeCount,  nKvHeads, maxPastLen,       headDim]
-    private void PackKvForDecode(
-        float[] slotKv,
-        int slotCapacity,
-        int maxKvSeqCapacity,
-        int[] activeToSlot,
-        int[] batchPastLens,
-        int activeCount,
-        int maxPastLen,
-        float[] batchKv)
-    {
-        for (int layer = 0; layer < _nLayers; layer++)
-        for (int b = 0; b < activeCount; b++)
-        {
-            int slot     = activeToSlot[b];
-            int validLen = batchPastLens[b];
-            for (int head = 0; head < _nKvHeads; head++)
-            {
-                int srcBase = (((layer * slotCapacity + slot) * _nKvHeads + head) * maxKvSeqCapacity) * _headDim;
-                int dstBase = (((layer * activeCount  + b)    * _nKvHeads + head) * maxPastLen)        * _headDim;
-                Array.Copy(slotKv, srcBase, batchKv, dstBase, validLen * _headDim);
-                if (validLen < maxPastLen)
-                    Array.Clear(batchKv, dstBase + validLen * _headDim, (maxPastLen - validLen) * _headDim);
-            }
-        }
-    }
-
-    // Appends the newly decoded token's KV (at position maxPastLen in present_kv) back to slot storage.
-    // presentKv: [nLayers, activeCount, nKvHeads, maxPastLen+1, headDim] (decoder output)
-    // slotKv:    [nLayers, slotCapacity, nKvHeads, maxKvSeqCapacity, headDim]
-    private void AppendTokenKvToSlots(
-        ReadOnlySpan<float> presentKv,
-        int activeCount,
-        int maxPastLen,
-        int[] activeToSlot,
-        int[] batchPastLens,
-        float[] slotKv,
-        int slotCapacity,
-        int maxKvSeqCapacity)
-    {
-        int presentSeqLen = maxPastLen + 1;
-        for (int layer = 0; layer < _nLayers; layer++)
-        for (int b = 0; b < activeCount; b++)
-        {
-            int slot     = activeToSlot[b];
-            int insertAt = batchPastLens[b]; // slot's past length before this token
-            for (int head = 0; head < _nKvHeads; head++)
-            {
-                int srcBase = (((layer * activeCount + b) * _nKvHeads + head) * presentSeqLen + maxPastLen) * _headDim;
-                int dstBase = (((layer * slotCapacity + slot) * _nKvHeads + head) * maxKvSeqCapacity + insertAt) * _headDim;
-                presentKv.Slice(srcBase, _headDim).CopyTo(slotKv.AsSpan(dstBase, _headDim));
-            }
-        }
-    }
-
-    private static void BuildBatchStepAttentionMaskInto(float[] buffer, int usedLength, int[] pastLengths, int count, int maxPastLen)
-    {
-        Array.Fill(buffer, float.MinValue, 0, usedLength);
-
-        for (int b = 0; b < count; b++)
-        {
-            int offset = b * (maxPastLen + 1);
-            for (int k = 0; k < pastLengths[b]; k++)
-                buffer[offset + k] = 0f;
-            buffer[offset + maxPastLen] = 0f;
-        }
-    }
-
-    private void AdmitUnifiedDecodeSlots(
-        IReadOnlyList<QwenEncodedItem> encodedItems,
-        int startIndex,
-        int admitCount,
-        int[] targetSlots,
-        int slotCapacity,
-        int maxKvSeqCapacity,
-        int maxNewTokens,
-        float[] pastKeys,
-        float[] pastValues,
-        int[] pastLengths,
-        int[] slotSegIds,
-        int[] slotNextTokens,
-        bool[] slotDone,
-        List<int>?[] slotRawTokens,
-        List<float>?[] slotRawLogprobs)
-    {
-        int maxAudioTokens = 0;
-        for (int i = 0; i < admitCount; i++)
-            maxAudioTokens = Math.Max(maxAudioTokens, encodedItems[startIndex + i].AudioTokenCount);
-
-        float[] audioFeatures = new float[admitCount * maxAudioTokens * _hiddenSize];
-        long[] audioLengths = new long[admitCount];
-        for (int i = 0; i < admitCount; i++)
-        {
-            var item = encodedItems[startIndex + i];
-            audioLengths[i] = item.AudioTokenCount;
-            for (int t = 0; t < item.AudioTokenCount; t++)
-            {
-                Array.Copy(
-                    item.AudioFeatures,
-                    t * _hiddenSize,
-                    audioFeatures,
-                    (i * maxAudioTokens + t) * _hiddenSize,
-                    _hiddenSize);
-            }
-        }
-
-        var (inputEmbeds, positionIds, prefillMask, seqLengths) =
-            BuildUnifiedBatchPrefillInputs(audioFeatures, audioLengths, admitCount, maxAudioTokens);
-
-        float[] emptyKv = [];
-        using var initResults = _decoder!.Run(
-        [
-            NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(inputEmbeds, [admitCount, seqLengths.Max(), _hiddenSize])),
-            NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(positionIds,   [admitCount, seqLengths.Max()])),
-            NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(prefillMask,  [admitCount, 1, seqLengths.Max(), seqLengths.Max()])),
-            NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(emptyKv,      [_nLayers, admitCount, _nKvHeads, 0, _headDim])),
-            NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(emptyKv,      [_nLayers, admitCount, _nKvHeads, 0, _headDim])),
-        ]);
-
-        float[] batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
-        float[] presentKeys = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
-        float[] presentValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
-        int vocabSize = batchedLogits.Length / (admitCount * seqLengths.Max());
-
-        for (int i = 0; i < admitCount; i++)
-        {
-            int slot = targetSlots[i];
-            var item = encodedItems[startIndex + i];
-            slotSegIds[slot] = item.SegId;
-            slotRawTokens[slot] = new List<int>(maxNewTokens);
-            slotRawLogprobs[slot] = new List<float>(maxNewTokens);
-            int logitOffset = i * seqLengths.Max() * vocabSize + (seqLengths[i] - 1) * vocabSize;
-            int firstToken = ArgMaxSpan(batchedLogits.AsSpan(logitOffset, vocabSize), out float firstLogprob);
-            slotNextTokens[slot] = firstToken;
-            slotRawTokens[slot]!.Add(firstToken);
-            slotRawLogprobs[slot]!.Add(firstLogprob);
-            slotDone[slot] = IsEos(firstToken) || slotRawTokens[slot]!.Count >= maxNewTokens;
-            pastLengths[slot] = seqLengths[i];
-            CopyPrefillKvToSlot(presentKeys, admitCount, seqLengths.Max(), i, pastKeys, slotCapacity, maxKvSeqCapacity, slot, seqLengths[i]);
-            CopyPrefillKvToSlot(presentValues, admitCount, seqLengths.Max(), i, pastValues, slotCapacity, maxKvSeqCapacity, slot, seqLengths[i]);
-        }
-    }
-
-    private void CopyPrefillKvToSlot(
-        float[] source,
-        int batchSize,
-        int sourceSeqLen,
-        int batchIndex,
-        float[] target,
-        int slotCapacity,
-        int targetSeqCapacity,
-        int slotIndex,
-        int validLen)
-    {
-        for (int layer = 0; layer < _nLayers; layer++)
-        for (int head = 0; head < _nKvHeads; head++)
-        {
-            int sourceBase = (((layer * batchSize + batchIndex) * _nKvHeads + head) * sourceSeqLen) * _headDim;
-            int targetBase = (((layer * slotCapacity + slotIndex) * _nKvHeads + head) * targetSeqCapacity) * _headDim;
-            Array.Clear(target, targetBase, targetSeqCapacity * _headDim);
-            Array.Copy(source, sourceBase, target, targetBase, validLen * _headDim);
         }
     }
 

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -330,6 +330,225 @@ public sealed class Qwen3Asr : IDisposable
         return Math.Max(1, (int)Math.Floor(referenceCap * scale));
     }
 
+    private List<QwenEncodedItem> EncodeBatchedItems(
+        IReadOnlyList<QwenBatchedItem> validItems,
+        long freeGpuMemoryMb)
+    {
+        var encodedItems = new List<QwenEncodedItem>(validItems.Count);
+        int index = 0;
+
+        while (index < validItems.Count)
+        {
+            var remainingDurations = validItems
+                .Skip(index)
+                .Select(it => it.DurationSamples / (double)SampleRate)
+                .ToList();
+            var plan = ComputeExperimentalBatchingPlan(remainingDurations, freeGpuMemoryMb);
+            int take = Math.Min(plan.BatchCount, validItems.Count - index);
+            var batch = validItems.Skip(index).Take(take).ToList();
+            index += take;
+
+            int maxMelFrames = batch.Max(it => it.MelFrames);
+            var melBatch = new float[take * NMels * maxMelFrames];
+            var inputLengths = new long[take];
+            for (int b = 0; b < take; b++)
+            {
+                inputLengths[b] = batch[b].MelFrames;
+                for (int melBin = 0; melBin < NMels; melBin++)
+                {
+                    Array.Copy(
+                        batch[b].Mel!,
+                        melBin * batch[b].MelFrames,
+                        melBatch,
+                        (b * NMels + melBin) * maxMelFrames,
+                        batch[b].MelFrames);
+                }
+            }
+
+            using var encoderResults = _encoderBatched!.Run(
+            [
+                NamedOnnxValue.CreateFromTensor("mel",           new DenseTensor<float>(melBatch, [take, NMels, maxMelFrames])),
+                NamedOnnxValue.CreateFromTensor("input_lengths", new DenseTensor<long>(inputLengths, [take])),
+            ]);
+
+            var audioFeaturesTensor = encoderResults.First(r => r.Name == "audio_features").AsTensor<float>();
+            var audioLengthsTensor = encoderResults.First(r => r.Name == "audio_feature_lengths").AsTensor<long>();
+
+            for (int b = 0; b < take; b++)
+            {
+                int audioTokenCount = (int)audioLengthsTensor[b];
+                float[] audioFeatures = new float[audioTokenCount * _hiddenSize];
+                for (int t = 0; t < audioTokenCount; t++)
+                for (int h = 0; h < _hiddenSize; h++)
+                    audioFeatures[t * _hiddenSize + h] = audioFeaturesTensor[b, t, h];
+
+                encodedItems.Add(new QwenEncodedItem(
+                    batch[b].SegId,
+                    batch[b].DurationSamples,
+                    audioFeatures,
+                    audioTokenCount));
+            }
+        }
+
+        return encodedItems;
+    }
+
+    private IEnumerable<QwenRecognitionResult> RecognizeUnifiedContinuousBatched(
+        IReadOnlyList<QwenBatchedItem> validItems,
+        long freeGpuMemoryMb,
+        int maxNewTokens)
+    {
+        var encodedItems = EncodeBatchedItems(validItems, freeGpuMemoryMb);
+        if (encodedItems.Count == 0)
+            yield break;
+
+        double maxSegmentSeconds = encodedItems.Max(it => it.DurationSamples / (double)SampleRate);
+        int slotCapacity = Math.Min(encodedItems.Count, EstimateExperimentalBatchCap(maxSegmentSeconds, freeGpuMemoryMb));
+        int maxPromptSeqLen = encodedItems.Max(it => BuildPromptIds(it.AudioTokenCount).Count);
+        int maxKvSeqCapacity = maxPromptSeqLen + maxNewTokens - 1;
+        int kvCapacity = _nLayers * slotCapacity * _nKvHeads * maxKvSeqCapacity * _headDim;
+
+        // Stable per-slot KV: [nLayers, slotCapacity, nKvHeads, maxKvSeqCapacity, headDim]
+        float[] slotKeys    = new float[kvCapacity];
+        float[] slotValues  = new float[kvCapacity];
+        // Temporary packed batch buffers for decoder: [nLayers, activeCount, nKvHeads, maxPastLen, headDim]
+        float[] batchKeys   = new float[kvCapacity];
+        float[] batchValues = new float[kvCapacity];
+
+        int[]          slotPastLengths  = new int[slotCapacity];
+        int[]          slotSegIds       = new int[slotCapacity];
+        int[]          slotNextTokens   = new int[slotCapacity];
+        bool[]         slotDone         = new bool[slotCapacity];
+        List<int>?[]   slotRawTokens    = new List<int>?[slotCapacity];
+        List<float>?[] slotRawLogprobs  = new List<float>?[slotCapacity];
+
+        int[]   activeToSlot   = new int[slotCapacity];
+        int[]   batchPastLens  = new int[slotCapacity];
+        int[]   freeSlots      = new int[slotCapacity];
+        float[] stepEmbeds     = new float[slotCapacity * _hiddenSize];
+        var     tokenEmbed     = new float[_hiddenSize];
+        long[]  stepPos        = new long[slotCapacity];
+        float[] stepMaskBuffer = new float[slotCapacity * (maxKvSeqCapacity + 1)];
+
+        using var cpuMemInfo = new OrtMemoryInfo("Cpu",  OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var runOpts    = new RunOptions();
+
+        int occupiedCount = 0;
+        int pendingIndex  = 0;
+
+        while (occupiedCount > 0 || pendingIndex < encodedItems.Count)
+        {
+            // Yield finished slots and release them
+            for (int slot = 0; slot < slotCapacity; slot++)
+            {
+                if (slotRawTokens[slot] is null || !slotDone[slot]) continue;
+
+                var (textTokens, textLogprobs) = ExtractTextTokens(slotRawTokens[slot]!, slotRawLogprobs[slot]!);
+                string rawText = DecodeTokens(textTokens);
+                var parsed = ParseMetadataPrefix(rawText);
+                yield return new QwenRecognitionResult(
+                    slotSegIds[slot], parsed.Text, slotRawTokens[slot]!, textTokens, textLogprobs, parsed.Language, rawText);
+
+                slotRawTokens[slot]   = null;
+                slotRawLogprobs[slot] = null;
+                slotDone[slot]        = false;
+                slotPastLengths[slot] = 0;
+                occupiedCount--;
+            }
+
+            // Fill free slots with pending segments
+            if (pendingIndex < encodedItems.Count)
+            {
+                int freeCount = 0;
+                for (int slot = 0; slot < slotCapacity && pendingIndex + freeCount < encodedItems.Count; slot++)
+                    if (slotRawTokens[slot] is null)
+                        freeSlots[freeCount++] = slot;
+
+                if (freeCount > 0)
+                {
+                    AdmitUnifiedDecodeSlots(
+                        encodedItems, pendingIndex, freeCount, freeSlots,
+                        slotCapacity, maxKvSeqCapacity, maxNewTokens,
+                        slotKeys, slotValues, slotPastLengths, slotSegIds,
+                        slotNextTokens, slotDone, slotRawTokens, slotRawLogprobs);
+                    pendingIndex  += freeCount;
+                    occupiedCount += freeCount;
+                }
+            }
+
+            // Build active set: occupied and not-done slots
+            int activeCount = 0;
+            for (int slot = 0; slot < slotCapacity; slot++)
+            {
+                if (slotRawTokens[slot] is not null && !slotDone[slot])
+                {
+                    activeToSlot[activeCount]  = slot;
+                    batchPastLens[activeCount] = slotPastLengths[slot];
+                    activeCount++;
+                }
+            }
+
+            if (activeCount == 0) continue;
+
+            for (int b = 0; b < activeCount; b++)
+            {
+                ReadTokenEmbedding(slotNextTokens[activeToSlot[b]], tokenEmbed);
+                Array.Copy(tokenEmbed, 0, stepEmbeds, b * _hiddenSize, _hiddenSize);
+                stepPos[b] = batchPastLens[b];
+            }
+
+            int maxPastLen     = MaxPrefix(batchPastLens, activeCount);
+            int stepMaskLength = activeCount * (maxPastLen + 1);
+            BuildBatchStepAttentionMaskInto(stepMaskBuffer, stepMaskLength, batchPastLens, activeCount, maxPastLen);
+
+            // Pack stable slot KV into a contiguous batch buffer with correct strides for the decoder
+            PackKvForDecode(slotKeys,   slotCapacity, maxKvSeqCapacity, activeToSlot, batchPastLens, activeCount, maxPastLen, batchKeys);
+            PackKvForDecode(slotValues, slotCapacity, maxKvSeqCapacity, activeToSlot, batchPastLens, activeCount, maxPastLen, batchValues);
+
+            // ORT reads exactly product(shape) elements from offset 0; arrays may be larger (pre-allocated for max capacity)
+            using var embVal      = OrtValue.CreateTensorValueFromMemory(stepEmbeds,     [activeCount, 1, _hiddenSize]);
+            using var posVal      = OrtValue.CreateTensorValueFromMemory(stepPos,         [activeCount, 1]);
+            using var maskVal     = OrtValue.CreateTensorValueFromMemory(stepMaskBuffer,  [activeCount, 1, 1, maxPastLen + 1]);
+            using var pastKeysVal = OrtValue.CreateTensorValueFromMemory(batchKeys,       [_nLayers, activeCount, _nKvHeads, maxPastLen, _headDim]);
+            using var pastValsVal = OrtValue.CreateTensorValueFromMemory(batchValues,     [_nLayers, activeCount, _nKvHeads, maxPastLen, _headDim]);
+
+            using var stepBinding = _decoder!.CreateIoBinding();
+            stepBinding.BindInput("input_embeds",   embVal);
+            stepBinding.BindInput("position_ids",   posVal);
+            stepBinding.BindInput("attention_mask", maskVal);
+            stepBinding.BindInput("past_keys",      pastKeysVal);
+            stepBinding.BindInput("past_values",    pastValsVal);
+            stepBinding.BindOutputToDevice("logits",         cpuMemInfo);
+            stepBinding.BindOutputToDevice("present_keys",   cpuMemInfo);
+            stepBinding.BindOutputToDevice("present_values", cpuMemInfo);
+            _decoder!.RunWithBinding(runOpts, stepBinding);
+
+            using var stepOutVals   = stepBinding.GetOutputValues();
+            var logitsSpan          = stepOutVals[0].GetTensorDataAsSpan<float>();
+            var presentKeysSpan     = stepOutVals[1].GetTensorDataAsSpan<float>();
+            var presentValsSpan     = stepOutVals[2].GetTensorDataAsSpan<float>();
+            int vocabSize           = logitsSpan.Length / activeCount;
+
+            for (int b = 0; b < activeCount; b++)
+            {
+                int slot  = activeToSlot[b];
+                int token = ArgMaxSpan(logitsSpan.Slice(b * vocabSize, vocabSize), out float logprob);
+                slotNextTokens[slot] = token;
+                slotRawTokens[slot]!.Add(token);
+                slotRawLogprobs[slot]!.Add(logprob);
+                if (IsEos(token) || slotRawTokens[slot]!.Count >= maxNewTokens)
+                    slotDone[slot] = true;
+            }
+
+            // Append the new token's KV from decoder output into stable slot storage
+            AppendTokenKvToSlots(presentKeysSpan, activeCount, maxPastLen, activeToSlot, batchPastLens, slotKeys,   slotCapacity, maxKvSeqCapacity);
+            AppendTokenKvToSlots(presentValsSpan, activeCount, maxPastLen, activeToSlot, batchPastLens, slotValues, slotCapacity, maxKvSeqCapacity);
+
+            for (int b = 0; b < activeCount; b++)
+                slotPastLengths[activeToSlot[b]]++;
+        }
+    }
+
     public IEnumerable<(int segId, string text)> Recognize(
         IReadOnlyList<(double start, double end, string spk)> segs,
         float[] audio,
@@ -537,6 +756,16 @@ public sealed class Qwen3Asr : IDisposable
         const long FallbackFreeVramMb = 8_000;
         long freeGpuMemoryMb = freeGpuMb > 0 ? freeGpuMb : FallbackFreeVramMb;
         Console.Error.WriteLine($"[Qwen3Asr] GPU memory: total={totalGpuMb} MB, free={freeGpuMb} MB (effective={freeGpuMemoryMb} MB)");
+
+        // Unified decoder: hand off all segments to the continuous-batch scheduler,
+        // which handles batched encoding + one decode scheduler over all segments.
+        if (_decoder is not null)
+        {
+            foreach (var r in RecognizeUnifiedContinuousBatched(validItems, freeGpuMemoryMb, maxNewTokens))
+                yield return r;
+            yield break;
+        }
+
         int index = 0;
 
         while (index < validItems.Count)
@@ -586,129 +815,7 @@ public sealed class Qwen3Asr : IDisposable
                 for (int h = 0; h < _hiddenSize; h++)
                     audioFeatures[(b * maxAudioTokens + t) * _hiddenSize + h] = audioFeaturesTensor[b, t, h];
 
-            // ── Batched prefill ──────────────────────────────────────────────
-            if (_decoder is not null)
-            {
-                var (unifiedInputEmbeds, unifiedPositionIds, unifiedPrefillMask, unifiedSeqLengths) =
-                    BuildUnifiedBatchPrefillInputs(audioFeatures, audioLengths, take, maxAudioTokens);
-
-                float[] emptyKv = [];
-                using var initResults = _decoder.Run(
-                [
-                    NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(unifiedInputEmbeds, [take, unifiedSeqLengths.Max(), _hiddenSize])),
-                    NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(unifiedPositionIds,  [take, unifiedSeqLengths.Max()])),
-                    NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(unifiedPrefillMask, [take, 1, unifiedSeqLengths.Max(), unifiedSeqLengths.Max()])),
-                    NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
-                    NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(emptyKv,     [_nLayers, take, _nKvHeads, 0, _headDim])),
-                ]);
-
-                float[] unifiedBatchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
-                float[] presentKeys = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
-                float[] presentValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
-                int maxKvSeqCapacity = unifiedSeqLengths.Max() + maxNewTokens - 1;
-                int kvCapacity = _nLayers * take * _nKvHeads * maxKvSeqCapacity * _headDim;
-                float[] pastKeys = new float[kvCapacity];
-                float[] pastValues = new float[kvCapacity];
-                CompactPrefillKvInto(presentKeys, unifiedSeqLengths, take, pastKeys);
-                CompactPrefillKvInto(presentValues, unifiedSeqLengths, take, pastValues);
-                int[] pastLengths = [.. unifiedSeqLengths];
-                int[] nextLengths = new int[take];
-                bool[] activeMask = new bool[take];
-                float[] nextKeysBuffer = new float[kvCapacity];
-                float[] nextValuesBuffer = new float[kvCapacity];
-                float[] stepEmbeds = new float[take * _hiddenSize];
-                var tokenEmbed = new float[_hiddenSize];
-                long[] stepPos = new long[take];
-                float[] stepMaskBuffer = new float[take * (maxKvSeqCapacity + 1)];
-
-                int unifiedVocabSize = unifiedBatchedLogits.Length / (take * unifiedSeqLengths.Max());
-                var unifiedSeqTokens = new List<int>[take];
-                var unifiedSeqLogprobs = new List<float>[take];
-                var unifiedSeqDone = new bool[take];
-                var nextTokens = new int[take];
-
-                for (int b = 0; b < take; b++)
-                {
-                    unifiedSeqTokens[b] = new List<int>(maxNewTokens);
-                    unifiedSeqLogprobs[b] = new List<float>(maxNewTokens);
-                    int logitOffset = b * unifiedSeqLengths.Max() * unifiedVocabSize + (unifiedSeqLengths[b] - 1) * unifiedVocabSize;
-                    int firstToken = ArgMaxSpan(unifiedBatchedLogits.AsSpan(logitOffset, unifiedVocabSize), out float firstLogprob);
-                    nextTokens[b] = firstToken;
-                    unifiedSeqTokens[b].Add(firstToken);
-                    unifiedSeqLogprobs[b].Add(firstLogprob);
-                    unifiedSeqDone[b] = IsEos(firstToken);
-                }
-
-                for (int step = 1; step < maxNewTokens && unifiedSeqDone.Any(done => !done); step++)
-                {
-                    for (int b = 0; b < take; b++)
-                    {
-                        ReadTokenEmbedding(nextTokens[b], tokenEmbed);
-                        Array.Copy(tokenEmbed, 0, stepEmbeds, b * _hiddenSize, _hiddenSize);
-                    }
-
-                    for (int b = 0; b < take; b++)
-                        stepPos[b] = pastLengths[b];
-
-                    int maxPastLen = pastLengths.Max();
-                    int stepMaskLength = take * (maxPastLen + 1);
-                    BuildBatchStepAttentionMaskInto(stepMaskBuffer, stepMaskLength, pastLengths, maxPastLen);
-                    int pastKvLength = _nLayers * take * _nKvHeads * maxPastLen * _headDim;
-
-                    using var stepOutputs = _decoder.Run(
-                    [
-                        NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(stepEmbeds, [take, 1, _hiddenSize])),
-                        NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(stepPos,     [take, 1])),
-                        NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(stepMaskBuffer.AsMemory(0, stepMaskLength), [take, 1, 1, maxPastLen + 1])),
-                        NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys.AsMemory(0, pastKvLength),   [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
-                        NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues.AsMemory(0, pastKvLength), [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
-                    ]);
-
-                    float[] stepLogits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
-                    float[] stepPresentKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
-                    float[] stepPresentValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
-                    for (int b = 0; b < take; b++)
-                        activeMask[b] = !unifiedSeqDone[b];
-
-                    for (int b = 0; b < take; b++)
-                    {
-                        int token = ArgMaxSpan(stepLogits.AsSpan(b * unifiedVocabSize, unifiedVocabSize), out float logprob);
-                        if (!activeMask[b])
-                            continue;
-
-                        nextTokens[b] = token;
-                        unifiedSeqTokens[b].Add(token);
-                        unifiedSeqLogprobs[b].Add(logprob);
-                        if (IsEos(token))
-                            unifiedSeqDone[b] = true;
-                    }
-
-                    CompactStepKvInto(
-                        stepPresentKeys,
-                        stepPresentValues,
-                        pastLengths,
-                        activeMask,
-                        take,
-                        nextKeysBuffer,
-                        nextValuesBuffer,
-                        nextLengths);
-
-                    (pastKeys, nextKeysBuffer) = (nextKeysBuffer, pastKeys);
-                    (pastValues, nextValuesBuffer) = (nextValuesBuffer, pastValues);
-                    (pastLengths, nextLengths) = (nextLengths, pastLengths);
-                }
-
-                for (int b = 0; b < take; b++)
-                {
-                    var (textTokens, textLogprobs2) = ExtractTextTokens(unifiedSeqTokens[b], unifiedSeqLogprobs[b]);
-                    string rawText = DecodeTokens(textTokens);
-                    var parsed = ParseMetadataPrefix(rawText);
-                    yield return new QwenRecognitionResult(
-                        batch[b].SegId, parsed.Text, unifiedSeqTokens[b], textTokens, textLogprobs2, parsed.Language, rawText);
-                }
-
-                continue;
-            }
+            // ── Batched prefill (split decoder_init_batched path) ───────────
 
             List<int> prompt    = BuildPromptIds(maxAudioTokens);
             int       audioOffset = GetAudioPadStart(prompt);
@@ -981,22 +1088,7 @@ public sealed class Qwen3Asr : IDisposable
         return mask;
     }
 
-    private void CompactPrefillKvInto(float[] present, int[] seqLengths, int batchSize, float[] target)
-    {
-        int maxSeqLen = seqLengths.Max();
-        Array.Clear(target, 0, _nLayers * batchSize * _nKvHeads * maxSeqLen * _headDim);
-
-        for (int layer = 0; layer < _nLayers; layer++)
-        for (int b = 0; b < batchSize; b++)
-        for (int head = 0; head < _nKvHeads; head++)
-        {
-            int validLen = seqLengths[b];
-            int sourceBase = (((layer * batchSize + b) * _nKvHeads + head) * maxSeqLen) * _headDim;
-            int destBase = sourceBase;
-            Array.Copy(present, sourceBase, target, destBase, validLen * _headDim);
-        }
-    }
-
+    // Used by the fixed-batch RecognizeBatchedDetailed path to compact step KV after each decode step.
     private void CompactStepKvInto(
         float[] presentKeys,
         float[] presentValues,
@@ -1007,14 +1099,14 @@ public sealed class Qwen3Asr : IDisposable
         float[] nextValues,
         int[] nextLengths)
     {
-        int appendIndex = pastLengths.Max();
+        int appendIndex = MaxPrefix(pastLengths, batchSize);
         Array.Copy(pastLengths, nextLengths, batchSize);
         for (int b = 0; b < batchSize; b++)
             if (activeMask[b])
                 nextLengths[b]++;
 
-        int maxNextLen = nextLengths.Max();
-        Array.Clear(nextKeys, 0, _nLayers * batchSize * _nKvHeads * maxNextLen * _headDim);
+        int maxNextLen = MaxPrefix(nextLengths, batchSize);
+        Array.Clear(nextKeys,   0, _nLayers * batchSize * _nKvHeads * maxNextLen * _headDim);
         Array.Clear(nextValues, 0, _nLayers * batchSize * _nKvHeads * maxNextLen * _headDim);
 
         for (int layer = 0; layer < _nLayers; layer++)
@@ -1023,38 +1115,85 @@ public sealed class Qwen3Asr : IDisposable
         {
             int sourceStride = appendIndex + 1;
             int sourceBase = (((layer * batchSize + b) * _nKvHeads + head) * sourceStride) * _headDim;
-            int destBase = (((layer * batchSize + b) * _nKvHeads + head) * maxNextLen) * _headDim;
+            int destBase   = (((layer * batchSize + b) * _nKvHeads + head) * maxNextLen)   * _headDim;
             int validPastLen = pastLengths[b];
 
             if (validPastLen > 0)
             {
-                Array.Copy(presentKeys, sourceBase, nextKeys, destBase, validPastLen * _headDim);
+                Array.Copy(presentKeys,   sourceBase, nextKeys,   destBase, validPastLen * _headDim);
                 Array.Copy(presentValues, sourceBase, nextValues, destBase, validPastLen * _headDim);
             }
 
             if (activeMask[b])
             {
-                Array.Copy(
-                    presentKeys,
-                    sourceBase + appendIndex * _headDim,
-                    nextKeys,
-                    destBase + validPastLen * _headDim,
-                    _headDim);
-                Array.Copy(
-                    presentValues,
-                    sourceBase + appendIndex * _headDim,
-                    nextValues,
-                    destBase + validPastLen * _headDim,
-                    _headDim);
+                Array.Copy(presentKeys,   sourceBase + appendIndex * _headDim, nextKeys,   destBase + validPastLen * _headDim, _headDim);
+                Array.Copy(presentValues, sourceBase + appendIndex * _headDim, nextValues, destBase + validPastLen * _headDim, _headDim);
             }
         }
     }
 
-    private static void BuildBatchStepAttentionMaskInto(float[] buffer, int usedLength, int[] pastLengths, int maxPastLen)
+    // Copies active-slot KV from stable slot storage into a contiguous batch buffer for the decoder.
+    // slotKv:  [nLayers, slotCapacity, nKvHeads, maxKvSeqCapacity, headDim]
+    // batchKv: [nLayers, activeCount,  nKvHeads, maxPastLen,       headDim]
+    private void PackKvForDecode(
+        float[] slotKv,
+        int slotCapacity,
+        int maxKvSeqCapacity,
+        int[] activeToSlot,
+        int[] batchPastLens,
+        int activeCount,
+        int maxPastLen,
+        float[] batchKv)
+    {
+        for (int layer = 0; layer < _nLayers; layer++)
+        for (int b = 0; b < activeCount; b++)
+        {
+            int slot     = activeToSlot[b];
+            int validLen = batchPastLens[b];
+            for (int head = 0; head < _nKvHeads; head++)
+            {
+                int srcBase = (((layer * slotCapacity + slot) * _nKvHeads + head) * maxKvSeqCapacity) * _headDim;
+                int dstBase = (((layer * activeCount  + b)    * _nKvHeads + head) * maxPastLen)        * _headDim;
+                Array.Copy(slotKv, srcBase, batchKv, dstBase, validLen * _headDim);
+                if (validLen < maxPastLen)
+                    Array.Clear(batchKv, dstBase + validLen * _headDim, (maxPastLen - validLen) * _headDim);
+            }
+        }
+    }
+
+    // Appends the newly decoded token's KV (at position maxPastLen in present_kv) back to slot storage.
+    // presentKv: [nLayers, activeCount, nKvHeads, maxPastLen+1, headDim] (decoder output)
+    // slotKv:    [nLayers, slotCapacity, nKvHeads, maxKvSeqCapacity, headDim]
+    private void AppendTokenKvToSlots(
+        ReadOnlySpan<float> presentKv,
+        int activeCount,
+        int maxPastLen,
+        int[] activeToSlot,
+        int[] batchPastLens,
+        float[] slotKv,
+        int slotCapacity,
+        int maxKvSeqCapacity)
+    {
+        int presentSeqLen = maxPastLen + 1;
+        for (int layer = 0; layer < _nLayers; layer++)
+        for (int b = 0; b < activeCount; b++)
+        {
+            int slot     = activeToSlot[b];
+            int insertAt = batchPastLens[b]; // slot's past length before this token
+            for (int head = 0; head < _nKvHeads; head++)
+            {
+                int srcBase = (((layer * activeCount + b) * _nKvHeads + head) * presentSeqLen + maxPastLen) * _headDim;
+                int dstBase = (((layer * slotCapacity + slot) * _nKvHeads + head) * maxKvSeqCapacity + insertAt) * _headDim;
+                presentKv.Slice(srcBase, _headDim).CopyTo(slotKv.AsSpan(dstBase, _headDim));
+            }
+        }
+    }
+
+    private static void BuildBatchStepAttentionMaskInto(float[] buffer, int usedLength, int[] pastLengths, int count, int maxPastLen)
     {
         Array.Fill(buffer, float.MinValue, 0, usedLength);
 
-        for (int b = 0; b < pastLengths.Length; b++)
+        for (int b = 0; b < count; b++)
         {
             int offset = b * (maxPastLen + 1);
             for (int k = 0; k < pastLengths[b]; k++)
@@ -1063,7 +1202,111 @@ public sealed class Qwen3Asr : IDisposable
         }
     }
 
-    private int ArgMaxSpan(Span<float> logits, out float logprob)
+    private void AdmitUnifiedDecodeSlots(
+        IReadOnlyList<QwenEncodedItem> encodedItems,
+        int startIndex,
+        int admitCount,
+        int[] targetSlots,
+        int slotCapacity,
+        int maxKvSeqCapacity,
+        int maxNewTokens,
+        float[] pastKeys,
+        float[] pastValues,
+        int[] pastLengths,
+        int[] slotSegIds,
+        int[] slotNextTokens,
+        bool[] slotDone,
+        List<int>?[] slotRawTokens,
+        List<float>?[] slotRawLogprobs)
+    {
+        int maxAudioTokens = 0;
+        for (int i = 0; i < admitCount; i++)
+            maxAudioTokens = Math.Max(maxAudioTokens, encodedItems[startIndex + i].AudioTokenCount);
+
+        float[] audioFeatures = new float[admitCount * maxAudioTokens * _hiddenSize];
+        long[] audioLengths = new long[admitCount];
+        for (int i = 0; i < admitCount; i++)
+        {
+            var item = encodedItems[startIndex + i];
+            audioLengths[i] = item.AudioTokenCount;
+            for (int t = 0; t < item.AudioTokenCount; t++)
+            {
+                Array.Copy(
+                    item.AudioFeatures,
+                    t * _hiddenSize,
+                    audioFeatures,
+                    (i * maxAudioTokens + t) * _hiddenSize,
+                    _hiddenSize);
+            }
+        }
+
+        var (inputEmbeds, positionIds, prefillMask, seqLengths) =
+            BuildUnifiedBatchPrefillInputs(audioFeatures, audioLengths, admitCount, maxAudioTokens);
+
+        float[] emptyKv = [];
+        using var initResults = _decoder!.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(inputEmbeds, [admitCount, seqLengths.Max(), _hiddenSize])),
+            NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(positionIds,   [admitCount, seqLengths.Max()])),
+            NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(prefillMask,  [admitCount, 1, seqLengths.Max(), seqLengths.Max()])),
+            NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(emptyKv,      [_nLayers, admitCount, _nKvHeads, 0, _headDim])),
+            NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(emptyKv,      [_nLayers, admitCount, _nKvHeads, 0, _headDim])),
+        ]);
+
+        float[] batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
+        float[] presentKeys = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
+        float[] presentValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
+        int vocabSize = batchedLogits.Length / (admitCount * seqLengths.Max());
+
+        for (int i = 0; i < admitCount; i++)
+        {
+            int slot = targetSlots[i];
+            var item = encodedItems[startIndex + i];
+            slotSegIds[slot] = item.SegId;
+            slotRawTokens[slot] = new List<int>(maxNewTokens);
+            slotRawLogprobs[slot] = new List<float>(maxNewTokens);
+            int logitOffset = i * seqLengths.Max() * vocabSize + (seqLengths[i] - 1) * vocabSize;
+            int firstToken = ArgMaxSpan(batchedLogits.AsSpan(logitOffset, vocabSize), out float firstLogprob);
+            slotNextTokens[slot] = firstToken;
+            slotRawTokens[slot]!.Add(firstToken);
+            slotRawLogprobs[slot]!.Add(firstLogprob);
+            slotDone[slot] = IsEos(firstToken) || slotRawTokens[slot]!.Count >= maxNewTokens;
+            pastLengths[slot] = seqLengths[i];
+            CopyPrefillKvToSlot(presentKeys, admitCount, seqLengths.Max(), i, pastKeys, slotCapacity, maxKvSeqCapacity, slot, seqLengths[i]);
+            CopyPrefillKvToSlot(presentValues, admitCount, seqLengths.Max(), i, pastValues, slotCapacity, maxKvSeqCapacity, slot, seqLengths[i]);
+        }
+    }
+
+    private void CopyPrefillKvToSlot(
+        float[] source,
+        int batchSize,
+        int sourceSeqLen,
+        int batchIndex,
+        float[] target,
+        int slotCapacity,
+        int targetSeqCapacity,
+        int slotIndex,
+        int validLen)
+    {
+        for (int layer = 0; layer < _nLayers; layer++)
+        for (int head = 0; head < _nKvHeads; head++)
+        {
+            int sourceBase = (((layer * batchSize + batchIndex) * _nKvHeads + head) * sourceSeqLen) * _headDim;
+            int targetBase = (((layer * slotCapacity + slotIndex) * _nKvHeads + head) * targetSeqCapacity) * _headDim;
+            Array.Clear(target, targetBase, targetSeqCapacity * _headDim);
+            Array.Copy(source, sourceBase, target, targetBase, validLen * _headDim);
+        }
+    }
+
+    private static int MaxPrefix(int[] values, int count)
+    {
+        int max = 0;
+        for (int i = 0; i < count; i++)
+            max = Math.Max(max, values[i]);
+        return max;
+    }
+
+    private int ArgMaxSpan(ReadOnlySpan<float> logits, out float logprob)
     {
         int   best    = 0;
         float bestVal = float.NegativeInfinity;
@@ -1977,6 +2220,12 @@ internal sealed record QwenPreparedSegment(
     double DurationSeconds,
     float[] Mel,
     int MelFrames);
+
+internal sealed record QwenEncodedItem(
+    int SegId,
+    int DurationSamples,
+    float[] AudioFeatures,
+    int AudioTokenCount);
 
 internal sealed record QwenBatchedItem(
     int SegId,

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -1,6 +1,8 @@
 using System.IO.MemoryMappedFiles;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Diagnostics;
 using MathNet.Numerics;
 using MathNet.Numerics.IntegralTransforms;
 using Microsoft.ML.OnnxRuntime;
@@ -24,7 +26,9 @@ namespace Vernacula.Base;
 public sealed class Qwen3Asr : IDisposable
 {
     public const string EncoderFile = "encoder.onnx";
+    public const string EncoderBatchedFile = "encoder_batched.onnx";
     public const string DecoderInitFile = "decoder_init.onnx";
+    public const string DecoderInitBatchedFile = "decoder_init_batched.onnx";
     public const string DecoderStepFile = "decoder_step.onnx";
     public const string EmbedTokensFile = "embed_tokens.bin";
     public const string TokenizerFile = "tokenizer.json";
@@ -46,14 +50,89 @@ public sealed class Qwen3Asr : IDisposable
     private const int SystemTokenId = 9125;
     private const int UserTokenId = 882;
     private const int AssistantTokenId = 77091;
+    private const string LanguagePrefix = "language ";
+    private const long BatchSizingReferenceFreeVramMb = 22_800;
+    private const double BatchSizingReferenceTotalSecondsCeiling = 192.0;
 
     private static readonly float[,] MelFilterbank = CreateMelFilterbank();
     private static readonly double[] HannWindow = Window.HannPeriodic(NFft);
+    private static readonly (double MaxSegmentSeconds, int ReferenceBatchCap)[] ExperimentalBatchFrontier =
+    [
+        (20.0, 10),
+        (24.0, 9),
+        (28.0, 8),
+        (32.0, 7),
+        (double.PositiveInfinity, 6),
+    ];
+    private static readonly string[] SpokenLanguageNames =
+    [
+        "Afrikaans",
+        "Arabic",
+        "Armenian",
+        "Azerbaijani",
+        "Belarusian",
+        "Bosnian",
+        "Bulgarian",
+        "Catalan",
+        "Chinese",
+        "Croatian",
+        "Czech",
+        "Danish",
+        "Dutch",
+        "English",
+        "Estonian",
+        "Finnish",
+        "French",
+        "Galician",
+        "German",
+        "Greek",
+        "Hebrew",
+        "Hindi",
+        "Hungarian",
+        "Icelandic",
+        "Indonesian",
+        "Italian",
+        "Japanese",
+        "Kannada",
+        "Kazakh",
+        "Korean",
+        "Latvian",
+        "Lithuanian",
+        "Macedonian",
+        "Malay",
+        "Marathi",
+        "Nepali",
+        "Norwegian",
+        "Persian",
+        "Polish",
+        "Portuguese",
+        "Romanian",
+        "Russian",
+        "Serbian",
+        "Slovak",
+        "Slovenian",
+        "Spanish",
+        "Swahili",
+        "Swedish",
+        "Tagalog",
+        "Tamil",
+        "Thai",
+        "Turkish",
+        "Ukrainian",
+        "Urdu",
+        "Vietnamese",
+        "Welsh",
+    ];
 
     private readonly InferenceSession _encoder;
     private readonly InferenceSession _decoderInit;
     private readonly InferenceSession _decoderStep;
+    private readonly InferenceSession? _encoderBatched;
+    private readonly InferenceSession? _decoderInitBatched;
     private readonly bool _useCudaIoBinding;
+    private readonly bool _preferBatched;
+    private readonly string _modelPath;
+    private readonly ExecutionProvider _executionProvider;
     private readonly int _hiddenSize;
     private readonly int _vocabSize;
     private readonly int _baseVocabSize;
@@ -65,8 +144,10 @@ public sealed class Qwen3Asr : IDisposable
     private readonly Dictionary<int, string> _addedTokenContent;
     private readonly Dictionary<char, byte> _byteLevelDecode;
 
-    public Qwen3Asr(string modelPath, ExecutionProvider ep = ExecutionProvider.Auto)
+    public Qwen3Asr(string modelPath, ExecutionProvider ep = ExecutionProvider.Auto, bool preferBatched = false)
     {
+        _modelPath = modelPath;
+        _executionProvider = ep;
         string configJson = File.ReadAllText(Path.Combine(modelPath, ConfigFile));
         using var configDoc = JsonDocument.Parse(configJson);
         var root = configDoc.RootElement;
@@ -81,10 +162,28 @@ public sealed class Qwen3Asr : IDisposable
 
         var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool encoderUsesCuda);
         var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool decoderUsesCuda);
-        _useCudaIoBinding = encoderUsesCuda && decoderUsesCuda;
 
-        _encoder = new InferenceSession(Path.Combine(modelPath, EncoderFile), encoderOpts);
-        _decoderInit = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), decoderOpts);
+        bool hasBatchedFiles = File.Exists(Path.Combine(modelPath, EncoderBatchedFile)) &&
+                               File.Exists(Path.Combine(modelPath, DecoderInitBatchedFile));
+        _preferBatched = preferBatched && hasBatchedFiles;
+
+        if (_preferBatched)
+        {
+            // Load only batched encoder + decoder_init + shared decoder_step.
+            // Skipping serial encoder/decoder_init avoids peak VRAM from 5 → 3 sessions.
+            _encoder      = null!;
+            _decoderInit  = null!;
+            _encoderBatched      = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile),      encoderOpts);
+            _decoderInitBatched  = new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile),  decoderOpts);
+            _useCudaIoBinding    = false;
+        }
+        else
+        {
+            _encoder     = new InferenceSession(Path.Combine(modelPath, EncoderFile),     encoderOpts);
+            _decoderInit = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), decoderOpts);
+            _useCudaIoBinding = encoderUsesCuda && decoderUsesCuda;
+        }
+
         _decoderStep = new InferenceSession(Path.Combine(modelPath, DecoderStepFile), decoderOpts);
 
         string embedPath = Path.Combine(modelPath, EmbedTokensFile);
@@ -93,6 +192,97 @@ public sealed class Qwen3Asr : IDisposable
 
         (_idToToken, _addedTokenContent) = LoadTokenizerVocab(Path.Combine(modelPath, TokenizerFile));
         _byteLevelDecode = BuildByteLevelDecode();
+    }
+
+    /// <summary>
+    /// Compute a conservative experimental GPU batching plan for the batched
+    /// Qwen3-ASR encoder + decoder-prefill path. The current heuristic is based
+    /// on CUDA sweep data from a 24 GB RTX 3090 with about 22.8 GB free VRAM
+    /// after the model package is loaded.
+    /// </summary>
+    public static QwenBatchingPlan ComputeExperimentalBatchingPlan(
+        IReadOnlyList<double> segmentDurationsSeconds,
+        long freeGpuMemoryMb)
+    {
+        if (segmentDurationsSeconds.Count == 0)
+            return new QwenBatchingPlan(0, 0, 0, 0, 0, freeGpuMemoryMb, 0);
+
+        double maxSegmentSeconds = 0;
+        foreach (double seconds in segmentDurationsSeconds)
+            maxSegmentSeconds = Math.Max(maxSegmentSeconds, Math.Max(0, seconds));
+
+        int batchCap = EstimateExperimentalBatchCap(maxSegmentSeconds, freeGpuMemoryMb);
+        double totalSecondsCeiling = EstimateExperimentalTotalSecondsCeiling(freeGpuMemoryMb);
+        double totalSeconds = 0;
+        int batchCount = 0;
+
+        foreach (double rawSeconds in segmentDurationsSeconds)
+        {
+            double seconds = Math.Max(0, rawSeconds);
+            if (batchCount >= batchCap)
+                break;
+
+            double projectedTotal = totalSeconds + seconds;
+            if (batchCount > 0 && projectedTotal > totalSecondsCeiling)
+                break;
+
+            batchCount++;
+            totalSeconds = projectedTotal;
+        }
+
+        if (batchCount == 0)
+        {
+            batchCount = 1;
+            totalSeconds = Math.Max(0, segmentDurationsSeconds[0]);
+        }
+
+        double scale = freeGpuMemoryMb > 0
+            ? freeGpuMemoryMb / (double)BatchSizingReferenceFreeVramMb
+            : 0.0;
+
+        return new QwenBatchingPlan(
+            batchCount,
+            batchCap,
+            totalSeconds,
+            totalSecondsCeiling,
+            maxSegmentSeconds,
+            freeGpuMemoryMb,
+            scale);
+    }
+
+    /// <summary>
+    /// Estimate the experimental total audio-seconds ceiling for one GPU batch.
+    /// </summary>
+    public static double EstimateExperimentalTotalSecondsCeiling(long freeGpuMemoryMb)
+    {
+        if (freeGpuMemoryMb <= 0)
+            return BatchSizingReferenceTotalSecondsCeiling;
+
+        double scale = freeGpuMemoryMb / (double)BatchSizingReferenceFreeVramMb;
+        return Math.Max(1.0, Math.Floor(BatchSizingReferenceTotalSecondsCeiling * scale));
+    }
+
+    /// <summary>
+    /// Estimate the experimental batch cap from the longest segment in the batch
+    /// and the current free GPU memory.
+    /// </summary>
+    public static int EstimateExperimentalBatchCap(double maxSegmentSeconds, long freeGpuMemoryMb)
+    {
+        int referenceCap = ExperimentalBatchFrontier[^1].ReferenceBatchCap;
+        foreach (var entry in ExperimentalBatchFrontier)
+        {
+            if (maxSegmentSeconds <= entry.MaxSegmentSeconds)
+            {
+                referenceCap = entry.ReferenceBatchCap;
+                break;
+            }
+        }
+
+        if (freeGpuMemoryMb <= 0)
+            return 1;
+
+        double scale = freeGpuMemoryMb / (double)BatchSizingReferenceFreeVramMb;
+        return Math.Max(1, (int)Math.Floor(referenceCap * scale));
     }
 
     public IEnumerable<(int segId, string text)> Recognize(
@@ -109,6 +299,10 @@ public sealed class Qwen3Asr : IDisposable
         float[] audio,
         int maxNewTokens = 256)
     {
+        if (_encoder is null)
+            throw new InvalidOperationException(
+                "Serial encoder sessions are not loaded. Construct with preferBatched:false or call RecognizeBatchedDetailed.");
+
         for (int segId = 0; segId < segs.Count; segId++)
         {
             var (start, end, _) = segs[segId];
@@ -116,7 +310,7 @@ public sealed class Qwen3Asr : IDisposable
             int endSample = Math.Clamp((int)Math.Round(end * SampleRate), 0, audio.Length);
             if (endSample <= startSample)
             {
-                yield return new QwenRecognitionResult(segId, "", [], [], []);
+                yield return new QwenRecognitionResult(segId, "", [], [], [], null, "");
                 continue;
             }
 
@@ -132,8 +326,16 @@ public sealed class Qwen3Asr : IDisposable
                 : DecodeOnCpu(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens);
 
             var (textTokens, textLogprobs) = ExtractTextTokens(rawTokens, rawLogprobs);
-            string text = DecodeTokens(textTokens);
-            yield return new QwenRecognitionResult(segId, text, rawTokens, textTokens, textLogprobs);
+            string rawText = DecodeTokens(textTokens);
+            var parsed = ParseMetadataPrefix(rawText);
+            yield return new QwenRecognitionResult(
+                segId,
+                parsed.Text,
+                rawTokens,
+                textTokens,
+                textLogprobs,
+                parsed.Language,
+                rawText);
         }
     }
 
@@ -184,6 +386,449 @@ public sealed class Qwen3Asr : IDisposable
         var features = results.First(r => r.Name == "audio_features").AsTensor<float>();
         audioTokenCount = features.Dimensions[1];
         return ExtractTensor(features);
+    }
+
+    private static float[] RunEncoderSession(
+        InferenceSession encoder,
+        float[] mel,
+        int melFrames,
+        out int audioTokenCount)
+    {
+        using var results = encoder.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("mel", new DenseTensor<float>(mel, [1, NMels, melFrames])),
+        ]);
+
+        var features = results.First(r => r.Name == "audio_features").AsTensor<float>();
+        audioTokenCount = features.Dimensions[1];
+        return ExtractTensor(features);
+    }
+
+    private void RunDecoderPrefill(IReadOnlyList<int> promptIds, int audioOffset, float[] audioFeatures, int audioTokenCount)
+    {
+        long[] inputIds = promptIds.Select(i => (long)i).ToArray();
+        long[] positionIds = Enumerable.Range(0, promptIds.Count).Select(i => (long)i).ToArray();
+        long[] audioOffsetTensor = [audioOffset];
+
+        using var initOutputs = _decoderInit.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(inputIds, [1, inputIds.Length])),
+            NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(positionIds, [1, positionIds.Length])),
+            NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures, [1, audioTokenCount, _hiddenSize])),
+            NamedOnnxValue.CreateFromTensor("audio_offset", new DenseTensor<long>(audioOffsetTensor, [1])),
+        ]);
+    }
+
+    private static void RunDecoderPrefillSession(
+        InferenceSession decoderInit,
+        int hiddenSize,
+        IReadOnlyList<int> promptIds,
+        int audioOffset,
+        float[] audioFeatures,
+        int audioTokenCount)
+    {
+        long[] inputIds = promptIds.Select(i => (long)i).ToArray();
+        long[] positionIds = Enumerable.Range(0, promptIds.Count).Select(i => (long)i).ToArray();
+        long[] audioOffsetTensor = [audioOffset];
+
+        using var initOutputs = decoderInit.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(inputIds, [1, inputIds.Length])),
+            NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(positionIds, [1, positionIds.Length])),
+            NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures, [1, audioTokenCount, hiddenSize])),
+            NamedOnnxValue.CreateFromTensor("audio_offset", new DenseTensor<long>(audioOffsetTensor, [1])),
+        ]);
+    }
+
+    /// <summary>
+    /// Batched encoder + decoder-prefill recognition. When batching artifacts are
+    /// present this runs all segments through encoder_batched.onnx and
+    /// decoder_init_batched.onnx in groups, then decodes each segment's token
+    /// stream serially using decoder_step.onnx. Falls back to serial
+    /// RecognizeDetailed when the batched sessions are not loaded.
+    /// </summary>
+    public IEnumerable<QwenRecognitionResult> RecognizeBatchedDetailed(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio,
+        int maxNewTokens = 256)
+    {
+        if (_encoderBatched is null || _decoderInitBatched is null)
+        {
+            foreach (var r in RecognizeDetailed(segs, audio, maxNewTokens))
+                yield return r;
+            yield break;
+        }
+
+        // Prepare all segments: compute mel spectrograms (parallel inside ComputeLogMelSpectrogram)
+        var prepared = new List<QwenBatchedItem>(segs.Count);
+        for (int segId = 0; segId < segs.Count; segId++)
+        {
+            var (start, end, _) = segs[segId];
+            int startSample = Math.Clamp((int)Math.Round(start * SampleRate), 0, audio.Length);
+            int endSample   = Math.Clamp((int)Math.Round(end   * SampleRate), 0, audio.Length);
+            if (endSample <= startSample)
+            {
+                prepared.Add(new QwenBatchedItem(segId, 0, null, 0));
+                continue;
+            }
+            float[] mel = ComputeLogMelSpectrogram(audio, startSample, endSample - startSample, out int melFrames);
+            prepared.Add(new QwenBatchedItem(segId, endSample - startSample, mel, melFrames));
+        }
+
+        foreach (var item in prepared.Where(it => it.Mel is null))
+            yield return new QwenRecognitionResult(item.SegId, "", [], [], [], null, "");
+
+        // Sort by duration descending for optimal GPU batching
+        var validItems = prepared
+            .Where(it => it.Mel is not null)
+            .OrderByDescending(it => it.DurationSamples)
+            .ToList();
+
+        var (totalGpuMb, freeGpuMb) = HardwareInfo.GetGpuMemoryMb();
+        // NVML may return 0 if the library is unavailable; fall back to a conservative 8 GB estimate
+        // so batch sizing still works rather than clamping to 1.
+        const long FallbackFreeVramMb = 8_000;
+        long freeGpuMemoryMb = freeGpuMb > 0 ? freeGpuMb : FallbackFreeVramMb;
+        Console.Error.WriteLine($"[Qwen3Asr] GPU memory: total={totalGpuMb} MB, free={freeGpuMb} MB (effective={freeGpuMemoryMb} MB)");
+        int index = 0;
+
+        while (index < validItems.Count)
+        {
+            var remainingDurations = validItems
+                .Skip(index)
+                .Select(it => it.DurationSamples / (double)SampleRate)
+                .ToList();
+            var plan = ComputeExperimentalBatchingPlan(remainingDurations, freeGpuMemoryMb);
+            int take  = Math.Min(plan.BatchCount, validItems.Count - index);
+            var batch = validItems.GetRange(index, take);
+            index += take;
+
+            // ── Batched encoder ──────────────────────────────────────────────
+            int maxMelFrames = batch.Max(it => it.MelFrames);
+            var melBatch     = new float[take * NMels * maxMelFrames];
+            var inputLengths = new long[take];
+            for (int b = 0; b < take; b++)
+            {
+                inputLengths[b] = batch[b].MelFrames;
+                Array.Copy(batch[b].Mel!, 0, melBatch, b * NMels * maxMelFrames, batch[b].Mel!.Length);
+            }
+
+            using var encoderResults = _encoderBatched.Run(
+            [
+                NamedOnnxValue.CreateFromTensor("mel",          new DenseTensor<float>(melBatch,     [take, NMels, maxMelFrames])),
+                NamedOnnxValue.CreateFromTensor("input_lengths", new DenseTensor<long>(inputLengths, [take])),
+            ]);
+
+            var audioFeaturesTensor = encoderResults.First(r => r.Name == "audio_features").AsTensor<float>();
+            var audioLengthsTensor  = encoderResults.First(r => r.Name == "audio_feature_lengths").AsTensor<long>();
+            int  maxAudioTokens     = (int)audioLengthsTensor.Max();
+            long[] audioLengths     = [.. audioLengthsTensor];
+
+            // Rearrange: [take, sourceTokens, hidden] → [take, maxAudioTokens, hidden]
+            float[] audioFeaturesSource     = ExtractTensor(audioFeaturesTensor);
+            int     sourceTokensPerBatch    = audioFeaturesTensor.Dimensions[1];
+            float[] audioFeatures           = new float[take * maxAudioTokens * _hiddenSize];
+            for (int b = 0; b < take; b++)
+            for (int t = 0; t < maxAudioTokens; t++)
+            {
+                int srcBase = (b * sourceTokensPerBatch + t) * _hiddenSize;
+                int dstBase = (b * maxAudioTokens      + t) * _hiddenSize;
+                Array.Copy(audioFeaturesSource, srcBase, audioFeatures, dstBase, _hiddenSize);
+            }
+
+            // ── Batched decoder_init ─────────────────────────────────────────
+            List<int> prompt   = BuildPromptIds(maxAudioTokens);
+            int       audioOffset = GetAudioPadStart(prompt);
+            int       seqLen   = prompt.Count;
+
+            var inputIds    = new long[take * seqLen];
+            var positionIds = new long[take * seqLen];
+            for (int b = 0; b < take; b++)
+            for (int t = 0; t < seqLen; t++)
+            {
+                inputIds   [b * seqLen + t] = prompt[t];
+                positionIds[b * seqLen + t] = t;
+            }
+
+            using var initResults = _decoderInitBatched.Run(
+            [
+                NamedOnnxValue.CreateFromTensor("input_ids",      new DenseTensor<long> (inputIds,     [take, seqLen])),
+                NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long> (positionIds,  [take, seqLen])),
+                NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures,[take, maxAudioTokens, _hiddenSize])),
+                NamedOnnxValue.CreateFromTensor("audio_lengths",  new DenseTensor<long> (audioLengths, [take])),
+                NamedOnnxValue.CreateFromTensor("audio_offset",   new DenseTensor<long> (new long[] { audioOffset }, [1])),
+            ]);
+
+            float[] batchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
+            float[] batchedKeys   = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
+            float[] batchedValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
+
+            int vocabSize      = batchedLogits.Length / (take * seqLen);
+            const int NLayers  = 28;
+            const int NKvHeads = 8;
+            const int HdDim    = 128;
+
+            // Extract first token per sequence from batched prefill logits
+            var seqTokens    = new List<int>  [take];
+            var seqLogprobs  = new List<float>[take];
+            var seqDone      = new bool[take];
+            var seqNextToken = new int[take];
+
+            for (int b = 0; b < take; b++)
+            {
+                seqTokens[b]   = new List<int>  (maxNewTokens);
+                seqLogprobs[b] = new List<float>(maxNewTokens);
+                int logitOffset = b * seqLen * vocabSize + (seqLen - 1) * vocabSize;
+                int firstToken  = ArgMaxSpan(batchedLogits.AsSpan(logitOffset, vocabSize), out float firstLogprob);
+                seqTokens[b].Add(firstToken);
+                seqLogprobs[b].Add(firstLogprob);
+                seqNextToken[b] = firstToken;
+                seqDone[b]      = IsEos(firstToken);
+            }
+
+            // ── Joint batched autoregressive decode ──────────────────────────
+            // All sequences share the same pastSeqLen (same prefill prompt length),
+            // so their KV caches stay in lockstep — no slicing needed.
+            float[] pastKeys   = batchedKeys;
+            float[] pastValues = batchedValues;
+            int pastSeqLen     = seqLen;
+
+            var batchEmbeds = new float[take * _hiddenSize];
+            var stepPosArr  = new long[take];
+            var tmpEmbed    = new float[_hiddenSize];
+
+            for (int step = 0; step < maxNewTokens - 1; step++)
+            {
+                if (Array.TrueForAll(seqDone, d => d)) break;
+
+                long pos = seqLen + step;
+                for (int b = 0; b < take; b++)
+                {
+                    ReadTokenEmbedding(seqNextToken[b], tmpEmbed);
+                    Array.Copy(tmpEmbed, 0, batchEmbeds, b * _hiddenSize, _hiddenSize);
+                    stepPosArr[b] = pos;
+                }
+
+                using var stepOutputs = _decoderStep.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(batchEmbeds, [take, 1, _hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long> (stepPosArr,  [take, 1])),
+                    NamedOnnxValue.CreateFromTensor("past_keys",    new DenseTensor<float>(pastKeys,    [NLayers, take, NKvHeads, pastSeqLen, HdDim])),
+                    NamedOnnxValue.CreateFromTensor("past_values",  new DenseTensor<float>(pastValues,  [NLayers, take, NKvHeads, pastSeqLen, HdDim])),
+                ]);
+
+                float[] stepLogits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
+                pastKeys   = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+                pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+                pastSeqLen++;
+
+                int stepVocabSize = stepLogits.Length / take; // [take, 1, vocab] flat
+                for (int b = 0; b < take; b++)
+                {
+                    if (seqDone[b]) continue;
+                    int nextToken = ArgMaxSpan(stepLogits.AsSpan(b * stepVocabSize, stepVocabSize), out float logprob);
+                    seqNextToken[b] = nextToken;
+                    seqTokens[b].Add(nextToken);
+                    seqLogprobs[b].Add(logprob);
+                    seqDone[b] = IsEos(nextToken) || seqTokens[b].Count >= maxNewTokens;
+                }
+            }
+
+            // Yield results for this batch
+            for (int b = 0; b < take; b++)
+            {
+                var (textTokens, textLogprobs2) = ExtractTextTokens(seqTokens[b], seqLogprobs[b]);
+                string rawText = DecodeTokens(textTokens);
+                var parsed = ParseMetadataPrefix(rawText);
+                yield return new QwenRecognitionResult(
+                    batch[b].SegId, parsed.Text, seqTokens[b], textTokens, textLogprobs2, parsed.Language, rawText);
+            }
+        }
+    }
+
+    private int ArgMaxSpan(Span<float> logits, out float logprob)
+    {
+        int   best    = 0;
+        float bestVal = float.NegativeInfinity;
+        for (int i = 0; i < logits.Length; i++)
+            if (logits[i] > bestVal) { bestVal = logits[i]; best = i; }
+
+        double sumExp = 0;
+        for (int i = 0; i < logits.Length; i++)
+            sumExp += Math.Exp(logits[i] - bestVal);
+        logprob = (float)(-Math.Log(sumExp));
+        return best;
+    }
+
+    public bool HasExperimentalBatchingArtifacts()
+        => _encoderBatched is not null && _decoderInitBatched is not null;
+
+    public QwenExperimentalBatchBenchmark BenchmarkExperimentalBatching(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio)
+        => BenchmarkExperimentalBatching(_modelPath, _executionProvider, segs, audio);
+
+    public static QwenExperimentalBatchBenchmark BenchmarkExperimentalBatching(
+        string modelPath,
+        ExecutionProvider ep,
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio)
+    {
+        if (!File.Exists(Path.Combine(modelPath, EncoderBatchedFile)) ||
+            !File.Exists(Path.Combine(modelPath, DecoderInitBatchedFile)))
+            throw new FileNotFoundException("Experimental batching artifacts are missing.");
+
+        string configJson = File.ReadAllText(Path.Combine(modelPath, ConfigFile));
+        using var configDoc = JsonDocument.Parse(configJson);
+        int hiddenSize = configDoc.RootElement.GetProperty("decoder").GetProperty("hidden_size").GetInt32();
+
+        var prepared = new List<QwenPreparedSegment>(segs.Count);
+        foreach (var (start, end, _) in segs)
+        {
+            int startSample = Math.Clamp((int)Math.Round(start * SampleRate), 0, audio.Length);
+            int endSample = Math.Clamp((int)Math.Round(end * SampleRate), 0, audio.Length);
+            if (endSample <= startSample)
+                continue;
+
+            int length = endSample - startSample;
+            float[] mel = ComputeLogMelSpectrogram(audio, startSample, length, out int melFrames);
+            prepared.Add(new QwenPreparedSegment(length / (double)SampleRate, mel, melFrames));
+        }
+
+        if (prepared.Count == 0)
+            return new QwenExperimentalBatchBenchmark(0, 0, 0, 0, 0, [], 0, 0, 0);
+
+        double serialEncoderMs = 0;
+        double serialPrefillMs = 0;
+        {
+            var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
+            var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
+            using var encoder = new InferenceSession(Path.Combine(modelPath, EncoderFile), encoderOpts);
+            using var decoderInit = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), decoderOpts);
+            foreach (var segment in prepared)
+            {
+                var sw = Stopwatch.StartNew();
+                float[] audioFeatures = RunEncoderSession(encoder, segment.Mel, segment.MelFrames, out int audioTokenCount);
+                sw.Stop();
+                serialEncoderMs += sw.Elapsed.TotalMilliseconds;
+
+                List<int> promptIds = BuildPromptIds(audioTokenCount);
+                int audioOffset = GetAudioPadStart(promptIds);
+                sw.Restart();
+                RunDecoderPrefillSession(decoderInit, hiddenSize, promptIds, audioOffset, audioFeatures, audioTokenCount);
+                sw.Stop();
+                serialPrefillMs += sw.Elapsed.TotalMilliseconds;
+            }
+        }
+
+        var sorted = prepared.OrderByDescending(p => p.DurationSeconds).ToList();
+        var batchStats = new List<QwenExperimentalBatchBenchmarkBatch>();
+        double batchedEncoderMs = 0;
+        double batchedPrefillMs = 0;
+        {
+            var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
+            var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out _);
+            using var encoderBatched = new InferenceSession(Path.Combine(modelPath, EncoderBatchedFile), encoderOpts);
+            using var decoderInitBatched = new InferenceSession(Path.Combine(modelPath, DecoderInitBatchedFile), decoderOpts);
+            long freeGpuMemoryMb = HardwareInfo.GetGpuMemoryMb().FreeMb;
+
+            int index = 0;
+            while (index < sorted.Count)
+            {
+                var remainingDurations = sorted.Skip(index).Select(s => s.DurationSeconds).ToArray();
+                QwenBatchingPlan plan = ComputeExperimentalBatchingPlan(remainingDurations, freeGpuMemoryMb);
+                int take = Math.Min(plan.BatchCount, sorted.Count - index);
+                var batch = sorted.GetRange(index, take);
+                index += take;
+
+                int maxMelFrames = batch.Max(s => s.MelFrames);
+                float[] mel = new float[take * NMels * maxMelFrames];
+                long[] inputLengths = new long[take];
+                for (int batchIndex = 0; batchIndex < take; batchIndex++)
+                {
+                    var segment = batch[batchIndex];
+                    inputLengths[batchIndex] = segment.MelFrames;
+                    Array.Copy(segment.Mel, 0, mel, batchIndex * NMels * maxMelFrames, segment.Mel.Length);
+                }
+
+                var sw = Stopwatch.StartNew();
+                using var encoderResults = encoderBatched.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("mel", new DenseTensor<float>(mel, [take, NMels, maxMelFrames])),
+                    NamedOnnxValue.CreateFromTensor("input_lengths", new DenseTensor<long>(inputLengths, [take])),
+                ]);
+                sw.Stop();
+                double encoderMs = sw.Elapsed.TotalMilliseconds;
+                batchedEncoderMs += encoderMs;
+
+                var audioFeaturesTensor = encoderResults.First(r => r.Name == "audio_features").AsTensor<float>();
+                var audioLengthsTensor = encoderResults.First(r => r.Name == "audio_feature_lengths").AsTensor<long>();
+                int maxAudioTokens = (int)audioLengthsTensor.Max();
+                int seqLen = BuildPromptIds(maxAudioTokens).Count;
+                List<int> prompt = BuildPromptIds(maxAudioTokens);
+                int audioOffset = GetAudioPadStart(prompt);
+
+                long[] inputIds = new long[take * seqLen];
+                long[] positionIds = new long[take * seqLen];
+                for (int batchIndex = 0; batchIndex < take; batchIndex++)
+                {
+                    for (int tokenIndex = 0; tokenIndex < seqLen; tokenIndex++)
+                    {
+                        inputIds[batchIndex * seqLen + tokenIndex] = prompt[tokenIndex];
+                        positionIds[batchIndex * seqLen + tokenIndex] = tokenIndex;
+                    }
+                }
+
+                float[] audioFeaturesSource = ExtractTensor(audioFeaturesTensor);
+                float[] audioFeatures = new float[take * maxAudioTokens * hiddenSize];
+                int sourceTokensPerBatch = audioFeaturesTensor.Dimensions[1];
+                for (int batchIndex = 0; batchIndex < take; batchIndex++)
+                {
+                    for (int tokenIndex = 0; tokenIndex < maxAudioTokens; tokenIndex++)
+                    {
+                        int srcBase = ((batchIndex * sourceTokensPerBatch) + tokenIndex) * hiddenSize;
+                        int dstBase = ((batchIndex * maxAudioTokens) + tokenIndex) * hiddenSize;
+                        Array.Copy(audioFeaturesSource, srcBase, audioFeatures, dstBase, hiddenSize);
+                    }
+                }
+
+                long[] audioLengths = [.. audioLengthsTensor];
+                long[] audioOffsetTensor = [audioOffset];
+
+                sw.Restart();
+                using var decoderResults = decoderInitBatched.Run(
+                [
+                    NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(inputIds, [take, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(positionIds, [take, seqLen])),
+                    NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures, [take, maxAudioTokens, hiddenSize])),
+                    NamedOnnxValue.CreateFromTensor("audio_lengths", new DenseTensor<long>(audioLengths, [take])),
+                    NamedOnnxValue.CreateFromTensor("audio_offset", new DenseTensor<long>(audioOffsetTensor, [1])),
+                ]);
+                sw.Stop();
+                double prefillMs = sw.Elapsed.TotalMilliseconds;
+                batchedPrefillMs += prefillMs;
+
+                batchStats.Add(new QwenExperimentalBatchBenchmarkBatch(
+                    take,
+                    batch.Sum(s => s.DurationSeconds),
+                    batch.Max(s => s.DurationSeconds),
+                    plan.BatchCap,
+                    plan.TotalSecondsCeiling,
+                    encoderMs,
+                    prefillMs));
+            }
+
+            return new QwenExperimentalBatchBenchmark(
+                prepared.Count,
+                serialEncoderMs,
+                serialPrefillMs,
+                batchedEncoderMs,
+                batchedPrefillMs,
+                batchStats,
+                freeGpuMemoryMb,
+                EstimateExperimentalTotalSecondsCeiling(freeGpuMemoryMb),
+                batchStats.Count);
+        }
     }
 
     private (List<int> rawTokens, List<float> rawLogprobs) DecodeOnCpu(
@@ -417,6 +1062,30 @@ public sealed class Qwen3Asr : IDisposable
 
     private bool IsEos(int token) => _eosTokenIdSet.Contains(token);
 
+    private static QwenMetadataParseResult ParseMetadataPrefix(string text)
+    {
+        if (!text.StartsWith(LanguagePrefix, StringComparison.OrdinalIgnoreCase))
+            return new QwenMetadataParseResult(text, null);
+
+        string remainder = text[LanguagePrefix.Length..];
+        foreach (string language in SpokenLanguageNames.OrderByDescending(name => name.Length))
+        {
+            if (!remainder.StartsWith(language, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            string content = remainder[language.Length..].TrimStart();
+            return new QwenMetadataParseResult(content, language);
+        }
+
+        Match match = Regex.Match(remainder, @"^([A-Za-z][A-Za-z\-]+)\s*(.*)$");
+        if (!match.Success)
+            return new QwenMetadataParseResult(text, null);
+
+        string detectedLanguage = match.Groups[1].Value;
+        string strippedText = match.Groups[2].Value.TrimStart();
+        return new QwenMetadataParseResult(strippedText, detectedLanguage);
+    }
+
     private static List<int> BuildPromptIds(int audioTokenCount)
     {
         var ids = new List<int>(audioTokenCount + 16)
@@ -637,8 +1306,10 @@ public sealed class Qwen3Asr : IDisposable
         _embedAccessor.Dispose();
         _embedMmf.Dispose();
         _decoderStep.Dispose();
-        _decoderInit.Dispose();
-        _encoder.Dispose();
+        _decoderInitBatched?.Dispose();
+        _encoderBatched?.Dispose();
+        _decoderInit?.Dispose();
+        _encoder?.Dispose();
     }
 }
 
@@ -647,4 +1318,54 @@ public sealed record QwenRecognitionResult(
     string Text,
     IReadOnlyList<int> RawTokens,
     IReadOnlyList<int> TextTokens,
-    IReadOnlyList<float> TextLogprobs);
+    IReadOnlyList<float> TextLogprobs,
+    string? Language,
+    string RawText);
+
+/// <summary>
+/// Experimental GPU batching plan for the batched Qwen3-ASR encoder +
+/// decoder-prefill path.
+/// </summary>
+public readonly record struct QwenBatchingPlan(
+    int BatchCount,
+    int BatchCap,
+    double TotalSeconds,
+    double TotalSecondsCeiling,
+    double MaxSegmentSeconds,
+    long FreeGpuMemoryMb,
+    double Scale);
+
+public sealed record QwenExperimentalBatchBenchmark(
+    int SegmentCount,
+    double SerialEncoderMilliseconds,
+    double SerialPrefillMilliseconds,
+    double BatchedEncoderMilliseconds,
+    double BatchedPrefillMilliseconds,
+    IReadOnlyList<QwenExperimentalBatchBenchmarkBatch> Batches,
+    long FreeGpuMemoryMb,
+    double TotalSecondsCeiling,
+    int BatchRuns);
+
+public sealed record QwenExperimentalBatchBenchmarkBatch(
+    int SegmentCount,
+    double TotalSeconds,
+    double MaxSegmentSeconds,
+    int BatchCap,
+    double TotalSecondsCeiling,
+    double EncoderMilliseconds,
+    double PrefillMilliseconds);
+
+internal sealed record QwenMetadataParseResult(
+    string Text,
+    string? Language);
+
+internal sealed record QwenPreparedSegment(
+    double DurationSeconds,
+    float[] Mel,
+    int MelFrames);
+
+internal sealed record QwenBatchedItem(
+    int SegId,
+    int DurationSamples,
+    float[]? Mel,
+    int MelFrames);

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -605,9 +605,21 @@ public sealed class Qwen3Asr : IDisposable
                 float[] unifiedBatchedLogits = ExtractTensor(initResults.First(r => r.Name == "logits").AsTensor<float>());
                 float[] presentKeys = ExtractTensor(initResults.First(r => r.Name == "present_keys").AsTensor<float>());
                 float[] presentValues = ExtractTensor(initResults.First(r => r.Name == "present_values").AsTensor<float>());
-                float[] pastKeys = CompactPrefillKv(presentKeys, unifiedSeqLengths, take);
-                float[] pastValues = CompactPrefillKv(presentValues, unifiedSeqLengths, take);
+                int maxKvSeqCapacity = unifiedSeqLengths.Max() + maxNewTokens - 1;
+                int kvCapacity = _nLayers * take * _nKvHeads * maxKvSeqCapacity * _headDim;
+                float[] pastKeys = new float[kvCapacity];
+                float[] pastValues = new float[kvCapacity];
+                CompactPrefillKvInto(presentKeys, unifiedSeqLengths, take, pastKeys);
+                CompactPrefillKvInto(presentValues, unifiedSeqLengths, take, pastValues);
                 int[] pastLengths = [.. unifiedSeqLengths];
+                int[] nextLengths = new int[take];
+                bool[] activeMask = new bool[take];
+                float[] nextKeysBuffer = new float[kvCapacity];
+                float[] nextValuesBuffer = new float[kvCapacity];
+                float[] stepEmbeds = new float[take * _hiddenSize];
+                var tokenEmbed = new float[_hiddenSize];
+                long[] stepPos = new long[take];
+                float[] stepMaskBuffer = new float[take * (maxKvSeqCapacity + 1)];
 
                 int unifiedVocabSize = unifiedBatchedLogits.Length / (take * unifiedSeqLengths.Max());
                 var unifiedSeqTokens = new List<int>[take];
@@ -629,34 +641,32 @@ public sealed class Qwen3Asr : IDisposable
 
                 for (int step = 1; step < maxNewTokens && unifiedSeqDone.Any(done => !done); step++)
                 {
-                    float[] stepEmbeds = new float[take * _hiddenSize];
-                    var tokenEmbed = new float[_hiddenSize];
                     for (int b = 0; b < take; b++)
                     {
                         ReadTokenEmbedding(nextTokens[b], tokenEmbed);
                         Array.Copy(tokenEmbed, 0, stepEmbeds, b * _hiddenSize, _hiddenSize);
                     }
 
-                    long[] stepPos = new long[take];
                     for (int b = 0; b < take; b++)
                         stepPos[b] = pastLengths[b];
 
                     int maxPastLen = pastLengths.Max();
-                    float[] stepMask = BuildBatchStepAttentionMask(pastLengths, maxPastLen);
+                    int stepMaskLength = take * (maxPastLen + 1);
+                    BuildBatchStepAttentionMaskInto(stepMaskBuffer, stepMaskLength, pastLengths, maxPastLen);
+                    int pastKvLength = _nLayers * take * _nKvHeads * maxPastLen * _headDim;
 
                     using var stepOutputs = _decoder.Run(
                     [
                         NamedOnnxValue.CreateFromTensor("input_embeds",   new DenseTensor<float>(stepEmbeds, [take, 1, _hiddenSize])),
                         NamedOnnxValue.CreateFromTensor("position_ids",   new DenseTensor<long>(stepPos,     [take, 1])),
-                        NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(stepMask,   [take, 1, 1, maxPastLen + 1])),
-                        NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys,   [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
-                        NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues, [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
+                        NamedOnnxValue.CreateFromTensor("attention_mask", new DenseTensor<float>(stepMaskBuffer.AsMemory(0, stepMaskLength), [take, 1, 1, maxPastLen + 1])),
+                        NamedOnnxValue.CreateFromTensor("past_keys",      new DenseTensor<float>(pastKeys.AsMemory(0, pastKvLength),   [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
+                        NamedOnnxValue.CreateFromTensor("past_values",    new DenseTensor<float>(pastValues.AsMemory(0, pastKvLength), [_nLayers, take, _nKvHeads, maxPastLen, _headDim])),
                     ]);
 
                     float[] stepLogits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
                     float[] stepPresentKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
                     float[] stepPresentValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
-                    bool[] activeMask = new bool[take];
                     for (int b = 0; b < take; b++)
                         activeMask[b] = !unifiedSeqDone[b];
 
@@ -673,7 +683,19 @@ public sealed class Qwen3Asr : IDisposable
                             unifiedSeqDone[b] = true;
                     }
 
-                    CompactStepKv(stepPresentKeys, stepPresentValues, pastLengths, activeMask, take, out pastKeys, out pastValues, out pastLengths);
+                    CompactStepKvInto(
+                        stepPresentKeys,
+                        stepPresentValues,
+                        pastLengths,
+                        activeMask,
+                        take,
+                        nextKeysBuffer,
+                        nextValuesBuffer,
+                        nextLengths);
+
+                    (pastKeys, nextKeysBuffer) = (nextKeysBuffer, pastKeys);
+                    (pastValues, nextValuesBuffer) = (nextValuesBuffer, pastValues);
+                    (pastLengths, nextLengths) = (nextLengths, pastLengths);
                 }
 
                 for (int b = 0; b < take; b++)
@@ -959,10 +981,10 @@ public sealed class Qwen3Asr : IDisposable
         return mask;
     }
 
-    private float[] CompactPrefillKv(float[] present, int[] seqLengths, int batchSize)
+    private void CompactPrefillKvInto(float[] present, int[] seqLengths, int batchSize, float[] target)
     {
         int maxSeqLen = seqLengths.Max();
-        float[] compact = new float[_nLayers * batchSize * _nKvHeads * maxSeqLen * _headDim];
+        Array.Clear(target, 0, _nLayers * batchSize * _nKvHeads * maxSeqLen * _headDim);
 
         for (int layer = 0; layer < _nLayers; layer++)
         for (int b = 0; b < batchSize; b++)
@@ -971,31 +993,29 @@ public sealed class Qwen3Asr : IDisposable
             int validLen = seqLengths[b];
             int sourceBase = (((layer * batchSize + b) * _nKvHeads + head) * maxSeqLen) * _headDim;
             int destBase = sourceBase;
-            Array.Copy(present, sourceBase, compact, destBase, validLen * _headDim);
+            Array.Copy(present, sourceBase, target, destBase, validLen * _headDim);
         }
-
-        return compact;
     }
 
-    private void CompactStepKv(
+    private void CompactStepKvInto(
         float[] presentKeys,
         float[] presentValues,
         int[] pastLengths,
         bool[] activeMask,
         int batchSize,
-        out float[] nextKeys,
-        out float[] nextValues,
-        out int[] nextLengths)
+        float[] nextKeys,
+        float[] nextValues,
+        int[] nextLengths)
     {
         int appendIndex = pastLengths.Max();
-        nextLengths = (int[])pastLengths.Clone();
+        Array.Copy(pastLengths, nextLengths, batchSize);
         for (int b = 0; b < batchSize; b++)
             if (activeMask[b])
                 nextLengths[b]++;
 
         int maxNextLen = nextLengths.Max();
-        nextKeys = new float[_nLayers * batchSize * _nKvHeads * maxNextLen * _headDim];
-        nextValues = new float[_nLayers * batchSize * _nKvHeads * maxNextLen * _headDim];
+        Array.Clear(nextKeys, 0, _nLayers * batchSize * _nKvHeads * maxNextLen * _headDim);
+        Array.Clear(nextValues, 0, _nLayers * batchSize * _nKvHeads * maxNextLen * _headDim);
 
         for (int layer = 0; layer < _nLayers; layer++)
         for (int b = 0; b < batchSize; b++)
@@ -1027,6 +1047,19 @@ public sealed class Qwen3Asr : IDisposable
                     destBase + validPastLen * _headDim,
                     _headDim);
             }
+        }
+    }
+
+    private static void BuildBatchStepAttentionMaskInto(float[] buffer, int usedLength, int[] pastLengths, int maxPastLen)
+    {
+        Array.Fill(buffer, float.MinValue, 0, usedLength);
+
+        for (int b = 0; b < pastLengths.Length; b++)
+        {
+            int offset = b * (maxPastLen + 1);
+            for (int k = 0; k < pastLengths[b]; k++)
+                buffer[offset + k] = 0f;
+            buffer[offset + maxPastLen] = 0f;
         }
     }
 

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -66,6 +66,112 @@ public sealed class Qwen3Asr : IDisposable
         (32.0,  8),
         (double.PositiveInfinity, 6),
     ];
+    // Maps ISO 639-1 codes → Qwen3-ASR language names (as they appear in model output).
+    private static readonly Dictionary<string, string> IsoToLanguageName = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["af"] = "Afrikaans",  ["ar"] = "Arabic",     ["hy"] = "Armenian",   ["az"] = "Azerbaijani",
+        ["be"] = "Belarusian", ["bs"] = "Bosnian",    ["bg"] = "Bulgarian",  ["ca"] = "Catalan",
+        ["zh"] = "Chinese",    ["hr"] = "Croatian",   ["cs"] = "Czech",      ["da"] = "Danish",
+        ["nl"] = "Dutch",      ["en"] = "English",    ["et"] = "Estonian",   ["fi"] = "Finnish",
+        ["fr"] = "French",     ["gl"] = "Galician",   ["de"] = "German",     ["el"] = "Greek",
+        ["he"] = "Hebrew",     ["hi"] = "Hindi",      ["hu"] = "Hungarian",  ["is"] = "Icelandic",
+        ["id"] = "Indonesian", ["it"] = "Italian",    ["ja"] = "Japanese",   ["kn"] = "Kannada",
+        ["kk"] = "Kazakh",     ["ko"] = "Korean",     ["lv"] = "Latvian",    ["lt"] = "Lithuanian",
+        ["mk"] = "Macedonian", ["ms"] = "Malay",      ["mr"] = "Marathi",    ["ne"] = "Nepali",
+        ["no"] = "Norwegian",  ["fa"] = "Persian",    ["pl"] = "Polish",     ["pt"] = "Portuguese",
+        ["ro"] = "Romanian",   ["ru"] = "Russian",    ["sr"] = "Serbian",    ["sk"] = "Slovak",
+        ["sl"] = "Slovenian",  ["es"] = "Spanish",    ["sw"] = "Swahili",    ["sv"] = "Swedish",
+        ["tl"] = "Tagalog",    ["ta"] = "Tamil",      ["th"] = "Thai",       ["tr"] = "Turkish",
+        ["uk"] = "Ukrainian",  ["ur"] = "Urdu",       ["vi"] = "Vietnamese", ["cy"] = "Welsh",
+    };
+
+    // Token ID sequences for "language <Name> " prefix, pre-computed from the Qwen3 BPE tokenizer.
+    // First token is always 11528 ("language"); last is always 220 (" ").
+    private static readonly Dictionary<string, int[]> LanguagePrefixTokens =
+        new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Afrikaans"]  = [11528, 12907, 40454, 596,   220],
+        ["Arabic"]     = [11528, 34117,               220],
+        ["Armenian"]   = [11528, 66742,               220],
+        ["Azerbaijani"]= [11528, 64323, 73,   5559,   220],
+        ["Belarusian"] = [11528, 69506, 1103,         220],
+        ["Bosnian"]    = [11528, 27971, 77,   1103,   220],
+        ["Bulgarian"]  = [11528, 88624,               220],
+        ["Catalan"]    = [11528, 80844,               220],
+        ["Chinese"]    = [11528,  8453,               220],
+        ["Croatian"]   = [11528, 99070,               220],
+        ["Czech"]      = [11528, 33150,               220],
+        ["Danish"]     = [11528, 43680,               220],
+        ["Dutch"]      = [11528, 23234,               220],
+        ["English"]    = [11528,  6364,               220],
+        ["Estonian"]   = [11528, 53323, 1103,         220],
+        ["Finnish"]    = [11528, 57853,               220],
+        ["French"]     = [11528,  8585,               220],
+        ["Galician"]   = [11528, 10620, 12452,        220],
+        ["German"]     = [11528,  5938,               220],
+        ["Greek"]      = [11528, 17860,               220],
+        ["Hebrew"]     = [11528, 36266,               220],
+        ["Hindi"]      = [11528, 43980,               220],
+        ["Hungarian"]  = [11528, 56769,               220],
+        ["Icelandic"]  = [11528, 99148,               220],
+        ["Indonesian"] = [11528, 58829,               220],
+        ["Italian"]    = [11528, 14811,               220],
+        ["Japanese"]   = [11528, 10769,               220],
+        ["Kannada"]    = [11528, 77211,  2584,        220],
+        ["Kazakh"]     = [11528, 34974, 21758,        220],
+        ["Korean"]     = [11528, 16134,               220],
+        ["Latvian"]    = [11528,  9926,    85,  1103, 220],
+        ["Lithuanian"] = [11528, 40578, 10386,  1103, 220],
+        ["Macedonian"] = [11528, 56452, 75491,        220],
+        ["Malay"]      = [11528, 79140,               220],
+        ["Marathi"]    = [11528,  2876, 66531,        220],
+        ["Nepali"]     = [11528, 36569,  7956,        220],
+        ["Norwegian"]  = [11528, 44621,               220],
+        ["Persian"]    = [11528, 49861,               220],
+        ["Polish"]     = [11528, 31984,               220],
+        ["Portuguese"] = [11528, 42188,               220],
+        ["Romanian"]   = [11528, 73597,               220],
+        ["Russian"]    = [11528,  8522,               220],
+        ["Serbian"]    = [11528, 87164,               220],
+        ["Slovak"]     = [11528, 61264,               220],
+        ["Slovenian"]  = [11528, 59395,  1103,        220],
+        ["Spanish"]    = [11528, 15154,               220],
+        ["Swahili"]    = [11528,  4492,  1466,  3921, 220],
+        ["Swedish"]    = [11528, 30109,               220],
+        ["Tagalog"]    = [11528, 12353, 30951,        220],
+        ["Tamil"]      = [11528, 43783,               220],
+        ["Thai"]       = [11528, 26392,               220],
+        ["Turkish"]    = [11528, 23734,               220],
+        ["Ukrainian"]  = [11528, 33625,               220],
+        ["Urdu"]       = [11528, 93335,               220],
+        ["Vietnamese"] = [11528, 48477,               220],
+        ["Welsh"]      = [11528, 45781,               220],
+    };
+
+    // Resolves an ISO 639-1 code or language name to a forced-prefix token sequence.
+    // Returns [] when forceLanguage is null; throws ArgumentException for unrecognised codes.
+    private static int[] ResolveForcedPrefix(string? forceLanguage)
+    {
+        if (forceLanguage is null) return [];
+        string name = IsoToLanguageName.TryGetValue(forceLanguage, out string? mapped)
+            ? mapped : forceLanguage;
+        if (LanguagePrefixTokens.TryGetValue(name, out int[]? tokens))
+        {
+            // Omit the trailing 220 ("Ġ" space). The model naturally chooses whether to emit
+            // a standalone space separator or jump straight to a Ġ-prefixed content token —
+            // forcing a fixed separator gives KV states the model wasn't trained on.
+            return tokens.Length > 0 && tokens[^1] == 220 ? tokens[..^1] : tokens;
+        }
+        throw new ArgumentException(
+            $"Language '{forceLanguage}' not found. Use an ISO 639-1 code (e.g. 'en') or a language name (e.g. 'English').");
+    }
+
+    private static string? ResolveForcedLanguageName(string? forceLanguage)
+    {
+        if (forceLanguage is null) return null;
+        return IsoToLanguageName.TryGetValue(forceLanguage, out string? name) ? name : forceLanguage;
+    }
+
     private static readonly string[] SpokenLanguageNames =
     [
         "Afrikaans",
@@ -396,8 +502,11 @@ public sealed class Qwen3Asr : IDisposable
     private IEnumerable<QwenRecognitionResult> RecognizeUnifiedContinuousBatched(
         IReadOnlyList<QwenBatchedItem> validItems,
         long freeGpuMemoryMb,
-        int maxNewTokens)
+        int maxNewTokens,
+        int[] forcedPrefix,
+        string? forcedLanguageName = null)
     {
+        forcedPrefix ??= [];
         var encodedItems = EncodeBatchedItems(validItems, freeGpuMemoryMb);
         if (encodedItems.Count == 0)
             yield break;
@@ -406,7 +515,9 @@ public sealed class Qwen3Asr : IDisposable
         //   prefill:  [groupSize, maxPromptLen, vocabSize] logits  (lm_head output, temporary but large)
         //   decode KV: [nLayers, groupSize, nKvHeads, maxKvSeqLen, headDim] × 2 (persistent throughout decode)
         // Budget 25% of free VRAM; remainder for model weights, activations, ORT arena overhead.
-        int  maxPromptSeqLen       = encodedItems.Max(it => BuildPromptIds(it.AudioTokenCount).Count);
+        // The forced prefix is appended to each item's prompt, so add its length to the base prompt length.
+        int  maxPromptSeqLen       = encodedItems.Max(it => BuildPromptIds(it.AudioTokenCount).Count)
+                                     + forcedPrefix.Length;
         int  maxKvSeqLen           = maxPromptSeqLen + maxNewTokens;
         long prefillLogitsPerSlot  = (long)maxPromptSeqLen * _vocabSize * 4;
         long decodeKvPerSlot       = (long)_nLayers * _nKvHeads * maxKvSeqLen * _headDim * 4 * 2;
@@ -443,7 +554,7 @@ public sealed class Qwen3Asr : IDisposable
             }
 
             var (inputEmbeds, positionIds, prefillMask, seqLengths) =
-                BuildUnifiedBatchPrefillInputs(audioFeatures, audioLengths, groupSize, maxAudioTokens);
+                BuildUnifiedBatchPrefillInputs(audioFeatures, audioLengths, groupSize, maxAudioTokens, forcedPrefix);
             int maxPromptLen = seqLengths.Max();
 
             // --- Prefill: use Run() — avoids GetTensorDataAsSpan failing on _decoder with mixed CPU/CUDA IO binding ---
@@ -487,7 +598,7 @@ public sealed class Qwen3Asr : IDisposable
             {
                 rawTokens[b]   = new List<int>(maxNewTokens);
                 rawLogprobs[b] = new List<float>(maxNewTokens);
-                int firstToken = ArgMaxSpan(lastPosLogits.AsSpan(b * _vocabSize, _vocabSize), out float firstLogprob);
+                int   firstToken  = ArgMaxSpan(lastPosLogits.AsSpan(b * _vocabSize, _vocabSize), out float firstLogprob);
                 nextTokens[b] = firstToken;
                 rawTokens[b].Add(firstToken);
                 rawLogprobs[b].Add(firstLogprob);
@@ -576,9 +687,11 @@ public sealed class Qwen3Asr : IDisposable
                 var item = encodedItems[pendingIndex + i];
                 var (textTokens, textLogprobs) = ExtractTextTokens(rawTokens[i], rawLogprobs[i]);
                 string rawText = DecodeTokens(textTokens);
-                var parsed = ParseMetadataPrefix(rawText);
+                var parsed = forcedLanguageName is null ? ParseMetadataPrefix(rawText) : null;
+                string text      = parsed?.Text ?? rawText;
+                string? language = forcedLanguageName ?? parsed?.Language;
                 yield return new QwenRecognitionResult(
-                    item.SegId, parsed.Text, rawTokens[i], textTokens, textLogprobs, parsed.Language, rawText);
+                    item.SegId, text, rawTokens[i], textTokens, textLogprobs, language, rawText);
             }
 
             pendingIndex += groupSize;
@@ -606,20 +719,25 @@ public sealed class Qwen3Asr : IDisposable
     public IEnumerable<(int segId, string text)> Recognize(
         IReadOnlyList<(double start, double end, string spk)> segs,
         float[] audio,
-        int maxNewTokens = 256)
+        int maxNewTokens = 256,
+        string? forceLanguage = null)
     {
-        foreach (var result in RecognizeDetailed(segs, audio, maxNewTokens))
+        foreach (var result in RecognizeDetailed(segs, audio, maxNewTokens, forceLanguage))
             yield return (result.SegmentId, result.Text);
     }
 
     public IEnumerable<QwenRecognitionResult> RecognizeDetailed(
         IReadOnlyList<(double start, double end, string spk)> segs,
         float[] audio,
-        int maxNewTokens = 256)
+        int maxNewTokens = 256,
+        string? forceLanguage = null)
     {
         if (_encoder is null)
             throw new InvalidOperationException(
                 "Serial encoder sessions are not loaded. Construct with preferBatched:false or call RecognizeBatchedDetailed.");
+
+        int[]   forcedPrefix        = ResolveForcedPrefix(forceLanguage);
+        string? forcedLanguageName  = ResolveForcedLanguageName(forceLanguage);
 
         for (int segId = 0; segId < segs.Count; segId++)
         {
@@ -640,21 +758,25 @@ public sealed class Qwen3Asr : IDisposable
             int audioOffset = GetAudioPadStart(promptIds);
 
             var (rawTokens, rawLogprobs) = _decoder is not null
-                ? DecodeOnCpuUnified(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens)
+                ? DecodeOnCpuUnified(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens, forcedPrefix)
                 : _useCudaIoBinding
-                    ? DecodeWithIoBinding(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens)
-                    : DecodeOnCpu(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens);
+                    ? DecodeWithIoBinding(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens, forcedPrefix)
+                    : DecodeOnCpu(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens, forcedPrefix);
 
             var (textTokens, textLogprobs) = ExtractTextTokens(rawTokens, rawLogprobs);
             string rawText = DecodeTokens(textTokens);
-            var parsed = ParseMetadataPrefix(rawText);
+            // When language is forced the prefix is in the prompt (not generated), so rawText IS
+            // the content directly. For auto-detect the prefix was generated and stripped above.
+            var parsed = forcedLanguageName is null ? ParseMetadataPrefix(rawText) : null;
+            string text     = parsed?.Text ?? rawText;
+            string? language = forcedLanguageName ?? parsed?.Language;
             yield return new QwenRecognitionResult(
                 segId,
-                parsed.Text,
+                text,
                 rawTokens,
                 textTokens,
                 textLogprobs,
-                parsed.Language,
+                language,
                 rawText);
         }
     }
@@ -770,11 +892,12 @@ public sealed class Qwen3Asr : IDisposable
     public IEnumerable<QwenRecognitionResult> RecognizeBatchedDetailed(
         IReadOnlyList<(double start, double end, string spk)> segs,
         float[] audio,
-        int maxNewTokens = 256)
+        int maxNewTokens = 256,
+        string? forceLanguage = null)
     {
         if (_encoderBatched is null || (_decoderInitBatched is null && _decoder is null))
         {
-            foreach (var r in RecognizeDetailed(segs, audio, maxNewTokens))
+            foreach (var r in RecognizeDetailed(segs, audio, maxNewTokens, forceLanguage))
                 yield return r;
             yield break;
         }
@@ -815,7 +938,9 @@ public sealed class Qwen3Asr : IDisposable
         // which handles batched encoding + one decode scheduler over all segments.
         if (_decoder is not null)
         {
-            foreach (var r in RecognizeUnifiedContinuousBatched(validItems, freeGpuMemoryMb, maxNewTokens))
+            int[]   forcedPrefix       = ResolveForcedPrefix(forceLanguage);
+            string? forcedLanguageName = ResolveForcedLanguageName(forceLanguage);
+            foreach (var r in RecognizeUnifiedContinuousBatched(validItems, freeGpuMemoryMb, maxNewTokens, forcedPrefix, forcedLanguageName))
                 yield return r;
             yield break;
         }
@@ -1010,8 +1135,10 @@ public sealed class Qwen3Asr : IDisposable
         float[] audioFeatures,
         long[] audioLengths,
         int batchSize,
-        int maxAudioTokens)
+        int maxAudioTokens,
+        int[]? forcedPrefix = null)
     {
+        forcedPrefix ??= [];
         var prompts = new List<int>[batchSize];
         var seqLengths = new int[batchSize];
         int maxSeqLen = 0;
@@ -1019,7 +1146,7 @@ public sealed class Qwen3Asr : IDisposable
         for (int b = 0; b < batchSize; b++)
         {
             prompts[b] = BuildPromptIds((int)audioLengths[b]);
-            seqLengths[b] = prompts[b].Count;
+            seqLengths[b] = prompts[b].Count + forcedPrefix.Length;
             maxSeqLen = Math.Max(maxSeqLen, seqLengths[b]);
         }
 
@@ -1046,6 +1173,15 @@ public sealed class Qwen3Asr : IDisposable
                     inputEmbeds,
                     (b * maxSeqLen + audioOffset + t) * _hiddenSize,
                     _hiddenSize);
+            }
+
+            // Append forced language prefix tokens after the prompt
+            for (int t = 0; t < forcedPrefix.Length; t++)
+            {
+                ReadTokenEmbedding(forcedPrefix[t], tokenEmbed);
+                int pos = prompt.Count + t;
+                Array.Copy(tokenEmbed, 0, inputEmbeds, (b * maxSeqLen + pos) * _hiddenSize, _hiddenSize);
+                positionIds[b * maxSeqLen + pos] = pos;
             }
         }
 
@@ -1422,10 +1558,19 @@ public sealed class Qwen3Asr : IDisposable
         int audioOffset,
         float[] audioFeatures,
         int audioTokenCount,
-        int maxNewTokens)
+        int maxNewTokens,
+        int[] forcedPrefix)
     {
-        long[] inputIds = promptIds.Select(i => (long)i).ToArray();
-        long[] positionIds = Enumerable.Range(0, promptIds.Count).Select(i => (long)i).ToArray();
+        // Include forced language prefix in the prompt so the model sees it as established context
+        // before generating content. This avoids the KV state distortion that occurs when token
+        // selection is overridden mid-generation.
+        IReadOnlyList<int> effectivePrompt = forcedPrefix.Length > 0
+            ? [..promptIds, ..forcedPrefix]
+            : promptIds;
+        int seqLen = effectivePrompt.Count;
+
+        long[] inputIds = effectivePrompt.Select(i => (long)i).ToArray();
+        long[] positionIds = Enumerable.Range(0, seqLen).Select(i => (long)i).ToArray();
         long[] audioOffsetTensor = [audioOffset];
 
         using var initOutputs = _decoderInit.Run(
@@ -1439,22 +1584,21 @@ public sealed class Qwen3Asr : IDisposable
         float[] logits = ExtractTensor(initOutputs.First(r => r.Name == "logits").AsTensor<float>());
         float[] pastKeys = ExtractTensor(initOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
         float[] pastValues = ExtractTensor(initOutputs.First(r => r.Name == "present_values").AsTensor<float>());
-        int pastSeqLen = promptIds.Count;
+        int pastSeqLen = seqLen;
         var tokenEmbed = new float[_hiddenSize];
         long[] stepPos = [0L];
 
-        var rawTokens = new List<int>(maxNewTokens);
+        var rawTokens   = new List<int>(maxNewTokens);
         var rawLogprobs = new List<float>(maxNewTokens);
 
-        int nextToken = ArgMaxLastLogits(logits, promptIds.Count, out float nextLogprob);
+        int   nextToken   = ArgMaxLastLogits(logits, seqLen, out float nextLogprob);
         rawTokens.Add(nextToken);
         rawLogprobs.Add(nextLogprob);
-        pastSeqLen = promptIds.Count;
 
         while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
         {
             ReadTokenEmbedding(nextToken, tokenEmbed);
-            stepPos[0] = promptIds.Count + rawTokens.Count - 1L;
+            stepPos[0] = seqLen + rawTokens.Count - 1L;
 
             using var stepOutputs = _decoderStep!.Run(
             [
@@ -1464,8 +1608,8 @@ public sealed class Qwen3Asr : IDisposable
                 NamedOnnxValue.CreateFromTensor("past_values", new DenseTensor<float>(pastValues, [28, 1, 8, pastSeqLen, 128])),
             ]);
 
-            logits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
-            pastKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+            logits     = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
+            pastKeys   = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
             pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
             pastSeqLen++;
 
@@ -1482,19 +1626,28 @@ public sealed class Qwen3Asr : IDisposable
         int audioOffset,
         float[] audioFeatures,
         int audioTokenCount,
-        int maxNewTokens)
+        int maxNewTokens,
+        int[] forcedPrefix)
     {
-        int seqLen = promptIds.Count;
+        int baseSeqLen = promptIds.Count;
+        // Extend the embedded prompt with forced language prefix tokens so the model treats
+        // them as established context rather than having its token selection overridden mid-gen.
+        int seqLen = baseSeqLen + forcedPrefix.Length;
 
-        // Build input_embeds: embedding lookup for all prompt tokens, then scatter audio features.
+        // Build input_embeds: embedding lookup for all prompt + forced-prefix tokens, then scatter audio.
         float[] inputEmbeds = new float[seqLen * _hiddenSize];
         var tmpEmbed = new float[_hiddenSize];
-        for (int t = 0; t < seqLen; t++)
+        for (int t = 0; t < baseSeqLen; t++)
         {
             ReadTokenEmbedding(promptIds[t], tmpEmbed);
             Array.Copy(tmpEmbed, 0, inputEmbeds, t * _hiddenSize, _hiddenSize);
         }
         Array.Copy(audioFeatures, 0, inputEmbeds, audioOffset * _hiddenSize, audioTokenCount * _hiddenSize);
+        for (int t = 0; t < forcedPrefix.Length; t++)
+        {
+            ReadTokenEmbedding(forcedPrefix[t], tmpEmbed);
+            Array.Copy(tmpEmbed, 0, inputEmbeds, (baseSeqLen + t) * _hiddenSize, _hiddenSize);
+        }
 
         long[] positionIds = Enumerable.Range(0, seqLen).Select(i => (long)i).ToArray();
         float[] emptyKv = [];
@@ -1520,7 +1673,7 @@ public sealed class Qwen3Asr : IDisposable
         var rawLogprobs = new List<float>(maxNewTokens);
         long[] stepPos  = [0L];
 
-        int nextToken = ArgMaxLastLogits(logits, seqLen, out float nextLogprob);
+        int   nextToken   = ArgMaxLastLogits(logits, seqLen, out float nextLogprob);
         rawTokens.Add(nextToken);
         rawLogprobs.Add(nextLogprob);
 
@@ -1640,14 +1793,21 @@ public sealed class Qwen3Asr : IDisposable
         int audioOffset,
         float[] audioFeatures,
         int audioTokenCount,
-        int maxNewTokens)
+        int maxNewTokens,
+        int[] forcedPrefix)
     {
         using var cpuMemInfo = new OrtMemoryInfo("Cpu", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
         using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
         using var runOpts = new RunOptions();
 
-        long[] inputIds = promptIds.Select(i => (long)i).ToArray();
-        long[] positionIds = Enumerable.Range(0, promptIds.Count).Select(i => (long)i).ToArray();
+        // Extend prompt with forced language prefix so the model generates content conditioned on it.
+        IReadOnlyList<int> effectivePrompt = forcedPrefix.Length > 0
+            ? [..promptIds, ..forcedPrefix]
+            : promptIds;
+        int seqLen = effectivePrompt.Count;
+
+        long[] inputIds = effectivePrompt.Select(i => (long)i).ToArray();
+        long[] positionIds = Enumerable.Range(0, seqLen).Select(i => (long)i).ToArray();
         long[] audioOffsetTensor = [audioOffset];
 
         using var inputIdsValue = OrtValue.CreateTensorValueFromMemory(inputIds, [1, inputIds.Length]);
@@ -1666,32 +1826,32 @@ public sealed class Qwen3Asr : IDisposable
         _decoderInit.RunWithBinding(runOpts, initBinding);
 
         var initOutputs = initBinding.GetOutputValues();
-        var rawTokens = new List<int>(maxNewTokens);
+        var rawTokens   = new List<int>(maxNewTokens);
         var rawLogprobs = new List<float>(maxNewTokens);
-        var tokenEmbed = new float[_hiddenSize];
-        long[] stepPos = [0L];
+        var tokenEmbed  = new float[_hiddenSize];
+        long[] stepPos  = [0L];
 
-        int nextToken = ArgMaxLastLogits(initOutputs[0], promptIds.Count, out float nextLogprob);
+        int   nextToken   = ArgMaxLastLogits(initOutputs[0], seqLen, out float nextLogprob);
         rawTokens.Add(nextToken);
         rawLogprobs.Add(nextLogprob);
 
         IDisposableReadOnlyCollection<OrtValue>? prevOutputs = initOutputs;
-        int pastSeqLen = promptIds.Count;
+        int pastSeqLen = seqLen;
 
         while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
         {
             ReadTokenEmbedding(nextToken, tokenEmbed);
-            stepPos[0] = promptIds.Count + rawTokens.Count - 1L;
+            stepPos[0] = seqLen + rawTokens.Count - 1L;
 
             using var tokenEmbedValue = OrtValue.CreateTensorValueFromMemory(tokenEmbed, [1, 1, _hiddenSize]);
-            using var stepPosValue = OrtValue.CreateTensorValueFromMemory(stepPos, [1, 1]);
-            using var stepBinding = _decoderStep!.CreateIoBinding();
+            using var stepPosValue    = OrtValue.CreateTensorValueFromMemory(stepPos, [1, 1]);
+            using var stepBinding     = _decoderStep!.CreateIoBinding();
             stepBinding.BindInput("input_embeds", tokenEmbedValue);
             stepBinding.BindInput("position_ids", stepPosValue);
-            stepBinding.BindInput("past_keys", prevOutputs![1]);
-            stepBinding.BindInput("past_values", prevOutputs[2]);
-            stepBinding.BindOutputToDevice("logits", cpuMemInfo);
-            stepBinding.BindOutputToDevice("present_keys", cudaMemInfo);
+            stepBinding.BindInput("past_keys",    prevOutputs![1]);
+            stepBinding.BindInput("past_values",  prevOutputs[2]);
+            stepBinding.BindOutputToDevice("logits",         cpuMemInfo);
+            stepBinding.BindOutputToDevice("present_keys",   cudaMemInfo);
             stepBinding.BindOutputToDevice("present_values", cudaMemInfo);
             _decoderStep.RunWithBinding(runOpts, stepBinding);
 
@@ -1777,6 +1937,30 @@ public sealed class Qwen3Asr : IDisposable
             {
                 textTokens.Add(token);
                 textLogprobs.Add(i < rawLogprobs.Count ? rawLogprobs[i] : 0f);
+            }
+        }
+
+        // Strip the "language <Name>" prefix tokens so stored tokens match result.Text.
+        // Known prefix entries end with 220 ("Ġ" space), but the model doesn't always emit that
+        // separator — sometimes it jumps straight to a Ġ-prefixed content token.
+        // Match the [11528, ...name tokens...] portion; optionally swallow a trailing 220.
+        if (textTokens.Count > 0 && textTokens[0] == 11528)
+        {
+            foreach (var prefix in LanguagePrefixTokens.Values)
+            {
+                int nameLen = prefix[^1] == 220 ? prefix.Length - 1 : prefix.Length;
+                if (textTokens.Count < nameLen) continue;
+                bool match = true;
+                for (int j = 0; j < nameLen && match; j++)
+                    if (textTokens[j] != prefix[j]) match = false;
+                if (!match) continue;
+
+                int skip = nameLen;
+                if (skip < textTokens.Count && textTokens[skip] == 220)
+                    skip++;
+
+                return (textTokens.GetRange(skip, textTokens.Count - skip),
+                        textLogprobs.GetRange(skip, textLogprobs.Count - skip));
             }
         }
 

--- a/src/Vernacula.Base/Qwen3Asr.cs
+++ b/src/Vernacula.Base/Qwen3Asr.cs
@@ -1,0 +1,641 @@
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using System.Text.Json;
+using MathNet.Numerics;
+using MathNet.Numerics.IntegralTransforms;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Models;
+
+namespace Vernacula.Base;
+
+/// <summary>
+/// Qwen3-ASR 1.7B runtime for the split ONNX export produced by scripts/qwen3asr_export.
+///
+/// Pipeline:
+///   1. Host-side Whisper-style log-mel frontend
+///   2. encoder.onnx          mel [1,128,T] -> audio_features [1,N,2048]
+///   3. decoder_init.onnx     prompt ids + audio features -> logits + KV cache
+///   4. decoder_step.onnx     token embedding + KV cache -> logits + updated KV cache
+///
+/// The decoder token embedding matrix is kept in a memory-mapped file so we do not
+/// need a 1.2 GB managed float[] on the LOH.
+/// </summary>
+public sealed class Qwen3Asr : IDisposable
+{
+    public const string EncoderFile = "encoder.onnx";
+    public const string DecoderInitFile = "decoder_init.onnx";
+    public const string DecoderStepFile = "decoder_step.onnx";
+    public const string EmbedTokensFile = "embed_tokens.bin";
+    public const string TokenizerFile = "tokenizer.json";
+    public const string ConfigFile = "config.json";
+
+    private const int SampleRate = 16_000;
+    private const int NFft = 400;
+    private const int HopLength = 160;
+    private const int NMels = 128;
+    private const float LogFloor = -10.0f;
+    private const float LogClampSpan = 8.0f;
+    private const float LogOffset = 4.0f;
+    private const int ImStartTokenId = 151644;
+    private const int ImEndTokenId = 151645;
+    private const int AudioStartTokenId = 151669;
+    private const int AudioEndTokenId = 151670;
+    private const int AudioPadTokenId = 151676;
+    private const int NewlineTokenId = 198;
+    private const int SystemTokenId = 9125;
+    private const int UserTokenId = 882;
+    private const int AssistantTokenId = 77091;
+
+    private static readonly float[,] MelFilterbank = CreateMelFilterbank();
+    private static readonly double[] HannWindow = Window.HannPeriodic(NFft);
+
+    private readonly InferenceSession _encoder;
+    private readonly InferenceSession _decoderInit;
+    private readonly InferenceSession _decoderStep;
+    private readonly bool _useCudaIoBinding;
+    private readonly int _hiddenSize;
+    private readonly int _vocabSize;
+    private readonly int _baseVocabSize;
+    private readonly int[] _eosTokenIds;
+    private readonly MemoryMappedFile _embedMmf;
+    private readonly MemoryMappedViewAccessor _embedAccessor;
+    private readonly string?[] _idToToken;
+    private readonly Dictionary<int, string> _addedTokenContent;
+    private readonly Dictionary<char, byte> _byteLevelDecode;
+
+    public Qwen3Asr(string modelPath, ExecutionProvider ep = ExecutionProvider.Auto)
+    {
+        string configJson = File.ReadAllText(Path.Combine(modelPath, ConfigFile));
+        using var configDoc = JsonDocument.Parse(configJson);
+        var root = configDoc.RootElement;
+        var decoderConfig = root.GetProperty("decoder");
+        var specialTokens = root.GetProperty("special_tokens");
+
+        _hiddenSize = decoderConfig.GetProperty("hidden_size").GetInt32();
+        _vocabSize = decoderConfig.GetProperty("vocab_size").GetInt32();
+        _baseVocabSize = root.GetProperty("embed_tokens_shape")[0].GetInt32();
+        _eosTokenIds = specialTokens.GetProperty("eos_token_ids").EnumerateArray().Select(e => e.GetInt32()).ToArray();
+
+        var encoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool encoderUsesCuda);
+        var decoderOpts = MakeSessionOptions(ep, GraphOptimizationLevel.ORT_ENABLE_EXTENDED, out bool decoderUsesCuda);
+        _useCudaIoBinding = encoderUsesCuda && decoderUsesCuda;
+
+        _encoder = new InferenceSession(Path.Combine(modelPath, EncoderFile), encoderOpts);
+        _decoderInit = new InferenceSession(Path.Combine(modelPath, DecoderInitFile), decoderOpts);
+        _decoderStep = new InferenceSession(Path.Combine(modelPath, DecoderStepFile), decoderOpts);
+
+        string embedPath = Path.Combine(modelPath, EmbedTokensFile);
+        _embedMmf = MemoryMappedFile.CreateFromFile(embedPath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+        _embedAccessor = _embedMmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+        (_idToToken, _addedTokenContent) = LoadTokenizerVocab(Path.Combine(modelPath, TokenizerFile));
+        _byteLevelDecode = BuildByteLevelDecode();
+    }
+
+    public IEnumerable<(int segId, string text)> Recognize(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio,
+        int maxNewTokens = 256)
+    {
+        foreach (var result in RecognizeDetailed(segs, audio, maxNewTokens))
+            yield return (result.SegmentId, result.Text);
+    }
+
+    public IEnumerable<QwenRecognitionResult> RecognizeDetailed(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio,
+        int maxNewTokens = 256)
+    {
+        for (int segId = 0; segId < segs.Count; segId++)
+        {
+            var (start, end, _) = segs[segId];
+            int startSample = Math.Clamp((int)Math.Round(start * SampleRate), 0, audio.Length);
+            int endSample = Math.Clamp((int)Math.Round(end * SampleRate), 0, audio.Length);
+            if (endSample <= startSample)
+            {
+                yield return new QwenRecognitionResult(segId, "", [], [], []);
+                continue;
+            }
+
+            int length = endSample - startSample;
+            var waveform = new float[length];
+            Array.Copy(audio, startSample, waveform, 0, length);
+
+            float[] mel = ComputeLogMelSpectrogram(waveform, out int melFrames);
+            float[] audioFeatures = RunEncoder(mel, melFrames, out int audioTokenCount);
+
+            List<int> promptIds = BuildPromptIds(audioTokenCount);
+            int audioOffset = GetAudioPadStart(promptIds);
+
+            var (rawTokens, rawLogprobs) = _useCudaIoBinding
+                ? DecodeWithIoBinding(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens)
+                : DecodeOnCpu(promptIds, audioOffset, audioFeatures, audioTokenCount, maxNewTokens);
+
+            var (textTokens, textLogprobs) = ExtractTextTokens(rawTokens, rawLogprobs);
+            string text = DecodeTokens(textTokens);
+            yield return new QwenRecognitionResult(segId, text, rawTokens, textTokens, textLogprobs);
+        }
+    }
+
+    private static SessionOptions MakeSessionOptions(
+        ExecutionProvider ep,
+        GraphOptimizationLevel optimizationLevel,
+        out bool usesCuda)
+    {
+        var opts = new SessionOptions { GraphOptimizationLevel = optimizationLevel };
+        usesCuda = false;
+
+        switch (ep)
+        {
+            case ExecutionProvider.Auto:
+                if (HardwareInfo.CanProbeCudaExecutionProvider())
+                {
+                    try
+                    {
+                        opts.AppendExecutionProvider_CUDA(0);
+                        usesCuda = true;
+                        break;
+                    }
+                    catch { }
+                }
+                try { opts.AppendExecutionProvider_DML(0); } catch { }
+                break;
+            case ExecutionProvider.Cuda:
+                opts.AppendExecutionProvider_CUDA(0);
+                usesCuda = true;
+                break;
+            case ExecutionProvider.DirectML:
+                opts.AppendExecutionProvider_DML(0);
+                break;
+            case ExecutionProvider.Cpu:
+                break;
+        }
+
+        return opts;
+    }
+
+    private float[] RunEncoder(float[] mel, int melFrames, out int audioTokenCount)
+    {
+        using var results = _encoder.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("mel", new DenseTensor<float>(mel, [1, NMels, melFrames])),
+        ]);
+
+        var features = results.First(r => r.Name == "audio_features").AsTensor<float>();
+        audioTokenCount = features.Dimensions[1];
+        return ExtractTensor(features);
+    }
+
+    private (List<int> rawTokens, List<float> rawLogprobs) DecodeOnCpu(
+        IReadOnlyList<int> promptIds,
+        int audioOffset,
+        float[] audioFeatures,
+        int audioTokenCount,
+        int maxNewTokens)
+    {
+        long[] inputIds = promptIds.Select(i => (long)i).ToArray();
+        long[] positionIds = Enumerable.Range(0, promptIds.Count).Select(i => (long)i).ToArray();
+        long[] audioOffsetTensor = [audioOffset];
+
+        using var initOutputs = _decoderInit.Run(
+        [
+            NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(inputIds, [1, inputIds.Length])),
+            NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(positionIds, [1, positionIds.Length])),
+            NamedOnnxValue.CreateFromTensor("audio_features", new DenseTensor<float>(audioFeatures, [1, audioTokenCount, _hiddenSize])),
+            NamedOnnxValue.CreateFromTensor("audio_offset", new DenseTensor<long>(audioOffsetTensor, [1])),
+        ]);
+
+        float[] logits = ExtractTensor(initOutputs.First(r => r.Name == "logits").AsTensor<float>());
+        float[] pastKeys = ExtractTensor(initOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+        float[] pastValues = ExtractTensor(initOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+        int pastSeqLen = promptIds.Count;
+
+        var rawTokens = new List<int>(maxNewTokens);
+        var rawLogprobs = new List<float>(maxNewTokens);
+
+        int nextToken = ArgMaxLastLogits(logits, promptIds.Count, out float nextLogprob);
+        rawTokens.Add(nextToken);
+        rawLogprobs.Add(nextLogprob);
+        pastSeqLen = promptIds.Count;
+
+        while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
+        {
+            float[] tokenEmbed = ReadTokenEmbedding(nextToken);
+            long[] stepPos = [promptIds.Count + rawTokens.Count - 1L];
+
+            using var stepOutputs = _decoderStep.Run(
+            [
+                NamedOnnxValue.CreateFromTensor("input_embeds", new DenseTensor<float>(tokenEmbed, [1, 1, _hiddenSize])),
+                NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(stepPos, [1, 1])),
+                NamedOnnxValue.CreateFromTensor("past_keys", new DenseTensor<float>(pastKeys, [28, 1, 8, pastSeqLen, 128])),
+                NamedOnnxValue.CreateFromTensor("past_values", new DenseTensor<float>(pastValues, [28, 1, 8, pastSeqLen, 128])),
+            ]);
+
+            logits = ExtractTensor(stepOutputs.First(r => r.Name == "logits").AsTensor<float>());
+            pastKeys = ExtractTensor(stepOutputs.First(r => r.Name == "present_keys").AsTensor<float>());
+            pastValues = ExtractTensor(stepOutputs.First(r => r.Name == "present_values").AsTensor<float>());
+            pastSeqLen++;
+
+            nextToken = ArgMaxLastLogits(logits, 1, out nextLogprob);
+            rawTokens.Add(nextToken);
+            rawLogprobs.Add(nextLogprob);
+        }
+
+        return (rawTokens, rawLogprobs);
+    }
+
+    private (List<int> rawTokens, List<float> rawLogprobs) DecodeWithIoBinding(
+        IReadOnlyList<int> promptIds,
+        int audioOffset,
+        float[] audioFeatures,
+        int audioTokenCount,
+        int maxNewTokens)
+    {
+        using var cpuMemInfo = new OrtMemoryInfo("Cpu", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var runOpts = new RunOptions();
+
+        long[] inputIds = promptIds.Select(i => (long)i).ToArray();
+        long[] positionIds = Enumerable.Range(0, promptIds.Count).Select(i => (long)i).ToArray();
+        long[] audioOffsetTensor = [audioOffset];
+
+        using var inputIdsValue = OrtValue.CreateTensorValueFromMemory(inputIds, [1, inputIds.Length]);
+        using var positionIdsValue = OrtValue.CreateTensorValueFromMemory(positionIds, [1, positionIds.Length]);
+        using var audioFeaturesValue = OrtValue.CreateTensorValueFromMemory(audioFeatures, [1, audioTokenCount, _hiddenSize]);
+        using var audioOffsetValue = OrtValue.CreateTensorValueFromMemory(audioOffsetTensor, [1]);
+
+        using var initBinding = _decoderInit.CreateIoBinding();
+        initBinding.BindInput("input_ids", inputIdsValue);
+        initBinding.BindInput("position_ids", positionIdsValue);
+        initBinding.BindInput("audio_features", audioFeaturesValue);
+        initBinding.BindInput("audio_offset", audioOffsetValue);
+        initBinding.BindOutputToDevice("logits", cpuMemInfo);
+        initBinding.BindOutputToDevice("present_keys", cudaMemInfo);
+        initBinding.BindOutputToDevice("present_values", cudaMemInfo);
+        _decoderInit.RunWithBinding(runOpts, initBinding);
+
+        var initOutputs = initBinding.GetOutputValues();
+        var rawTokens = new List<int>(maxNewTokens);
+        var rawLogprobs = new List<float>(maxNewTokens);
+
+        int nextToken = ArgMaxLastLogits(initOutputs[0], promptIds.Count, out float nextLogprob);
+        rawTokens.Add(nextToken);
+        rawLogprobs.Add(nextLogprob);
+
+        IDisposableReadOnlyCollection<OrtValue>? prevOutputs = initOutputs;
+        int pastSeqLen = promptIds.Count;
+
+        while (rawTokens.Count < maxNewTokens && !IsEos(nextToken))
+        {
+            float[] tokenEmbed = ReadTokenEmbedding(nextToken);
+            long[] stepPos = [promptIds.Count + rawTokens.Count - 1L];
+
+            using var tokenEmbedValue = OrtValue.CreateTensorValueFromMemory(tokenEmbed, [1, 1, _hiddenSize]);
+            using var stepPosValue = OrtValue.CreateTensorValueFromMemory(stepPos, [1, 1]);
+            using var stepBinding = _decoderStep.CreateIoBinding();
+            stepBinding.BindInput("input_embeds", tokenEmbedValue);
+            stepBinding.BindInput("position_ids", stepPosValue);
+            stepBinding.BindInput("past_keys", prevOutputs![1]);
+            stepBinding.BindInput("past_values", prevOutputs[2]);
+            stepBinding.BindOutputToDevice("logits", cpuMemInfo);
+            stepBinding.BindOutputToDevice("present_keys", cudaMemInfo);
+            stepBinding.BindOutputToDevice("present_values", cudaMemInfo);
+            _decoderStep.RunWithBinding(runOpts, stepBinding);
+
+            var curOutputs = stepBinding.GetOutputValues();
+            nextToken = ArgMaxLastLogits(curOutputs[0], 1, out nextLogprob);
+            rawTokens.Add(nextToken);
+            rawLogprobs.Add(nextLogprob);
+            pastSeqLen++;
+
+            prevOutputs.Dispose();
+            prevOutputs = curOutputs;
+        }
+
+        prevOutputs?.Dispose();
+        return (rawTokens, rawLogprobs);
+    }
+
+    private int ArgMaxLastLogits(float[] logits, int seqLen, out float logprob)
+    {
+        int vocabSize = logits.Length / seqLen;
+        int offset = (seqLen - 1) * vocabSize;
+        int best = 0;
+        float bestVal = float.NegativeInfinity;
+        for (int i = 0; i < vocabSize; i++)
+        {
+            float value = logits[offset + i];
+            if (value > bestVal)
+            {
+                bestVal = value;
+                best = i;
+            }
+        }
+
+        double sumExp = 0;
+        for (int i = 0; i < vocabSize; i++)
+            sumExp += Math.Exp(logits[offset + i] - bestVal);
+
+        logprob = (float)(-Math.Log(sumExp));
+        return best;
+    }
+
+    private int ArgMaxLastLogits(OrtValue logits, int seqLen, out float logprob)
+    {
+        var span = logits.GetTensorDataAsSpan<float>();
+        int vocabSize = span.Length / seqLen;
+        int offset = (seqLen - 1) * vocabSize;
+        int best = 0;
+        float bestVal = float.NegativeInfinity;
+        for (int i = 0; i < vocabSize; i++)
+        {
+            float value = span[offset + i];
+            if (value > bestVal)
+            {
+                bestVal = value;
+                best = i;
+            }
+        }
+
+        double sumExp = 0;
+        for (int i = 0; i < vocabSize; i++)
+            sumExp += Math.Exp(span[offset + i] - bestVal);
+
+        logprob = (float)(-Math.Log(sumExp));
+        return best;
+    }
+
+    private float[] ReadTokenEmbedding(int tokenId)
+    {
+        var embedding = new float[_hiddenSize];
+        long byteOffset = (long)tokenId * _hiddenSize * sizeof(float);
+        _embedAccessor.ReadArray(byteOffset, embedding, 0, _hiddenSize);
+        return embedding;
+    }
+
+    private static (List<int> textTokens, List<float> textLogprobs) ExtractTextTokens(
+        IReadOnlyList<int> rawTokens,
+        IReadOnlyList<float> rawLogprobs)
+    {
+        var textTokens = new List<int>(rawTokens.Count);
+        var textLogprobs = new List<float>(rawTokens.Count);
+        for (int i = 0; i < rawTokens.Count; i++)
+        {
+            int token = rawTokens[i];
+            if (token >= 0 && token < 151643)
+            {
+                textTokens.Add(token);
+                textLogprobs.Add(i < rawLogprobs.Count ? rawLogprobs[i] : 0f);
+            }
+        }
+
+        return (textTokens, textLogprobs);
+    }
+
+    public string DecodeTokens(IReadOnlyList<int> tokens)
+    {
+        var bytes = new List<byte>(tokens.Count * 4);
+        foreach (int token in tokens)
+        {
+            if (token < 0 || token >= _idToToken.Length)
+                continue;
+
+            string? raw = _idToToken[token];
+            if (raw is null)
+                continue;
+
+            foreach (char ch in raw)
+                if (_byteLevelDecode.TryGetValue(ch, out byte value))
+                    bytes.Add(value);
+        }
+
+        string text = Encoding.UTF8.GetString(bytes.ToArray());
+        return text.Length > 0 && text[0] == ' ' ? text[1..] : text;
+    }
+
+    private bool IsEos(int token) => _eosTokenIds.Contains(token);
+
+    private static List<int> BuildPromptIds(int audioTokenCount)
+    {
+        var ids = new List<int>(audioTokenCount + 16)
+        {
+            ImStartTokenId,
+            SystemTokenId,
+            NewlineTokenId,
+            ImEndTokenId,
+            NewlineTokenId,
+            ImStartTokenId,
+            UserTokenId,
+            NewlineTokenId,
+            AudioStartTokenId,
+        };
+
+        for (int i = 0; i < audioTokenCount; i++)
+            ids.Add(AudioPadTokenId);
+
+        ids.Add(AudioEndTokenId);
+        ids.Add(ImEndTokenId);
+        ids.Add(NewlineTokenId);
+        ids.Add(ImStartTokenId);
+        ids.Add(AssistantTokenId);
+        ids.Add(NewlineTokenId);
+        return ids;
+    }
+
+    private static int GetAudioPadStart(IReadOnlyList<int> promptIds)
+    {
+        for (int i = 0; i < promptIds.Count; i++)
+            if (promptIds[i] == AudioPadTokenId)
+                return i;
+        throw new InvalidOperationException("Prompt does not contain <|audio_pad|> tokens.");
+    }
+
+    private static float[] ComputeLogMelSpectrogram(float[] signal, out int framesOut)
+    {
+        int pad = NFft / 2;
+        float[] padded = ReflectPad(signal, pad);
+        int frameCount = ((padded.Length - NFft) / HopLength) + 1;
+        int keptFrames = Math.Max(frameCount - 1, 1);
+        int freqBins = (NFft / 2) + 1;
+        var mel = new float[NMels * keptFrames];
+        var fft = new Complex32[NFft];
+
+        float maxLog = float.NegativeInfinity;
+        for (int frame = 0; frame < frameCount; frame++)
+        {
+            int start = frame * HopLength;
+            Array.Clear(fft, 0, fft.Length);
+            for (int i = 0; i < NFft; i++)
+                fft[i] = new Complex32((float)(padded[start + i] * HannWindow[i]), 0f);
+
+            Fourier.Forward(fft, FourierOptions.NoScaling);
+
+            if (frame >= keptFrames)
+                continue;
+
+            for (int m = 0; m < NMels; m++)
+            {
+                double sum = 0;
+                for (int k = 0; k < freqBins; k++)
+                {
+                    float re = fft[k].Real;
+                    float im = fft[k].Imaginary;
+                    sum += MelFilterbank[m, k] * (re * re + im * im);
+                }
+
+                float log = MathF.Log10(MathF.Max((float)sum, 1e-10f));
+                mel[m * keptFrames + frame] = log;
+                if (log > maxLog)
+                    maxLog = log;
+            }
+        }
+
+        float floor = MathF.Max(maxLog - LogClampSpan, LogFloor);
+        for (int i = 0; i < mel.Length; i++)
+            mel[i] = (MathF.Max(mel[i], floor) + LogOffset) / LogOffset;
+
+        framesOut = keptFrames;
+        return mel;
+    }
+
+    private static float[] ReflectPad(float[] signal, int pad)
+    {
+        if (signal.Length == 0)
+            return new float[pad * 2];
+
+        var padded = new float[signal.Length + (pad * 2)];
+        Array.Copy(signal, 0, padded, pad, signal.Length);
+
+        for (int i = 0; i < pad; i++)
+        {
+            int leftSrc = Math.Min(signal.Length - 1, pad - i);
+            int rightSrc = Math.Max(0, signal.Length - 2 - i);
+            padded[i] = signal[leftSrc];
+            padded[pad + signal.Length + i] = signal[rightSrc];
+        }
+
+        return padded;
+    }
+
+    private static float[,] CreateMelFilterbank()
+    {
+        int freqBins = (NFft / 2) + 1;
+        var fb = new float[NMels, freqBins];
+
+        var fftFreqs = new double[freqBins];
+        for (int k = 0; k < freqBins; k++)
+            fftFreqs[k] = (double)k * SampleRate / NFft;
+
+        double fminMel = AudioUtils.HzToMelSlaney(0.0);
+        double fmaxMel = AudioUtils.HzToMelSlaney(SampleRate / 2.0);
+        var melF = new double[NMels + 2];
+        for (int i = 0; i <= NMels + 1; i++)
+        {
+            double m = fminMel + (fmaxMel - fminMel) * i / (NMels + 1);
+            melF[i] = AudioUtils.MelToHzSlaney(m);
+        }
+
+        var fdiff = new double[NMels + 1];
+        for (int i = 0; i <= NMels; i++)
+            fdiff[i] = melF[i + 1] - melF[i];
+
+        for (int i = 0; i < NMels; i++)
+        {
+            for (int k = 0; k < freqBins; k++)
+            {
+                double lower = (fftFreqs[k] - melF[i]) / fdiff[i];
+                double upper = (melF[i + 2] - fftFreqs[k]) / fdiff[i + 1];
+                fb[i, k] = (float)Math.Max(0.0, Math.Min(lower, upper));
+            }
+        }
+
+        for (int i = 0; i < NMels; i++)
+        {
+            float enorm = (float)(2.0 / (melF[i + 2] - melF[i]));
+            for (int k = 0; k < freqBins; k++)
+                fb[i, k] *= enorm;
+        }
+
+        return fb;
+    }
+
+    private static float[] ExtractTensor(Tensor<float> tensor)
+    {
+        if (tensor is DenseTensor<float> dense)
+            return dense.Buffer.ToArray();
+
+        var result = new float[tensor.Length];
+        int i = 0;
+        foreach (float value in tensor)
+            result[i++] = value;
+        return result;
+    }
+
+    private static (string?[] idToToken, Dictionary<int, string> addedTokenContent) LoadTokenizerVocab(string path)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var root = doc.RootElement;
+        var vocab = root.GetProperty("model").GetProperty("vocab");
+        int maxId = -1;
+        foreach (var kv in vocab.EnumerateObject())
+            maxId = Math.Max(maxId, kv.Value.GetInt32());
+
+        var added = new Dictionary<int, string>();
+        if (root.TryGetProperty("added_tokens", out var addedTokens))
+        {
+            foreach (var token in addedTokens.EnumerateArray())
+            {
+                int id = token.GetProperty("id").GetInt32();
+                string content = token.GetProperty("content").GetString() ?? "";
+                added[id] = content;
+                maxId = Math.Max(maxId, id);
+            }
+        }
+
+        var idToToken = new string?[maxId + 1];
+        foreach (var kv in vocab.EnumerateObject())
+            idToToken[kv.Value.GetInt32()] = kv.Name;
+
+        return (idToToken, added);
+    }
+
+    private static Dictionary<char, byte> BuildByteLevelDecode()
+    {
+        var bs = new List<int>();
+        for (int i = (int)'!'; i <= (int)'~'; i++) bs.Add(i);
+        for (int i = 0xA1; i <= 0xAC; i++) bs.Add(i);
+        for (int i = 0xAE; i <= 0xFF; i++) bs.Add(i);
+
+        var cs = new List<int>(bs);
+        int extra = 0;
+        for (int b = 0; b < 256; b++)
+        {
+            if (bs.Contains(b)) continue;
+            bs.Add(b);
+            cs.Add(256 + extra);
+            extra++;
+        }
+
+        var map = new Dictionary<char, byte>(256);
+        for (int i = 0; i < bs.Count; i++)
+            map[(char)cs[i]] = (byte)bs[i];
+        return map;
+    }
+
+    public void Dispose()
+    {
+        _embedAccessor.Dispose();
+        _embedMmf.Dispose();
+        _decoderStep.Dispose();
+        _decoderInit.Dispose();
+        _encoder.Dispose();
+    }
+}
+
+public sealed record QwenRecognitionResult(
+    int SegmentId,
+    string Text,
+    IReadOnlyList<int> RawTokens,
+    IReadOnlyList<int> TextTokens,
+    IReadOnlyList<float> TextLogprobs);

--- a/src/Vernacula.Base/Vernacula.Base.csproj
+++ b/src/Vernacula.Base/Vernacula.Base.csproj
@@ -20,7 +20,7 @@
        provide their own variant at runtime without package duplication.
        The managed assembly version here must match what the consuming app provides at runtime. -->
   <ItemGroup Condition="'$(EP)' == 'Cuda' AND !($([MSBuild]::IsOSPlatform('OSX')) AND $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'X64')">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.2"
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.4"
                       PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(EP)' == 'DirectML'">
@@ -28,7 +28,7 @@
                       PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(EP)' == 'Cpu' AND !($([MSBuild]::IsOSPlatform('OSX')) AND $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'X64')">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2"
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4"
                       PrivateAssets="all" />
   </ItemGroup>
   <!-- macOS x64 (Intel): 1.24.x dropped osx-x64 native support; pin to 1.19.2 to match runtime -->

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -23,6 +23,7 @@ string  asrBackend      = "parakeet";   // parakeet, cohere, qwen3asr, or vibevo
 string? cohereModelDir  = null;         // defaults to <modelDir>/cohere_transcribe
 string? cohereLanguage  = null;         // ISO 639-1 forced language (e.g. "en")
 string? qwen3AsrModelDir = null;        // defaults to <modelDir>/qwen3asr
+bool    forceQwen3AsrSerial = false;    // --qwen3asr-serial disables experimental batching
 string? vibevoiceModelDir = null;       // defaults to <modelDir>/vibevoice_asr
 string? profileOutputDir  = null;       // ORT profiling output dir (vibevoice only)
 int     profileMaxTokens  = 200;        // cap maxNewTokens during profiling to stay under ORT 1M event limit
@@ -71,6 +72,7 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--cohere-model":     cohereModelDir    = args[++i]; break;
         case "--qwen3asr-model":   qwen3AsrModelDir  = args[++i]; break;
+        case "--qwen3asr-serial":  forceQwen3AsrSerial = true; break;
         case "--vibevoice-model":  vibevoiceModelDir = args[++i]; break;
         case "--min-asr-seconds":  minAsrSeconds     = double.Parse(args[++i]); break;
         case "--asr-buffer":       asrBufferSeconds  = double.Parse(args[++i]); break;
@@ -553,13 +555,16 @@ try
 
         bool hasExperimentalQwenBatchingArtifacts;
         {
-            bool hasBatchedFiles = File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.EncoderBatchedFile)) &&
+            bool hasBatchedFiles = !forceQwen3AsrSerial &&
+                                   File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.EncoderBatchedFile)) &&
                                    File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.DecoderInitBatchedFile));
             using var qwen3Asr = new Qwen3Asr(qwen3AsrDir, preferBatched: hasBatchedFiles);
             int totalSegs = segs.Count;
             int completed = 0;
             hasExperimentalQwenBatchingArtifacts = qwen3Asr.HasExperimentalBatchingArtifacts();
-            string batchNote = hasExperimentalQwenBatchingArtifacts ? " (batched encoder+prefill)" : "";
+            string batchNote = forceQwen3AsrSerial
+                ? " (serial forced)"
+                : hasExperimentalQwenBatchingArtifacts ? " (batched encoder+prefill)" : "";
 
             Console.WriteLine($"Transcribing {totalSegs} segment(s) (Qwen3-ASR{batchNote})...");
             var recognitionResults = hasExperimentalQwenBatchingArtifacts
@@ -778,6 +783,7 @@ static void PrintUsage()
     Console.WriteLine("  --asr <parakeet|cohere|qwen3asr|vibevoice>  ASR backend (default: parakeet)");
     Console.WriteLine("  --cohere-model <dir>               Path to Cohere Transcribe model dir (default: <model>/cohere_transcribe)");
     Console.WriteLine("  --qwen3asr-model <dir>             Path to Qwen3-ASR model dir (default: <model>/qwen3asr)");
+    Console.WriteLine("  --qwen3asr-serial                  Force serial Qwen3-ASR, disabling experimental batching");
     Console.WriteLine("  --vibevoice-model <dir>            Path to VibeVoice-ASR model dir (default: <model>/vibevoice_asr)");
     Console.WriteLine("  --min-asr-seconds <n>              Minimum audio span (s) per ASR group when using segmented VibeVoice (default: 5.0)");
     Console.WriteLine("  --asr-buffer <n>                   Seconds of audio padding on each side of a group (default: 0.0); helps boundary transitions");

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -363,6 +363,7 @@ try
 
     var results = new List<(double start, double end, string spkId, string text)>(segs.Count);
     var swAsr = Stopwatch.StartNew();
+    QwenExperimentalBatchBenchmark? qwenBatchBenchmark = null;
 
     if (skipAsr)
     {
@@ -550,22 +551,51 @@ try
             return 1;
         }
 
-        using var qwen3Asr = new Qwen3Asr(qwen3AsrDir);
-        int totalSegs = segs.Count;
-        int completed = 0;
-
-        Console.WriteLine($"Transcribing {totalSegs} segment(s) (Qwen3-ASR)...");
-        foreach (var result in qwen3Asr.RecognizeDetailed(segs, audio))
+        bool hasExperimentalQwenBatchingArtifacts;
         {
-            cts.Token.ThrowIfCancellationRequested();
-            completed++;
-            var (start, end, spkId) = segs[result.SegmentId];
-            results.Add((start, end, spkId, result.Text));
-            Console.Write($"\r  {completed}/{totalSegs}");
+            bool hasBatchedFiles = File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.EncoderBatchedFile)) &&
+                                   File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.DecoderInitBatchedFile));
+            using var qwen3Asr = new Qwen3Asr(qwen3AsrDir, preferBatched: hasBatchedFiles);
+            int totalSegs = segs.Count;
+            int completed = 0;
+            hasExperimentalQwenBatchingArtifacts = qwen3Asr.HasExperimentalBatchingArtifacts();
+            string batchNote = hasExperimentalQwenBatchingArtifacts ? " (batched encoder+prefill)" : "";
+
+            Console.WriteLine($"Transcribing {totalSegs} segment(s) (Qwen3-ASR{batchNote})...");
+            var recognitionResults = hasExperimentalQwenBatchingArtifacts
+                ? qwen3Asr.RecognizeBatchedDetailed(segs, audio)
+                : qwen3Asr.RecognizeDetailed(segs, audio);
+
+            foreach (var result in recognitionResults)
+            {
+                cts.Token.ThrowIfCancellationRequested();
+                completed++;
+                var (start, end, spkId) = segs[result.SegmentId];
+                results.Add((start, end, spkId, result.Text));
+                Console.Write($"\r  {completed}/{totalSegs}");
+            }
         }
 
         Console.WriteLine();
         swAsr.Stop();
+
+        if (showBenchmark)
+        {
+            if (hasExperimentalQwenBatchingArtifacts)
+            {
+                Console.Write("Benchmarking experimental Qwen batching... ");
+                qwenBatchBenchmark = Qwen3Asr.BenchmarkExperimentalBatching(
+                    qwen3AsrDir,
+                    ExecutionProvider.Auto,
+                    segs,
+                    audio);
+                Console.WriteLine("done");
+            }
+            else
+            {
+                Console.WriteLine("Experimental Qwen batching artifacts not found; skipping batching benchmark.");
+            }
+        }
     }
     else
     {
@@ -620,6 +650,31 @@ try
         Console.WriteLine($"ASR             : {swAsr.ElapsedMilliseconds}ms");
         Console.WriteLine($"Total           : {totalMs}ms");
         Console.WriteLine($"Real-time factor: {rtf:F4}  (< 1.0 = faster than real-time)");
+
+        if (qwenBatchBenchmark is not null)
+        {
+            double serialStageMs = qwenBatchBenchmark.SerialEncoderMilliseconds + qwenBatchBenchmark.SerialPrefillMilliseconds;
+            double batchedStageMs = qwenBatchBenchmark.BatchedEncoderMilliseconds + qwenBatchBenchmark.BatchedPrefillMilliseconds;
+            double speedup = batchedStageMs > 0 ? serialStageMs / batchedStageMs : 0;
+
+            Console.WriteLine();
+            Console.WriteLine("Qwen Experimental Batching (encoder + prefill only):");
+            Console.WriteLine($"  Free VRAM      : {qwenBatchBenchmark.FreeGpuMemoryMb} MB");
+            Console.WriteLine($"  Segments       : {qwenBatchBenchmark.SegmentCount}");
+            Console.WriteLine($"  Batch runs     : {qwenBatchBenchmark.BatchRuns}");
+            Console.WriteLine($"  Seconds ceiling: {qwenBatchBenchmark.TotalSecondsCeiling:F0}s");
+            Console.WriteLine($"  Serial encoder : {qwenBatchBenchmark.SerialEncoderMilliseconds:F1}ms");
+            Console.WriteLine($"  Serial prefill : {qwenBatchBenchmark.SerialPrefillMilliseconds:F1}ms");
+            Console.WriteLine($"  Batched encoder: {qwenBatchBenchmark.BatchedEncoderMilliseconds:F1}ms");
+            Console.WriteLine($"  Batched prefill: {qwenBatchBenchmark.BatchedPrefillMilliseconds:F1}ms");
+            Console.WriteLine($"  Stage speedup  : {speedup:F2}x");
+            foreach (var batch in qwenBatchBenchmark.Batches)
+            {
+                Console.WriteLine(
+                    $"    batch segs={batch.SegmentCount}, total={batch.TotalSeconds:F1}s, max={batch.MaxSegmentSeconds:F1}s, " +
+                    $"encoder={batch.EncoderMilliseconds:F1}ms, prefill={batch.PrefillMilliseconds:F1}ms");
+            }
+        }
     }
 }
 catch (OperationCanceledException)

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -24,6 +24,7 @@ string? cohereModelDir  = null;         // defaults to <modelDir>/cohere_transcr
 string? cohereLanguage  = null;         // ISO 639-1 forced language (e.g. "en")
 string? qwen3AsrModelDir = null;        // defaults to <modelDir>/qwen3asr
 bool    forceQwen3AsrSerial = false;    // --qwen3asr-serial disables experimental batching
+GraphOptimizationLevel qwen3AsrOrtOptLevel = GraphOptimizationLevel.ORT_ENABLE_EXTENDED;
 string? vibevoiceModelDir = null;       // defaults to <modelDir>/vibevoice_asr
 string? profileOutputDir  = null;       // ORT profiling output dir (vibevoice only)
 int     profileMaxTokens  = 200;        // cap maxNewTokens during profiling to stay under ORT 1M event limit
@@ -73,6 +74,21 @@ for (int i = 0; i < args.Length; i++)
         case "--cohere-model":     cohereModelDir    = args[++i]; break;
         case "--qwen3asr-model":   qwen3AsrModelDir  = args[++i]; break;
         case "--qwen3asr-serial":  forceQwen3AsrSerial = true; break;
+        case "--qwen3asr-ort-opt":
+            string qwenOptLevel = args[++i].ToLowerInvariant();
+            qwen3AsrOrtOptLevel = qwenOptLevel switch
+            {
+                "extended" => GraphOptimizationLevel.ORT_ENABLE_EXTENDED,
+                "basic" => GraphOptimizationLevel.ORT_ENABLE_BASIC,
+                "disabled" => GraphOptimizationLevel.ORT_DISABLE_ALL,
+                _ => (GraphOptimizationLevel)(-1),
+            };
+            if ((int)qwen3AsrOrtOptLevel == -1)
+            {
+                Console.Error.WriteLine($"Unknown Qwen ORT optimization level: {qwenOptLevel}. Choose: extended, basic, disabled.");
+                return 1;
+            }
+            break;
         case "--vibevoice-model":  vibevoiceModelDir = args[++i]; break;
         case "--min-asr-seconds":  minAsrSeconds     = double.Parse(args[++i]); break;
         case "--asr-buffer":       asrBufferSeconds  = double.Parse(args[++i]); break;
@@ -557,8 +573,12 @@ try
         {
             bool hasBatchedFiles = !forceQwen3AsrSerial &&
                                    File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.EncoderBatchedFile)) &&
-                                   File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.DecoderInitBatchedFile));
-            using var qwen3Asr = new Qwen3Asr(qwen3AsrDir, preferBatched: hasBatchedFiles);
+                                   (File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.DecoderFile)) ||
+                                    File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.DecoderInitBatchedFile)));
+            using var qwen3Asr = new Qwen3Asr(
+                qwen3AsrDir,
+                preferBatched: hasBatchedFiles,
+                optimizationLevel: qwen3AsrOrtOptLevel);
             int totalSegs = segs.Count;
             int completed = 0;
             hasExperimentalQwenBatchingArtifacts = qwen3Asr.HasExperimentalBatchingArtifacts();
@@ -593,7 +613,8 @@ try
                     qwen3AsrDir,
                     ExecutionProvider.Auto,
                     segs,
-                    audio);
+                    audio,
+                    qwen3AsrOrtOptLevel);
                 Console.WriteLine("done");
             }
             else
@@ -784,6 +805,8 @@ static void PrintUsage()
     Console.WriteLine("  --cohere-model <dir>               Path to Cohere Transcribe model dir (default: <model>/cohere_transcribe)");
     Console.WriteLine("  --qwen3asr-model <dir>             Path to Qwen3-ASR model dir (default: <model>/qwen3asr)");
     Console.WriteLine("  --qwen3asr-serial                  Force serial Qwen3-ASR, disabling experimental batching");
+    Console.WriteLine("  --qwen3asr-ort-opt <extended|basic|disabled>");
+    Console.WriteLine("                                     ONNX Runtime graph optimization level for Qwen3-ASR");
     Console.WriteLine("  --vibevoice-model <dir>            Path to VibeVoice-ASR model dir (default: <model>/vibevoice_asr)");
     Console.WriteLine("  --min-asr-seconds <n>              Minimum audio span (s) per ASR group when using segmented VibeVoice (default: 5.0)");
     Console.WriteLine("  --asr-buffer <n>                   Seconds of audio padding on each side of a group (default: 0.0); helps boundary transitions");

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -19,9 +19,10 @@ bool    showBenchmark   = false;
 bool    skipAsr         = false;
 string  denoiser        = "none";       // none, dfn3
 string? denoiserModels  = null;         // defaults to <modelDir>/deepfilternet3
-string  asrBackend      = "parakeet";   // parakeet, cohere, or vibevoice
+string  asrBackend      = "parakeet";   // parakeet, cohere, qwen3asr, or vibevoice
 string? cohereModelDir  = null;         // defaults to <modelDir>/cohere_transcribe
 string? cohereLanguage  = null;         // ISO 639-1 forced language (e.g. "en")
+string? qwen3AsrModelDir = null;        // defaults to <modelDir>/qwen3asr
 string? vibevoiceModelDir = null;       // defaults to <modelDir>/vibevoice_asr
 string? profileOutputDir  = null;       // ORT profiling output dir (vibevoice only)
 int     profileMaxTokens  = 200;        // cap maxNewTokens during profiling to stay under ORT 1M event limit
@@ -62,13 +63,14 @@ for (int i = 0; i < args.Length; i++)
         case "--denoiser-models": denoiserModels = args[++i]; break;
         case "--asr":
             asrBackend = args[++i].ToLowerInvariant();
-            if (asrBackend is not ("parakeet" or "cohere" or "vibevoice"))
+            if (asrBackend is not ("parakeet" or "cohere" or "qwen3asr" or "vibevoice"))
             {
-                Console.Error.WriteLine($"Unknown ASR backend: {asrBackend}. Choose: parakeet, cohere, vibevoice.");
+                Console.Error.WriteLine($"Unknown ASR backend: {asrBackend}. Choose: parakeet, cohere, qwen3asr, vibevoice.");
                 return 1;
             }
             break;
         case "--cohere-model":     cohereModelDir    = args[++i]; break;
+        case "--qwen3asr-model":   qwen3AsrModelDir  = args[++i]; break;
         case "--vibevoice-model":  vibevoiceModelDir = args[++i]; break;
         case "--min-asr-seconds":  minAsrSeconds     = double.Parse(args[++i]); break;
         case "--asr-buffer":       asrBufferSeconds  = double.Parse(args[++i]); break;
@@ -533,6 +535,38 @@ try
         Console.WriteLine();
         swAsr.Stop();
     }
+    else if (asrBackend == "qwen3asr")
+    {
+        string qwen3AsrDir = qwen3AsrModelDir
+            ?? (Directory.Exists(Path.Combine(modelDir, Config.Qwen3AsrSubDir))
+                ? Path.Combine(modelDir, Config.Qwen3AsrSubDir)
+                : modelDir);
+
+        if (!File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.EncoderFile)))
+        {
+            Console.Error.WriteLine($"\nError: Qwen3-ASR model not found in: {qwen3AsrDir}");
+            Console.Error.WriteLine($"Expected {Qwen3Asr.EncoderFile} and related files there.");
+            Console.Error.WriteLine("Use --qwen3asr-model <dir> to specify the directory explicitly.");
+            return 1;
+        }
+
+        using var qwen3Asr = new Qwen3Asr(qwen3AsrDir);
+        int totalSegs = segs.Count;
+        int completed = 0;
+
+        Console.WriteLine($"Transcribing {totalSegs} segment(s) (Qwen3-ASR)...");
+        foreach (var result in qwen3Asr.RecognizeDetailed(segs, audio))
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            completed++;
+            var (start, end, spkId) = segs[result.SegmentId];
+            results.Add((start, end, spkId, result.Text));
+            Console.Write($"\r  {completed}/{totalSegs}");
+        }
+
+        Console.WriteLine();
+        swAsr.Stop();
+    }
     else
     {
         var (encoderFile, decoderJointFile) = Config.GetAsrFiles(precision);
@@ -686,8 +720,9 @@ static void PrintUsage()
     Console.WriteLine("  --diarization <backend>            Diarization backend: sortformer, diarizen, vad, vibevoice-asr-builtin");
     Console.WriteLine("                                     (default: sortformer, or vibevoice-asr-builtin when --asr vibevoice)");
     Console.WriteLine("  --vad                              Use VAD instead of diarization (deprecated)");
-    Console.WriteLine("  --asr <parakeet|cohere|vibevoice>  ASR backend (default: parakeet)");
+    Console.WriteLine("  --asr <parakeet|cohere|qwen3asr|vibevoice>  ASR backend (default: parakeet)");
     Console.WriteLine("  --cohere-model <dir>               Path to Cohere Transcribe model dir (default: <model>/cohere_transcribe)");
+    Console.WriteLine("  --qwen3asr-model <dir>             Path to Qwen3-ASR model dir (default: <model>/qwen3asr)");
     Console.WriteLine("  --vibevoice-model <dir>            Path to VibeVoice-ASR model dir (default: <model>/vibevoice_asr)");
     Console.WriteLine("  --min-asr-seconds <n>              Minimum audio span (s) per ASR group when using segmented VibeVoice (default: 5.0)");
     Console.WriteLine("  --asr-buffer <n>                   Seconds of audio padding on each side of a group (default: 0.0); helps boundary transitions");

--- a/src/Vernacula.CLI/Vernacula.CLI.csproj
+++ b/src/Vernacula.CLI/Vernacula.CLI.csproj
@@ -24,7 +24,7 @@
 
   <!-- CUDA execution provider (NVIDIA GPU) -->
   <ItemGroup Condition="'$(EP)' == 'Cuda'">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.2" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.4" />
   </ItemGroup>
 
   <!-- DirectML execution provider (any DX12 GPU: AMD, Intel, NVIDIA) -->
@@ -34,7 +34,7 @@
 
   <!-- CPU-only baseline -->
   <ItemGroup Condition="'$(EP)' == 'Cpu'">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds full Qwen3-ASR-1.7B support to the app:

- **ONNX export pipeline** — Python scripts for encoder + unified decoder export, batching variants, parity verification, and graph optimization.
- **C# runtime** — single-stream + GPU-batched decode paths with continuous batching, GPU KV chaining (no PCIe round-trips between decode steps), and NVML-based batch sizing fallback.
- **UI integration** — Qwen3-ASR selectable as an ASR backend in settings, with force-language picker; transcript editor gets a per-segment language chip that pre-fills from detected language and forces that language on redo ASR.
- **Force-language implementation** — forced prefix tokens are prepended to the prompt (processed through prefill as established context) rather than injected mid-generation; overriding token selection during decode caused KV-state distortion that produced garbage output on short segments.
- **Code review pass** — unified the language-option record across settings + editor, localized the language-chip tooltip, fixed hardcoded KV dims, removed dead variables.

## Test plan

- [ ] Run a Qwen3-ASR job end-to-end on a multi-segment audio file; confirm no "language English" prefix leaks into the transcript
- [ ] Toggle force-language in settings across several ISO codes; confirm the transcript matches the forced language and segments don't produce corrupted output
- [ ] In the transcript editor, open a Qwen3-ASR job and verify the language chip shows the detected language
- [ ] Change chip language and run Redo ASR; confirm the new language is forced and the chip updates to the result language
- [ ] Run a non-Qwen3-ASR job (Parakeet / Cohere / VibeVoice) and confirm the language chip is hidden
- [ ] Verify GPU batching by checking stderr for `[Qwen3Asr] static-batch decode:` lines with sane slot counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)