### PR TITLE
Replace LM file picker with built-in language dropdown

### DIFF
--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -16,10 +16,13 @@ public class AppSettings
     // or ambiguous audio and is a prerequisite for shallow LM fusion.
     public int                ParakeetBeamWidth   { get; set; } = 1;
 
-    // Optional ARPA (.arpa or .arpa.gz) subword language model used for
-    // shallow fusion during Parakeet beam search. Empty string = fusion off.
-    // When set, auto-bumps beam width to at least 4 since greedy can't
-    // benefit from fusion.
+    // Which KenLM the Parakeet decoder should shallow-fuse.
+    // Stable key from KenLmCatalog — "none" (default), a built-in key like
+    // "en-general", or "custom" (paired with ParakeetLmPath below).
+    public string             ParakeetLmSelection     { get; set; } = "none";
+    // Free-form path used only when ParakeetLmSelection == "custom".
+    // When a built-in option is selected, the app resolves the path via
+    // ModelManagerService (downloading on demand) instead.
     public string             ParakeetLmPath          { get; set; } = "";
     // Shallow-fusion weight. Typical 0.1–0.5.
     public float              ParakeetLmWeight        { get; set; } = 0.3f;

--- a/src/Vernacula.Avalonia/Models/KenLmOptions.cs
+++ b/src/Vernacula.Avalonia/Models/KenLmOptions.cs
@@ -1,0 +1,63 @@
+using Vernacula.Base;
+
+namespace Vernacula.App.Models;
+
+/// <summary>
+/// One selectable KenLM option for Parakeet shallow fusion. Maps a stable
+/// key persisted in <see cref="AppSettings.ParakeetLmSelection"/> to a
+/// user-facing label and (for built-in options) the HF file we download
+/// on demand. <c>None</c> and <c>Custom</c> have no HF file.
+/// </summary>
+public sealed record KenLmOption(
+    string  Key,
+    string  DisplayName,
+    string? RemoteFileName,
+    long?   ExpectedSizeBytes);
+
+public static class KenLmCatalog
+{
+    public const string KeyNone   = "none";
+    public const string KeyCustom = "custom";
+
+    /// <summary>
+    /// Built-in options, ordered as they should appear in the Settings
+    /// dropdown. Keep <c>None</c> first and <c>Custom</c> last. New
+    /// languages/domains slot between them.
+    /// </summary>
+    public static readonly IReadOnlyList<KenLmOption> All =
+    [
+        new(KeyNone,       "None (greedy / beam only)",                    null,                 null),
+        new("en-general",  "English — General (conversational)",           "en-general.arpa.gz", 69_980_766L),
+        new(KeyCustom,     "Custom ARPA file…",                            null,                 null),
+    ];
+
+    public static KenLmOption? Find(string? key) =>
+        string.IsNullOrEmpty(key)
+            ? null
+            : All.FirstOrDefault(o => o.Key == key);
+
+    /// <summary>
+    /// Resolves the active LM path the decoder should load, based on the
+    /// user's saved selection. Returns null when fusion should be off
+    /// (selection is <c>None</c>, a built-in isn't downloaded yet, or a
+    /// custom path doesn't exist). Callers should treat null as "decoder
+    /// runs without fusion".
+    /// </summary>
+    public static string? ResolvePath(AppSettings settings, string kenLmDir)
+    {
+        string sel = settings.ParakeetLmSelection ?? KeyNone;
+        if (sel == KeyNone) return null;
+
+        if (sel == KeyCustom)
+        {
+            string p = settings.ParakeetLmPath ?? "";
+            return !string.IsNullOrWhiteSpace(p) && File.Exists(p) ? p : null;
+        }
+
+        var opt = Find(sel);
+        if (opt?.RemoteFileName is null) return null;
+
+        string localPath = Path.Combine(kenLmDir, opt.RemoteFileName);
+        return File.Exists(localPath) ? localPath : null;
+    }
+}

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -502,6 +502,50 @@ internal class ModelManagerService
         await DownloadMissingAssetsAsync(dir, missing, progress, ct);
     }
 
