### PR TITLE
Add shallow KenLM fusion for Parakeet

### DIFF
--- a/scripts/kenlm_build/README.md
+++ b/scripts/kenlm_build/README.md
@@ -1,5 +1,17 @@
 # Build a subword-level KenLM for Parakeet shallow fusion
 
+## Workflow
+
+1. `extract_hf_corpus.py` — stream transcripts from permissive HF ASR datasets
+   into a plain-text corpus file (column-pruned Parquet reads, so audio bytes
+   never cross the wire).
+2. `build_kenlm_parakeet.py` — tokenise the corpus with Parakeet's tokenizer
+   and drive `lmplz` to produce an ARPA keyed by subword IDs.
+3. The resulting `.arpa` or `.arpa.gz` can be pointed at via CLI
+   `--lm <path>` or in Settings → Speech Recognition → Language model.
+
+
+
 Tool output: an ARPA file whose tokens are **Parakeet subword IDs** (integers).
 Matches the format that [`KenLmScorer`](../../src/Vernacula.Base/KenLmScorer.cs) expects.
 
@@ -19,23 +31,40 @@ huggingface-cli download nvidia/parakeet-tdt-0.6b-v3 tokenizer.json \
   --local-dir /tmp/parakeet-tok
 ```
 
-## Build
+## Fetch a corpus
+
+For conversational English (best fit for casual/telephony audio), the
+included extractor streams **MLCommons/peoples_speech** (CC-BY-4.0,
+ungated) by column-pruning Parquet shards — audio bytes are never
+downloaded.
+
+```bash
+pip install pyarrow fsspec requests
+python3 extract_hf_corpus.py \
+  --output    ~/corpora/peoples-speech-en.txt.gz \
+  --sources   peoples \
+  --max-words 15000000 \
+  --workers   6
+```
+
+`speechcolab/gigaspeech` (Apache 2.0 data, but gated on HF) can be added
+with `--sources peoples,gigaspeech` once you've accepted its terms and
+authenticated via `huggingface-cli login`.
+
+For a more general-English LM, an extra Wikipedia or Common Crawl slice
+can be concatenated in yourself — the downstream build script accepts any
+one-sentence-per-line text file.
+
+## Build the LM
 
 ```bash
 python3 build_kenlm_parakeet.py \
-  --corpus    /path/to/english_corpus.txt \
+  --corpus    ~/corpora/peoples-speech-en.txt.gz \
   --tokenizer /tmp/parakeet-tok/tokenizer.json \
   --order     4 \
   --prune     "0 0 1 1" \
   --output    kenlm-parakeet-en.arpa.gz
 ```
-
-**Corpus sources that work well:**
-
-- English: Wikipedia dump (e.g. `enwiki-latest-pages-articles`), OpenSubtitles, Common Crawl news slice.
-- Spanish / French / etc.: same sources per language.
-- Target ~50M words per language for a good general-purpose LM.
-- One sentence per line; lowercase is fine but not required.
 
 **Size expectations (4-gram, prune "0 0 1 1"):**
 

--- a/scripts/kenlm_build/README.md
+++ b/scripts/kenlm_build/README.md
@@ -1,0 +1,58 @@
+# Build a subword-level KenLM for Parakeet shallow fusion
+
+Tool output: an ARPA file whose tokens are **Parakeet subword IDs** (integers).
+Matches the format that [`KenLmScorer`](../../src/Vernacula.Base/KenLmScorer.cs) expects.
+
+## One-time setup
+
+```bash
+pip install tokenizers
+
+# Build KenLM tools (lmplz + build_binary)
+git clone https://github.com/kpu/kenlm /tmp/kenlm
+cd /tmp/kenlm && mkdir -p build && cd build
+cmake .. && make -j"$(nproc)"
+export PATH="$PWD/bin:$PATH"
+
+# Fetch the Parakeet tokenizer
+huggingface-cli download nvidia/parakeet-tdt-0.6b-v3 tokenizer.json \
+  --local-dir /tmp/parakeet-tok
+```
+
+## Build
+
+```bash
+python3 build_kenlm_parakeet.py \
+  --corpus    /path/to/english_corpus.txt \
+  --tokenizer /tmp/parakeet-tok/tokenizer.json \
+  --order     4 \
+  --prune     "0 0 1 1" \
+  --output    kenlm-parakeet-en.arpa.gz
+```
+
+**Corpus sources that work well:**
+
+- English: Wikipedia dump (e.g. `enwiki-latest-pages-articles`), OpenSubtitles, Common Crawl news slice.
+- Spanish / French / etc.: same sources per language.
+- Target ~50M words per language for a good general-purpose LM.
+- One sentence per line; lowercase is fine but not required.
+
+**Size expectations (4-gram, prune "0 0 1 1"):**
+
+| Corpus words | Uncompressed ARPA | Gzipped |
+|---|---|---|
+| 1M | 3 MB | 1 MB |
+| 10M | 25 MB | 7 MB |
+| 50M | 100 MB | 30 MB |
+| 500M | 800 MB | 220 MB |
+
+## Use
+
+```bash
+vernacula --audio sample.wav --model ~/.../parakeet \
+  --lm kenlm-parakeet-en.arpa.gz \
+  --lm-weight 0.3
+```
+
+Passing `--lm` auto-bumps the beam width to 4 (fusion has no effect in greedy
+mode, since greedy commits to the argmax before the LM can influence anything).

--- a/scripts/kenlm_build/README.md
+++ b/scripts/kenlm_build/README.md
@@ -31,6 +31,26 @@ huggingface-cli download nvidia/parakeet-tdt-0.6b-v3 tokenizer.json \
   --local-dir /tmp/parakeet-tok
 ```
 
+## Recipe: what we ship
+
+The default `vernacula/kenlm-parakeet-en` LM is built from a 3:1 mix of:
+- **GigaSpeech** (subset `s`, Apache 2.0) — 2.5M words, cased + punctuated
+  (explicit `<COMMA>/<PERIOD>/<QUESTIONMARK>/<EXCLAMATIONPOINT>` tokens restored
+  in place). Carries the case/punctuation priors that Parakeet's output expects.
+- **MLCommons/peoples_speech** (subset `clean`, CC-BY-4.0) — 15M words,
+  lowercase conversational speech. Carries the backchannel and disfluency
+  priors ("uh huh", "yeah", "mm-hmm") that fix the multilingual-drift cases
+  noted in issue #13.
+
+GigaSpeech is duplicated 3× before concatenation — without this upweighting
+the 6:1 raw size asymmetry lets the lowercase People's Speech style dominate
+the LM's priors and decapitalize Parakeet's output.
+
+Validation: a 600s en-US sample exhibits a beam=4 regression where English
+"Uh uh. Ya." was decoded as Spanish "ajá, ya". With this mixed LM at
+fusion weight 0.15, the line recovers to "Uh uh, yeah." while ~500 other
+lines stay unchanged vs greedy.
+
 ## Fetch a corpus
 
 For conversational English (best fit for casual/telephony audio), the
