### PR TITLE
AsrMismatch popup: add force-language affordance for no-alternative branch

### DIFF
--- a/src/Vernacula.Avalonia/App.axaml.cs
+++ b/src/Vernacula.Avalonia/App.axaml.cs
@@ -149,7 +149,7 @@ public partial class App : Application
             // awaits the user's choice before the worker continues.
             Transcription.OnAsrLanguageMismatch = async (lidResult, currentBackend, suggestedBackend) =>
             {
-                Views.Dialogs.AsrMismatchChoice? choice = null;
+                Views.Dialogs.AsrMismatchResult? result = null;
                 await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
                 {
                     var dialog = new Views.Dialogs.AsrMismatchDialog();
@@ -159,9 +159,9 @@ public partial class App : Application
                         detectedProbability: lidResult.TopProbability,
                         currentBackend:     currentBackend,
                         suggestedBackend:   suggestedBackend);
-                    choice = await dialog.ShowDialog<Views.Dialogs.AsrMismatchChoice?>(desktop.MainWindow!);
+                    result = await dialog.ShowDialog<Views.Dialogs.AsrMismatchResult?>(desktop.MainWindow!);
                 });
-                return choice;
+                return result;
             };
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)

--- a/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
+++ b/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
@@ -204,4 +204,49 @@ public static class AsrLanguageSupport
         AsrBackend.VibeVoice => "vibevoice/vibevoice-asr",
         _ => throw new ArgumentOutOfRangeException(nameof(backend)),
     };
+
+    // English display names for every ISO 639-1 code that appears in any
+    // backend's supported set. Centralised here so the force-language picker
+    // (AsrMismatchDialog) can label languages for backends like Parakeet
+    // and VibeVoice that don't otherwise carry per-code display names.
+    private static readonly FrozenDictionary<string, string> IsoDisplayNamesMap =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ar"] = "Arabic",      ["bg"] = "Bulgarian",  ["cs"] = "Czech",
+            ["da"] = "Danish",      ["de"] = "German",     ["el"] = "Greek",
+            ["en"] = "English",     ["es"] = "Spanish",    ["et"] = "Estonian",
+            ["fa"] = "Persian",     ["fi"] = "Finnish",    ["fr"] = "French",
+            ["hi"] = "Hindi",       ["hr"] = "Croatian",   ["hu"] = "Hungarian",
+            ["id"] = "Indonesian",  ["it"] = "Italian",    ["ja"] = "Japanese",
+            ["ko"] = "Korean",      ["lt"] = "Lithuanian", ["lv"] = "Latvian",
+            ["mk"] = "Macedonian",  ["ms"] = "Malay",      ["mt"] = "Maltese",
+            ["nl"] = "Dutch",       ["pl"] = "Polish",     ["pt"] = "Portuguese",
+            ["ro"] = "Romanian",    ["ru"] = "Russian",    ["sk"] = "Slovak",
+            ["sl"] = "Slovenian",   ["sv"] = "Swedish",    ["th"] = "Thai",
+            ["tl"] = "Filipino",    ["tr"] = "Turkish",    ["uk"] = "Ukrainian",
+            ["vi"] = "Vietnamese",  ["zh"] = "Chinese",
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// English display name for an ISO 639-1 code, or the code itself if
+    /// no name is registered. Case-insensitive; deprecated codes are
+    /// normalized via <see cref="NormalizeIso"/>.
+    /// </summary>
+    public static string LanguageDisplayName(string iso)
+    {
+        if (string.IsNullOrWhiteSpace(iso)) return iso ?? string.Empty;
+        string code = NormalizeIso(iso);
+        return IsoDisplayNamesMap.TryGetValue(code, out string? name) ? name : code;
+    }
+
+    /// <summary>
+    /// Returns the user-pickable language list for a backend, sorted by
+    /// display name. Used by the force-language affordance in the LID
+    /// mismatch popup; does not include an "auto-detect" entry.
+    /// </summary>
+    public static IReadOnlyList<AsrLanguageOption> LanguageOptions(AsrBackend backend) =>
+        Get(backend)
+            .Select(c => new AsrLanguageOption(c, LanguageDisplayName(c)))
+            .OrderBy(o => o.DisplayName, StringComparer.Ordinal)
+            .ToArray();
 }

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -23,7 +23,7 @@ internal class TranscriptionService
     /// pipeline just logs the mismatch and continues with the current
     /// backend — matching what happened before the popup was added.
     /// </summary>
