### PR TITLE
Migrate Cohere ONNX export to dynamo (torch.export) path

### DIFF
--- a/scripts/cohere_export/README.md
+++ b/scripts/cohere_export/README.md
@@ -34,7 +34,7 @@ Export the standard Cohere ONNX package. This now exports the KV-cache decoder p
 ```bash
 python public/scripts/cohere_export/export_cohere_transcribe_to_onnx.py \
   --output-dir ./models/cohere_transcribe \
-  --opset 17
+  --opset 18
 ```
 
 Useful options:
@@ -45,6 +45,39 @@ Useful options:
 - `--overwrite` to replace an existing export
 - `--skip-encoder`, `--skip-decoder`, or `--skip-mel` to rerun only part of the export
 - `--conventional-decoder` to export the older `decoder.onnx` path instead of `decoder_init.onnx` + `decoder_step.onnx`
+- `--legacy-exporter` to fall back to the deprecated TorchScript ONNX path (`dynamo=False`); kept as an escape hatch for parity comparison
+
+## ONNX Exporter Choice
+
+The script defaults to the modern `torch.export`-based ONNX exporter (PyTorch's
+`torch.onnx.export(..., dynamo=True)`). Notes on the migration from the legacy
+TorchScript exporter:
+
+- `dynamic_axes` is replaced with `dynamic_shapes` (`torch.export.Dim`) per call site.
+- `onnxscript` is now a runtime requirement of the exporter; install via the updated `requirements.txt`.
+- Opset is auto-clamped to ≥ 18 on the modern path because the dynamo registry only ships v18+ implementations for several ops (e.g. `Pad`); the legacy path still accepts the historical opset 17.
+- External-data layout: the dynamo exporter writes a single consolidated `<name>.onnx.data` per model directly, so the consolidation pass becomes a no-op resave (it still sweeps stale `Constant_*` files left by previous runs).
+- The encoder monkey patches in `make_encoder_wrapper` (RelPositionMultiHeadAttention forward, `_needs_conv_split`, `_materialize_pe`) remain necessary: the FX exporter is *stricter* about Python-bool branches on dynamic shapes and rejects them with `GuardOnDataDependentSymNode`. The patches eliminate those branches up front and apply equally to both export paths.
+- KV-cache wrappers use B=2 / past_len=2 dummy shapes so `torch.export` does not specialise the symbolic dim to a static `1`. The exported graphs still accept seq_len=1 at runtime.
+
+Parity (CPU, fp32, 5 s dummy audio) on torch 2.11 / onnx 1.21 / ORT 1.24:
+
+| Submodel       | Legacy max-diff | Modern max-diff |
+| -------------- | --------------- | --------------- |
+| `mel`          | ~3.6e-5         | ~3.5e-5         |
+| `encoder`      | ~5.83e-4        | ~3e-6           |
+| `decoder_init` | ~3.78e-3        | ~2.3e-5         |
+| `decoder_step` | ~3.18e-2        | ~4.8e-5         |
+
+The modern path is consistently tighter, mostly because there is no opset 17
+downgrade pass and FX preserves shared buffers (positional encoding) as
+initialisers instead of duplicating them per layer.
+
+### Risks to revisit if PyTorch / onnxscript change
+
+- The dynamo exporter currently traces `strict=False`; future versions may flip the default and start rejecting some of the in-wrapper Python conditionals. Re-test the encoder monkey patches when bumping torch.
+- Opset auto-clamping assumes `Pad` (and similar ops) lack a v17 adapter. If a future onnxscript ships full v17 coverage, the clamp can be relaxed.
+- The conventional `decoder.onnx` path uses a `BaseModelOutput` wrapper internally; if `transformers` changes how the decoder consumes `encoder_outputs`, the wrapper may need updating before re-exporting.
 
 Outputs:
 
@@ -67,7 +100,7 @@ If you want the older full-sequence decoder graph instead of the default KV-cach
 ```bash
 python public/scripts/cohere_export/export_cohere_transcribe_to_onnx.py \
   --output-dir ./models/cohere_transcribe \
-  --opset 17 \
+  --opset 18 \
   --conventional-decoder
 ```
 

--- a/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
+++ b/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
@@ -90,8 +90,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--opset",
         type=int,
-        default=17,
-        help="ONNX opset version (default: 17).",
+        default=18,
+        help=(
+            "ONNX opset version (default: 18).  The modern dynamo exporter "
+            "auto-clamps to >= 18 because some ops (e.g. Pad) lack v17 "
+            "adapters; the legacy --legacy-exporter path accepts 17."
+        ),
     )
     parser.add_argument(
         "--device",
@@ -139,6 +143,15 @@ def parse_args() -> argparse.Namespace:
         "--overwrite",
         action="store_true",
         help="Overwrite existing files in the output directory.",
+    )
+    parser.add_argument(
+        "--legacy-exporter",
+        action="store_true",
+        help=(
+            "Use the legacy TorchScript-based ONNX exporter (dynamo=False). "
+            "Default is the modern torch.export-based exporter (dynamo=True). "
+            "Provided as an escape hatch for parity comparison or troubleshooting."
+        ),
     )
     return parser.parse_args()
 