@@ -47,19 +67,37 @@ python3 extract_hf_corpus.py \
   --workers   6
 ```
 
-`speechcolab/gigaspeech` (Apache 2.0 data, but gated on HF) can be added
-with `--sources peoples,gigaspeech` once you've accepted its terms and
-authenticated via `huggingface-cli login`.
+`speechcolab/gigaspeech` (Apache 2.0 data, but gated on HF — accept the
+terms on https://huggingface.co/datasets/speechcolab/gigaspeech and run
+`huggingface-cli login` first) can be added with
+`--sources peoples,gigaspeech`.
+
+```bash
+python3 extract_hf_corpus.py \
+  --output    ~/corpora/gigaspeech-s.txt.gz \
+  --sources   gigaspeech \
+  --max-words 15000000
+```
+
+Then build the mixed corpus the ship LM uses:
+
+```bash
+# 3x GigaSpeech (upweight for case/punct priors) + 1x People's Speech
+(for i in 1 2 3; do zcat ~/corpora/gigaspeech-s.txt.gz; done;
+ zcat ~/corpora/peoples-speech-en.txt.gz) | gzip > ~/corpora/en-mixed.txt.gz
+```
 
 For a more general-English LM, an extra Wikipedia or Common Crawl slice
 can be concatenated in yourself — the downstream build script accepts any
-one-sentence-per-line text file.
+one-sentence-per-line text file. For lowercase-only corpora (e.g. older
+research datasets), a LanguageTool pass is one way to recover casing and
+sentence-final punctuation before training; not yet packaged here.
 
 ## Build the LM
 
 ```bash
 python3 build_kenlm_parakeet.py \
-  --corpus    ~/corpora/peoples-speech-en.txt.gz \
+  --corpus    ~/corpora/en-mixed.txt.gz \
   --tokenizer /tmp/parakeet-tok/tokenizer.json \
   --order     4 \
   --prune     "0 0 1 1" \