+    // ── KenLM for Parakeet (per-language/domain files under a single repo) ──
+
+    /// <summary>
+    /// Full local path the given built-in LM option would live at. Returns
+    /// <c>null</c> for the <c>none</c> and <c>custom</c> slots, which have
+    /// no remote file.
+    /// </summary>
+    public string? GetKenLmLocalPath(KenLmOption option)
+    {
+        if (option.RemoteFileName is null) return null;
+        return Path.Combine(_settings.GetKenLmParakeetDir(), option.RemoteFileName);
+    }
+
+    /// <summary>True when the option's file is already on disk.</summary>
+    public bool IsKenLmReady(KenLmOption option)
+    {
+        string? path = GetKenLmLocalPath(option);
+        return path is not null && File.Exists(path);
+    }
+
+    /// <summary>
+    /// Downloads a single KenLM file if missing. Reports byte-precise
+    /// progress through the shared pipeline. No-op if the file already
+    /// exists, or the option has no remote file (none/custom).
+    /// </summary>
+    public async Task DownloadKenLmAsync(
+        KenLmOption option,
+        IProgress<DownloadProgress> progress,
+        CancellationToken ct = default)
+    {
+        if (option.RemoteFileName is null) return;
+        string dir = _settings.GetKenLmParakeetDir();
+        Directory.CreateDirectory(dir);
+
+        string localPath = Path.Combine(dir, option.RemoteFileName);
+        if (File.Exists(localPath)) return;
+
+        var asset = new RepoAsset(
+            Config.KenLmParakeetRepoBase,
+            option.RemoteFileName,
+            option.RemoteFileName);
+        await DownloadMissingAssetsAsync(dir, [asset], progress, ct);
+    }
+
     public async Task DownloadMissingVoxLinguaModelsAsync(
         IProgress<DownloadProgress> progress,
         string? voxLinguaDir = null,

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -106,6 +106,9 @@ internal class SettingsService
             ? Path.Combine(GetModelsDir(), Config.VoxLinguaSubDir)
             : Current.VoxLinguaModelsDir;
 
+    public string GetKenLmParakeetDir() =>
+        Path.Combine(GetModelsDir(), Config.KenLmParakeetSubDir);
+
     public string GetJobsDir()
     {
         string dir = Path.Combine(

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -956,16 +956,17 @@ internal class TranscriptionService
                 // LM fusion requires beam search. If the user has an LM set but beam is still 1,
                 // silently bump to 4 so the feature works without requiring them to also
                 // remember to raise the beam.
-                string lmPath       = _settings.Current.ParakeetLmPath ?? "";
-                bool   lmActive     = !string.IsNullOrWhiteSpace(lmPath) && File.Exists(lmPath);
-                int    effectiveBeam = lmActive && _settings.Current.ParakeetBeamWidth < 2
+                string? lmPath       = KenLmCatalog.ResolvePath(
+                    _settings.Current, _settings.GetKenLmParakeetDir());
+                bool    lmActive     = lmPath is not null;
+                int     effectiveBeam = lmActive && _settings.Current.ParakeetBeamWidth < 2
                     ? 4 : _settings.Current.ParakeetBeamWidth;
 
                 using var parakeet = new ParakeetAsr(parakeetModelsDir, encoderFile, decoderJointFile,
                     beamWidth: effectiveBeam);
                 if (lmActive)
                 {
-                    parakeet.LmScorer        = KenLmScorer.LoadArpa(lmPath);
+                    parakeet.LmScorer        = KenLmScorer.LoadArpa(lmPath!);
                     parakeet.LmWeight        = _settings.Current.ParakeetLmWeight;
                     parakeet.LmLengthPenalty = _settings.Current.ParakeetLmLengthPenalty;
                 }

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -37,6 +37,13 @@ internal partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private int _parakeetBeamWidth;
 
+    // Selected KenLM option (from KenLmCatalog.All). Changing this triggers
+    // a lazy download when a built-in option isn't yet on disk.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowCustomLmPath), nameof(IsLmDownloading), nameof(LmStatusText))]
+    private KenLmOption? _selectedLmOption;
+
+    // Free-form path used only when SelectedLmOption is the "custom" entry.
     [ObservableProperty]
     private string _parakeetLmPath = "";
 
@@ -45,6 +52,45 @@ internal partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private float _parakeetLmLengthPenalty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsLmDownloading), nameof(LmStatusText))]
+    private bool _isLmDownloadingInternal;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LmStatusText))]
+    private double _lmDownloadPercent;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LmStatusText))]
+    private string _lmDownloadStatusText = "";
+
+    private CancellationTokenSource? _lmDownloadCts;
+
+    public IReadOnlyList<KenLmOption> AvailableLmOptions => KenLmCatalog.All;
+
+    public bool ShowCustomLmPath  => SelectedLmOption?.Key == KenLmCatalog.KeyCustom;
+    public bool IsLmDownloading   => IsLmDownloadingInternal;
+
+    public string LmStatusText
+    {
+        get
+        {
+            if (IsLmDownloading) return LmDownloadStatusText;
+            var opt = SelectedLmOption;
+            if (opt is null) return "";
+            if (opt.Key == KenLmCatalog.KeyNone) return "Fusion disabled — decoder uses greedy or beam only.";
+            if (opt.Key == KenLmCatalog.KeyCustom)
+                return string.IsNullOrWhiteSpace(ParakeetLmPath)
+                    ? "Custom — pick an ARPA file to enable fusion."
+                    : File.Exists(ParakeetLmPath)
+                        ? "Custom ARPA ready."
+                        : "Custom ARPA path doesn't exist.";
+            return _modelMgr.IsKenLmReady(opt)
+                ? "Downloaded and ready."
+                : $"Not yet downloaded (~{(opt.ExpectedSizeBytes ?? 0) / 1_000_000} MB). Will fetch on save.";
+        }
+    }
 
     [ObservableProperty]
     private AsrLanguageOption? _selectedCohereLanguage;