-    public Func<Vernacula.Base.Models.LidResult, AsrBackend, AsrBackend?, Task<Views.Dialogs.AsrMismatchChoice?>>? OnAsrLanguageMismatch { get; set; }
+    public Func<Vernacula.Base.Models.LidResult, AsrBackend, AsrBackend?, Task<Views.Dialogs.AsrMismatchResult?>>? OnAsrLanguageMismatch { get; set; }
 
     public TranscriptionService(SettingsService settings, LangIdService langId)
     {
@@ -608,12 +608,12 @@ internal class TranscriptionService
                         // If the host wired up the interactive callback (Avalonia
                         // does; CLI / tests don't), ask the user what to do.
                         // Otherwise fall through to the log-and-continue fallback.
-                        Views.Dialogs.AsrMismatchChoice? choice = null;
+                        Views.Dialogs.AsrMismatchResult? result = null;
                         if (OnAsrLanguageMismatch is not null)
                         {
                             try
                             {
-                                choice = await OnAsrLanguageMismatch(lidResult, backend.Value, alt).ConfigureAwait(false);
+                                result = await OnAsrLanguageMismatch(lidResult, backend.Value, alt).ConfigureAwait(false);
                             }
                             catch (Exception ex)
                             {
@@ -622,7 +622,7 @@ internal class TranscriptionService
                             }
                         }
 
-                        switch (choice)
+                        switch (result?.Choice)
                         {
                             case Views.Dialogs.AsrMismatchChoice.SwitchBackend when alt is not null:
                                 string newModelName = AsrLanguageSupport.ModelName(alt.Value);
@@ -646,6 +646,22 @@ internal class TranscriptionService
                                 // for a mismatch the user already resolved).
                                 db.UpdateMetadata("asr_model", newModelName);
                                 db.InsertMetadata("asr_model_overridden_from", AsrLanguageSupport.BackendOf(AsrLanguageSupport.ModelName(backend.Value))?.ToString() ?? backend.Value.ToString());
+                                break;
+
+                            case Views.Dialogs.AsrMismatchChoice.ForceLanguage
+                                when !string.IsNullOrWhiteSpace(result?.ForcedIso)
+                                  && AsrLanguageSupport.Supports(backend.Value, result!.ForcedIso!):
+                                string forcedIso = AsrLanguageSupport.NormalizeIso(result.ForcedIso!);
+                                Console.WriteLine(
+                                    $"[Transcription] LID mismatch: user forced language " +
+                                    $"'{forcedIso}' on {backend.Value} despite detected '{lidResult.Iso}'.");
+                                asrLanguageCode = forcedIso;
+                                // Mark the override so the Results view shows a
+                                // "user-forced language" badge instead of the
+                                // amber mismatch banner. Also remember what was
+                                // detected so the badge can explain the gap.
+                                db.InsertMetadata("asr_language_user_forced", "1");
+                                db.InsertMetadata("asr_language_user_forced_from", lidResult.Iso);
                                 break;
 
                             case Views.Dialogs.AsrMismatchChoice.CancelJob:

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -19,9 +19,13 @@ internal class TranscriptionService
     /// Optional callback invoked when LID detects a language the current
     /// ASR backend can't handle. Receives the LID result, the current
     /// backend, and the best alternative backend (or null if none). The
-    /// callback returns the user's choice. When unset (CLI / tests), the
-    /// pipeline just logs the mismatch and continues with the current
-    /// backend — matching what happened before the popup was added.
+    /// callback returns an <see cref="Views.Dialogs.AsrMismatchResult"/>
+    /// carrying the user's choice plus, for
+    /// <see cref="Views.Dialogs.AsrMismatchChoice.ForceLanguage"/>, the
+    /// ISO code they asked the current backend to transcribe as. When
+    /// unset (CLI / tests), the pipeline just logs the mismatch and
+    /// continues with the current backend — matching what happened before
+    /// the popup was added.
     /// </summary>
     public Func<Vernacula.Base.Models.LidResult, AsrBackend, AsrBackend?, Task<Views.Dialogs.AsrMismatchResult?>>? OnAsrLanguageMismatch { get; set; }
 
@@ -649,9 +653,9 @@ internal class TranscriptionService
                                 break;
 
                             case Views.Dialogs.AsrMismatchChoice.ForceLanguage
-                                when !string.IsNullOrWhiteSpace(result?.ForcedIso)
-                                  && AsrLanguageSupport.Supports(backend.Value, result!.ForcedIso!):
-                                string forcedIso = AsrLanguageSupport.NormalizeIso(result.ForcedIso!);
+                                when result is { ForcedIso: { Length: > 0 } pickedIso }
+                                  && AsrLanguageSupport.Supports(backend.Value, pickedIso):
+                                string forcedIso = AsrLanguageSupport.NormalizeIso(pickedIso);
                                 Console.WriteLine(
                                     $"[Transcription] LID mismatch: user forced language " +
                                     $"'{forcedIso}' on {backend.Value} despite detected '{lidResult.Iso}'.");
@@ -663,6 +667,17 @@ internal class TranscriptionService
                                 db.InsertMetadata("asr_language_user_forced", "1");
                                 db.InsertMetadata("asr_language_user_forced_from", lidResult.Iso);
                                 break;
+
+                            case Views.Dialogs.AsrMismatchChoice.ForceLanguage:
+                                // Picker emitted a code the current backend
+                                // doesn't actually support, or no code at all.
+                                // The dialog's own filter should prevent this,
+                                // so log loudly and treat as KeepCurrent.
+                                Console.WriteLine(
+                                    $"[Transcription] LID mismatch: ForceLanguage rejected — " +
+                                    $"forcedIso='{result?.ForcedIso ?? "<null>"}' is not supported " +
+                                    $"by {backend.Value}. Falling through to KeepCurrent.");
+                                goto default;
 
                             case Views.Dialogs.AsrMismatchChoice.CancelJob:
                                 Console.WriteLine("[Transcription] LID mismatch: user cancelled the job.");

--- a/src/Vernacula.Avalonia/ViewModels/ResultsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/ResultsViewModel.cs
@@ -107,12 +107,15 @@ internal partial class ResultsViewModel : ObservableObject
             probSuffix = $", {p0:P0} confidence";
 
         string effectiveSuffix = "";
-        if (!string.IsNullOrWhiteSpace(effectiveIso)
+        if (!userForced
+            && !string.IsNullOrWhiteSpace(effectiveIso)
             && !string.Equals(effectiveIso, "auto", StringComparison.OrdinalIgnoreCase)
             && !string.Equals(effectiveIso, detectedIso, StringComparison.OrdinalIgnoreCase))
         {
             // Rare: ASR ran with a different language than LID detected
             // (e.g. user kept the current backend on the mismatch popup).
+            // Suppressed for user-forced runs — the dedicated badge below
+            // already explains the gap and would just be repeating itself.
             effectiveSuffix = $"; ASR ran as {effectiveIso}";
         }
 

--- a/src/Vernacula.Avalonia/ViewModels/ResultsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/ResultsViewModel.cs
@@ -34,6 +34,14 @@ internal partial class ResultsViewModel : ObservableObject
     [ObservableProperty] private string _reprocessButtonText = "Reprocess";
     [ObservableProperty] private bool _canReprocess;
 
+    /// <summary>
+    /// True when the user picked an explicit force-language in the LID
+    /// mismatch popup ("I know better — transcribe as X"). Drives a neutral
+    /// info badge that supersedes the amber mismatch banner.
+    /// </summary>
+    [ObservableProperty] private bool _showUserForcedLanguageBadge;
+    [ObservableProperty] private string _userForcedLanguageBadgeText = "";
+
     private int?       _jobId;
     private string?    _mismatchDetectedIso;
     private AsrBackend? _mismatchSuggestedBackend;
@@ -72,6 +80,8 @@ internal partial class ResultsViewModel : ObservableObject
         ShowDetectedLanguageInfo = false;
         DetectedLanguageInfoText = "";
         ShowMismatchBanner       = false;
+        ShowUserForcedLanguageBadge = false;
+        UserForcedLanguageBadgeText = "";
         CanReprocess             = false;
         _mismatchDetectedIso     = null;
         _mismatchSuggestedBackend = null;
@@ -84,6 +94,8 @@ internal partial class ResultsViewModel : ObservableObject
         bool    mismatch     = db.GetMetadata("detected_language_backend_mismatch") == "1";
         string? suggestedStr = db.GetMetadata("detected_language_suggested_backend");
         string? asrModel     = db.GetMetadata("asr_model");
+        bool    userForced   = db.GetMetadata("asr_language_user_forced") == "1";
+        string? userForcedFromIso = db.GetMetadata("asr_language_user_forced_from");
 
         if (string.IsNullOrWhiteSpace(detectedIso)) return;
 
@@ -108,6 +120,22 @@ internal partial class ResultsViewModel : ObservableObject
             (ambiguous ? "Language detection (ambiguous): " : "Language detected: ")
             + $"{detectedName} ({detectedIso}{probSuffix}){effectiveSuffix}";
         ShowDetectedLanguageInfo = true;
+
+        // User-forced override supersedes the amber mismatch banner — the
+        // job ran on a related language they explicitly picked, so it isn't
+        // an unresolved problem and we shouldn't nudge them to reprocess.
+        if (userForced && !string.IsNullOrWhiteSpace(effectiveIso))
+        {
+            string forcedName = AsrLanguageSupport.LanguageDisplayName(effectiveIso);
+            string fromName   = string.IsNullOrWhiteSpace(userForcedFromIso)
+                ? (detectedName ?? detectedIso)
+                : AsrLanguageSupport.LanguageDisplayName(userForcedFromIso!);
+            UserForcedLanguageBadgeText =
+                $"User-forced language: transcribed as {forcedName} ({effectiveIso}) " +
+                $"despite {fromName} being detected.";
+            ShowUserForcedLanguageBadge = true;
+            return;
+        }
 
         if (!mismatch) return;
 

--- a/src/Vernacula.Avalonia/Views/Dialogs/AsrMismatchDialog.axaml
+++ b/src/Vernacula.Avalonia/Views/Dialogs/AsrMismatchDialog.axaml
@@ -1,7 +1,7 @@
 <Window x:Class="Vernacula.App.Views.Dialogs.AsrMismatchDialog"
         xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Width="520"
+        Width="540"
         SizeToContent="Height"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
@@ -21,6 +21,39 @@
                        TextWrapping="Wrap"
                        Foreground="{DynamicResource SubtextBrush}"
                        FontSize="11" />
+
+            <!-- Force-language picker, shown only when no alternative backend
+                 supports the detected language. Lets the user pick a related
+                 language from the current backend's supported set ("I know
+                 better — transcribe as <X>"). -->
+            <Border x:Name="ForceLanguagePanel"
+                    IsVisible="False"
+                    Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource OverlayBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="10">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="I know better — transcribe as:"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource TextBrush}" />
+                    <TextBlock Text="Pick a related language the current backend supports (e.g. Croatian for Serbian). The Results view will flag this as a user-forced language."
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource SubtextBrush}"
+                               FontSize="11" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                        <ComboBox x:Name="ForceLanguageBox"
+                                  Grid.Column="0"
+                                  HorizontalAlignment="Stretch"
+                                  SelectionChanged="ForceLanguageBox_SelectionChanged" />
+                        <Button x:Name="ForceLanguageButton"
+                                Grid.Column="1"
+                                Content="Transcribe as selected"
+                                IsEnabled="False"
+                                Click="ForceLanguage_Click" />
+                    </Grid>
+                </StackPanel>
+            </Border>
 
             <StackPanel Orientation="Horizontal"
                         HorizontalAlignment="Right"

--- a/src/Vernacula.Avalonia/Views/Dialogs/AsrMismatchDialog.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/Dialogs/AsrMismatchDialog.axaml.cs
@@ -14,7 +14,19 @@ public enum AsrMismatchChoice
     SwitchBackend,
     KeepCurrent,
     CancelJob,
+    /// <summary>
+    /// User asserted "I know better" and picked a related language the
+    /// current backend can transcribe (e.g. Croatian for Serbian).
+    /// <see cref="AsrMismatchResult.ForcedIso"/> carries the picked code.
+    /// </summary>
+    ForceLanguage,
 }