--- a/scripts/kenlm_build/build_kenlm_parakeet.py
+++ b/scripts/kenlm_build/build_kenlm_parakeet.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Build a subword-level n-gram language model for Parakeet-TDT shallow fusion.
+
+The resulting ARPA file has Parakeet subword *IDs* (integers) as the "words",
+matching the format KenLmScorer.cs (src/Vernacula.Base/KenLmScorer.cs) expects.
+Users pick one via `--lm` on the CLI or via the Language picker in Settings.
+
+Inputs:
+  --corpus <path>   Plain-text training corpus (one sentence per line).
+  --tokenizer <p>   HuggingFace tokenizer.json for nvidia/parakeet-tdt-0.6b-v3.
+                    (grab with: huggingface-cli download nvidia/parakeet-tdt-0.6b-v3 tokenizer.json)
+  --order <N>       N-gram order (default: 4).
+  --prune <spec>    lmplz prune spec, e.g. "0 0 1 1" (default drops 3- and 4-grams seen once).
+  --output <path>   Output ARPA path. Gzip if it ends in .gz.
+
+Requires:
+  pip install tokenizers
+  KenLM tools (lmplz, build_binary) on PATH.
+
+Build KenLM tools from source:
+  git clone https://github.com/kpu/kenlm
+  cd kenlm && mkdir build && cd build && cmake .. && make -j$(nproc)
+  export PATH="$PWD/bin:$PATH"
+"""
+import argparse
+import gzip
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--corpus",    required=True, type=Path)
+    ap.add_argument("--tokenizer", required=True, type=Path)
+    ap.add_argument("--order",     type=int, default=4)
+    ap.add_argument("--prune",     default="0 0 1 1",
+                    help="lmplz prune spec matching --order, e.g. '0 0 1 1'")
+    ap.add_argument("--output",    required=True, type=Path)
+    args = ap.parse_args()
+
+    try:
+        from tokenizers import Tokenizer
+    except ImportError:
+        print("error: `pip install tokenizers` first.", file=sys.stderr)
+        return 1
+
+    tok = Tokenizer.from_file(str(args.tokenizer))
+    vocab_size = tok.get_vocab_size()
+    print(f"loaded tokenizer, vocab size = {vocab_size}", file=sys.stderr)
+    if vocab_size > 16384:
+        print(f"error: vocab size {vocab_size} exceeds the 14-bit packing limit "
+              f"(16384) in KenLmScorer.", file=sys.stderr)
+        return 1
+
+    tokenized_corpus = args.corpus.with_suffix(args.corpus.suffix + ".tok")
+    print(f"tokenizing {args.corpus} -> {tokenized_corpus}", file=sys.stderr)
+    lines = 0
+    subwords = 0
+    with open_maybe_gz(args.corpus, "r") as f_in, tokenized_corpus.open("w") as f_out:
+        batch = []
+        for raw in f_in:
+            raw = raw.strip()
+            if not raw:
+                continue
+            batch.append(raw)
+            if len(batch) >= 1024:
+                write_tokenized(tok, batch, f_out)
+                lines += len(batch)
+                for enc in tok.encode_batch(batch):
+                    subwords += len(enc.ids)
+                batch.clear()
+        if batch:
+            write_tokenized(tok, batch, f_out)
+            lines += len(batch)
+            for enc in tok.encode_batch(batch):
+                subwords += len(enc.ids)
+
+    print(f"tokenized {lines:,} sentences, {subwords:,} subwords "
+          f"({subwords / max(lines, 1):.1f}/sentence)", file=sys.stderr)
+
+    arpa_tmp = args.output.with_suffix(".arpa.tmp")
+    lmplz = run_lmplz(tokenized_corpus, arpa_tmp, args.order, args.prune, vocab_size)
+    if lmplz != 0:
+        return lmplz
+
+    if str(args.output).endswith(".gz"):
+        print(f"gzipping -> {args.output}", file=sys.stderr)
+        with arpa_tmp.open("rb") as f_in, gzip.open(args.output, "wb", compresslevel=6) as f_out:
+            while chunk := f_in.read(1 << 20):
+                f_out.write(chunk)
+        arpa_tmp.unlink()
+    else:
+        arpa_tmp.rename(args.output)
+
+    size_mb = args.output.stat().st_size / (1 << 20)
+    print(f"wrote {args.output} ({size_mb:.1f} MB)", file=sys.stderr)
+    return 0
+
+
+def open_maybe_gz(path: Path, mode: str):
+    if path.suffix == ".gz":
+        return gzip.open(path, mode + "t", encoding="utf-8")
+    return path.open(mode, encoding="utf-8")
+
+
+def write_tokenized(tok, batch, f_out):
+    for enc in tok.encode_batch(batch):
+        ids = enc.ids
+        # Skip empty encodings (lines with no normal tokens, e.g. all-special).
+        if not ids:
+            continue
+        f_out.write(" ".join(str(i) for i in ids))
+        f_out.write("\n")
+
+
+def run_lmplz(tokenized: Path, out_arpa: Path, order: int, prune: str, vocab_size: int) -> int:
+    cmd = [
+        "lmplz",
+        "-o", str(order),
+        "--prune", *prune.split(),
+        "--discount_fallback",
+        "--vocab_estimate", str(vocab_size),
+        "--text", str(tokenized),
+        "--arpa", str(out_arpa),
+    ]
+    print("running:", " ".join(cmd), file=sys.stderr)
+    try:
+        p = subprocess.run(cmd, check=False)
+    except FileNotFoundError:
+        print("error: `lmplz` not found on PATH. See header for build instructions.", file=sys.stderr)
+        return 1
+    return p.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kenlm_build/extract_hf_corpus.py
+++ b/scripts/kenlm_build/extract_hf_corpus.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Stream transcripts from permissive HF ASR datasets by reading ONLY the text
+column of their Parquet shards (skipping audio bytes entirely), in parallel
+across shards. Produces one plain-text corpus file, ready for
+`build_kenlm_parakeet.py` downstream.
+
+Sources (hard-coded for simplicity — extend if needed):
+  - MLCommons/peoples_speech   "clean" subset (CC-BY-4.0, ungated)
+                               Lowercase conversational text, no punctuation.
+  - speechcolab/gigaspeech     "xl" subset (Apache 2.0, but GATED on HF —
+                               must be logged-in with access granted).
+                               Uppercase with <COMMA>/<PERIOD>/<QUESTIONMARK>/
+                               <EXCLAMATIONPOINT>; we restore real punctuation.
+
+Register target: conversational English with backchannels — the exact
+register where Parakeet's multilingual drift (e.g. "uh uh" → "ajá") bites.
+
+Output sentences are cased + punctuated to roughly match Parakeet's output
+style. Case is restored crudely (sentence-initial only).
+"""
+import argparse
+import gzip
+import re
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+try:
+    import pyarrow.parquet as pq
+    import fsspec
+    import requests
+except ImportError as e:
+    print(f"missing dep: {e}. install: pip install pyarrow fsspec requests", file=sys.stderr)
+    sys.exit(1)
+
+
+GIGASPEECH_PUNCT = {
+    "<COMMA>":            ",",
+    "<PERIOD>":           ".",
+    "<QUESTIONMARK>":     "?",
+    "<EXCLAMATIONPOINT>": "!",
+}
+
+
+def normalize_gigaspeech(text: str) -> str | None:
+    text = text.strip()
+    if not text:
+        return None
+    tokens = text.split()
+    cleaned = []
+    for tok in tokens:
+        mapped = GIGASPEECH_PUNCT.get(tok)
+        if mapped is not None:
+            if cleaned:
+                cleaned[-1] = cleaned[-1] + mapped
+            continue
+        if tok.startswith("<") and tok.endswith(">"):
+            continue
+        cleaned.append(tok.lower())
+    if not cleaned:
+        return None
+    s = " ".join(cleaned)
+    return s[0].upper() + s[1:]
+
+
+def normalize_peoples_speech(text: str) -> str | None:
+    text = text.strip()
+    if not text:
+        return None
+    return text[0].upper() + text[1:]
+
+
+def list_parquet_shards(repo: str, subdir: str, name_prefix: str = "train-") -> list[str]:
+    """
+    Enumerate parquet files under repo/subdir matching name_prefix (default
+    "train-" so test/validation shards are skipped) via the HF tree API.
+    """
+    url = f"https://huggingface.co/api/datasets/{repo}/tree/main/{subdir}"
+    paths: list[str] = []
+    cursor = None
+    while True:
+        full = url + (f"?cursor={cursor}" if cursor else "")
+        r = requests.get(full, timeout=60)
+        r.raise_for_status()
+        items = r.json()
+        if not items:
+            break
+        for it in items:
+            path = it.get("path", "")
+            base = path.rsplit("/", 1)[-1]
+            if base.endswith(".parquet") and base.startswith(name_prefix):
+                paths.append(path)
+        link = r.headers.get("Link", "")
+        if 'rel="next"' in link:
+            m = re.search(r'cursor=([^>;]+)', link)
+            if m:
+                cursor = m.group(1)
+                continue
+        break
+    return sorted(paths)
+
+
+def resolve_url(repo: str, path: str) -> str:
+    return f"https://huggingface.co/datasets/{repo}/resolve/main/{path}"
+
+
+def read_text_column(url: str, text_col: str = "text") -> list[str]:
+    """Download one parquet, read ONLY the text column, return the strings."""
+    fs = fsspec.filesystem("http")
+    with fs.open(url, "rb") as f:
+        pf = pq.ParquetFile(f)
+        table = pf.read(columns=[text_col])
+    return [s.as_py() for s in table.column(text_col)]
+
+
+def open_output(path: Path):
+    if path.suffix == ".gz":
+        return gzip.open(path, "wt", encoding="utf-8", compresslevel=6)
+    return path.open("w", encoding="utf-8")
+
+
+def process_source(repo: str, subdir: str, normalize, max_words: int,
+                   total_words_so_far: list[int], fout, fout_lock,
+                   workers: int = 4, progress_every: int = 100_000):
+    """Download parquet shards in parallel, write normalized lines sequentially."""
+    print(f"[{repo}] enumerating shards under {subdir}/...", file=sys.stderr)
+    paths = list_parquet_shards(repo, subdir)
+    print(f"[{repo}] found {len(paths)} parquet shards", file=sys.stderr)
+    if not paths:
+        return 0, 0
+
+    lines = 0
+    words = 0
+    t_start = time.time()
+
+    # ThreadPoolExecutor downloads + reads shards in parallel. We submit in batches
+    # and process results in submission order so output is deterministic-ish.
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = []
+        for p in paths:
+            if total_words_so_far[0] + words >= max_words:
+                break
+            futures.append(pool.submit(read_text_column, resolve_url(repo, p)))
+
+        for i, fut in enumerate(futures):
+            try:
+                texts = fut.result()
+            except Exception as e:
+                print(f"[{repo}] shard {i} error: {e}", file=sys.stderr)
+                continue
+
+            with fout_lock:
+                for text in texts:
+                    s = normalize(text) if text else None
+                    if not s:
+                        continue
+                    fout.write(s)
+                    fout.write("\n")
+                    n = s.count(" ") + 1
+                    words += n
+                    lines += 1
+
+            done_words = total_words_so_far[0] + words
+            if lines // progress_every > (lines - len(texts)) // progress_every:
+                elapsed = time.time() - t_start
+                rate = words / max(elapsed, 0.1)
+                print(f"  [{repo}] shard {i+1}/{len(paths)}: {lines:,} lines, "
+                      f"{words:,} words @ {rate/1000:.1f}k words/s "
+                      f"(total: {done_words:,})", file=sys.stderr)
+
+            if done_words >= max_words:
+                # Cancel outstanding futures so we stop quickly
+                for f in futures[i+1:]:
+                    f.cancel()
+                break
+
+    return lines, words
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--output",   required=True, type=Path)
+    ap.add_argument("--max-words", type=int, default=200_000_000,
+                    help="Stop after this many words (default 200M)")
+    ap.add_argument("--sources",  default="peoples",
+                    help="Comma-separated subset of: peoples, gigaspeech "
+                         "(gigaspeech is gated — requires HF auth)")
+    ap.add_argument("--workers",  type=int, default=6,
+                    help="Parallel parquet downloads per source (default 6)")
+    args = ap.parse_args()
+
+    sources = [s.strip() for s in args.sources.split(",") if s.strip()]
+
+    fout_lock = threading.Lock()
+    total_words = [0]
+    total_lines = 0
+
+    config = {
+        "peoples":    ("MLCommons/peoples_speech",    "clean",      normalize_peoples_speech),
+        "gigaspeech": ("speechcolab/gigaspeech",      "data/xl",    normalize_gigaspeech),
+    }
+
+    with open_output(args.output) as fout:
+        for src in sources:
+            if total_words[0] >= args.max_words:
+                break
+            if src not in config:
+                print(f"[skip] unknown source: {src}", file=sys.stderr)
+                continue
+            repo, subdir, normalize = config[src]
+            lines, words = process_source(
+                repo, subdir, normalize,
+                max_words=args.max_words,
+                total_words_so_far=total_words,
+                fout=fout, fout_lock=fout_lock,
+                workers=args.workers)
+            total_words[0] += words
+            total_lines += lines
+            print(f"[{src}] done: {lines:,} lines / {words:,} words "
+                  f"(total so far: {total_words[0]:,})", file=sys.stderr)
+
+    print(f"[total] {total_lines:,} lines / {total_words[0]:,} words -> {args.output}",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kenlm_build/extract_hf_corpus.py
+++ b/scripts/kenlm_build/extract_hf_corpus.py
@@ -37,6 +37,19 @@ except ImportError as e:
     sys.exit(1)
 
 
+def _hf_token() -> str | None:
+    """Resolve the user's stored Hugging Face token. None if not logged in."""
+    try:
+        from huggingface_hub import get_token
+        return get_token()
+    except Exception:
+        return None
+
+
+_HF_TOKEN = _hf_token()
+_HF_HEADERS = {"Authorization": f"Bearer {_HF_TOKEN}"} if _HF_TOKEN else {}
+
+
 GIGASPEECH_PUNCT = {
     "<COMMA>":            ",",
     "<PERIOD>":           ".",
@@ -83,7 +96,7 @@ def list_parquet_shards(repo: str, subdir: str, name_prefix: str = "train-") -> 
     cursor = None
     while True:
         full = url + (f"?cursor={cursor}" if cursor else "")
-        r = requests.get(full, timeout=60)
+        r = requests.get(full, timeout=60, headers=_HF_HEADERS)
         r.raise_for_status()
         items = r.json()
         if not items:
@@ -109,7 +122,10 @@ def resolve_url(repo: str, path: str) -> str:
 
 def read_text_column(url: str, text_col: str = "text") -> list[str]:
     """Download one parquet, read ONLY the text column, return the strings."""
-    fs = fsspec.filesystem("http")
+    # fsspec's http backend takes kwargs for client session; pass auth header
+    # when available so gated repos (e.g. speechcolab/gigaspeech) work.
+    client_kwargs = {"headers": _HF_HEADERS} if _HF_HEADERS else {}
+    fs = fsspec.filesystem("http", client_kwargs=client_kwargs)
     with fs.open(url, "rb") as f:
         pf = pq.ParquetFile(f)
         table = pf.read(columns=[text_col])
@@ -199,8 +215,11 @@ def main() -> int:
     total_lines = 0
 
     config = {
-        "peoples":    ("MLCommons/peoples_speech",    "clean",      normalize_peoples_speech),
-        "gigaspeech": ("speechcolab/gigaspeech",      "data/xl",    normalize_gigaspeech),
+        "peoples":    ("MLCommons/peoples_speech", "clean",            normalize_peoples_speech),
+        # Use the "s" subset by default (~250h, 8 parquets) — big enough for case/
+        # punctuation priors, small enough to pull over the wire quickly when column-
+        # pruned. Bump to parquet-data/m or /xl if you need more volume.
+        "gigaspeech": ("speechcolab/gigaspeech",   "parquet-data/s",   normalize_gigaspeech),
     }
 
     with open_output(args.output) as fout:

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -15,6 +15,17 @@ public class AppSettings
     // beam search — ~3–5× slower per segment but improves accuracy on hard
     // or ambiguous audio and is a prerequisite for shallow LM fusion.
     public int                ParakeetBeamWidth   { get; set; } = 1;
+
+    // Optional ARPA (.arpa or .arpa.gz) subword language model used for
+    // shallow fusion during Parakeet beam search. Empty string = fusion off.
+    // When set, auto-bumps beam width to at least 4 since greedy can't
+    // benefit from fusion.
+    public string             ParakeetLmPath          { get; set; } = "";
+    // Shallow-fusion weight. Typical 0.1–0.5.
+    public float              ParakeetLmWeight        { get; set; } = 0.3f;
+    // Per-emitted-token reward that offsets the LM's shortening bias.
+    // Typical 0.0–1.0.
+    public float              ParakeetLmLengthPenalty { get; set; } = 0.6f;
     public string             CohereLanguage      { get; set; } = "";
     public string             Qwen3AsrLanguage    { get; set; } = "";
     public DenoiserMode       Denoiser            { get; set; } = DenoiserMode.None;

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -953,8 +953,22 @@ internal class TranscriptionService
                 var (encoderFile, decoderJointFile) =
                     Config.GetAsrFiles(ModelPrecision.Fp32);
 
+                // LM fusion requires beam search. If the user has an LM set but beam is still 1,
+                // silently bump to 4 so the feature works without requiring them to also
+                // remember to raise the beam.
+                string lmPath       = _settings.Current.ParakeetLmPath ?? "";
+                bool   lmActive     = !string.IsNullOrWhiteSpace(lmPath) && File.Exists(lmPath);
+                int    effectiveBeam = lmActive && _settings.Current.ParakeetBeamWidth < 2
+                    ? 4 : _settings.Current.ParakeetBeamWidth;
+
                 using var parakeet = new ParakeetAsr(parakeetModelsDir, encoderFile, decoderJointFile,
-                    beamWidth: _settings.Current.ParakeetBeamWidth);
+                    beamWidth: effectiveBeam);
+                if (lmActive)
+                {
+                    parakeet.LmScorer        = KenLmScorer.LoadArpa(lmPath);
+                    parakeet.LmWeight        = _settings.Current.ParakeetLmWeight;
+                    parakeet.LmLengthPenalty = _settings.Current.ParakeetLmLengthPenalty;
+                }
                 foreach (var (segId, text, tokens, timestamps, durations, logprobs) in
                     parakeet.Recognize(segsSubset, audio))
                 {

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Vernacula.Base;
@@ -35,6 +36,15 @@ internal partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private int _parakeetBeamWidth;
+
+    [ObservableProperty]
+    private string _parakeetLmPath = "";
+
+    [ObservableProperty]
+    private float _parakeetLmWeight;
+
+    [ObservableProperty]
+    private float _parakeetLmLengthPenalty;
 
     [ObservableProperty]
     private AsrLanguageOption? _selectedCohereLanguage;
@@ -221,6 +231,9 @@ internal partial class SettingsViewModel : ObservableObject
         _selectedQwen3AsrLanguage     = Qwen3AsrLanguages.FirstOrDefault(l => l.Code == svc.Current.Qwen3AsrLanguage)
                                         ?? Qwen3AsrLanguages[0];
         _parakeetBeamWidth            = Math.Max(1, svc.Current.ParakeetBeamWidth);
+        _parakeetLmPath               = svc.Current.ParakeetLmPath ?? "";
+        _parakeetLmWeight             = svc.Current.ParakeetLmWeight;
+        _parakeetLmLengthPenalty      = svc.Current.ParakeetLmLengthPenalty;
         _selectedDenoiser             = svc.Current.Denoiser;
         _selectedEditorPlaybackMode   = svc.Current.EditorPlaybackMode;
         _selectedLanguage             = svc.Current.Language;
@@ -338,6 +351,67 @@ internal partial class SettingsViewModel : ObservableObject
         _svc.Current.ParakeetBeamWidth = clamped;
         _svc.Save();
     }
+
+    partial void OnParakeetLmPathChanged(string value)
+    {
+        _svc.Current.ParakeetLmPath = value ?? "";
+        _svc.Save();
+    }
+
+    partial void OnParakeetLmWeightChanged(float value)
+    {
+        float clamped = Math.Clamp(value, 0f, 2f);
+        if (Math.Abs(clamped - value) > 1e-6f)
+        {
+            ParakeetLmWeight = clamped;
+            return;
+        }
+        _svc.Current.ParakeetLmWeight = clamped;
+        _svc.Save();
+    }
+
+    partial void OnParakeetLmLengthPenaltyChanged(float value)
+    {
+        float clamped = Math.Clamp(value, 0f, 2f);
+        if (Math.Abs(clamped - value) > 1e-6f)
+        {
+            ParakeetLmLengthPenalty = clamped;
+            return;
+        }
+        _svc.Current.ParakeetLmLengthPenalty = clamped;
+        _svc.Save();
+    }
+
+    [RelayCommand]
+    private async Task BrowseParakeetLm()
+    {
+        if (Application.Current?.ApplicationLifetime is not
+            Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+            return;
+        var window = desktop.MainWindow;
+        if (window is null) return;
+
+        var picker = await window.StorageProvider.OpenFilePickerAsync(new()
+        {
+            Title = "Select KenLM ARPA file",
+            AllowMultiple = false,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("KenLM ARPA (.arpa, .arpa.gz)")
+                {
+                    Patterns = new[] { "*.arpa", "*.arpa.gz" },
+                },
+                new FilePickerFileType("All files") { Patterns = new[] { "*.*" } },
+            },
+        });
+        if (picker.Count == 0) return;
+        var p = picker[0].TryGetLocalPath();
+        if (!string.IsNullOrEmpty(p))
+            ParakeetLmPath = p;
+    }
+
+    [RelayCommand]
+    private void ClearParakeetLm() => ParakeetLmPath = "";
 
     partial void OnSelectedEditorPlaybackModeChanged(PlaybackMode value)
     {

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1048,7 +1048,10 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             string? qwen3AsrModelsDir = null,
             string? vibeVoiceModelsDir = null,
             string? qwen3AsrLanguageCode = null,
-            int parakeetBeamWidth = 1)
+            int parakeetBeamWidth = 1,
+            string? parakeetLmPath = null,
+            float parakeetLmWeight = 0.3f,
+            float parakeetLmLengthPenalty = 0.6f)
     {
         if (index < 0 || index >= Segments.Count || _dbPath is null || _fullAudio is null)
             return null;
@@ -1146,8 +1149,16 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         else
         {
             // Run ASR — the slice starts at t=0, so pass a 0-based time range
+            bool lmActive = !string.IsNullOrWhiteSpace(parakeetLmPath) && File.Exists(parakeetLmPath);
+            int  effectiveBeam = lmActive && parakeetBeamWidth < 2 ? 4 : parakeetBeamWidth;
             using var parakeet = new ParakeetAsr(parakeetModelsDir, encoderFile, decoderJointFile,
-                beamWidth: parakeetBeamWidth);
+                beamWidth: effectiveBeam);
+            if (lmActive)
+            {
+                parakeet.LmScorer        = KenLmScorer.LoadArpa(parakeetLmPath!);
+                parakeet.LmWeight        = parakeetLmWeight;
+                parakeet.LmLengthPenalty = parakeetLmLengthPenalty;
+            }
             foreach (var (_, t, tk, ts, dur, lp) in parakeet.Recognize(asrSeg, mono16k))
             {
                 text = t; tokens = tk; timestamps = ts; durations = dur; logprobs = lp;

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -511,6 +511,65 @@
                         </StackPanel>
 
                         <StackPanel Margin="24,10,0,0"
+                                    IsVisible="{Binding IsAsrParakeet}">
+                            <TextBlock Text="Language model (shallow fusion)"
+                                       Foreground="{DynamicResource TextBrush}"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,0,6" />
+                            <TextBlock Text="Optional. Biases decoding toward text that matches the supplied subword n-gram model. Fixes occasional multilingual drift (e.g. English &quot;uh uh&quot; transcribed as Spanish &quot;ajá&quot;). Auto-enables beam search. Point at an .arpa or .arpa.gz built with scripts/kenlm_build/."
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <Grid ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,8">
+                                <TextBox Grid.Column="0"
+                                         Text="{Binding ParakeetLmPath}"
+                                         Watermark="(no LM — greedy/beam decoding only)"
+                                         Background="{DynamicResource OverlayBrush}"
+                                         Foreground="{DynamicResource TextBrush}"
+                                         BorderBrush="{DynamicResource OverlayBrush}"
+                                         IsReadOnly="True"
+                                         Margin="0,0,6,0" />
+                                <Button Grid.Column="1"
+                                        Content="Browse…"
+                                        Command="{Binding BrowseParakeetLmCommand}"
+                                        Margin="0,0,6,0" />
+                                <Button Grid.Column="2"
+                                        Content="Clear"
+                                        Command="{Binding ClearParakeetLmCommand}" />
+                            </Grid>
+
+                            <TextBlock Text="Fusion weight (typical 0.1–0.5)"
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       Margin="0,8,0,4" />
+                            <NumericUpDown Value="{Binding ParakeetLmWeight}"
+                                           Minimum="0" Maximum="2"
+                                           Increment="0.05"
+                                           FormatString="0.00"
+                                           Background="{DynamicResource OverlayBrush}"
+                                           Foreground="{DynamicResource TextBrush}"
+                                           BorderBrush="{DynamicResource OverlayBrush}"
+                                           HorizontalAlignment="Left"
+                                           MinWidth="120"
+                                           Margin="0,0,0,8" />
+
+                            <TextBlock Text="Length penalty (offsets LM shortening bias; 0.0–1.0)"
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       Margin="0,0,0,4" />
+                            <NumericUpDown Value="{Binding ParakeetLmLengthPenalty}"
+                                           Minimum="0" Maximum="2"
+                                           Increment="0.1"
+                                           FormatString="0.00"
+                                           Background="{DynamicResource OverlayBrush}"
+                                           Foreground="{DynamicResource TextBrush}"
+                                           BorderBrush="{DynamicResource OverlayBrush}"
+                                           HorizontalAlignment="Left"
+                                           MinWidth="120" />
+                        </StackPanel>
+
+                        <StackPanel Margin="24,10,0,0"
                                     IsVisible="{Binding ShowCohereLanguagePicker}">
                             <TextBlock Text="Forced Language"
                                        Foreground="{DynamicResource TextBrush}"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -1295,7 +1295,10 @@ public partial class TranscriptEditorWindow : Window
                 qwen3AsrModelsDir: App.Current.Settings.GetQwen3AsrModelsDir(),
                 vibeVoiceModelsDir: App.Current.Settings.GetVibeVoiceModelsDir(),
                 qwen3AsrLanguageCode: _isQwen3Asr ? card.SelectedRedoLanguage?.Code : null,
-                parakeetBeamWidth: App.Current.Settings.Current.ParakeetBeamWidth));
+                parakeetBeamWidth:       App.Current.Settings.Current.ParakeetBeamWidth,
+                parakeetLmPath:          App.Current.Settings.Current.ParakeetLmPath,
+                parakeetLmWeight:        App.Current.Settings.Current.ParakeetLmWeight,
+                parakeetLmLengthPenalty: App.Current.Settings.Current.ParakeetLmLengthPenalty));
             if (result is null)
             {
                 SetCardStatus(card, "Redo ASR did not produce a result.");

--- a/src/Vernacula.Base/KenLmScorer.cs
+++ b/src/Vernacula.Base/KenLmScorer.cs
@@ -1,0 +1,227 @@
+using System.IO.Compression;
+using System.Text;
+
+namespace Vernacula.Base;
+
+/// <summary>
+/// Pure-C# scorer for ARPA-format n-gram language models built over a
+/// Parakeet-compatible subword vocabulary. Integer token IDs are used as
+/// "words" in the ARPA file so the decoder can look up the LM without any
+/// string<->ID round-trip. Supports Katz backoff with per-context weights,
+/// matching KenLM's default behavior.
+///
+/// Not intended as a full KenLM replacement — we only need the subset the
+/// shallow-fusion beam decoder calls on the hot path (single-token score
+/// given a variable-length history).
+/// </summary>
+public sealed class KenLmScorer
+{
+    /// <summary>Packs up to four 14-bit token IDs into a single ulong for fast hashing.</summary>
+    private const int TokenBits = 14;                   // supports vocab up to 16384 (covers Parakeet's 8193)
+    private const ulong TokenMask = (1UL << TokenBits) - 1;
+    private const int MaxOrder = 4;                     // higher orders would overflow ulong (5×14 = 70 bits)
+
+    private readonly Dictionary<ulong, (float logProb, float backoff)>[] _ngrams;
+    private readonly float _unkLogProb;
+    private readonly int _order;
+
+    public int Order => _order;
+    public float LogProbNatural(float log10) => log10 * 2.302585093f;
+
+    private KenLmScorer(
+        Dictionary<ulong, (float, float)>[] ngrams,
+        float unkLogProb,
+        int order)
+    {
+        _ngrams     = ngrams;
+        _unkLogProb = unkLogProb;
+        _order      = order;
+    }
+
+    /// <summary>
+    /// Loads an ARPA file (optionally gzip-compressed — detected by .gz suffix
+    /// or a gzip magic header). The token column is expected to contain
+    /// integer subword IDs matching the Parakeet vocabulary.
+    /// </summary>
+    public static KenLmScorer LoadArpa(string path)
+    {
+        using var fs     = File.OpenRead(path);
+        using var reader = OpenMaybeGzip(fs, path);
+        return LoadArpaCore(reader);
+    }
+
+    private static StreamReader OpenMaybeGzip(Stream raw, string path)
+    {
+        // Detect by magic or .gz extension
+        Stream inner = raw;
+        if (path.EndsWith(".gz", StringComparison.OrdinalIgnoreCase))
+        {
+            inner = new GZipStream(raw, CompressionMode.Decompress);
+        }
+        else
+        {
+            int b0 = raw.ReadByte();
+            int b1 = raw.ReadByte();
+            raw.Position = 0;
+            if (b0 == 0x1f && b1 == 0x8b)
+                inner = new GZipStream(raw, CompressionMode.Decompress);
+        }
+        return new StreamReader(inner, Encoding.UTF8);
+    }
+
+    private static KenLmScorer LoadArpaCore(StreamReader reader)
+    {
+        // Phase 1: scan \data\ block for ngram counts to pre-size dictionaries
+        string? line;
+        int order = 0;
+        var counts = new List<int>(); // counts[i] = number of (i+1)-grams
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+            if (line == "\\data\\") break;
+        }
+        if (line is null)
+            throw new FormatException("ARPA file missing \\data\\ header.");
+
+        while ((line = reader.ReadLine()) != null)
+        {
+            line = line.Trim();
+            if (line.Length == 0) break;
+            if (!line.StartsWith("ngram ", StringComparison.Ordinal)) continue;
+            // "ngram N=COUNT"
+            int eq    = line.IndexOf('=');
+            int nOrd  = int.Parse(line.AsSpan(6, eq - 6));
+            int count = int.Parse(line.AsSpan(eq + 1));
+            while (counts.Count < nOrd) counts.Add(0);
+            counts[nOrd - 1] = count;
+            if (nOrd > order) order = nOrd;
+        }
+
+        if (order < 1 || order > MaxOrder)
+            throw new FormatException($"Unsupported LM order {order} (max {MaxOrder}).");
+
+        var ngrams = new Dictionary<ulong, (float, float)>[order];
+        for (int i = 0; i < order; i++)
+            ngrams[i] = new Dictionary<ulong, (float, float)>(Math.Max(counts[i], 16));
+
+        // Phase 2: read each "\N-grams:" section
+        float unkLogProb = -10f; // fallback if LM has no explicit <unk>
+        int currentOrder = 0;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (line.Length == 0) continue;
+            if (line == "\\end\\") break;
+
+            if (line.Length > 2 && line[0] == '\\' && line.EndsWith("-grams:", StringComparison.Ordinal))
+            {
+                currentOrder = int.Parse(line.AsSpan(1, line.IndexOf('-') - 1));
+                continue;
+            }
+            if (currentOrder == 0) continue;
+
+            ParseAndStoreNgram(line, currentOrder, ngrams, ref unkLogProb);
+        }
+
+        return new KenLmScorer(ngrams, unkLogProb, order);
+    }
+
+    private static void ParseAndStoreNgram(
+        string line,
+        int currentOrder,
+        Dictionary<ulong, (float, float)>[] ngrams,
+        ref float unkLogProb)
+    {
+        // Format: "logprob\tt1 t2 ... tN[\tbackoff]"  — whitespace may be tab OR space
+        var parts = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        int needed = 1 + currentOrder; // logprob + N tokens
+        if (parts.Length < needed) return;
+
+        float logProb = float.Parse(parts[0], System.Globalization.CultureInfo.InvariantCulture);
+        float backoff = parts.Length >= needed + 1
+            ? float.Parse(parts[needed], System.Globalization.CultureInfo.InvariantCulture)
+            : 0f;
+
+        ulong key = 0;
+        bool ok = true;
+        for (int k = 0; k < currentOrder; k++)
+        {
+            string tok = parts[1 + k];
+            if (tok == "<unk>")
+            {
+                if (currentOrder == 1) unkLogProb = logProb;
+                ok = false;
+                break;
+            }
+            if (tok == "<s>" || tok == "</s>")
+            {
+                // We skip sentence boundaries: decoder-level fusion operates
+                // on per-segment token streams, not sentence-delimited text,
+                // so <s>/</s> lookups would just miss.
+                ok = false;
+                break;
+            }
+            if (!int.TryParse(tok, out int id) || id < 0 || (ulong)id > TokenMask)
+            {
+                ok = false;
+                break;
+            }
+            key |= (ulong)id << (k * TokenBits);
+        }
+
+        if (ok) ngrams[currentOrder - 1][key] = (logProb, backoff);
+    }
+
+    /// <summary>
+    /// Log-probability (natural log, not log10) of <paramref name="nextToken"/>
+    /// given <paramref name="context"/>. Applies Katz backoff when the full
+    /// n-gram is missing.
+    /// </summary>
+    public float LogProb(IReadOnlyList<int> context, int nextToken)
+    {
+        int ctxUsed = Math.Min(context.Count, _order - 1);
+
+        // Try longest-first: (ctxUsed+1)-gram down to unigram
+        for (int n = ctxUsed; n >= 0; n--)
+        {
+            ulong key = 0;
+            int start = context.Count - n;
+            bool inRange = true;
+            for (int k = 0; k < n; k++)
+            {
+                int id = context[start + k];
+                if (id < 0 || (ulong)id > TokenMask) { inRange = false; break; }
+                key |= (ulong)id << (k * TokenBits);
+            }
+            if (!inRange) continue;
+            if (nextToken < 0 || (ulong)nextToken > TokenMask) continue;
+            key |= (ulong)nextToken << (n * TokenBits);
+
+            if (_ngrams[n].TryGetValue(key, out var entry))
+            {
+                float s = entry.logProb;
+                // Add backoff weights for the (shorter) contexts we skipped past.
+                // For each skipped order m in (n+1 .. ctxUsed), accumulate
+                // backoff of the m-length context that was too long to match.
+                for (int skip = n + 1; skip <= ctxUsed; skip++)
+                {
+                    ulong ctxKey = 0;
+                    int cs = context.Count - skip;
+                    bool ok = true;
+                    for (int k = 0; k < skip; k++)
+                    {
+                        int id = context[cs + k];
+                        if (id < 0 || (ulong)id > TokenMask) { ok = false; break; }
+                        ctxKey |= (ulong)id << (k * TokenBits);
+                    }
+                    if (ok && _ngrams[skip - 1].TryGetValue(ctxKey, out var be))
+                        s += be.backoff;
+                }
+                return Log10ToNat(s);
+            }
+        }
+
+        return Log10ToNat(_unkLogProb);
+    }
+
+    private static float Log10ToNat(float log10) => log10 * 2.302585093f;
+}

