### PR TITLE
Surface real TDT per-token durations from Parakeet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ obj/
 .venv*/
 **/__pycache__/
 tmp/
+.claude/

--- a/src/Vernacula.Avalonia/Models/EditorSegment.cs
+++ b/src/Vernacula.Avalonia/Models/EditorSegment.cs
@@ -26,6 +26,7 @@ internal partial class EditorSegment : ObservableObject
 
     public IReadOnlyList<int>        Tokens     { get; set; } = [];
     public IReadOnlyList<int>        Timestamps { get; set; } = [];
+    public IReadOnlyList<int>        Durations  { get; set; } = [];
     public IReadOnlyList<float>      Logprobs   { get; set; } = [];
     public IReadOnlyList<CardSource> Sources    { get; set; } = [];
 

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -954,7 +954,7 @@ internal class TranscriptionService
                     Config.GetAsrFiles(ModelPrecision.Fp32);
 
                 using var parakeet = new ParakeetAsr(parakeetModelsDir, encoderFile, decoderJointFile);
-                foreach (var (segId, text, tokens, timestamps, logprobs) in
+                foreach (var (segId, text, tokens, timestamps, durations, logprobs) in
                     parakeet.Recognize(segsSubset, audio))
                 {
                     ct.ThrowIfCancellationRequested();
@@ -968,7 +968,8 @@ internal class TranscriptionService
                         content:    text,
                         tokens:     JsonSerializer.Serialize(tokens),
                         timestamps: JsonSerializer.Serialize(timestamps),
-                        logprobs:   JsonSerializer.Serialize(logprobs));
+                        logprobs:   JsonSerializer.Serialize(logprobs),
+                        durations:  durations.Count > 0 ? JsonSerializer.Serialize(durations) : null);
 
                     onSegmentText(absId, text);
 

--- a/src/Vernacula.Avalonia/TranscriptionDb.cs
+++ b/src/Vernacula.Avalonia/TranscriptionDb.cs
@@ -116,6 +116,8 @@ internal sealed class TranscriptionDb : IDisposable
         catch (SqliteException) { /* column already exists */ }
         try { Execute("ALTER TABLE results ADD COLUMN lid_language TEXT"); }
         catch (SqliteException) { /* column already exists */ }
+        try { Execute("ALTER TABLE results ADD COLUMN durations TEXT"); }
+        catch (SqliteException) { /* column already exists */ }
 
         MigrateToCardLayer();
     }
@@ -221,9 +223,10 @@ internal sealed class TranscriptionDb : IDisposable
         string? tokens,
         string? timestamps,
         string? logprobs,
-        string? language = null,
-        string? emotion  = null,
-        string? asrMeta  = null)
+        string? language  = null,
+        string? emotion   = null,
+        string? asrMeta   = null,
+        string? durations = null)
     {
         using var cmd = CreateCmd();
         cmd.CommandText = """
@@ -231,10 +234,10 @@ internal sealed class TranscriptionDb : IDisposable
                 (diarization_speaker_id, speaker_id,
                  start_time, end_time, start_time_f, end_time_f,
                  asr_content, content, tokens, timestamps, logprobs,
-                 language, emotion, asr_meta)
+                 language, emotion, asr_meta, durations)
             VALUES
                 ($dspk, $spk, $st, $et, $stf, $etf, $asr, $con, $tok, $ts, $lp,
-                 $lang, $emo, $meta)
+                 $lang, $emo, $meta, $dur)
             """;
         cmd.Parameters.AddWithValue("$dspk", diarizationSpeakerId);
         cmd.Parameters.AddWithValue("$spk",  speakerId);
@@ -250,6 +253,7 @@ internal sealed class TranscriptionDb : IDisposable
         cmd.Parameters.AddWithValue("$lang", (object?)language   ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$emo",  (object?)emotion    ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$meta", (object?)asrMeta    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$dur",  (object?)durations  ?? DBNull.Value);
         cmd.ExecuteNonQuery();
     }
 
@@ -274,9 +278,10 @@ internal sealed class TranscriptionDb : IDisposable
         string? tokens,
         string? timestamps,
         string? logprobs,
-        string? language = null,
-        string? emotion  = null,
-        string? asrMeta  = null)
+        string? language  = null,
+        string? emotion   = null,
+        string? asrMeta   = null,
+        string? durations = null)
     {
         using var cmd = CreateCmd();
         cmd.CommandText = """
@@ -288,7 +293,8 @@ internal sealed class TranscriptionDb : IDisposable
                 logprobs    = $lp,
                 language    = $lang,
                 emotion     = $emo,
-                asr_meta    = $meta
+                asr_meta    = $meta,
+                durations   = $dur
             WHERE result_id = $id
             """;
         cmd.Parameters.AddWithValue("$asr",  (object?)asrContent ?? DBNull.Value);
@@ -299,6 +305,7 @@ internal sealed class TranscriptionDb : IDisposable
         cmd.Parameters.AddWithValue("$lang", (object?)language   ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$emo",  (object?)emotion    ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$meta", (object?)asrMeta    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$dur",  (object?)durations  ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$id",   resultId);
         cmd.ExecuteNonQuery();
     }