+
+/// <summary>
+/// Bundles the user's choice plus, for <see cref="AsrMismatchChoice.ForceLanguage"/>,
+/// the ISO 639-1 code they picked from the current backend's supported set.
+/// </summary>
+public sealed record AsrMismatchResult(AsrMismatchChoice Choice, string? ForcedIso = null);
 
 public partial class AsrMismatchDialog : Window
 {
@@ -47,25 +59,44 @@ public partial class AsrMismatchDialog : Window
                 $"“Switch ASR” to use it for this job.";
             SwitchBackendButton.Content = $"Switch to {AsrLanguageSupport.DisplayName(alt)}";
             SwitchBackendButton.IsEnabled = true;
+            ForceLanguagePanel.IsVisible = false;
         }
         else
         {
             SubtleText.Text =
-                $"No available ASR backend supports {detectedName}. " +
+                $"No installed ASR backend supports {detectedName}. " +
                 $"You can keep the current backend (the transcription will " +
-                $"likely be wrong), or cancel the job and pick a different " +
-                $"audio file.";
+                $"likely be wrong), pick a related language below, or cancel " +
+                $"the job.";
             SwitchBackendButton.Content = "No alternative available";
             SwitchBackendButton.IsEnabled = false;
+
+            // Conservative scope: list only languages the *current* backend
+            // can actually transcribe. The other branch (suggested backend)
+            // already covers cases where some installed backend supports the
+            // detected ISO directly, so a union picker would add nothing here.
+            ForceLanguageBox.ItemsSource = AsrLanguageSupport.LanguageOptions(currentBackend);
+            ForceLanguageBox.SelectedIndex = -1;
+            ForceLanguageButton.IsEnabled = false;
+            ForceLanguagePanel.IsVisible = true;
         }
     }
 