--- a/src/Vernacula.Base/Parakeet.cs
+++ b/src/Vernacula.Base/Parakeet.cs
@@ -30,6 +30,27 @@ public sealed class Parakeet : IDisposable
     /// </summary>
     public int BeamWidth { get; set; } = 1;
 
+    /// <summary>
+    /// Optional subword-level language model used for shallow fusion during
+    /// beam search. Ignored when <see cref="BeamWidth"/> is 1.
+    /// </summary>
+    public KenLmScorer? LmScorer { get; set; }
+
+    /// <summary>
+    /// Shallow-fusion weight applied to the LM log-prob. Typical values are
+    /// 0.1–0.5. Ignored when <see cref="LmScorer"/> is null.
+    /// </summary>
+    public float LmWeight { get; set; } = 0.3f;
+
+    /// <summary>
+    /// Per-emitted-token reward added to each beam's cumulative score. Offsets
+    /// the shortening bias that shallow LM fusion otherwise introduces
+    /// (every emission pays an LM cost, so beams that emit fewer tokens
+    /// would win without this). Typical range 0.0–1.0; 0.6 is a reasonable
+    /// default when <see cref="LmWeight"/> is around 0.3.
+    /// </summary>
+    public float LmLengthPenalty { get; set; } = 0.6f;
+
     // ── Construction ─────────────────────────────────────────────────────────
 
     public Parakeet(string modelPath)