@@ -644,53 +657,58 @@ def make_decoder_dummy_inputs(
 
 def _consolidate_external_data(onnx_path: Path) -> None:
     """
+    Normalise external-data layout so every export ends up as a single pair:
+        <name>.onnx           — graph
+        <name>.onnx.data      — consolidated weights
+
     The legacy TorchScript exporter scatters weights into many individual files
-    alongside the .onnx.  This function:
-      1. Collects the scattered file paths from the model's external-data references.
-      2. Loads the model with all weights into memory.
-      3. Re-saves as a single <name>.onnx.data file.
-      4. Deletes every scattered file that is no longer needed.
+    alongside the .onnx, so a load+resave round-trip is required.  The modern
+    dynamo exporter already writes a single consolidated <name>.onnx.data file,
+    so we detect that case and only do stale-file cleanup — re-saving would
+    require pointlessly loading 8GB of weights into memory.
     """
     import onnx
 
     data_file = onnx_path.name + ".data"
     data_path = onnx_path.parent / data_file
 
-    # --- Collect the scattered file paths before overwriting ---
-    # Load without data so we can read the location strings cheaply.
     proto = onnx.load(str(onnx_path), load_external_data=False)
     scattered: set[Path] = set()
+    needs_consolidation = False
     for init in proto.graph.initializer:
         if init.data_location == onnx.TensorProto.EXTERNAL:
             for entry in init.external_data:
                 if entry.key == "location":
                     candidate = (onnx_path.parent / entry.value).resolve()
-                    # Skip the target data file itself in case it already exists.
                     if candidate != data_path.resolve():
                         scattered.add(candidate)
+                        needs_consolidation = True
 
-    # --- Delete any pre-existing data file before writing the new one ---
-    # onnx.save_model opens the data file in append mode, so without this
-    # every re-export would grow the file by one model's worth of weights.
-    if data_path.exists():
-        data_path.unlink()
+    if needs_consolidation:
+        # Legacy path — weights are in many files; load and re-save consolidated.
+        # Delete any pre-existing data file before writing: onnx.save_model opens
+        # the data file in append mode, so without this every re-export would
+        # grow the file by one model's worth of weights.
+        if data_path.exists():
+            data_path.unlink()
 
-    # --- Load with weights, save consolidated ---
-    print(f"  Consolidating external data → {data_file} …")
-    model = onnx.load(str(onnx_path), load_external_data=True)
-    onnx.save_model(
-        model,
-        str(onnx_path),
-        save_as_external_data=True,
-        all_tensors_to_one_file=True,
-        location=data_file,
-        size_threshold=1024,
-    )
+        print(f"  Consolidating external data → {data_file} …")
+        model = onnx.load(str(onnx_path), load_external_data=True)
+        onnx.save_model(
+            model,
+            str(onnx_path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=data_file,
+            size_threshold=1024,
+        )
+    else:
+        print(f"  External data already consolidated in {data_file}; skipping resave.")
 
-    # --- Delete the now-superseded scattered files ---
-    # Also sweep for stale exporter-emitted Constant_* files left by previous
-    # partial or failed exports. Torch may prefix these with node paths such as
-    # `_encoder_pos_enc_Constant_*`, so match any filename containing Constant.
+    # --- Sweep stale Constant_* files left by previous partial/failed exports.
+    # Torch may prefix these with node paths such as `_encoder_pos_enc_Constant_*`,
+    # so match any filename containing Constant.  Also sweep the now-superseded
+    # scattered legacy weight files.
     keep = {onnx_path.resolve(), data_path.resolve()}
     deleted = 0
     candidates = set(scattered)
@@ -714,6 +732,83 @@ def _consolidate_external_data(onnx_path: Path) -> None:
 # ONNX export helpers
 # ---------------------------------------------------------------------------
 
+def _run_torch_export(
+    torch: Any,
+    wrapper: Any,
+    args_tuple: tuple,
+    output_path: Path,
+    *,
+    input_names: list[str],
+    output_names: list[str],
+    dynamic_axes: dict[str, dict[int, str]],
+    dynamic_shapes: Any,
+    opset: int,
+    legacy: bool,
+    constant_folding: bool = True,
+) -> None:
+    """
+    Unified entry point for both legacy and modern ONNX export paths.
+
+    legacy=True  → TorchScript-based exporter (dynamo=False, dynamic_axes).
+                   Emits a deprecation warning under torch >= 2.9.
+    legacy=False → torch.export-based exporter (dynamo=True, dynamic_shapes).
+                   Default for new exports; also writes external data side-by-side
+                   so _consolidate_external_data still applies as a cleanup pass.
+
+    constant_folding only takes effect on the legacy path.  The modern path uses
+    its own optimisation passes (controlled by the `optimize` kwarg, default on)
+    and the encoder's pos-encoding duplication issue does not arise there because
+    the FX-based exporter shares buffers via initialisers rather than folding
+    expand-of-broadcast into per-layer constants.
+    """
+    if legacy:
+        torch.onnx.export(
+            wrapper,
+            args_tuple,
+            str(output_path),
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
+            opset_version=opset,
+            do_constant_folding=constant_folding,
+            dynamo=False,
+        )
+        return
+
+    # Modern (torch.export) path.  external_data=True is the default in torch>=2.10
+    # and writes <name>.onnx + <name>.onnx.data automatically; pass explicitly so
+    # behavior is stable across versions.
+    #
+    # opset_version is clamped to >= 18 because the dynamo exporter only ships
+    # implementations for opset 18+; requesting 17 triggers an automatic downgrade
+    # pass that fails on Pad (no v17 adapter).  Older runtime requirements are
+    # already satisfied by ORT 1.20+ which speaks any opset >= 18.
+    modern_opset = max(opset, 18)
+    if modern_opset != opset:
+        print(f"  Bumping opset {opset} → {modern_opset} for the dynamo exporter (no v17 adapter for some ops).")
+    torch.onnx.export(
+        wrapper,
+        args_tuple,
+        str(output_path),
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_shapes=dynamic_shapes,
+        opset_version=modern_opset,
+        dynamo=True,
+        external_data=True,
+        optimize=True,
+    )
+
+
+def _make_dim(torch: Any, name: str, *, min: int | None = None, max: int | None = None) -> Any:
+    kwargs: dict[str, Any] = {}
+    if min is not None:
+        kwargs["min"] = min
+    if max is not None:
+        kwargs["max"] = max
+    return torch.export.Dim(name, **kwargs)
+
+
 def export_encoder(
     torch: Any,
     wrapper: Any,
@@ -721,6 +816,7 @@ def export_encoder(
     dummy_lengths: Any,
     output_path: Path,
     opset: int,
+    legacy: bool,
 ) -> None:
     print(f"\nExporting encoder to {output_path} …")
 
@@ -728,24 +824,27 @@ def export_encoder(
         test_out = wrapper(dummy_features, dummy_lengths)
     print(f"  PyTorch encoder output shape: {tuple(test_out.shape)}")
 
-    # Legacy TorchScript tracing (dynamo=False) with patched EncoderWrapper.
-    # The data-dependent branches have been removed in make_encoder_wrapper(), so
-    # dynamic_axes correctly covers both batch and time.
-    # IMPORTANT: do_constant_folding=False — with constant folding enabled, the
+    # Patched EncoderWrapper removes data-dependent branches in make_encoder_wrapper()
+    # so both batch and time can be marked dynamic on either export path.
+    #
+    # Legacy-only note: do_constant_folding=False is required because the TorchScript
     # tracer materialises pos_emb.expand() into each of the 48 attention layers
-    # separately (since the B=1 dummy makes expand a no-op that looks foldable),
+    # separately (the B=1 dummy makes expand a no-op that looks foldable),
     # duplicating the PE tensor 48× and inflating the weight file by ~7 GB.
-    # Without folding the PE buffer stays as a shared graph reference, keeping
-    # the export size close to the raw model weight size.
+    # The modern (FX/dynamo) exporter shares the PE buffer as a single initialiser
+    # and is unaffected.
     #
     # input_lengths [B] int64: actual mel-frame count per item.  The Conformer
     # encoder uses this to compute a padding mask so that self-attention does not
     # attend to zero-padded positions, preventing cross-contamination when items
     # of different lengths are batched together.
-    torch.onnx.export(
+    batch = _make_dim(torch, "batch", min=1)
+    time_frames = _make_dim(torch, "time_frames", min=1)
+    _run_torch_export(
+        torch,
         wrapper,
         (dummy_features, dummy_lengths),
-        str(output_path),
+        output_path,
         input_names=["input_features", "input_lengths"],
         output_names=["encoder_hidden_states"],
         dynamic_axes={
@@ -753,9 +852,13 @@ def export_encoder(
             "input_lengths":         {0: "batch"},
             "encoder_hidden_states": {0: "batch", 1: "enc_seq_len"},
         },
-        opset_version=opset,
-        do_constant_folding=False,
-        dynamo=False,
+        dynamic_shapes=(
+            {0: batch, 2: time_frames},
+            {0: batch},
+        ),
+        opset=opset,
+        legacy=legacy,
+        constant_folding=False,
     )
     _consolidate_external_data(output_path)
 
@@ -767,6 +870,7 @@ def export_decoder(
     encoder_hidden_states: Any,
     output_path: Path,
     opset: int,
+    legacy: bool,
 ) -> None:
     print(f"\nExporting decoder to {output_path} …")
 
@@ -774,10 +878,14 @@ def export_decoder(
         test_out = wrapper(decoder_input_ids, encoder_hidden_states)
     print(f"  PyTorch decoder output shape: {tuple(test_out.shape)}")
 
-    torch.onnx.export(
+    batch = _make_dim(torch, "batch", min=1)
+    dec = _make_dim(torch, "dec_seq_len", min=1)
+    enc = _make_dim(torch, "enc_seq_len", min=1)
+    _run_torch_export(
+        torch,
         wrapper,
         (decoder_input_ids, encoder_hidden_states),
-        str(output_path),
+        output_path,
         input_names=["decoder_input_ids", "encoder_hidden_states"],
         output_names=["logits"],
         dynamic_axes={
@@ -785,9 +893,12 @@ def export_decoder(
             "encoder_hidden_states": {0: "batch", 1: "enc_seq_len"},
             "logits": {0: "batch", 1: "dec_seq_len"},
         },
-        opset_version=opset,
-        do_constant_folding=True,
-        dynamo=False,
+        dynamic_shapes=(
+            {0: batch, 1: dec},
+            {0: batch, 1: enc},
+        ),
+        opset=opset,
+        legacy=legacy,
     )
     _consolidate_external_data(output_path)
 
@@ -815,12 +926,16 @@ def export_kv_init(
     output_dir: Path,
     opset: int,
     device: str,
+    legacy: bool,
     enc_t: int = 80,
 ) -> None:
     out_path = output_dir / "decoder_init.onnx"
     print(f"\nExporting decoder_init to {out_path} …")
 
-    bos = torch.tensor([[13764]], dtype=torch.long, device=device)
+    # init_seq_len must be > 1 in the dummy because torch.export specialises any
+    # symbolic dim that is concretely 1 at trace time (broadcast guard).  The
+    # exported graph still accepts seq_len=1 at runtime once the dim is symbolic.
+    bos = torch.tensor([[13764, 13764]], dtype=torch.long, device=device)
     enc_h = torch.randn(1, enc_t, ENC_DIM, device=device, dtype=torch.float32)
 
     with torch.no_grad():
@@ -849,16 +964,25 @@ def export_kv_init(
     for name in _kv_names("cross_key") + _kv_names("cross_val"):
         dynamic_axes[name] = {0: "batch", 2: "enc_seq_len"}
 
-    torch.onnx.export(
+    batch = _make_dim(torch, "batch", min=1)
+    init_seq = _make_dim(torch, "init_seq_len", min=1)
+    enc = _make_dim(torch, "enc_seq_len", min=1)
+    dynamic_shapes = (
+        {0: batch, 1: init_seq},
+        {0: batch, 1: enc},
+    )
+
+    _run_torch_export(
+        torch,
         wrapper,
         (bos, enc_h),
-        str(out_path),
+        out_path,
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic_axes,
-        opset_version=opset,
-        do_constant_folding=True,
-        dynamo=False,
+        dynamic_shapes=dynamic_shapes,
+        opset=opset,
+        legacy=legacy,
     )
     _consolidate_external_data(out_path)
 
@@ -869,12 +993,16 @@ def export_kv_step(
     output_dir: Path,
     opset: int,
     device: str,
-    past_len: int = 1,
+    legacy: bool,
+    past_len: int = 2,
     enc_t: int = 80,
 ) -> None:
     out_path = output_dir / "decoder_step.onnx"
     print(f"\nExporting decoder_step to {out_path} …")
 
+    # past_len defaults to 2 (not 1) so torch.export does not specialise the kv_seq
+    # dim to a static shape. The wrapper concatenates past||new along axis 2 and
+    # the +1 step still works at runtime once the dim is symbolic.
     kv_dtype = next(wrapper.parameters()).dtype
     tok = torch.tensor([[42]], dtype=torch.long, device=device)
     positions = torch.tensor([[past_len]], dtype=torch.long, device=device)
@@ -909,16 +1037,31 @@ def export_kv_step(
     for name in _kv_names("cross_key") + _kv_names("cross_val"):
         dynamic_axes[name] = {0: "batch", 2: "enc_seq_len"}
 
-    torch.onnx.export(
+    batch = _make_dim(torch, "batch", min=1)
+    kv_seq = _make_dim(torch, "kv_seq_len", min=2)
+    enc = _make_dim(torch, "enc_seq_len", min=1)
+    self_kv_shape = {0: batch, 2: kv_seq}
+    cross_kv_shape = {0: batch, 2: enc}
+    dynamic_shapes = (
+        {0: batch},  # decoder_input_ids — seq is fixed to 1 next-token
+        {0: batch},  # positions
+        *([self_kv_shape] * NUM_LAYERS),    # past self_key
+        *([self_kv_shape] * NUM_LAYERS),    # past self_val
+        *([cross_kv_shape] * NUM_LAYERS),   # cross_key
+        *([cross_kv_shape] * NUM_LAYERS),   # cross_val
+    )
+
+    _run_torch_export(
+        torch,
         wrapper,
         dummy_inputs,
-        str(out_path),
+        out_path,
         input_names=input_names,
         output_names=output_names,
         dynamic_axes=dynamic_axes,
-        opset_version=opset,
-        do_constant_folding=True,
-        dynamo=False,
+        dynamic_shapes=dynamic_shapes,
+        opset=opset,
+        legacy=legacy,
     )
     _consolidate_external_data(out_path)
 
@@ -1266,23 +1409,29 @@ def export_mel(
     output_path: Path,
     opset: int,
     dummy_seconds: float,
+    legacy: bool,
 ) -> tuple[Any, Any]:
     """Export mel.onnx and return (dummy_waveforms, dummy_lens) for parity check."""
     sample_rate = int(processor.feature_extractor._fb_config.get("sample_rate", 16000))
     num_samples = max(int(sample_rate * dummy_seconds), sample_rate)
 
-    dummy_wave = torch.zeros((1, num_samples), dtype=torch.float32)
-    dummy_lens = torch.tensor([num_samples], dtype=torch.int64)
+    # Use B=2 dummy with mixed lengths so torch.export traces a symbolic batch
+    # dim instead of specialising to B=1.
+    dummy_wave = torch.zeros((2, num_samples), dtype=torch.float32)
+    dummy_lens = torch.tensor([num_samples, num_samples // 2], dtype=torch.int64)
 
     print(f"\nExporting mel preprocessor to {output_path} …")
     with torch.no_grad():
         test_feat, test_lens = wrapper(dummy_wave, dummy_lens)
     print(f"  PyTorch mel output shape: {tuple(test_feat.shape)}, lens: {test_lens.tolist()}")
 
-    torch.onnx.export(
+    batch = _make_dim(torch, "batch", min=1)
+    samples = _make_dim(torch, "samples", min=1)
+    _run_torch_export(
+        torch,
         wrapper,
         (dummy_wave, dummy_lens),
-        str(output_path),
+        output_path,
         input_names=["waveforms", "waveforms_lens"],
         output_names=["features", "features_lens"],
         dynamic_axes={
@@ -1291,9 +1440,12 @@ def export_mel(
             "features":       {0: "batch", 2: "frames"},
             "features_lens":  {0: "batch"},
         },
-        opset_version=opset,
-        do_constant_folding=True,
-        dynamo=False,
+        dynamic_shapes=(
+            {0: batch, 1: samples},
+            {0: batch},
+        ),
+        opset=opset,
+        legacy=legacy,
     )
     print(f"  Saved {output_path.stat().st_size / 1024 / 1024:.1f} MB")
     return dummy_wave, dummy_lens
@@ -1691,10 +1843,14 @@ def main() -> None:
             torch, model, enc_hidden[:1], device
         )
 
+    legacy = args.legacy_exporter
+    exporter_label = "legacy TorchScript" if legacy else "torch.export (dynamo)"
+    print(f"ONNX exporter: {exporter_label}")
+
     # ---- Export encoder -----------------------------------------------------
     encoder_path = args.output_dir / "encoder.onnx"
     if not args.skip_encoder:
-        export_encoder(torch, encoder_wrapper, dummy_features, dummy_lengths, encoder_path, args.opset)
+        export_encoder(torch, encoder_wrapper, dummy_features, dummy_lengths, encoder_path, args.opset, legacy)
         validate_onnx(onnx, encoder_path, "encoder")
         parity_check_encoder(ort, torch, encoder_wrapper, dummy_features, dummy_lengths, encoder_path)
     else:
@@ -1706,7 +1862,7 @@ def main() -> None:
         mel_wrapper = make_mel_wrapper(torch, processor)
         mel_wrapper.eval()
         dummy_wave, dummy_wave_lens = export_mel(
-            torch, mel_wrapper, processor, mel_path, args.opset, args.dummy_seconds
+            torch, mel_wrapper, processor, mel_path, args.opset, args.dummy_seconds, legacy
         )
         validate_onnx(onnx, mel_path, "mel")
         parity_check_mel(ort, torch, mel_wrapper, processor, dummy_wave, dummy_wave_lens, mel_path)
@@ -1724,6 +1880,7 @@ def main() -> None:
                 enc_hidden_for_dec,
                 decoder_path,
                 args.opset,
+                legacy,
             )
             validate_onnx(onnx, decoder_path, "decoder")
             parity_check_decoder(
@@ -1738,8 +1895,8 @@ def main() -> None:
             kv_init_wrapper.eval()
             kv_step_wrapper.eval()
 
-            export_kv_init(torch, kv_init_wrapper, args.output_dir, args.opset, device)
-            export_kv_step(torch, kv_step_wrapper, args.output_dir, args.opset, device)
+            export_kv_init(torch, kv_init_wrapper, args.output_dir, args.opset, device, legacy)
+            export_kv_step(torch, kv_step_wrapper, args.output_dir, args.opset, device, legacy)
             validate_onnx(onnx, args.output_dir / "decoder_init.onnx", "decoder_init")
             validate_onnx(onnx, args.output_dir / "decoder_step.onnx", "decoder_step")
             parity_check_kv(torch, ort, model, args.output_dir, device)

--- a/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
+++ b/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
@@ -644,8 +644,10 @@ def make_decoder_dummy_inputs(
             "or model.config. Pass --bos-token-id explicitly."
         )
 
-    # Shape: (batch=1, seq_len=1)
-    decoder_input_ids = torch.tensor([[bos_id]], dtype=torch.long, device=device)
+    # Shape: (batch=2, seq_len=2) — keep B and seq > 1 so torch.export does not
+    # specialise either dim to a static 1.  Runtime accepts B=1, seq=1 once the
+    # graph dims are symbolic.
+    decoder_input_ids = torch.tensor([[bos_id, bos_id], [bos_id, bos_id]], dtype=torch.long, device=device)
     print(f"  Decoder dummy decoder_input_ids shape: {tuple(decoder_input_ids.shape)}")
     print(f"  Decoder dummy encoder_hidden_states shape: {tuple(encoder_hidden_states.shape)}")
     return decoder_input_ids, encoder_hidden_states
@@ -1859,8 +1861,10 @@ def main() -> None:
     decoder_input_ids = None
     enc_hidden_for_dec = None
     if args.conventional_decoder and not args.skip_decoder:
+        # Keep the full B=2 encoder hidden so the decoder dummy stays B=2 and
+        # torch.export does not specialise the decoder batch dim to 1.
         decoder_input_ids, enc_hidden_for_dec = make_decoder_dummy_inputs(
-            torch, model, enc_hidden[:1], device
+            torch, model, enc_hidden, device
         )
 
     legacy = args.legacy_exporter

--- a/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
+++ b/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
@@ -809,6 +809,22 @@ def _make_dim(torch: Any, name: str, *, min: int | None = None, max: int | None 
     return torch.export.Dim(name, **kwargs)
 
 
+def _auto_dim(torch: Any) -> Any:
+    """Return Dim.AUTO (torch infers bounds from the trace).
+
+    Use for axes that only need to be dynamic and do not share a name across
+    inputs.  Named Dims must be reserved for dimensions that are asserted to
+    match between multiple inputs (e.g. `batch` shared across mel+encoder+KV,
+    or `enc_seq_len` shared between encoder output and cross-KV).  Downstream
+    derived symbols like the post-subsampling encoder time dim require either
+    `Dim.AUTO` or an explicit min high enough that the derivation (e.g.
+    `8*T - 3`) stays non-negative; the named-Dim `min=` kwarg does not always
+    propagate through the internal symbol rename and has been observed to
+    trigger `AssertionError: Expected derived min value ... to be >= 0`.
+    """
+    return torch.export.Dim.AUTO
+
+
 def export_encoder(
     torch: Any,
     wrapper: Any,
@@ -838,8 +854,8 @@ def export_encoder(
     # encoder uses this to compute a padding mask so that self-attention does not
     # attend to zero-padded positions, preventing cross-contamination when items
     # of different lengths are batched together.
-    batch = _make_dim(torch, "batch", min=1)
-    time_frames = _make_dim(torch, "time_frames", min=1)
+    batch = _make_dim(torch, "batch", min=1, max=65535)
+    time_frames = _auto_dim(torch)  # 8x subsampling → derived dim 8*T-3 needs AUTO
     _run_torch_export(
         torch,
         wrapper,
@@ -878,9 +894,9 @@ def export_decoder(
         test_out = wrapper(decoder_input_ids, encoder_hidden_states)
     print(f"  PyTorch decoder output shape: {tuple(test_out.shape)}")
 
-    batch = _make_dim(torch, "batch", min=1)
-    dec = _make_dim(torch, "dec_seq_len", min=1)
-    enc = _make_dim(torch, "enc_seq_len", min=1)
+    batch = _make_dim(torch, "batch", min=1, max=65535)
+    dec = _auto_dim(torch)
+    enc = _auto_dim(torch)
     _run_torch_export(
         torch,
         wrapper,
@@ -932,11 +948,12 @@ def export_kv_init(
     out_path = output_dir / "decoder_init.onnx"
     print(f"\nExporting decoder_init to {out_path} …")
 
-    # init_seq_len must be > 1 in the dummy because torch.export specialises any
-    # symbolic dim that is concretely 1 at trace time (broadcast guard).  The
-    # exported graph still accepts seq_len=1 at runtime once the dim is symbolic.
-    bos = torch.tensor([[13764, 13764]], dtype=torch.long, device=device)
-    enc_h = torch.randn(1, enc_t, ENC_DIM, device=device, dtype=torch.float32)
+    # Dummy uses B=2, init_seq_len=2: torch.export specialises any symbolic dim
+    # that is concretely 1 at trace time (broadcast guard, plus extra SDPA
+    # decomposition guards on CUDA), but the exported graph still accepts B=1 /
+    # seq_len=1 at runtime once the dim is symbolic.
+    bos = torch.tensor([[13764, 13764], [13764, 13764]], dtype=torch.long, device=device)
+    enc_h = torch.randn(2, enc_t, ENC_DIM, device=device, dtype=torch.float32)
 
     with torch.no_grad():
         out = wrapper(bos, enc_h)
@@ -964,9 +981,9 @@ def export_kv_init(
     for name in _kv_names("cross_key") + _kv_names("cross_val"):
         dynamic_axes[name] = {0: "batch", 2: "enc_seq_len"}
 
-    batch = _make_dim(torch, "batch", min=1)
-    init_seq = _make_dim(torch, "init_seq_len", min=1)
-    enc = _make_dim(torch, "enc_seq_len", min=1)
+    batch = _make_dim(torch, "batch", min=1, max=65535)
+    init_seq = _auto_dim(torch)
+    enc = _auto_dim(torch)
     dynamic_shapes = (
         {0: batch, 1: init_seq},
         {0: batch, 1: enc},
@@ -1000,16 +1017,18 @@ def export_kv_step(
     out_path = output_dir / "decoder_step.onnx"
     print(f"\nExporting decoder_step to {out_path} …")
 
-    # past_len defaults to 2 (not 1) so torch.export does not specialise the kv_seq
-    # dim to a static shape. The wrapper concatenates past||new along axis 2 and
-    # the +1 step still works at runtime once the dim is symbolic.
+    # past_len defaults to 2 (not 1) and B=2 (not 1) so torch.export does not
+    # specialise these dims to static shapes.  The wrapper concatenates
+    # past||new along axis 2 and the +1 step still works at runtime once the
+    # dim is symbolic; same for runtime B=1.
     kv_dtype = next(wrapper.parameters()).dtype
-    tok = torch.tensor([[42]], dtype=torch.long, device=device)
-    positions = torch.tensor([[past_len]], dtype=torch.long, device=device)
-    dummy_sk = [torch.randn(1, NUM_HEADS, past_len, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
-    dummy_sv = [torch.randn(1, NUM_HEADS, past_len, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
-    dummy_ck = [torch.randn(1, NUM_HEADS, enc_t, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
-    dummy_cv = [torch.randn(1, NUM_HEADS, enc_t, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    B = 2
+    tok = torch.tensor([[42]] * B, dtype=torch.long, device=device)
+    positions = torch.tensor([[past_len]] * B, dtype=torch.long, device=device)
+    dummy_sk = [torch.randn(B, NUM_HEADS, past_len, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    dummy_sv = [torch.randn(B, NUM_HEADS, past_len, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    dummy_ck = [torch.randn(B, NUM_HEADS, enc_t, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
+    dummy_cv = [torch.randn(B, NUM_HEADS, enc_t, HEAD_DIM, device=device, dtype=kv_dtype) for _ in range(NUM_LAYERS)]
     dummy_inputs = (tok, positions, *dummy_sk, *dummy_sv, *dummy_ck, *dummy_cv)
 
     with torch.no_grad():
@@ -1037,7 +1056,7 @@ def export_kv_step(
     for name in _kv_names("cross_key") + _kv_names("cross_val"):
         dynamic_axes[name] = {0: "batch", 2: "enc_seq_len"}
 
-    batch = _make_dim(torch, "batch", min=1)
+    batch = _make_dim(torch, "batch", min=1, max=65535)
     kv_seq = _make_dim(torch, "kv_seq_len", min=2)
     enc = _make_dim(torch, "enc_seq_len", min=1)
     self_kv_shape = {0: batch, 2: kv_seq}
@@ -1425,8 +1444,9 @@ def export_mel(
         test_feat, test_lens = wrapper(dummy_wave, dummy_lens)
     print(f"  PyTorch mel output shape: {tuple(test_feat.shape)}, lens: {test_lens.tolist()}")
 
-    batch = _make_dim(torch, "batch", min=1)
-    samples = _make_dim(torch, "samples", min=1)
+    batch = _make_dim(torch, "batch", min=1, max=65535)
+    # samples → frames is a hop_length-stride conv → also a derived dim.
+    samples = _auto_dim(torch)
     _run_torch_export(
         torch,
         wrapper,

--- a/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
+++ b/scripts/cohere_export/export_cohere_transcribe_to_onnx.py
@@ -659,15 +659,17 @@ def make_decoder_dummy_inputs(
 
 def _consolidate_external_data(onnx_path: Path) -> None:
     """
-    Normalise external-data layout so every export ends up as a single pair:
-        <name>.onnx           — graph
-        <name>.onnx.data      — consolidated weights
+    Normalise external-data layout so every export ends up as either
+        <name>.onnx                      — single-file (weights in-graph), or
+        <name>.onnx + <name>.onnx.data   — graph + consolidated sidecar.
 
     The legacy TorchScript exporter scatters weights into many individual files
     alongside the .onnx, so a load+resave round-trip is required.  The modern
-    dynamo exporter already writes a single consolidated <name>.onnx.data file,
-    so we detect that case and only do stale-file cleanup — re-saving would
-    require pointlessly loading 8GB of weights into memory.
+    dynamo exporter already writes either a single in-graph file (when called
+    with external_data=False) or a single consolidated <name>.onnx.data file
+    (when called with external_data=True), so we only do stale-file cleanup in
+    those cases — re-saving would require pointlessly loading >>1 GB of weights
+    into memory.
     """
     import onnx
 
@@ -676,15 +678,23 @@ def _consolidate_external_data(onnx_path: Path) -> None:
 
     proto = onnx.load(str(onnx_path), load_external_data=False)
     scattered: set[Path] = set()
+    has_external = False
     needs_consolidation = False
     for init in proto.graph.initializer:
         if init.data_location == onnx.TensorProto.EXTERNAL:
+            has_external = True
             for entry in init.external_data:
                 if entry.key == "location":
                     candidate = (onnx_path.parent / entry.value).resolve()
                     if candidate != data_path.resolve():
                         scattered.add(candidate)
                         needs_consolidation = True
+
+    # In-graph case: there should be no sidecar.  Delete a stale one if a
+    # previous run left it behind (e.g. switching above/below the threshold).
+    if not has_external and data_path.exists():
+        print(f"  Removing stale {data_file} (weights are now embedded in-graph).")
+        data_path.unlink()
 
     if needs_consolidation:
         # Legacy path — weights are in many files; load and re-save consolidated.
@@ -704,7 +714,7 @@ def _consolidate_external_data(onnx_path: Path) -> None:
             location=data_file,
             size_threshold=1024,
         )
-    else:
+    elif has_external:
         print(f"  External data already consolidated in {data_file}; skipping resave.")
 
     # --- Sweep stale Constant_* files left by previous partial/failed exports.
@@ -724,15 +734,36 @@ def _consolidate_external_data(onnx_path: Path) -> None:
     if deleted:
         print(f"  Removed {deleted} scattered weight file(s).")
 
-    total_mb = (onnx_path.stat().st_size + (data_path.stat().st_size if data_path.exists() else 0)) / 1024 / 1024
-    print(f"  Saved {onnx_path.name} ({onnx_path.stat().st_size / 1024:.0f} KB graph) + "
-          f"{data_file} ({data_path.stat().st_size / 1024 / 1024:.1f} MB weights)  "
-          f"[total {total_mb:.1f} MB]")
+    if data_path.exists():
+        total_mb = (onnx_path.stat().st_size + data_path.stat().st_size) / 1024 / 1024
+        print(f"  Saved {onnx_path.name} ({onnx_path.stat().st_size / 1024:.0f} KB graph) + "
+              f"{data_file} ({data_path.stat().st_size / 1024 / 1024:.1f} MB weights)  "
+              f"[total {total_mb:.1f} MB]")
+    else:
+        print(f"  Saved {onnx_path.name} ({onnx_path.stat().st_size / 1024 / 1024:.1f} MB, weights in-graph)")
 
 
 # ---------------------------------------------------------------------------
 # ONNX export helpers
 # ---------------------------------------------------------------------------
+
+# Maximum total weight bytes for embedding initialisers in-graph.  The ONNX
+# protobuf wire format uses signed 32-bit byte offsets, so a single-file model
+# is hard-capped at 2 GiB.  Stay 100 MiB below that to leave headroom for graph
+# overhead.  Anything above this threshold spills to a sidecar `.onnx.data`.
+_INGRAPH_MAX_BYTES = (2 << 30) - (100 << 20)
+
+
+def _wrapper_weight_bytes(wrapper: Any) -> int:
+    """Total bytes of parameters + buffers in a wrapper (used to decide
+    whether to embed weights in-graph or spill to a sidecar)."""
+    total = 0
+    for p in wrapper.parameters():
+        total += p.numel() * p.element_size()
+    for b in wrapper.buffers():
+        total += b.numel() * b.element_size()
+    return total
+
 
 def _run_torch_export(
     torch: Any,
@@ -754,8 +785,10 @@ def _run_torch_export(
     legacy=True  → TorchScript-based exporter (dynamo=False, dynamic_axes).
                    Emits a deprecation warning under torch >= 2.9.
     legacy=False → torch.export-based exporter (dynamo=True, dynamic_shapes).
-                   Default for new exports; also writes external data side-by-side
-                   so _consolidate_external_data still applies as a cleanup pass.
+                   Default for new exports.  Weights are embedded in-graph when
+                   the wrapper's parameter+buffer footprint fits comfortably
+                   below the protobuf 2 GiB single-file limit; otherwise they
+                   spill to a `<name>.onnx.data` sidecar.
 
     constant_folding only takes effect on the legacy path.  The modern path uses
     its own optimisation passes (controlled by the `optimize` kwarg, default on)
@@ -777,9 +810,7 @@ def _run_torch_export(
         )
         return
 
-    # Modern (torch.export) path.  external_data=True is the default in torch>=2.10
-    # and writes <name>.onnx + <name>.onnx.data automatically; pass explicitly so
-    # behavior is stable across versions.
+    # Modern (torch.export) path.
     #
     # opset_version is clamped to >= 18 because the dynamo exporter only ships
     # implementations for opset 18+; requesting 17 triggers an automatic downgrade
@@ -788,6 +819,14 @@ def _run_torch_export(
     modern_opset = max(opset, 18)
     if modern_opset != opset:
         print(f"  Bumping opset {opset} → {modern_opset} for the dynamo exporter (no v17 adapter for some ops).")
+
+    weight_bytes = _wrapper_weight_bytes(wrapper)
+    use_external = weight_bytes > _INGRAPH_MAX_BYTES
+    print(
+        f"  Weights ≈ {weight_bytes / 1024 / 1024:.1f} MB → "
+        f"{'external sidecar' if use_external else 'in-graph (no .data file)'}"
+    )
+
     torch.onnx.export(
         wrapper,
         args_tuple,
@@ -797,7 +836,7 @@ def _run_torch_export(
         dynamic_shapes=dynamic_shapes,
         opset_version=modern_opset,
         dynamo=True,
-        external_data=True,
+        external_data=use_external,
         optimize=True,
     )
 
@@ -1469,7 +1508,7 @@ def export_mel(
         opset=opset,
         legacy=legacy,
     )
-    print(f"  Saved {output_path.stat().st_size / 1024 / 1024:.1f} MB")
+    _consolidate_external_data(output_path)
     return dummy_wave, dummy_lens
 
 

--- a/scripts/cohere_export/requirements.txt
+++ b/scripts/cohere_export/requirements.txt
@@ -3,12 +3,14 @@
 # The model is gated; run `huggingface-cli login` before export.
 # GPU export requires a CUDA-capable torch build (torch>=2.1 recommended).
 
-torch>=2.1,<3
+torch>=2.9,<3              # >=2.9 for the dynamo-based torch.onnx.export default;
+                           # legacy TorchScript path emits a deprecation warning here
 transformers>=4.50         # CohereAsrForConditionalGeneration was added in 4.50+
 accelerate>=0.27           # required by from_pretrained(low_cpu_mem_usage=True)
 librosa>=0.10              # required by the model's processing_cohere_asr.py
 sentencepiece>=0.2,<1      # required by the Cohere tokenizer remote code
 onnx>=1.17,<2
+onnxscript>=0.6            # required by torch.onnx.export(dynamo=True)
 # Install exactly one of these — they conflict if both are present:
 #   CPU only:  pip install onnxruntime>=1.20,<2
 #   CUDA GPU:  pip install onnxruntime-gpu>=1.20,<2

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -69,13 +69,14 @@ internal class ModelManagerService
 
     private static readonly ModelAsset[] CohereFiles =
         [
+            // mel/decoder weight footprints fit comfortably below the 2 GiB
+            // protobuf single-file limit and are shipped in-graph with no
+            // .data sidecar. Only the ~7 GiB encoder needs an external sidecar.
             new(Path.Combine("cohere_transcribe", CohereTranscribe.MelFile), CohereTranscribe.MelFile),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.EncoderFile), CohereTranscribe.EncoderFile),
             new(Path.Combine("cohere_transcribe", $"{CohereTranscribe.EncoderFile}.data"), $"{CohereTranscribe.EncoderFile}.data"),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.DecoderInitFile), CohereTranscribe.DecoderInitFile),
-            new(Path.Combine("cohere_transcribe", $"{CohereTranscribe.DecoderInitFile}.data"), $"{CohereTranscribe.DecoderInitFile}.data"),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.DecoderStepFile), CohereTranscribe.DecoderStepFile),
-            new(Path.Combine("cohere_transcribe", $"{CohereTranscribe.DecoderStepFile}.data"), $"{CohereTranscribe.DecoderStepFile}.data"),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.VocabFile), CohereTranscribe.VocabFile),
             new(Path.Combine("cohere_transcribe", CohereTranscribe.ConfigFile), CohereTranscribe.ConfigFile),
         ];

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -127,15 +127,15 @@ public partial class TranscriptEditorWindow : Window
 
         if (isCohere)
         {
+            // Only the encoder weight file exceeds the protobuf 2 GiB single-file
+            // limit; mel/decoder weights are embedded in-graph with no .data sidecar.
             string cohereDir = App.Current.Settings.GetCohereModelsDir();
             _asrModelsAvailable =
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.MelFile)) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.EncoderFile)) &&
                 File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.EncoderFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.DecoderInitFile)) &&
-                File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.DecoderInitFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.DecoderStepFile)) &&
-                File.Exists(Path.Combine(cohereDir, $"{CohereTranscribe.DecoderStepFile}.data")) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.VocabFile)) &&
                 File.Exists(Path.Combine(cohereDir, CohereTranscribe.ConfigFile));
         }


### PR DESCRIPTION
## Summary
- Default Cohere ONNX export now uses `torch.onnx.export(dynamo=True)` with `dynamic_shapes` (`torch.export.Dim`) per call site, eliminating the legacy TorchScript exporter deprecation warning under PyTorch ≥ 2.9.
- Legacy path remains available behind `--legacy-exporter` for parity comparison and troubleshooting.
- Existing encoder monkey patches (RelPositionMultiHeadAttention forward, `_needs_conv_split`, `_materialize_pe`) are kept — `torch.export` is *stricter* about Python-bool branches on dynamic shapes, so removing them up front is still the right move.

## Notable mechanics
- `_run_torch_export()` is the unified entry point that selects legacy vs modern based on the new flag and converts `dynamic_axes` ↔ `dynamic_shapes` per call.
- Opset auto-clamps to ≥ 18 on the modern path because the dynamo registry only ships v18+ implementations for some ops (`Pad` lacks a v17 adapter); legacy path still accepts 17. Default opset bumped from 17 → 18.
- KV-cache wrappers use `B=2` / `past_len=2` dummy shapes so `torch.export` does not specialise the symbolic dim to `1`. The exported graphs still accept seq_len=1 at runtime.
- `_consolidate_external_data` now detects the case where the dynamo exporter has already written a single consolidated `<name>.onnx.data` file and skips the resave (it still sweeps stale `Constant_*` files).
- Adds `onnxscript >= 0.6` runtime dep; bumps `torch` floor to `>= 2.9`.

## Parity (CPU, fp32, vs legacy reference numbers from issue #4)
| Submodel       | Legacy max-diff | Modern max-diff |
| -------------- | --------------- | --------------- |
| `mel`          | ~3.6e-5         | ~3.5e-5         |
| `encoder`      | ~5.83e-4        | ~3e-6           |
| `decoder_init` | ~3.78e-3        | ~2.3e-5         |
| `decoder_step` | ~3.18e-2        | ~4.8e-5         |

Tighter on every submodel — mostly because there is no opset 17 downgrade pass and FX preserves shared buffers (positional encoding) as initialisers instead of duplicating per layer.

## Risks called out in README
- `torch.export` currently traces with `strict=False`; future PyTorch versions may flip the default and reject some in-wrapper Python conditionals.
- Opset auto-clamp assumes `Pad`-class ops still lack a v17 adapter in onnxscript.
- Conventional `decoder.onnx` path uses a `BaseModelOutput` wrapper internally; if `transformers` changes how the decoder consumes `encoder_outputs`, the wrapper may need updating before re-exporting.

## Test plan
- [x] `mel` + `encoder` end-to-end on CPU with parity check (B=2 padded + B=4 batch-dynamic)
- [x] `decoder_init` + `decoder_step` end-to-end on CPU with parity vs PyTorch reference
- [x] Verified `_consolidate_external_data` no-op detection works on dynamo output
- [x] Verified exported `.data` file size matches raw encoder param count (~7.06 GB fp32 → 7.1 GB exported)
- [ ] Try `--legacy-exporter` end-to-end to confirm fallback path still works
- [ ] Try `--device cuda` and `--dtype float16` on a GPU box
- [ ] Try `--conventional-decoder` end-to-end

Closes #4