+    private void ForceLanguageBox_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        => ForceLanguageButton.IsEnabled = ForceLanguageBox.SelectedItem is AsrLanguageOption;
+
+    private void ForceLanguage_Click(object? sender, RoutedEventArgs e)
+    {
+        if (ForceLanguageBox.SelectedItem is AsrLanguageOption opt)
+            Close(new AsrMismatchResult(AsrMismatchChoice.ForceLanguage, opt.Code));
+    }
+
     private void SwitchBackend_Click(object? sender, RoutedEventArgs e)
-        => Close(AsrMismatchChoice.SwitchBackend);
+        => Close(new AsrMismatchResult(AsrMismatchChoice.SwitchBackend));
 
     private void KeepCurrent_Click(object? sender, RoutedEventArgs e)
-        => Close(AsrMismatchChoice.KeepCurrent);
+        => Close(new AsrMismatchResult(AsrMismatchChoice.KeepCurrent));
 
     private void CancelJob_Click(object? sender, RoutedEventArgs e)
-        => Close(AsrMismatchChoice.CancelJob);
+        => Close(new AsrMismatchResult(AsrMismatchChoice.CancelJob));
 }

--- a/src/Vernacula.Avalonia/Views/ResultsView.axaml
+++ b/src/Vernacula.Avalonia/Views/ResultsView.axaml
@@ -79,6 +79,22 @@
             </Grid>
         </Border>
 