@@ -231,6 +277,7 @@ internal partial class SettingsViewModel : ObservableObject
         _selectedQwen3AsrLanguage     = Qwen3AsrLanguages.FirstOrDefault(l => l.Code == svc.Current.Qwen3AsrLanguage)
                                         ?? Qwen3AsrLanguages[0];
         _parakeetBeamWidth            = Math.Max(1, svc.Current.ParakeetBeamWidth);
+        _selectedLmOption             = KenLmCatalog.Find(svc.Current.ParakeetLmSelection) ?? KenLmCatalog.All[0];
         _parakeetLmPath               = svc.Current.ParakeetLmPath ?? "";
         _parakeetLmWeight             = svc.Current.ParakeetLmWeight;
         _parakeetLmLengthPenalty      = svc.Current.ParakeetLmLengthPenalty;
@@ -356,7 +403,66 @@ internal partial class SettingsViewModel : ObservableObject
     {
         _svc.Current.ParakeetLmPath = value ?? "";
         _svc.Save();
+        OnPropertyChanged(nameof(LmStatusText));
     }
+
+    partial void OnSelectedLmOptionChanged(KenLmOption? value)
+    {
+        if (value is null) return;
+        _svc.Current.ParakeetLmSelection = value.Key;
+        _svc.Save();
+        OnPropertyChanged(nameof(LmStatusText));
+
+        // Auto-download built-in options on selection, unless already present.
+        if (value.RemoteFileName is not null && !_modelMgr.IsKenLmReady(value))
+            _ = DownloadSelectedLmAsync();
+    }
+
+    [RelayCommand]
+    private async Task DownloadSelectedLmAsync()
+    {
+        var opt = SelectedLmOption;
+        if (opt is null || opt.RemoteFileName is null) return;
+        if (_modelMgr.IsKenLmReady(opt))
+        {
+            LmDownloadStatusText = "Already downloaded.";
+            return;
+        }
+
+        IsLmDownloadingInternal = true;
+        LmDownloadPercent       = 0;
+        LmDownloadStatusText    = $"Downloading {opt.DisplayName}…";
+        _lmDownloadCts          = new CancellationTokenSource();
+
+        var progress = new Progress<DownloadProgress>(p =>
+        {
+            LmDownloadPercent    = p.OverallPercent;
+            LmDownloadStatusText =
+                $"{opt.DisplayName} — {p.SizeText} ({p.OverallPercent:F1}%)";
+        });
+
+        try
+        {
+            await _modelMgr.DownloadKenLmAsync(opt, progress, _lmDownloadCts.Token);
+            LmDownloadStatusText = $"{opt.DisplayName} ready.";
+        }
+        catch (OperationCanceledException)
+        {
+            LmDownloadStatusText = $"{opt.DisplayName} download cancelled.";
+        }
+        catch (Exception ex)
+        {
+            LmDownloadStatusText = $"{opt.DisplayName} download failed: {ex.Message}";
+        }
+        finally
+        {
+            IsLmDownloadingInternal = false;
+            OnPropertyChanged(nameof(LmStatusText));
+        }
+    }
+
+    [RelayCommand]
+    private void CancelLmDownload() => _lmDownloadCts?.Cancel();
 
     partial void OnParakeetLmWeightChanged(float value)
     {

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -512,32 +512,67 @@
 
                         <StackPanel Margin="24,10,0,0"
                                     IsVisible="{Binding IsAsrParakeet}">
-                            <TextBlock Text="Language model (shallow fusion)"
+                            <TextBlock Text="Language model"
                                        Foreground="{DynamicResource TextBrush}"
                                        FontWeight="SemiBold"
                                        Margin="0,0,0,6" />
-                            <TextBlock Text="Optional. Biases decoding toward text that matches the supplied subword n-gram model. Fixes occasional multilingual drift (e.g. English &quot;uh uh&quot; transcribed as Spanish &quot;ajá&quot;). Auto-enables beam search. Point at an .arpa or .arpa.gz built with scripts/kenlm_build/."
+                            <TextBlock Text="Biases decoding toward text that matches the chosen language/domain, fixing occasional multilingual drift (e.g. English &quot;uh uh&quot; transcribed as Spanish &quot;ajá&quot;). Built-ins download on demand. Selecting anything other than None auto-enables beam search."
                                        Foreground="{DynamicResource SubtextBrush}"
                                        FontSize="11"
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8" />
-                            <Grid ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,8">
-                                <TextBox Grid.Column="0"
-                                         Text="{Binding ParakeetLmPath}"
-                                         Watermark="(no LM — greedy/beam decoding only)"
-                                         Background="{DynamicResource OverlayBrush}"
-                                         Foreground="{DynamicResource TextBrush}"
-                                         BorderBrush="{DynamicResource OverlayBrush}"
-                                         IsReadOnly="True"
-                                         Margin="0,0,6,0" />
-                                <Button Grid.Column="1"
-                                        Content="Browse…"
-                                        Command="{Binding BrowseParakeetLmCommand}"
-                                        Margin="0,0,6,0" />
-                                <Button Grid.Column="2"
-                                        Content="Clear"
-                                        Command="{Binding ClearParakeetLmCommand}" />
-                            </Grid>
+
+                            <ComboBox ItemsSource="{Binding AvailableLmOptions}"
+                                      SelectedItem="{Binding SelectedLmOption}"
+                                      Background="{DynamicResource OverlayBrush}"
+                                      Foreground="{DynamicResource TextBrush}"
+                                      BorderBrush="{DynamicResource OverlayBrush}"
+                                      HorizontalAlignment="Stretch"
+                                      Margin="0,0,0,6">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+
+                            <TextBlock Text="{Binding LmStatusText}"
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,4" />
+
+                            <ProgressBar Value="{Binding LmDownloadPercent}"
+                                         Maximum="100"
+                                         Height="6"
+                                         IsVisible="{Binding IsLmDownloading}"
+                                         Margin="0,0,0,4" />
+                            <Button Content="Cancel download"
+                                    Command="{Binding CancelLmDownloadCommand}"
+                                    IsVisible="{Binding IsLmDownloading}"
+                                    HorizontalAlignment="Left"
+                                    Margin="0,0,0,8" />
+
+                            <!-- Custom-ARPA path picker, visible only when Custom is chosen. -->
+                            <StackPanel IsVisible="{Binding ShowCustomLmPath}" Margin="0,6,0,8">
+                                <Grid ColumnDefinitions="*,Auto,Auto">
+                                    <TextBox Grid.Column="0"
+                                             Text="{Binding ParakeetLmPath}"
+                                             Watermark="(pick a locally built ARPA file)"
+                                             Background="{DynamicResource OverlayBrush}"
+                                             Foreground="{DynamicResource TextBrush}"
+                                             BorderBrush="{DynamicResource OverlayBrush}"
+                                             IsReadOnly="True"
+                                             Margin="0,0,6,0" />
+                                    <Button Grid.Column="1"
+                                            Content="Browse…"
+                                            Command="{Binding BrowseParakeetLmCommand}"
+                                            Margin="0,0,6,0" />
+                                    <Button Grid.Column="2"
+                                            Content="Clear"
+                                            Command="{Binding ClearParakeetLmCommand}" />
+                                </Grid>
+                            </StackPanel>
 
                             <TextBlock Text="Fusion weight (typical 0.1–0.5)"
                                        Foreground="{DynamicResource SubtextBrush}"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -1296,7 +1296,9 @@ public partial class TranscriptEditorWindow : Window
                 vibeVoiceModelsDir: App.Current.Settings.GetVibeVoiceModelsDir(),
                 qwen3AsrLanguageCode: _isQwen3Asr ? card.SelectedRedoLanguage?.Code : null,
                 parakeetBeamWidth:       App.Current.Settings.Current.ParakeetBeamWidth,
-                parakeetLmPath:          App.Current.Settings.Current.ParakeetLmPath,
+                parakeetLmPath:          KenLmCatalog.ResolvePath(
+                                             App.Current.Settings.Current,
+                                             App.Current.Settings.GetKenLmParakeetDir()),
                 parakeetLmWeight:        App.Current.Settings.Current.ParakeetLmWeight,
                 parakeetLmLengthPenalty: App.Current.Settings.Current.ParakeetLmLengthPenalty));
             if (result is null)