@@ -435,6 +456,15 @@ public sealed class Parakeet : IDisposable
 
                             if (!isBlank)
                             {
+                                // Shallow LM fusion: only score non-blank tokens so the
+                                // blank head's probability mass isn't double-weighted.
+                                // Length penalty counteracts the shortening bias LM
+                                // fusion introduces (beams that emit fewer tokens would
+                                // otherwise accumulate lower LM cost regardless of fit).
+                                if (LmScorer != null)
+                                    nh.Score += LmWeight * LmScorer.LogProb(h.Tokens, token)
+                                              + LmLengthPenalty;
+
                                 nh.Tokens.Add(token);
                                 nh.Timestamps.Add(h.T);
                                 nh.Durations.Add(dIdx);

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -35,6 +35,9 @@ bool    downloadVoxLingua = false;      // --download-voxlingua: fetch the LID m
 bool    runLid             = false;      // --lid: run LID on --audio and print result, then exit
 ModelPrecision precision = ModelPrecision.Fp32;
 int     parakeetBeam      = 1;          // --parakeet-beam N: 1 = greedy (default), >1 = TDT beam search
+string? parakeetLmPath    = null;       // --lm <path> to ARPA(.gz) subword n-gram model; implies beam ≥ 4
+float   parakeetLmWeight  = 0.3f;       // --lm-weight <w> shallow fusion scalar
+float   parakeetLmLen     = 0.6f;       // --lm-length-penalty <p> per-emitted-token reward to offset LM shortening bias
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -111,6 +114,25 @@ for (int i = 0; i < args.Length; i++)
             if (!int.TryParse(args[++i], out parakeetBeam) || parakeetBeam < 1)
             {
                 Console.Error.WriteLine("--parakeet-beam expects a positive integer (1 = greedy).");
+                return 1;
+            }
+            break;
+        case "--lm":
+            parakeetLmPath = args[++i];
+            break;
+        case "--lm-weight":
+            if (!float.TryParse(args[++i], System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture, out parakeetLmWeight))
+            {
+                Console.Error.WriteLine("--lm-weight expects a float (typical range 0.1–0.5).");
+                return 1;
+            }
+            break;
+        case "--lm-length-penalty":
+            if (!float.TryParse(args[++i], System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture, out parakeetLmLen))
+            {
+                Console.Error.WriteLine("--lm-length-penalty expects a float (typical 0.0–1.0).");
                 return 1;
             }
             break;
@@ -662,8 +684,24 @@ try
     else
     {
         var (encoderFile, decoderJointFile) = Config.GetAsrFiles(precision);
+
+        // LM fusion only takes effect during beam search. Auto-bump to a
+        // minimal beam when --lm is passed without an explicit --parakeet-beam
+        // so `--lm foo.arpa` Just Works.
+        int effectiveBeam = parakeetLmPath != null && parakeetBeam < 2 ? 4 : parakeetBeam;
+
         using var parakeet = new ParakeetAsr(modelDir, encoderFile, decoderJointFile,
-            beamWidth: parakeetBeam);
+            beamWidth: effectiveBeam);
+
+        if (parakeetLmPath != null)
+        {
+            Console.Write($"Loading language model {Path.GetFileName(parakeetLmPath)}... ");
+            var lmSw = Stopwatch.StartNew();
+            parakeet.LmScorer       = KenLmScorer.LoadArpa(parakeetLmPath);
+            parakeet.LmWeight       = parakeetLmWeight;
+            parakeet.LmLengthPenalty = parakeetLmLen;
+            Console.WriteLine($"order={parakeet.LmScorer.Order} weight={parakeetLmWeight:F2} length-penalty={parakeetLmLen:F2} ({lmSw.ElapsedMilliseconds}ms)");
+        }
 
         int totalSegs = segs.Count;
         int completed = 0;
@@ -1022,6 +1060,9 @@ static void PrintUsage()
     Console.WriteLine("  --denoiser-models <dir>            Path to denoiser ONNX models (default: <model>/deepfilternet3)");
     Console.WriteLine("  --precision <fp32|int8>            Model precision (default: fp32, parakeet only)");
     Console.WriteLine("  --parakeet-beam <N>                Parakeet TDT beam width (default: 1 = greedy; 4–8 = beam search, 3–5x slower)");
+    Console.WriteLine("  --lm <path>                        Parakeet shallow LM fusion — ARPA(.gz) subword n-gram. Auto-bumps beam to 4.");
+    Console.WriteLine("  --lm-weight <w>                    Shallow-fusion weight (default: 0.3; typical 0.1–0.5)");
+    Console.WriteLine("  --lm-length-penalty <p>            Per-token reward offsetting LM shortening bias (default: 0.6; typical 0.0–1.0)");
     Console.WriteLine("  --skip-asr                         Export diarization/VAD segments without transcription");
     Console.WriteLine("  --benchmark                        Print timing / RTF after transcription");
     Console.WriteLine("  --profile-sortformer               Print fine-grained timing breakdown for Sortformer");


### PR DESCRIPTION
## Summary

Implements subword-level shallow language-model fusion on top of the TDT beam decoder from #18. The LM is applied to every non-blank emission, scaled by a weight, with a per-token length penalty to counteract the shortening bias shallow fusion otherwise introduces.

## Pieces

- **\`KenLmScorer.cs\`** — pure-C# ARPA reader with Katz backoff. Tokens stored as Parakeet subword IDs packed into ulong keys (14 bits × up to 4-gram). Supports gzipped ARPA. No native dependency.
- **\`Parakeet.cs\`** — \`LmScorer\`, \`LmWeight\`, \`LmLengthPenalty\` on the decoder; fusion fires inside \`DecoderBeam\` on non-blank token emission only.
- **CLI flags:** \`--lm <path>\`, \`--lm-weight <w>\`, \`--lm-length-penalty <p>\`. Passing \`--lm\` auto-bumps beam width to 4.
- **Settings UI:** new panel under Parakeet → TDT beam width with an ARPA file picker, weight slider, and length-penalty slider. Visible when Parakeet is the active ASR backend. Job pipeline and editor redo-ASR both respect the setting; auto-bumps beam to 4 when an LM is configured.
- **\`scripts/kenlm_build/\`** — Python tooling:
  - \`extract_hf_corpus.py\` — column-pruned Parquet streaming from HuggingFace ASR datasets so audio bytes are never downloaded. Supports People's Speech (ungated) and GigaSpeech (gated, auto-resolves HF token).
  - \`build_kenlm_parakeet.py\` — drives \`lmplz\` with Parakeet's tokenizer.json to produce a subword-ID ARPA.
  - \`README.md\` — full extract → mix → build recipe.

## Validated

End-to-end A/B on a 600s en-US conversational sample:

| Run | Wall time | Line 67 (target regression) |
|---|---|---|
| Greedy | 8.3s | \`Uh uh. Ya.\` ✓ |
| Beam=4 | 29s | \`ajá, ya\` ✗ (regression) |
| Beam=4 + Mixed LM (w=0.15) | 31s | \`Uh uh, yeah.\` ✓ (recovered) |

The mixed LM (3× GigaSpeech + 1× People's Speech) fixes the multilingual-drift regression cleanly at fusion weight 0.15, preserves proper nouns (\`Garrett\`, \`Memphis\`, \`Sergeant Ingram\`), preserves punctuation, and leaves ~500 other lines unchanged vs greedy. GigaSpeech alone carries the case/punctuation priors; People's Speech alone carries the conversational-register priors; the 3× upweight balances the 6:1 raw size asymmetry so case/punct signal survives.

Remaining (follow-up PR): upload \`kenlm-parakeet-en.arpa.gz\` to HuggingFace, wire it into \`ModelManagerService\`, and replace the current file-picker with a Language: Auto/English/… dropdown that triggers download on selection.

Addresses candidate #2 from #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)