+        <!-- User-forced language badge (supersedes the mismatch banner when
+             the user explicitly chose to transcribe as a related language). -->
+        <Border Grid.Row="3"
+                IsVisible="{Binding ShowUserForcedLanguageBadge}"
+                Background="{DynamicResource SurfaceBrush}"
+                BorderBrush="{DynamicResource OverlayBrush}"
+                BorderThickness="1"
+                CornerRadius="4"
+                Padding="8,4"
+                HorizontalAlignment="Left"
+                Margin="0,0,0,12">
+            <TextBlock Text="{Binding UserForcedLanguageBadgeText}"
+                       Foreground="{DynamicResource SubtextBrush}"
+                       FontSize="11" />
+        </Border>
+
         <!-- Segments table -->
         <DataGrid x:Name="SegmentsGrid"
                   Grid.Row="4"


### PR DESCRIPTION
## Summary
- Replaces the dead-end "No available ASR backend supports `<X>`" UI in `AsrMismatchDialog` with an **"I know better — transcribe as `<picker>`"** affordance, per the design comment in `AsrLanguageSupport.cs` ("Cross-language fallback policy")
- Picker lists the current backend's supported ISO codes (conservative scope — the alternative-backend branch already covers cases where some installed backend supports the detected ISO directly)
- On confirm, the run sets `asr_language_code` to the picked ISO and records `asr_language_user_forced=1` (+ `asr_language_user_forced_from=<detected iso>`) in metadata; the Results view shows a neutral "user-forced language" badge that supersedes the amber mismatch banner so the user isn't nudged to reprocess a deliberate choice