--- a/src/Vernacula.Base/Config.cs
+++ b/src/Vernacula.Base/Config.cs
@@ -188,6 +188,20 @@ public static class Config
 
     // ── Language identification (VoxLingua107 ECAPA-TDNN) ────────────────────
     /// <summary>
+    /// Directory (relative to models dir) for the Parakeet shallow-fusion
+    /// KenLM n-gram models. Files are named per language/domain, e.g.
+    /// <c>en-general.arpa.gz</c>, <c>en-medical.arpa.gz</c>.
+    /// </summary>
+    public const string KenLmParakeetSubDir = "kenlm_parakeet";
+
+    /// <summary>
+    /// HF repo hosting the per-language/domain KenLM files. Each asset
+    /// lives at <c>{KenLmParakeetRepoBase}/{file-name}</c>.
+    /// </summary>
+    public const string KenLmParakeetRepoBase =
+        "https://huggingface.co/christopherthompson81/kenlm-parakeet/resolve/main";
+
+    /// <summary>
     /// Directory (relative to models dir) for the language-ID model.
     /// </summary>
     public const string VoxLinguaSubDir   = "voxlingua107";


### PR DESCRIPTION
## Summary
- Settings → Speech Recognition → Language model is now a ComboBox whose items come from a central \`KenLmCatalog\`. Selecting a built-in option auto-downloads the corresponding KenLM from [christopherthompson81/kenlm-parakeet](https://huggingface.co/christopherthompson81/kenlm-parakeet) via the existing \`ModelManagerService\` pipeline and wires it into the decoder on the next transcription or redo.
- Catalog for v1: **None** / **English — General (conversational)** / **Custom ARPA file…** The "English — General" LM is the validated 3× GigaSpeech + 1× People's Speech mix from PR #19.
- Flat catalog so adding English — Medical / Legal later is one line + one HF upload.

## Plumbing
- \`Config.KenLmParakeetSubDir\` + \`KenLmParakeetRepoBase\`
- \`Models/KenLmOptions.cs\` — catalog + \`ResolvePath\` helper so services don't replicate selection state logic
- \`ModelManagerService\` — \`IsKenLmReady\` / \`DownloadKenLmAsync\` on top of the shared download pipeline (byte-precise progress, resume-on-partial, cancellable)
- \`SettingsService.GetKenLmParakeetDir\`
- \`TranscriptionService\` + \`TranscriptEditorWindow\` resolve the active LM via \`KenLmCatalog.ResolvePath\` instead of reading \`ParakeetLmPath\` directly

## Test plan
- [x] \`dotnet build\` clean
- [x] HF repo exists at https://huggingface.co/christopherthompson81/kenlm-parakeet with model card + en-general.arpa.gz (67 MB)
- [ ] User-verified dropdown flow: selecting "English — General" downloads the file, next transcription run picks it up, "ajá, ya" regression is fixed
- [ ] Custom slot still works (file picker reveals when "Custom ARPA file…" selected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)