@@ -349,19 +356,20 @@ internal sealed class TranscriptionDb : IDisposable
         string? tokens,
         string? timestamps,
         string? logprobs,
-        string? language = null,
-        string? emotion  = null,
-        string? asrMeta  = null)
+        string? language  = null,
+        string? emotion   = null,
+        string? asrMeta   = null,
+        string? durations = null)
     {
         using var cmd = CreateCmd();
         cmd.CommandText = """
             INSERT INTO results
                 (diarization_speaker_id, speaker_id, start_time, end_time,
                  start_time_f, end_time_f, asr_content, content, tokens, timestamps, logprobs,
-                 language, emotion, asr_meta)
+                 language, emotion, asr_meta, durations)
             VALUES
                 ($dspk, $spk, $st, $et, $stf, $etf, $asr, $asr, $tok, $ts, $lp,
-                 $lang, $emo, $meta);
+                 $lang, $emo, $meta, $dur);
             SELECT last_insert_rowid();
             """;
         cmd.Parameters.AddWithValue("$dspk", speakerId);
@@ -377,6 +385,7 @@ internal sealed class TranscriptionDb : IDisposable
         cmd.Parameters.AddWithValue("$lang", (object?)language   ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$emo",  (object?)emotion    ?? DBNull.Value);
         cmd.Parameters.AddWithValue("$meta", (object?)asrMeta    ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$dur",  (object?)durations  ?? DBNull.Value);
         return Convert.ToInt32(cmd.ExecuteScalar());
     }
 
@@ -496,7 +505,7 @@ internal sealed class TranscriptionDb : IDisposable
             double playStart, double playEnd, string? content, bool verified, bool suppressed,
             int resultId, int tokenStart, int? tokenEnd, int tsFrameOffset, int sourceOrder,
             string? tokensJson, string? timestampsJson, string? logprobsJson, string asrContent,
-            string? language, string? lidLanguage)>();
+            string? language, string? lidLanguage, string? durationsJson)>();
 
         using var cmd = CreateCmd();
         cmd.CommandText = """
@@ -505,7 +514,7 @@ internal sealed class TranscriptionDb : IDisposable
                    cs.result_id, cs.token_start, cs.token_end, cs.ts_frame_offset, cs.source_order,
                    r.tokens, r.timestamps, r.logprobs,
                    coalesce(r.asr_content, coalesce(r.content, '')),
-                   r.language, r.lid_language
+                   r.language, r.lid_language, r.durations
             FROM segment_cards c
             JOIN speakers s  ON c.speaker_id  = s.speaker_id
             JOIN card_sources cs ON cs.card_id = c.card_id
@@ -537,7 +546,8 @@ internal sealed class TranscriptionDb : IDisposable
                     reader.IsDBNull(16) ? null : reader.GetString(16),
                     reader.GetString(17),
                     reader.IsDBNull(18) ? null : reader.GetString(18),
-                    reader.IsDBNull(19) ? null : reader.GetString(19)));
+                    reader.IsDBNull(19) ? null : reader.GetString(19),
+                    reader.IsDBNull(20) ? null : reader.GetString(20)));
             }
         }
 
@@ -553,8 +563,10 @@ internal sealed class TranscriptionDb : IDisposable
             var sources    = new List<CardSource>();
             var tokens     = new List<int>();
             var timestamps = new List<int>();
+            var durations  = new List<int>();
             var logprobs   = new List<float>();
             var asrParts   = new List<string>();
+            bool durationsAligned = true;
             string? cardLanguage = null;
             string? cardLidLanguage = null;
 
@@ -570,6 +582,7 @@ internal sealed class TranscriptionDb : IDisposable
                 var srcTokens     = ParseJsonList<int>(row.tokensJson);
                 var srcTimestamps = ParseJsonList<int>(row.timestampsJson);
                 var srcLogprobs   = ParseJsonList<float>(row.logprobsJson);
+                var srcDurations  = ParseJsonList<int>(row.durationsJson);
 
                 int tStart = row.tokenStart;
                 int tEnd   = row.tokenEnd ?? srcTokens.Count;
@@ -583,9 +596,26 @@ internal sealed class TranscriptionDb : IDisposable
                 for (int t = tStart; t < tEnd && t < srcLogprobs.Count; t++)
                     logprobs.Add(srcLogprobs[t]);
 
+                // Durations must cover every token emitted by this source, otherwise the
+                // aggregate list would be misaligned with `tokens`. Drop the entire card's
+                // durations if any source is missing them.
+                if (srcDurations.Count >= tEnd)
+                {
+                    for (int t = tStart; t < tEnd; t++)
+                        durations.Add(srcDurations[t]);
+                }
+                else
+                {
+                    durationsAligned = false;
+                }
+
                 string part = row.asrContent.Trim();
                 if (part.Length > 0) asrParts.Add(part);
             }
+
+            IReadOnlyList<int> cardDurations = durationsAligned && durations.Count == tokens.Count
+                ? durations
+                : [];
 
             string asrContent = string.Join(" ", asrParts);
             string displayContent = first.content ?? asrContent;
@@ -604,6 +634,7 @@ internal sealed class TranscriptionDb : IDisposable
                 Sources:     sources,
                 Tokens:      tokens,
                 Timestamps:  timestamps,
+                Durations:   cardDurations,
                 Logprobs:    logprobs,
                 AsrContent:  asrContent,
                 Language:    cardLanguage,
@@ -934,6 +965,7 @@ internal record CardQueryRow(
     IReadOnlyList<CardSource> Sources,
     IReadOnlyList<int>        Tokens,
     IReadOnlyList<int>        Timestamps,
+    IReadOnlyList<int>        Durations,
     IReadOnlyList<float>      Logprobs,
     string  AsrContent,
     string? Language,

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -78,6 +78,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
                 Content            = row.Content,
                 Tokens             = row.Tokens,
                 Timestamps         = row.Timestamps,
+                Durations          = row.Durations,
                 Logprobs           = row.Logprobs,
                 Sources            = row.Sources,
                 Verified           = row.Verified,
@@ -572,6 +573,15 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             else
                 break;
         }
+        // If durations are aligned with tokens (Parakeet TDT), clamp the last token's
+        // highlight to its real end frame so the highlight doesn't linger past the
+        // spoken word when playback sits in post-speech silence.
+        if (best == seg.Timestamps.Count - 1 && seg.Durations.Count == seg.Timestamps.Count && best >= 0)
+        {
+            double endSec = (seg.Timestamps[best] + seg.Durations[best]) * frameSeconds;
+            if (secondsIntoSegment > endSec)
+                best = -1;
+        }
         HighlightedToken = best;
     }
 
@@ -798,6 +808,11 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             .Concat(b.Timestamps.Select(t => t + bTsOffset))
             .ToList();
         var mergedLogprobs = a.Logprobs.Concat(b.Logprobs).ToList();
+        // Preserve durations only if both sides have them (else drop to empty — a partial
+        // list misaligns with tokens and is worse than none).
+        var mergedDurations = a.Durations.Count == a.Tokens.Count && b.Durations.Count == b.Tokens.Count
+            ? a.Durations.Concat(b.Durations).ToList()
+            : new List<int>();
 
         // Merged content — always stored explicitly for multi-source cards because
         // the export query only joins source_order=0 and can't reconstruct the full text.
@@ -854,6 +869,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         a.Content     = mergedCon;
         a.Tokens      = mergedTokens;
         a.Timestamps  = mergedTimestamps;
+        a.Durations   = mergedDurations;
         a.Logprobs    = mergedLogprobs;
         a.Sources     = newSources;
 
@@ -1017,9 +1033,10 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     /// <summary>
     /// Re-runs ASR on the segment's audio and replaces all its sources with a single fresh result.
     /// <para>MUST be called from a background thread — loads and runs the ONNX model.</para>
-    /// Returns (newResultId, asrContent, tokens, timestamps, logprobs) on success, or null.
+    /// Returns (newResultId, asrContent, tokens, timestamps, durations, logprobs, language) on success,
+    /// or null. <c>durations</c> is empty for backends that don't emit per-token frame durations.
     /// </summary>
-    public (int newResultId, string asrContent, List<int> tokens, List<int> timestamps, List<float> logprobs, string? language)?
+    public (int newResultId, string asrContent, List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs, string? language)?
         PerformRedoAsr(
             int index,
             string asrModel,
@@ -1056,6 +1073,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         string text = "";
         List<int> tokens = [];
         List<int> timestamps = [];
+        List<int> durations = [];
         List<float> logprobs = [];
         string? language = null;
         string? emotion = null;
@@ -1128,9 +1146,9 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         {
             // Run ASR — the slice starts at t=0, so pass a 0-based time range
             using var parakeet = new ParakeetAsr(parakeetModelsDir, encoderFile, decoderJointFile);
-            foreach (var (_, t, tk, ts, lp) in parakeet.Recognize(asrSeg, mono16k))
+            foreach (var (_, t, tk, ts, dur, lp) in parakeet.Recognize(asrSeg, mono16k))
             {
-                text = t; tokens = tk; timestamps = ts; logprobs = lp;
+                text = t; tokens = tk; timestamps = ts; durations = dur; logprobs = lp;
             }
         }
 
@@ -1147,7 +1165,8 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
                 logprobs:   JsonSerializer.Serialize(logprobs),
                 language:   language,
                 emotion:    emotion,
-                asrMeta:    asrMeta);
+                asrMeta:    asrMeta,
+                durations:  durations.Count > 0 ? JsonSerializer.Serialize(durations) : null);
 
             db.DeleteCardSources(seg.CardId);
             db.AddCardSource(seg.CardId, newResultId, 0, null, 0, 0);
@@ -1155,7 +1174,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             db.DeleteOrphanedResults(oldResultIds);
         }
 
-        return (newResultId, text, tokens, timestamps, logprobs, language);
+        return (newResultId, text, tokens, timestamps, durations, logprobs, language);
     }
 
     private const string CohereSyntheticTimestampMode = "uniform_segment_frames_v1";
@@ -1188,7 +1207,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     /// <see cref="PerformRedoAsr"/> completes.
     /// </summary>
     public void ApplyRedoAsr(int index, int newResultId, string asrContent,
-        List<int> tokens, List<int> timestamps, List<float> logprobs, string? language = null)
+        List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs, string? language = null)
     {
         if (index < 0 || index >= Segments.Count) return;
         var seg = Segments[index];
@@ -1196,6 +1215,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         seg.Content    = asrContent;
         seg.Tokens     = tokens;
         seg.Timestamps = timestamps;
+        seg.Durations  = durations;
         seg.Logprobs   = logprobs;
         seg.Language   = language;
         seg.Sources    = new List<CardSource>
@@ -1235,6 +1255,8 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         var secondTs     = seg.Timestamps.Skip(splitIndex).Select(t => t - tAtSplit).ToList();
         var firstLp      = seg.Logprobs.Take(splitIndex).ToList();
         var secondLp     = seg.Logprobs.Skip(splitIndex).ToList();
+        var firstDur     = seg.Durations.Count == seg.Tokens.Count ? seg.Durations.Take(splitIndex).ToList()  : new List<int>();
+        var secondDur    = seg.Durations.Count == seg.Tokens.Count ? seg.Durations.Skip(splitIndex).ToList() : new List<int>();
 
         // Decoded content for each half
         string firstAsr, secondAsr, firstCon, secondCon;
@@ -1296,6 +1318,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         seg.Content    = firstCon;
         seg.Tokens     = firstTokens;
         seg.Timestamps = firstTs;
+        seg.Durations  = firstDur;
         seg.Logprobs   = firstLp;
         seg.Sources    = new List<CardSource>
         {
@@ -1314,6 +1337,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             Content            = secondCon,
             Tokens             = secondTokens,
             Timestamps         = secondTs,
+            Durations          = secondDur,
             Logprobs           = secondLp,
             Sources            = new List<CardSource>
             {

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -1302,7 +1302,8 @@ public partial class TranscriptEditorWindow : Window
             }
 
             _vm.ApplyRedoAsr(card.Index, result.Value.newResultId, result.Value.asrContent,
-                result.Value.tokens, result.Value.timestamps, result.Value.logprobs, result.Value.language);
+                result.Value.tokens, result.Value.timestamps, result.Value.durations,
+                result.Value.logprobs, result.Value.language);
 
             if (_isQwen3Asr)
                 card.SelectedRedoLanguage = TranscriptEditorCardState.MatchLanguageOption(result.Value.language);

--- a/src/Vernacula.Base/Parakeet.cs
+++ b/src/Vernacula.Base/Parakeet.cs
@@ -275,7 +275,7 @@ public sealed class Parakeet : IDisposable
 
     // ── Streaming decoder ─────────────────────────────────────────────────────
 
-    private IEnumerable<(List<int> tokens, List<int> timestamps, List<float> logprobs)>
+    private IEnumerable<(List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs)>
         Decoder(float[,,] encoderOut, long[] encoderLens)
     {
         int B = encoderOut.GetLength(0);
@@ -288,6 +288,7 @@ public sealed class Parakeet : IDisposable
             var prevState     = CreateState();
             var tokens        = new List<int>();
             var timestamps    = new List<int>();
+            var durations     = new List<int>();
             var logprobs      = new List<float>();
             var frame         = new float[D];
             int t             = 0;
@@ -305,6 +306,7 @@ public sealed class Parakeet : IDisposable
                     prevState = newState;
                     tokens.Add(token);
                     timestamps.Add(t);
+                    durations.Add(step);
                     emittedTokens++;
                     logprobs.Add(AudioUtils.LogSoftmax(logits)[token]);
                 }
@@ -321,7 +323,7 @@ public sealed class Parakeet : IDisposable
                 }
             }
 
-            yield return (tokens, timestamps, logprobs);
+            yield return (tokens, timestamps, durations, logprobs);
         }
     }
 
@@ -409,7 +411,7 @@ public sealed class Parakeet : IDisposable
     /// GPU phase: encode and decode a batch already preprocessed by
     /// <see cref="PrepareBatch"/>. Results are yielded in original segment order.
     /// </summary>
-    public IEnumerable<(int segId, string text, List<int> tokens, List<int> timestamps, List<float> logprobs)>
+    public IEnumerable<(int segId, string text, List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs)>
         RecognizePrepared(PreparedBatch prepared)
     {
         int sortedPos = 0;
@@ -418,11 +420,11 @@ public sealed class Parakeet : IDisposable
             var (encoderOut, encoderLens) = Encode(features, featLens);
 
             int j = 0;
-            foreach (var (tokens, timestamps, logprobs) in Decoder(encoderOut, encoderLens))
+            foreach (var (tokens, timestamps, durations, logprobs) in Decoder(encoderOut, encoderLens))
             {
                 int origIdx = prepared.OriginalIndices[sortedPos + j];
                 string text = string.Concat(tokens.Select(t => _vocab.TryGetValue(t, out var s) ? s : "")).Trim();
-                yield return (origIdx, text, tokens, timestamps, logprobs);
+                yield return (origIdx, text, tokens, timestamps, durations, logprobs);
                 j++;
             }
             sortedPos += segCount;
@@ -432,7 +434,7 @@ public sealed class Parakeet : IDisposable
     /// <summary>
     /// Convenience wrapper: CPU preprocess then GPU encode+decode in one call.
     /// </summary>
-    public IEnumerable<(int segId, string text, List<int> tokens, List<int> timestamps, List<float> logprobs)>
+    public IEnumerable<(int segId, string text, List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs)>
         Recognize(IReadOnlyList<(double start, double end, string spk)> segs, float[] audio)
     {
         var prepared = PrepareBatch(segs, audio);

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -660,7 +660,7 @@ try
         int completed = 0;
 
         Console.WriteLine($"Transcribing {totalSegs} segment(s)...");
-        foreach (var (segId, text, _, _, _) in parakeet.Recognize(segs, audio))
+        foreach (var (segId, text, _, _, _, _) in parakeet.Recognize(segs, audio))
         {
             cts.Token.ThrowIfCancellationRequested();
             completed++;


### PR DESCRIPTION
## Summary
- Parakeet decoder now captures the TDT duration-head value per emitted token and surfaces it through `Recognize()` / `RecognizePrepared()` alongside the existing start-frame timestamps.
- New nullable `results.durations` column (lazy ALTER — existing DBs upgrade in place; legacy rows fall back to prior boundary logic).
- Editor highlighter clamps the final token's active window to `start + duration` so the highlight releases during end-of-segment silence instead of lingering. Non-Parakeet backends leave durations NULL and keep existing behavior.

Addresses candidate #3 from #13 (real timestamps).

## Test plan
- [x] `dotnet build` clean
- [x] User-verified runtime behavior in the transcript editor
- [ ] Resume from a pre-migration `.db` to confirm the lazy ALTER path works transparently
- [ ] Merge/split/redo-ASR flows preserve aligned durations (and cleanly drop them when mixing sources that lack them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)