## Files
- `Models/AsrLanguageSupport.cs` — added `IsoDisplayNamesMap`, `LanguageDisplayName(iso)`, `LanguageOptions(backend)` so backends without a per-code picker list (Parakeet, VibeVoice) can be labelled
- `Views/Dialogs/AsrMismatchDialog.axaml{,.cs}` — new `ForceLanguage` choice + `AsrMismatchResult` record (choice + optional `ForcedIso`); ComboBox panel shown only when no alternative backend exists
- `Services/TranscriptionService.cs` — callback signature returns `AsrMismatchResult?`; `ForceLanguage` case sets `asrLanguageCode` and persists the new metadata, guarded by `Supports(backend, forcedIso)`
- `App.axaml.cs` — lambda updated for the new return type
- `ViewModels/ResultsViewModel.cs` + `Views/ResultsView.axaml` — `ShowUserForcedLanguageBadge` / `UserForcedLanguageBadgeText`; rendered as a neutral subtle-info badge

Closes #12

## Test plan
- [ ] LID detects an unsupported language with no installed backend supporting it (e.g. force `sr` detection on a Parakeet-only install) → popup shows the new picker
- [ ] Pick a related language (e.g. `hr`), confirm → job runs with that code; Results view shows the user-forced badge, no amber mismatch banner
- [ ] LID detects a language another installed backend supports → popup still shows the SwitchBackend path (picker hidden)
- [ ] Cancel/KeepCurrent paths still work as before
- [ ] CLI / non-interactive callers (`OnAsrLanguageMismatch == null`) still fall through to log-and-continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)