### PR TITLE
IndicConformer 600M — 22-language Indic ASR backend

### DIFF
--- a/Vernacula.slnx
+++ b/Vernacula.slnx
@@ -29,4 +29,11 @@
     <Platform Solution="*|x64" Project="x64" />
     <Platform Solution="*|x86" Project="x64" />
   </Project>
+  <Project Path="tests/IndicConformerTest/IndicConformerTest.csproj">
+    <Platform Solution="*|Any CPU" Project="x64" />
+    <Platform Solution="*|ARM" Project="x64" />
+    <Platform Solution="*|ARM64" Project="x64" />
+    <Platform Solution="*|x64" Project="x64" />
+    <Platform Solution="*|x86" Project="x64" />
+  </Project>
 </Solution>

--- a/docs/indicconformer_investigation.md
+++ b/docs/indicconformer_investigation.md
@@ -1,0 +1,424 @@
+# IndicConformer investigation log
+
+Running log for the IndicConformer ONNX export feasibility spike and
+subsequent export/parity work. Plan reference:
+`~/Programming/parakeet_csharp/data/IndicConformer_plan.md` (6-phase plan,
+Phase 1 is the blocking gate).
+
+Each entry is one run or one discrete investigation, stamped with local date/time.
+
+---
+
+## Run 0 — 2026-04-20 (setup)
+
+**Question:** What checkpoint shape are we actually exporting? The plan
+leaves open whether language is a shared-vocab routing trick (Parakeet
+style) or something else.
+
+**Pre-run research (web):**
+
+- AI4Bharat's NeMo fork lives at `github.com/AI4Bharat/NeMo`, branch
+  `nemo-v2`. The repo's one-line self-description is "implements
+  multi-softmax in ASR models" — a third option the plan didn't name.
+- Two checkpoint families exist on HF:
+  - Per-language: `ai4bharat/indicconformer_stt_{lang}_hybrid_ctc_rnnt_large`
+    (hi, bn, ta, te, ml, pa, as, …). Each is a standalone Conformer with
+    its own CTC + RNNT heads, trained on one language's data.
+  - Unified: `ai4bharat/IndicConformer` — 22 languages, undocumented card.
+    Inferred to be a **shared encoder + 22 per-language CTC heads + 22
+    per-language RNNT heads**, selected at inference via `language_id='hi'`.
+- The multi-softmax design is forced by script diversity: the 22 official
+  Indian languages span 11+ distinct scripts (Devanagari, Bengali, Tamil,
+  Gurmukhi, Ol Chiki, Meitei Mayek, Perso-Arabic, …), so a Parakeet-style
+  shared subword vocab would be enormous and dilute per-script capacity.
+
+**Consequence for Phase 1:** the language-routing question is now "how
+exactly are the 22 heads wired in the checkpoint" — one `Linear` with a
+gather-by-lang-id, or 22 separate submodules? That decides whether Phase 2
+ships one ONNX with a language-id input, one ONNX per language, or an
+encoder ONNX + 22 small head ONNX.
+
+**Next:** install `.venv-indicconformer-export`, run
+`inspect_indicconformer.py` against (a) the Hindi-only checkpoint as a
+warm-up, (b) the unified `ai4bharat/IndicConformer` to answer the wiring
+question.
+
+---
+
+## Run 1 — 2026-04-20 12:18 (env setup)
+
+**Command:** `python3 scripts/indicconformer_export/setup_indicconformer_env.py --cuda-version cu128`
+
+**Result:** Exit 0. `.venv-indicconformer-export` created with PyTorch +
+cu128, onnxruntime-gpu, AI4Bharat NeMo fork cloned to
+`.venv-indicconformer-export/_src/NeMo` (branch `nemo-v2`) and installed
+editable with `[asr]` extras.
+
+**Surprise:** The fork ships as `nemo_toolkit-1.23.0rc0` — pre-2.0.
+Upstream current is 2.7.1. So this is a significantly older NeMo base.
+Implication: our `export_parakeet_nemo_to_onnx.py` export patterns may not
+translate directly — 1.x has different `.export()` semantics and may not
+have the DFT-conv1d preprocessor insertion point we use on 2.x.
+
+---
+
+## Run 2 — 2026-04-20 12:20 (inspection, attempt 1)
+
+**Command:** inspect_indicconformer.py on the Hindi-only HF repo.
+
+**Result:** Crash at `import nemo.collections.asr`:
+`AttributeError: module 'pyarrow' has no attribute 'PyExtensionType'`.
+
+**Diagnosis:** `datasets==2.14.4` (pinned transitively by the fork) uses
+`pa.PyExtensionType`, which pyarrow removed in v15. Fork install pulled
+`pyarrow-23.0.1`.
+
+**Fix:** `pip install 'pyarrow<15'` → 14.0.2. Added `pyarrow<15` to
+`scripts/indicconformer_export/requirements.txt` so this is pinned next
+time the env is built from scratch.
+
+---
+
+## Run 3 — 2026-04-20 12:21 (inspection, attempt 2)
+
+**Command:** same inspect command.
+
+**Result:** Crash at `import pyarrow as pa`: `_ARRAY_API not found`,
+followed by the NumPy 2.x / 1.x ABI warning. pyarrow 14.0.2 was compiled
+against NumPy 1.x; env currently has `numpy-2.4.4`.
+
+**Fix:** `pip install 'numpy<2'` → 1.26.4. pyannote.core/metrics complain
+about numpy<2, but those are diarization paths we don't hit in the export
+pipeline.
+
+**To add to requirements.txt next commit:** `numpy<2` (same rationale as
+`pyarrow<15`).
+
+---
+
+## Run 4 — 2026-04-20 12:21 (inspection, attempt 3 — Hindi-only)
+
+**Result:** NeMo imports cleanly. HF download fails:
+
+```
+GatedRepoError: Cannot access gated repo for url
+https://huggingface.co/ai4bharat/indicconformer_stt_hi_hybrid_ctc_rnnt_large/
+resolve/main/indicconformer_stt_hi_hybrid_ctc_rnnt_large.nemo
+Access to model ai4bharat/indicconformer_stt_hi_hybrid_ctc_rnnt_large is
+restricted and you are not in the authorized list.
+```
+
+`huggingface-cli whoami` confirms logged in as `christopherthompson81`,
+but the account isn't on AI4Bharat's approved list for this gated repo.
+
+---
+
+## Run 5 — 2026-04-20 12:22 (inspection, attempt 4 — unified)
+
+**Result:** Same 403 / GatedRepoError against
+`ai4bharat/IndicConformer`. Both the per-language and the unified
+checkpoints are gated.
+
+---
+
+## Decision point — 2026-04-20 12:23
+
+**Blocker:** Phase 1 can't continue without a checkpoint. Two paths:
+
+**A. Request access on HF.** Visit the repo pages and click "Agree and
+access terms." AI4Bharat typically approves within hours. Unblocks both
+the per-language and unified inspection paths cleanly.
+
+**B. Use the non-gated legacy checkpoints via
+`objectstore.e2enetworks.net`.** AI4Bharat's `indic-asr-api-backend`
+still points to direct URLs:
+
+```
+https://objectstore.e2enetworks.net/indic-asr-public/checkpoints/
+  conformer/stt_hi_conformer_ctc_large_v2.nemo
+```
+
+These are the older **Conformer-CTC** models, **not** the current
+hybrid CTC-RNNT. Exporting one would still exercise the fork + DFT
+preprocessor path and prove ONNX parity — useful de-risking — but
+answers a different question than the plan's gate: the hybrid
+multi-softmax wiring is only visible in the gated checkpoints.
+
+**Recommendation:** Do A, and pause Phase 1 until access lands. The
+legacy CTC checkpoint would burn time on a path we're not shipping.
+
+---
+
+## Run 6 — 2026-04-20 12:27 (gate approved, retry Hindi-only)
+
+**Command:** same as Run 4, after user agreed to HF access terms.
+
+**Result:** Download succeeds (~500 MB). NeMo then crashes on
+`FileNotFoundError: model_config.yaml` — it picked the "pre-extracted
+directory" code path instead of the tarball-extract path. Side finding:
+the file on disk is named `indicconformer_stt_hi_hybrid_rnnt_large.nemo`
+(no "ctc" in the filename, despite the HF repo name).
+
+---
+
+## Run 7 — 2026-04-20 12:29 (inspect local .nemo file — THE decisive run)
+
+**Command:** `inspect_indicconformer.py --nemo <local path to the
+downloaded .nemo>` to skip NeMo's HF-cache path-resolution bug.
+
+**Result: Phase 1 answered.** The full JSON report is at
+`/tmp/indicconformer_hi_report.json`. Key facts:
+
+### The "Hindi-only" HF repo is actually the 22-language unified model
+
+- `model_class: EncDecHybridRNNTCTCBPEModel` — standard NeMo hybrid
+  CTC+RNNT, with the `ExportableEncDecModel` mixin in the MRO.
+- NeMo logs `_setup_tokenizer: detected an aggregate tokenizer` and
+  `Aggregate vocab size: 5632` with 22 separate SentencePieceTokenizers
+  loaded, each `initialized with 256 tokens`. So the per-language HF
+  repos are training-shorthand aliases of the same 22-language
+  checkpoint, not language-specific models.
+- `tokenizer_class: MultilingualTokenizer`, `tokenizer_langs` lists all
+  22: `as, bn, brx, doi, kok, gu, hi, kn, ks, mai, ml, mr, mni, ne, or,
+  pa, sa, sat, sd, ta, te, ur`.
+
+### The "multi-softmax" design is simpler than feared
+
+- `ctc_decoder_class: ConvASRDecoder`, `ctc_decoder_param_names:
+  ["decoder_layers.0.weight", "decoder_layers.0.bias"]`. That is **one
+  Linear layer** (encoder_dim → 5632), NOT 22 separate softmax heads.
+- The config carries `"multisoftmax": true` alongside a
+  `language_masks:` array; NeMo logs `Creating masks for multi-softmax
+  layer`. So "multi-softmax" here means **one shared softmax + a
+  per-language output mask** that zeroes the 5376 logits belonging to
+  other languages. `language_id` at inference selects which mask to
+  apply.
+- `can_set_cur_decoder_ctc: true` — CTC is a first-class alternative
+  path on the hybrid model, as hoped.
+
+### Preprocessor matches Parakeet
+
+- `AudioToMelSpectrogramPreprocessor`, `sample_rate: 16000`, `features:
+  80`, `n_fft: 512`, `window_size: 0.025`, `window_stride: 0.01`,
+  `window: hann`, `normalize: per_feature`. Same family as Parakeet's
+  frontend, so the DFT-conv1d preprocessor trick in
+  `scripts/nemo_export/export_parakeet_nemo_to_onnx.py` should apply
+  with only parameter substitution.
+
+### Training config surprises (non-blocking, worth recording)
+
+- `return_language_id: true` in the train/val manifests confirms the
+  model was trained with the language as a side input — used to pick
+  the mask at loss time.
+- `concat_sampling_technique: temperature`, `temperature: 1.5` across
+  all 22 language manifests — classic multilingual upsampling of
+  low-resource languages.
+
+### Phase 1 decision
+
+**Commit Phase 2 to a Parakeet-shaped export package with one extra
+artifact:** encoder.onnx + ctc_decoder.onnx + nemo128.onnx + vocab.txt
+(flat 5632 entries) + **language_spans.json** (22 entries, each a
+`[start_id, length]` pair into the vocab) + config.json. Language
+selection happens entirely in C# post-argmax, by filtering to token
+ids in the requested language's span. No need for a language-id input
+on the ONNX graph, no per-language ONNX files.
+
+**Unified `ai4bharat/IndicConformer` inspection:** skipping unless the
+above turns out wrong. The per-language repo has already yielded the
+22-language multi-softmax checkpoint.
+
+**Open questions for Phase 2:**
+1. Does NeMo 1.23.0's `.export()` produce the same split
+   encoder/decoder ONNX artifacts as 2.7.1's, or does it only support
+   whole-model export? (Affects whether we can reuse Parakeet's export
+   module surgery or need a different approach.)
+2. Where exactly does the language mask live — on the tokenizer, on
+   the decoder, or as a runtime-only filter? If it's on the decoder as
+   a fixed tensor, we may be able to bake it into vocab.txt and skip
+   language_spans.json entirely.
+3. Hindi-only BPE subword preview from the Unicode ranges suggests
+   each 256-slot language block is contiguous in the flat vocab. Need
+   to confirm with a small script that reads the tokenizer's
+   `token_id_offset_by_tokenizer_num` and dumps per-language spans.
+
+---
+
+## Run 8 — 2026-04-20 12:36 (vocab span probe)
+
+**Command:** `probe_vocab_spans.py` — loads the .nemo locally, walks the
+MultilingualTokenizer, dumps flat vocab + per-language spans, and peeks
+at `model.language_masks`.
+
+**Result:** Spans are **perfectly contiguous, 256 tokens each** in
+alphabetical-ish order:
+
+```
+as  : [   0, 256]   bn  : [ 256, 256]   brx : [ 512, 256]   doi : [ 768, 256]
+kok : [1024, 256]   gu  : [1280, 256]   hi  : [1536, 256]   kn  : [1792, 256]
+ks  : [2048, 256]   mai : [2304, 256]   ml  : [2560, 256]   mr  : [2816, 256]
+mni : [3072, 256]   ne  : [3328, 256]   or  : [3584, 256]   pa  : [3840, 256]
+sa  : [4096, 256]   sat : [4352, 256]   sd  : [4608, 256]   ta  : [4864, 256]
+te  : [5120, 256]   ur  : [5376, 256]
+```
+
+22 × 256 = 5632 = `tokenizer.vocab_size`. No gaps. Answer to Phase 1
+question #3: **yes, contiguous.**
+
+**Surprises:**
+
+- **CTC Linear outputs 5633**, not 5632. `decoder_layers.0.weight` is
+  shape `(5633, 512, 1)` — an extra slot for the CTC **blank** at
+  index 5632. That's standard CTC shape and belongs in every language's
+  mask. Our `vocab.txt` will have 5632 real tokens; the blank is
+  implicit at `vocab_size`.
+- **`model.language_masks` is a pre-materialized `dict[str, list[bool]]`**
+  with 22 entries, each of length 5633. So the mask *is* stored on the
+  model object, but it's a derived artifact of the span layout — we
+  don't need to serialize the masks, we can ship the 22 × `[start,
+  length]` spans and reconstruct on the C# side. (Blank is always
+  unmasked.)
+
+**Answer to Phase 1 question #2:** Language mask is a Python-side
+Python-list on the model, not a tensor buffer on the CTC decoder module.
+It's not in the forward graph — the decoder produces all 5633 logits
+every time, and the mask is applied by NeMo's decoding strategy after
+argmax. Confirms the design: **zero ONNX changes for multi-language
+support.** The exported encoder+CTC graph is language-agnostic.
+
+**Artifacts written:**
+
+- `/tmp/indicconformer_vocab.txt` (5632 lines)
+- `/tmp/indicconformer_language_spans.json` (22 × `{start, length}`)
+
+---
+
+## Phase 1 gate — 2026-04-20 12:38 (PASS, with one caveat)
+
+The plan's original Phase 1 decision ("language as encoder input tensor
+vs shared 22-language vocab") is now moot. The real answer is:
+
+**IndicConformer has a language-agnostic ONNX forward graph**
+(encoder + one `Linear` CTC head → 5633 logits). Language selection
+is a post-argmax filter applied in C# using a 22-entry
+`[start, length]` table shipped alongside the ONNX files.
+
+**Caveat: Phase 1 never exported a CTC graph to ONNX.** The plan
+called for doing a small export + parity check before committing to
+Phase 2. We *inferred* the export will be clean because:
+
+- `model.encoder` is a standard Conformer encoder, already tested by
+  `ExportableEncDecModel` mixin.
+- `model.ctc_decoder` is `ConvASRDecoder` → one `Conv1d` used as a
+  logits projection. Two parameters. Trivial.
+- Preprocessor is byte-identical to Parakeet's — DFT trick ports
+  with parameter substitution.
+
+That inference is strong, but the plan asked for a proof. We'll satisfy
+the gate in the next run: write a minimal `export_indicconformer_*` that
+ships encoder.onnx + ctc_decoder.onnx, run a synthetic-input parity
+check (PyTorch vs ORT on the same random mel-spec), and only then
+commit Phase 2.
+
+**On the "use our own export, not NeMo's" discussion:** Parakeet's
+exporter calls `model.export(...)` for the split encoder/decoder
+artifacts but hand-rolls the preprocessor via `torch.onnx.export`
+against `CustomPreprocessorWrapper` — a mixed strategy. For
+IndicConformer we can go fully hand-rolled, because both the encoder
+and the CTC head are plain `nn.Module`s with clean `(features,
+features_lens) → (logits, lens)` contracts. That sidesteps NeMo
+1.23.0rc0's possibly-stale `.export()` path entirely and makes the
+version-skew risk zero. Committing to this approach for Phase 1
+spike.
+
+---
+
+## Run 9 — 2026-04-20 12:44 (Phase 1 export, attempt 1)
+
+**Command:** `export_indicconformer_nemo_to_onnx.py --device auto` (CUDA).
+
+**Result:** Both ONNX exports succeed cleanly. Hand-rolled
+`torch.onnx.export` on `EncoderWrapper(model.encoder)` and
+`CtcDecoderWrapper(model.ctc_decoder)`, opset 17, dynamic batch+frames.
+
+Sidecar dump crashes at `write_vocab`:
+`MultilingualTokenizer.ids_to_tokens() missing 1 required positional
+argument: 'lang_id'`. The MultilingualTokenizer's flat `ids_to_tokens`
+requires a `lang_id` — need to walk per-sub-tokenizer instead.
+
+**Note:** Run 8's probe had a try/except around the same call and
+silently wrote 5632 error strings to `/tmp/indicconformer_vocab.txt`.
+Lesson: guard against exception-swallowing in diagnostic scripts by
+validating the first line of the output before declaring success.
+Folded into the fixed `write_vocab`: walk `tok.tokenizers_dict[lang]`
+in offset order and stitch the results.
+
+---
+
+## Run 10 — 2026-04-20 12:47 (Phase 1 export, attempt 2; parity attempt 1 on CUDA)
+
+**Command:** same, with the vocab walker rewritten.
+
+**Result:** All artifacts written:
+
+```
+encoder-model.onnx       459 MB
+ctc_decoder-model.onnx    11 MB
+vocab.txt                 40 KB  (5632 lines, real tokens)
+language_spans.json       1.4 KB
+config.json               444 B
+```
+
+**Parity on CUDA (PyTorch ref) vs CPU (ORT):**
+
+- encoded max-abs delta: **5.99e-03**
+- logits  max-abs delta: **2.49e-02** (tolerance 1e-3) → **FAIL**
+
+**Suspected cause:** cross-device FP32 drift. PyTorch ran on CUDA,
+onnxruntime on CPU (we don't have `onnxruntime-gpu` pinned in the
+session yet). 17 conformer layers compound the drift, and the
+`encoder_dim→5633` Conv1d projection amplifies it at the output.
+
+---
+
+## Run 11 — 2026-04-20 12:49 (Phase 1 export, attempt 3; parity on CPU-CPU)
+
+**Command:** `--device cpu --parity-tolerance 1e-2` (the loose tolerance
+was just to confirm PASS — actual delta blew past even the strict
+1e-3).
+
+**Result: PARITY PASS.**
+
+- encoded max-abs delta: **1.54e-05**
+- logits  max-abs delta: **6.87e-05**
+- PASS at `1e-2`, also passes at the original strict `1e-3`.
+
+Confirms the CUDA-vs-CPU FAIL in Run 10 was purely cross-device FP32
+drift, not a graph-correctness bug. The ONNX export faithfully
+reproduces the PyTorch forward when both run on the same device.
+
+Implication for C# runtime: **CPU execution path is numerically
+exact.** CUDA path will have e-2 scale drift that C# callers won't
+feel (argmax on the masked 256-token Hindi slice swamps e-2 perturbations
+unless the top-2 tokens are already close to tied — rare, and
+mitigable with a CPU re-run on ambiguous frames if we ever see it).
+
+---
+
+## Phase 1 gate: **CLOSED**
+
+All four Phase 1 subgoals satisfied:
+
+1. ✅ AI4Bharat NeMo fork standing up in an isolated venv (with pins for
+   `pyarrow<15` and `numpy<2`).
+2. ✅ CTC-head ONNX export — hand-rolled, no dependency on NeMo
+   1.23.0rc0's `.export()` path.
+3. ✅ Parity vs PyTorch reference — 6.87e-05 logit delta on CPU, well
+   inside any reasonable tolerance.
+4. ✅ Language-passing mechanism decided — post-argmax vocab-span mask
+   in C#, zero ONNX graph changes.
+
+**Proceed to Phase 2** (full export pipeline including nemo128
+preprocessor, HF repo publishing shape).
+
+---

--- a/docs/indicconformer_investigation.md
+++ b/docs/indicconformer_investigation.md
@@ -405,6 +405,104 @@ mitigable with a CPU re-run on ambiguous frames if we ever see it).
 
 ---
 
+## Run 12 — 2026-04-20 13:50 (Phase 2: DFT preprocessor, attempt 1)
+
+Ported the Parakeet `DFTConvPreprocessorWrapper` from
+`scripts/nemo_export/export_parakeet_nemo_to_onnx.py`, added an
+`export_preprocessor` function emitting `nemo128.onnx`, and wired a real-audio
+parity path that chains nemo128 → encoder → ctc_decoder in both PyTorch and
+ORT for an actual wav file.
+
+**Result — Attempt 1:** Crash at wrapper init.
+```
+AttributeError: 'FilterbankFeatures' object has no attribute 'exact_pad'
+```
+
+**Diagnosis:** `exact_pad` and `stft_pad_amount` are NeMo 2.x additions; the
+AI4Bharat fork runs NeMo 1.23.0rc0 where they don't exist. NeMo 1.x always
+uses center + reflect padding — equivalent to 2.x `exact_pad=False,
+stft_pad_amount=None`. Fixed by defaulting both to the 1.x behavior via
+`getattr(..., default)`.
+
+---
+
+## Run 13 — 2026-04-20 13:58 (Phase 2, attempt 2 — big feature delta)
+
+**Result:** All exports succeed. Synthetic parity still passes (6.87e-05).
+But real-audio parity **fails hard**:
+
+```
+[parity-audio] features max-abs delta: 1.467379e+00
+[parity-audio] logits   max-abs delta: 2.092063e+01
+[parity-audio] FAIL
+```
+
+e-0 delta on features is not numerical noise — something structural is wrong.
+
+**Diagnostic (preproc_parity_debug2.py):** compare live NeMo preprocessor
+vs DFT wrapper, both in PyTorch (cut the ONNX export out of the loop).
+
+Output:
+
+```
+live shape torch.Size([1, 80, 937]), live_lens [937]
+wrap shape torch.Size([1, 80, 937]), wrap_lens [936]
+cells with delta > 0.5: 41
+first 10: [[0, 0, 936], [0, 1, 936], ...]  # all at frame 936
+at (0, 0, 936): live=-0.6387542486190796, wrap=0.0
+max-per-frame last 10: [..., 0.0026, 1.4673793]
+```
+
+**Root cause:** off-by-one on `seq_len`. Live NeMo emits 937 valid frames;
+wrapper emits 936, so frame 936 gets masked to pad_value while live NeMo
+fills it with real content. All 0..935 frames match within ~4e-3; the
+single frame 936 carries the entire 1.47 delta.
+
+Grep on NeMo fork's `FilterbankFeatures.get_seq_len` at
+`features.py:390`:
+
+```
+seq_len = torch.floor_divide((seq_len + pad_amount - self.n_fft), self.hop_length) + 1
+```
+
+There's a trailing **+1** that the wrapper I copied over was missing.
+`scripts/nemo_export/`'s own README calls this out for the `custom` mode
+fallback, but the DFT wrapper there — our source — dropped it anyway.
+Added to the IndicConformer wrapper.
+
+---
+
+## Run 14 — 2026-04-20 14:05 (Phase 2, attempt 3 — end-to-end parity)
+
+**Result: PASS on both parity paths.**
+
+- Synthetic (encoder + ctc_decoder only): logits delta 6.87e-05
+- Real audio (hi-IN Fleurs clip, full nemo128 + encoder + ctc_decoder):
+  - features delta: **7.87e-06**
+  - logits delta:   **8.96e-05**
+  - Tolerance:      1e-02 (loose) and 1e-03 (strict) both pass.
+
+**Final export package** at `~/models/indicconformer_onnx/`:
+
+```
+encoder-model.onnx        459 MB
+ctc_decoder-model.onnx     11 MB
+nemo128.onnx              1.1 MB   <-- new in Phase 2
+vocab.txt                  40 KB
+language_spans.json       1.4 KB
+config.json                444 B
+export-report.json         (both parity numbers + PASS flags)
+```
+
+## Phase 2 gate: **CLOSED**
+
+Full pipeline is numerically faithful on real audio for Hindi. By the
+language-agnostic ONNX design (no language_id input on any graph), this
+same package covers all 22 languages — Phase 6's smoke test just needs to
+exercise the C# masking path per language, not re-export anything.
+
+---
+
 ## Phase 1 gate: **CLOSED**
 
 All four Phase 1 subgoals satisfied:

--- a/docs/indicconformer_investigation.md
+++ b/docs/indicconformer_investigation.md
@@ -494,7 +494,167 @@ config.json                444 B
 export-report.json         (both parity numbers + PASS flags)
 ```
 
-## Phase 2 gate: **CLOSED**
+## Run 15 — 2026-04-20 14:40 (600M discovery)
+
+**Pivot:** user preferred the 600M variant (`ai4bharat/indic-conformer-600m-multilingual`)
+over the 120M we'd been exporting. Standard parameter-scaling motivation.
+
+Inspecting the 600M HF repo reveals it's an **already-exported ONNX package**,
+not a `.nemo` file:
+
+- `assets/encoder.onnx` (3 MB metadata + 2.43 GB external-data weights spread
+  across ~360 per-tensor blob files under `assets/layers.*`, `assets/onnx__*`,
+  `assets/pre_encode.*`, and `assets/Constant_*`)
+- `assets/ctc_decoder.onnx` (23 MB, inline)
+- 22× `assets/joint_post_net_<lang>.onnx` plus `joint_enc/joint_pred/joint_pre_net/rnnt_decoder.onnx` — RNNT-side, we don't need any of them
+- `assets/language_masks.json` — pre-materialized 22 × 5633 bool arrays
+- `assets/vocab.json` — per-language dict (see below)
+- `assets/preprocessor.ts` — **TorchScript**, not ONNX
+- `model_onnx.py` — reference inference script
+- `config.json` — minimal, mostly RNNT params plus `BLANK_ID: 256`
+
+**Shipping-shape diff from our 120M package:**
+
+| | 120M (our export) | 600M (AI4Bharat ships) |
+|---|---|---|
+| Encoder IO | `features/features_lens → encoded/encoded_lens` | `audio_signal/length → outputs/encoded_lengths` |
+| CTC IO | `encoded → logits` | `encoder_output → logprobs` |
+| Preprocessor | ONNX (our DFT wrapper) | TorchScript |
+| Vocab | flat `vocab.txt`, 5632 lines | per-lang JSON dict, 22 × 257 entries |
+| Language mask | 22 × `[start, length]` spans | 22 × length-5633 bool arrays |
+
+**Preprocessor config match check** — dumped `preprocessor.ts`'s TorchScript
+`.code`. The forward does exactly: seq_len = `length // 160 + 1`, reflect-pad
+by 256 on each side, `torch.stft(input, 512, 160, 400, hann, ...)`, power-
+spectrogram (pow 2), 80-mel matmul, `log(x + 5.96e-08)`, per-feature
+mean/std normalize. **Byte-identical** to our 120M preprocessor config → our
+existing `nemo128.onnx` works for 600M without re-export.
+
+---
+
+## Run 16 — 2026-04-20 14:50 (600M repackaging, attempt 1)
+
+Wrote `scripts/indicconformer_export/repackage_600m_indicconformer.py` that:
+
+1. `snapshot_download` the 600M `assets/*` (2.4 GB, 371 files)
+2. Load encoder.onnx + external data, rename 4 IO tensors + node
+   references, save with single consolidated `encoder-model.onnx.data`
+3. Same for ctc_decoder.onnx (inlined, only 23 MB)
+4. Copy our existing nemo128.onnx verbatim
+5. Flatten vocab.json dict → flat `vocab.txt`
+6. Convert bool masks → `[start, length]` spans + verify they agree with
+   AI4Bharat's published masks
+
+**Attempt 1 crash:** `onnx.load(..., load_external_data=True)` refuses
+symlinked external data (safety check). HF stores blobs at `cache/blobs/*`
+and symlinks into `assets/*` — so all 366 weight file links trip the check.
+
+**Fix:** `load_external_data=False` to get the graph only, then manually
+walk `graph.initializer`, `.resolve()` each referenced path through the
+symlink, read raw bytes, set `raw_data` inline, clear the external-data
+marker. Re-save with `save_as_external_data=True` then rebuilds a clean
+single-sidecar package.
+
+---
+
+## Run 17 — 2026-04-20 14:56 (repackaging, attempt 2 — vocab assertion)
+
+**Crash:** `AssertionError: as: middle slice is 255 tokens`. I assumed the
+per-lang vocab shape was `[<unk>, t1..t255, <blank>]` so the "real" slice
+was `vocab[1:-1]`. Actually the layout is `[<unk>, t1..t256]` — 257 entries
+where the last is a real token (not a blank marker). The CTC softmax emits
+256 logits per lang; the 257th output slot is the shared CTC blank and
+doesn't need a vocab entry. Fixed by slicing `vocab[lang][:256]` — keep
+`<unk>` at local id 0 plus 255 real tokens.
+
+This matches the flat layout our 120M export produced (verified by
+re-reading the 120M `vocab.txt`: each 256-slot block starts with `<unk>`).
+
+---
+
+## Run 18 — 2026-04-20 14:58 (repackaging, attempt 3 — ORT init crash)
+
+Repackage succeeds, ORT fails to load `encoder-model.onnx`:
+
+```
+RuntimeException: cannot get file size: ... /Constant_1970_attr__value
+```
+
+**Diagnosis:** the repackaged ONNX still has a reference to
+`Constant_1970_attr__value` — a file sitting in `assets/` that the ONNX
+graph doesn't reach through `graph.initializer`. It's external data on a
+**node attribute** (a Constant op's baked-in tensor). My resolver only
+walked initializers.
+
+**Fix:** walk `node.attribute` recursively too — handle both scalar
+TENSOR attrs and TENSORS lists, and descend into subgraphs (GRAPH/GRAPHS
+types) for if/loop nodes. Updated the helper.
+
+---
+
+## Run 19 — 2026-04-20 14:58 (repackaging, attempt 4 — clean)
+
+Repackager output:
+
+```
+[encoder]    resolved 366 external tensors (initializers + attrs)
+             rewrote 4 IO refs, saved encoder-model.onnx + .data (2.43 GB)
+[ctc_decoder] resolved 0 external tensors; rewrote 2 IO refs; inline 23.1 MB
+[nemo128]    copied from 120M package (byte-identical config)
+[vocab]      5632 lines (22 × 256)
+[verify]     masks match derived spans for all 22 languages  ✓
+[spans]      22 × {start, length}
+[config]     sample_rate, preprocessor params, ctc.blank_token_id=5632
+```
+
+---
+
+## Run 20 — 2026-04-20 14:59 (600M end-to-end Hindi validation)
+
+First working decode through the full ONNX package:
+
+```
+validate_indicconformer_package.py --package <600m> --wav hi-IN_fleurs_01.wav --lang hi
+
+decoded (hi): स्कीम मार्ग को एक हाइकिंग लंबी पैदल यात्रा मार्ग जैसा ही सोचें
+expected:     स्कीइंग मार्ग को एक हाईकिंग लंबी पैदल यात्रा मार्ग जैसा ही सोचें।
+```
+
+~2 word-level edits out of 11 words on a 9.4-sec clip — ordinary WER for a
+multilingual ASR model on one short clip, not a pipeline defect. Important
+positives:
+
+- Pipeline runs end-to-end with our renamed IO conventions
+- 2.43 GB consolidated external-data sidecar loads cleanly in ORT
+- 120M's nemo128.onnx works unchanged for 600M
+- Devanagari script renders correctly (verifies vocab flattening handled
+  SentencePiece `▁` markers and UTF-8 write)
+- Language-span mask correctly selects Hindi's 256-token slice
+- SentencePiece detokenization (`▁` → space) produces readable text
+
+---
+
+## Phase 2 gate (600M): **CLOSED**
+
+**Final 600M package** at `~/models/indicconformer_600m_onnx/`:
+
+```
+encoder-model.onnx        42 MB
+encoder-model.onnx.data  2.43 GB
+ctc_decoder-model.onnx   23 MB
+nemo128.onnx             1.1 MB
+vocab.txt                 41 KB
+language_spans.json      1.4 KB
+config.json              467 B
+```
+
+Contract identical to the 120M package (same file names, same IO names,
+same vocab.txt / language_spans.json shape). **The same C# backend we
+write in Phase 3 will load either package without branching.**
+
+---
+
+## Phase 2 gate (120M): **CLOSED**
 
 Full pipeline is numerically faithful on real audio for Hindi. By the
 language-agnostic ONNX design (no language_id input on any graph), this

--- a/scripts/indicconformer_export/README.md
+++ b/scripts/indicconformer_export/README.md
@@ -1,0 +1,68 @@
+# IndicConformer ONNX Export
+
+This folder will hold the ONNX export pipeline for AI4Bharat's IndicConformer
+(Hybrid CTC-RNNT Conformer, 22 official Indian languages). It parallels
+`scripts/nemo_export/` but uses AI4Bharat's NeMo fork rather than upstream
+NeMo, so the two envs must stay isolated.
+
+See [../../README.md](../../README.md) for the full project context and
+[IndicConformer_plan.md](../../IndicConformer_plan.md) once promoted, or the
+6-phase plan kept in `~/Programming/parakeet_csharp/data/IndicConformer_plan.md`.
+
+## Status
+
+**Phase 1 — Feasibility spike (in progress).** Nothing C#-side is worth
+touching until CTC export + parity are proven.
+
+## Environment
+
+Use Python 3.10, 3.11, or 3.12. The AI4Bharat fork requires Python >= 3.10.
+
+```bash
+python3 scripts/indicconformer_export/setup_indicconformer_env.py
+source .venv-indicconformer-export/bin/activate
+```
+
+This env is separate from `.venv-nemo-export/` on purpose: the fork pins
+different NeMo/Transformer internals, and mixing them would break Parakeet
+export.
+
+Install with a specific CUDA build or CPU-only:
+
+```bash
+# CUDA 12.1
+python3 scripts/indicconformer_export/setup_indicconformer_env.py --cuda-version cu121
+# CPU only
+python3 scripts/indicconformer_export/setup_indicconformer_env.py --cuda-version ""
+```
+
+## Phase 1 — Discovery
+
+Before writing any exporter, load a checkpoint and dump its structure:
+
+```bash
+python scripts/indicconformer_export/inspect_indicconformer.py \
+  --hf-repo ai4bharat/indicconformer_stt_hi_hybrid_ctc_rnnt_large \
+  --out /tmp/indicconformer_hi.json
+```
+
+What we're looking for in the report:
+
+- **`has_ctc_head`** — must be true (CTC-head export is the whole plan)
+- **`ctc_decoder_param_names`** — are there per-language weight tensors?
+  That would confirm AI4Bharat's "multi-softmax" design
+- **`tokenizer_langs` / `tokenizer_class`** — `AggregateTokenizer` with 22
+  langs is the shape we expect for the unified model
+- **`cfg_preprocessor`** — confirms we can reuse the DFT preprocessor from
+  `nemo_export/` (same 80-mel Conformer frontend, presumably)
+
+Once that report lands, Phase 1's open question — "how is language selected
+at inference?" — is answered, and we can commit Phase 2's export shape
+(single ONNX file with a language-id input vs. one ONNX per language).
+
+## References
+
+- [AI4Bharat/NeMo fork (nemo-v2 branch)](https://github.com/AI4Bharat/NeMo/tree/nemo-v2)
+- [ai4bharat/IndicConformer (unified, 22 langs)](https://huggingface.co/ai4bharat/IndicConformer)
+- [ai4bharat/indicconformer_stt_hi_hybrid_ctc_rnnt_large (Hindi-only)](https://huggingface.co/ai4bharat/indicconformer_stt_hi_hybrid_ctc_rnnt_large)
+- [AI4Bharat/indic-asr-api-backend](https://github.com/AI4Bharat/indic-asr-api-backend) — reference inference code

--- a/scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py
+++ b/scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py
@@ -9,16 +9,19 @@ preprocessor + vocab + config) with one extra artifact (language_spans.json)
 that tells the C# side which 256-token slice belongs to each of the 22
 languages.
 
-Phase 1 scope of this script:
+Shipping package:
   1. encoder-model.onnx          — Conformer encoder, (features, lens) → (encoded, encoded_lens)
   2. ctc_decoder-model.onnx      — single Conv1d projection, encoded → logits
-  3. vocab.txt                   — flat 5632-line vocab (blank is implicit at id 5632)
-  4. language_spans.json         — 22 × {start, length}
-  5. config.json                 — preprocessor + encoder metadata
-  6. export-report.json          — record of what we did and any parity numbers
-  7. Parity check on synthetic input vs the PyTorch forward
+  3. nemo128.onnx                — DFT-conv1d 80-mel preprocessor, waveform → features
+  4. vocab.txt                   — flat 5632-line vocab (blank is implicit at id 5632)
+  5. language_spans.json         — 22 × {start, length}
+  6. config.json                 — preprocessor + encoder metadata
+  7. export-report.json          — record of what we did and any parity numbers
 
-Phase 2 adds nemo128.onnx (DFT preprocessor, ported from nemo_export/).
+Parity checks:
+  - synthetic: random log-mel features → encoder → ctc_decoder, PyTorch vs ORT.
+  - real-audio (optional, --parity-audio path): .wav → full pipeline PyTorch
+    vs ORT (nemo128 + encoder + ctc_decoder chained).
 
 Usage:
   python scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py \\
@@ -31,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 
@@ -59,6 +63,14 @@ def parse_args() -> argparse.Namespace:
         "--skip-parity", action="store_true",
         help="Skip the PyTorch/ONNX parity check (for iteration on the export only).",
     )
+    p.add_argument(
+        "--parity-audio", default=None,
+        help="Optional .wav file for real-audio end-to-end parity (nemo128 + encoder + ctc_decoder).",
+    )
+    p.add_argument(
+        "--parity-audio-tolerance", type=float, default=1e-2,
+        help="Tolerance for real-audio parity. Looser than synthetic because it compounds three graphs.",
+    )
     p.add_argument("--overwrite", action="store_true")
     return p.parse_args()
 
@@ -68,11 +80,14 @@ class ExportReport:
     model_class: str = ""
     encoder_onnx: str = ""
     ctc_decoder_onnx: str = ""
+    preprocessor_onnx: str = ""
     vocab_size: int = 0
     num_languages: int = 0
     languages: list[str] = field(default_factory=list)
     parity_max_abs_delta: float | None = None
     parity_pass: bool | None = None
+    parity_audio_max_abs_delta: float | None = None
+    parity_audio_pass: bool | None = None
     notes: list[str] = field(default_factory=list)
 
 
@@ -81,6 +96,155 @@ class ExportReport:
 # NeMo modules accept keyword-argument forwards (audio_signal=, length=) and
 # mix data/length tensors in ways torch.onnx.export can trip over. Thin
 # wrappers give the exporter positional signatures it can trace cleanly.
+
+
+def build_dft_preprocessor_wrapper(torch, preprocessor):
+    """DFT-basis preprocessor wrapper. Ported from
+    scripts/nemo_export/export_parakeet_nemo_to_onnx.py — same IndicConformer
+    preprocessor config family (80 mel, 16 kHz, n_fft=512, 25/10 ms, per_feature
+    normalize, hann window, log+add guard).
+
+    Replaces torch.stft with F.conv1d on a precomputed windowed cos/sin basis
+    matrix so the ONNX graph contains only Conv/Pow/Add/Sqrt/Log/MatMul ops —
+    no STFT op (ONNX Runtime's STFT diverges from PyTorch's on this toolchain).
+    """
+
+    class DFTConvPreprocessorWrapper(torch.nn.Module):
+        def __init__(self, pre):
+            super().__init__()
+            f = pre.featurizer
+            self.preemph = float(f.preemph)
+            self.n_fft = int(f.n_fft)
+            self.hop_length = int(f.hop_length)
+            self.win_length = int(f.win_length)
+            self.mag_power = float(f.mag_power)
+            # NeMo 1.x FilterbankFeatures has neither `exact_pad` nor
+            # `stft_pad_amount`; it always uses center-reflect padding. NeMo 2.x
+            # added both. Default to the 1.x behavior when missing.
+            self.exact_pad = bool(getattr(f, "exact_pad", False))
+            _stft_pad = getattr(f, "stft_pad_amount", None)
+            self.stft_pad_amount = None if _stft_pad is None else int(_stft_pad)
+            self.log_zero_guard_type = str(f.log_zero_guard_type)
+            self.log_zero_guard_value = float(f.log_zero_guard_value)
+            self.normalize = str(getattr(f, "normalize", "None"))
+            self.pad_to = getattr(f, "pad_to", 0)
+            self.pad_value = float(getattr(f, "pad_value", 0.0))
+
+            # Windowed DFT basis, built in fp64 then cast to fp32.
+            win = f.window.detach().float().cpu()
+            if win.shape[0] < self.n_fft:
+                left = (self.n_fft - win.shape[0]) // 2
+                right = self.n_fft - win.shape[0] - left
+                win = torch.nn.functional.pad(win, [left, right])
+            n_bins = self.n_fft // 2 + 1
+            n_range = torch.arange(self.n_fft, dtype=torch.float64)
+            k_range = torch.arange(n_bins, dtype=torch.float64)
+            angles = 2.0 * math.pi * k_range.unsqueeze(1) * n_range.unsqueeze(0) / self.n_fft
+            win64 = win.to(dtype=torch.float64)
+            cos_b = (torch.cos(angles) * win64.unsqueeze(0)).to(dtype=torch.float32)
+            sin_b = (torch.sin(angles) * win64.unsqueeze(0)).to(dtype=torch.float32)
+            # conv1d weight shape: [out_channels, in_channels=1, kernel=n_fft]
+            dft_matrix = torch.cat([cos_b, sin_b], dim=0).unsqueeze(1)
+            self.register_buffer("dft_matrix", dft_matrix)
+            self.register_buffer("fb", f.fb.detach().float().cpu())
+
+        def get_seq_len(self, seq_len):
+            # Matches NeMo FilterbankFeatures.get_seq_len exactly, including
+            # the trailing +1 that was missing from the NeMo-2.x-derived
+            # reference wrapper in scripts/nemo_export/.
+            pad = (self.stft_pad_amount * 2 if self.stft_pad_amount is not None
+                   else (self.n_fft // 2) * 2)
+            return (torch.floor_divide(seq_len + pad - self.n_fft, self.hop_length) + 1).to(dtype=torch.long)
+
+        def _normalize_per_feature(self, features, seq_len):
+            bs, _, max_t = features.shape
+            t_idx = torch.arange(max_t, device=features.device).unsqueeze(0).expand(bs, max_t)
+            mask = t_idx < seq_len.unsqueeze(1)
+            masked = torch.where(mask.unsqueeze(1), features, 0.0)
+            numer = masked.sum(axis=2)
+            denom = mask.sum(axis=1)
+            mean = numer / denom.unsqueeze(1)
+            var = torch.sum(
+                torch.where(mask.unsqueeze(1), features - mean.unsqueeze(2), 0.0) ** 2,
+                axis=2,
+            ) / (denom.unsqueeze(1) - 1.0)
+            std = torch.sqrt(var).masked_fill(torch.sqrt(var).isnan(), 0.0) + 1e-5
+            return (features - mean.unsqueeze(2)) / std.unsqueeze(2)
+
+        def forward(self, waveforms, waveforms_lens):
+            seq_len_unfixed = self.get_seq_len(waveforms_lens.float())
+            seq_len = torch.where(
+                waveforms_lens == 0, torch.zeros_like(seq_len_unfixed), seq_len_unfixed
+            )
+
+            # Time mask + pre-emphasis.
+            t_mask = (torch.arange(waveforms.shape[1], device=waveforms.device).unsqueeze(0)
+                      < waveforms_lens.unsqueeze(1))
+            waveforms = torch.cat(
+                (waveforms[:, :1], waveforms[:, 1:] - self.preemph * waveforms[:, :-1]),
+                dim=1,
+            ).masked_fill(~t_mask, 0.0)
+
+            # Padding matches torch.stft semantics: constant zeros if exact_pad,
+            # otherwise reflection pad of n_fft//2 each side.
+            if self.stft_pad_amount is not None:
+                waveforms = torch.nn.functional.pad(
+                    waveforms.unsqueeze(1),
+                    (self.stft_pad_amount, self.stft_pad_amount),
+                    "constant",
+                ).squeeze(1)
+            elif not self.exact_pad:
+                half = self.n_fft // 2
+                waveforms = torch.nn.functional.pad(
+                    waveforms.unsqueeze(1), (half, half), "reflect",
+                ).squeeze(1)
+
+            # Conv1d DFT: [B,1,T] * [2*n_bins,1,n_fft] -> [B, 2*n_bins, frames]
+            frames = torch.nn.functional.conv1d(
+                waveforms.unsqueeze(1),
+                self.dft_matrix.to(dtype=waveforms.dtype, device=waveforms.device),
+                stride=self.hop_length,
+                padding=0,
+            )
+            n_bins = self.n_fft // 2 + 1
+            real, imag = frames[:, :n_bins, :], frames[:, n_bins:, :]
+            features = torch.sqrt(real.pow(2) + imag.pow(2))
+            if self.mag_power != 1.0:
+                features = features.pow(self.mag_power)
+
+            features = torch.matmul(
+                self.fb.to(dtype=features.dtype, device=features.device), features
+            )
+
+            if self.log_zero_guard_type == "add":
+                features = torch.log(features + self.log_zero_guard_value)
+            elif self.log_zero_guard_type == "clamp":
+                features = torch.log(torch.clamp(features, min=self.log_zero_guard_value))
+            else:
+                raise RuntimeError(f"Unsupported log_zero_guard_type: {self.log_zero_guard_type}")
+
+            if self.normalize == "per_feature":
+                features = self._normalize_per_feature(features, seq_len)
+            elif self.normalize not in ("", "None", "none"):
+                raise RuntimeError(f"Unsupported normalize mode: {self.normalize}")
+
+            max_len = features.size(-1)
+            pad_mask = (torch.arange(max_len, device=features.device).repeat(features.size(0), 1)
+                        >= seq_len.unsqueeze(1))
+            features = features.masked_fill(pad_mask.unsqueeze(1), self.pad_value)
+
+            if isinstance(self.pad_to, int) and self.pad_to > 0:
+                pad_amt = features.size(-1) % self.pad_to
+                if pad_amt != 0:
+                    features = torch.nn.functional.pad(
+                        features, (0, self.pad_to - pad_amt), value=self.pad_value
+                    )
+            return features, seq_len
+
+    w = DFTConvPreprocessorWrapper(preprocessor)
+    w.eval()
+    return w
+
 
 def build_encoder_wrapper(torch, encoder):
     class EncoderWrapper(torch.nn.Module):
@@ -154,6 +318,39 @@ def export_encoder(torch, model, output_path: Path, opset: int, parity_seconds: 
         )
     print("[encoder] done")
     return features, lens
+
+
+def export_preprocessor(torch, model, output_path: Path, opset: int,
+                        dummy_seconds: float = 4.0) -> None:
+    print(f"[preprocessor] exporting to {output_path}")
+    wrapper = build_dft_preprocessor_wrapper(torch, model.preprocessor)
+    device = next(model.parameters()).device
+    wrapper.to(device)
+
+    sample_rate = int(getattr(model.preprocessor, "_sample_rate", 16000))
+    num_samples = max(int(dummy_seconds * sample_rate), sample_rate)
+    waveforms = torch.zeros((1, num_samples), dtype=torch.float32, device=device)
+    waveforms_lens = torch.tensor([num_samples], dtype=torch.int64, device=device)
+
+    dynamic_axes = {
+        "waveforms": {0: "batch", 1: "samples"},
+        "waveforms_lens": {0: "batch"},
+        "features": {0: "batch", 2: "frames"},
+        "features_lens": {0: "batch"},
+    }
+
+    with torch.inference_mode():
+        torch.onnx.export(
+            wrapper,
+            (waveforms, waveforms_lens),
+            str(output_path),
+            input_names=["waveforms", "waveforms_lens"],
+            output_names=["features", "features_lens"],
+            dynamic_axes=dynamic_axes,
+            opset_version=opset,
+            dynamo=False,
+        )
+    print("[preprocessor] done")
 
 
 def export_ctc_decoder(torch, model, output_path: Path, opset: int,
@@ -241,6 +438,73 @@ def write_config(model, dst: Path) -> None:
 
 # --- Parity check -----------------------------------------------------------
 
+def parity_check_real_audio(
+    torch, model, wav_path: Path, preprocessor_onnx: Path,
+    encoder_onnx: Path, ctc_decoder_onnx: Path, tolerance: float,
+) -> tuple[float, bool]:
+    """End-to-end parity: load a real .wav, run the full PyTorch pipeline
+    (preprocessor → encoder → ctc_decoder), run the full ONNX pipeline
+    (nemo128 → encoder → ctc_decoder), compare final logits.
+    """
+    import numpy as np
+    import soundfile as sf
+    import onnxruntime as ort
+
+    print(f"\n[parity-audio] loading {wav_path}")
+    arr, sr = sf.read(str(wav_path), dtype="float32")
+    if arr.ndim > 1:
+        arr = arr.mean(axis=1)
+    if sr != 16000:
+        raise RuntimeError(
+            f"Parity audio must be 16 kHz mono; got {sr} Hz. "
+            "The test_audio library stores Indic clips already at 16 kHz."
+        )
+    waveforms_np = arr[None, :].astype(np.float32)
+    lens_np = np.array([arr.shape[0]], dtype=np.int64)
+
+    device = next(model.parameters()).device
+    waveforms_t = torch.from_numpy(waveforms_np).to(device)
+    lens_t = torch.from_numpy(lens_np).to(device)
+
+    print("[parity-audio] PyTorch reference: preprocessor → encoder → ctc_decoder")
+    with torch.inference_mode():
+        features_ref, features_lens_ref = model.preprocessor(
+            input_signal=waveforms_t, length=lens_t
+        )
+        encoded_ref, _ = model.encoder(audio_signal=features_ref, length=features_lens_ref)
+        logits_ref = model.ctc_decoder(encoder_output=encoded_ref)
+    logits_ref_np = logits_ref.detach().cpu().numpy()
+    features_ref_np = features_ref.detach().cpu().numpy()
+
+    print("[parity-audio] ORT: nemo128 → encoder → ctc_decoder")
+    cpu = ["CPUExecutionProvider"]
+    pre_sess = ort.InferenceSession(str(preprocessor_onnx), providers=cpu)
+    enc_sess = ort.InferenceSession(str(encoder_onnx), providers=cpu)
+    dec_sess = ort.InferenceSession(str(ctc_decoder_onnx), providers=cpu)
+
+    pre_out = pre_sess.run(None, {"waveforms": waveforms_np, "waveforms_lens": lens_np})
+    features_ort, features_lens_ort = pre_out[0], pre_out[1]
+
+    enc_out = enc_sess.run(None, {"features": features_ort, "features_lens": features_lens_ort})
+    encoded_ort = enc_out[0]
+
+    dec_out = dec_sess.run(None, {"encoded": encoded_ort})
+    logits_ort = dec_out[0]
+
+    assert logits_ref_np.shape == logits_ort.shape, (
+        f"logits shape mismatch: ref {logits_ref_np.shape} vs ort {logits_ort.shape}"
+    )
+
+    feat_delta = float(np.max(np.abs(features_ref_np - features_ort)))
+    logits_delta = float(np.max(np.abs(logits_ref_np - logits_ort)))
+    print(f"[parity-audio] features max-abs delta: {feat_delta:.6e}")
+    print(f"[parity-audio] logits   max-abs delta: {logits_delta:.6e}")
+    print(f"[parity-audio] tolerance:              {tolerance:.6e}")
+    passed = logits_delta <= tolerance
+    print(f"[parity-audio] {'PASS' if passed else 'FAIL'}")
+    return logits_delta, passed
+
+
 def parity_check(torch, model, encoder_onnx: Path, ctc_decoder_onnx: Path,
                  parity_seconds: float, tolerance: float) -> tuple[float, bool]:
     import numpy as np
@@ -311,14 +575,15 @@ def main() -> None:
 
     encoder_onnx = out_dir / "encoder-model.onnx"
     ctc_decoder_onnx = out_dir / "ctc_decoder-model.onnx"
+    preprocessor_onnx = out_dir / "nemo128.onnx"
     vocab_txt = out_dir / "vocab.txt"
     spans_json = out_dir / "language_spans.json"
     config_json = out_dir / "config.json"
     report_json = out_dir / "export-report.json"
 
     if not args.overwrite:
-        existing = [p for p in (encoder_onnx, ctc_decoder_onnx, vocab_txt,
-                                spans_json, config_json) if p.exists()]
+        existing = [p for p in (encoder_onnx, ctc_decoder_onnx, preprocessor_onnx,
+                                vocab_txt, spans_json, config_json) if p.exists()]
         if existing:
             raise SystemExit(
                 "Output directory already contains export targets. "
@@ -345,6 +610,7 @@ def main() -> None:
         model_class=type(model).__name__,
         encoder_onnx=str(encoder_onnx),
         ctc_decoder_onnx=str(ctc_decoder_onnx),
+        preprocessor_onnx=str(preprocessor_onnx),
     )
 
     # 1. Encoder.
@@ -359,7 +625,10 @@ def main() -> None:
         )
     export_ctc_decoder(torch, model, ctc_decoder_onnx, args.opset, encoded_example)
 
-    # 3. Sidecars.
+    # 3. Preprocessor (DFT-conv1d).
+    export_preprocessor(torch, model, preprocessor_onnx, args.opset, args.parity_seconds)
+
+    # 4. Sidecars.
     vocab_size = write_vocab(model, vocab_txt)
     langs = write_language_spans(model, spans_json)
     write_config(model, config_json)
@@ -367,7 +636,7 @@ def main() -> None:
     report.languages = langs
     report.num_languages = len(langs)
 
-    # 4. Parity.
+    # 5. Synthetic parity (encoder + ctc_decoder only, random mel input).
     if not args.skip_parity:
         delta, passed = parity_check(
             torch, model, encoder_onnx, ctc_decoder_onnx,
@@ -377,6 +646,16 @@ def main() -> None:
         report.parity_pass = passed
     else:
         report.notes.append("parity skipped by --skip-parity")
+
+    # 6. Real-audio parity (full pipeline: nemo128 → encoder → ctc_decoder).
+    if args.parity_audio and not args.skip_parity:
+        audio_delta, audio_pass = parity_check_real_audio(
+            torch, model, Path(args.parity_audio).expanduser(),
+            preprocessor_onnx, encoder_onnx, ctc_decoder_onnx,
+            args.parity_audio_tolerance,
+        )
+        report.parity_audio_max_abs_delta = audio_delta
+        report.parity_audio_pass = audio_pass
 
     report_json.write_text(json.dumps(asdict(report), indent=2))
     print(f"\n[report] wrote {report_json}")

--- a/scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py
+++ b/scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+export_indicconformer_nemo_to_onnx.py
+
+Phase 1/2 exporter for AI4Bharat's IndicConformer hybrid CTC+RNNT model.
+
+The plan is to ship a Parakeet-shaped package (encoder + CTC decoder +
+preprocessor + vocab + config) with one extra artifact (language_spans.json)
+that tells the C# side which 256-token slice belongs to each of the 22
+languages.
+
+Phase 1 scope of this script:
+  1. encoder-model.onnx          — Conformer encoder, (features, lens) → (encoded, encoded_lens)
+  2. ctc_decoder-model.onnx      — single Conv1d projection, encoded → logits
+  3. vocab.txt                   — flat 5632-line vocab (blank is implicit at id 5632)
+  4. language_spans.json         — 22 × {start, length}
+  5. config.json                 — preprocessor + encoder metadata
+  6. export-report.json          — record of what we did and any parity numbers
+  7. Parity check on synthetic input vs the PyTorch forward
+
+Phase 2 adds nemo128.onnx (DFT preprocessor, ported from nemo_export/).
+
+Usage:
+  python scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py \\
+    --nemo <path to .nemo> \\
+    --output-dir ~/models/indicconformer_onnx \\
+    --opset 17
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--nemo", required=True, help="Path to a local .nemo file.")
+    p.add_argument(
+        "--output-dir", required=True,
+        help="Directory that will receive the exported package."
+    )
+    p.add_argument("--opset", type=int, default=17)
+    p.add_argument(
+        "--device", choices=("auto", "cpu", "cuda"), default="auto",
+        help="Device for the NeMo restore and the PyTorch reference forward.",
+    )
+    p.add_argument(
+        "--parity-seconds", type=float, default=4.0,
+        help="Synthetic audio duration (sec) for the parity check.",
+    )
+    p.add_argument(
+        "--parity-tolerance", type=float, default=1e-3,
+        help="Max absolute logit delta allowed between PyTorch and ONNX Runtime.",
+    )
+    p.add_argument(
+        "--skip-parity", action="store_true",
+        help="Skip the PyTorch/ONNX parity check (for iteration on the export only).",
+    )
+    p.add_argument("--overwrite", action="store_true")
+    return p.parse_args()
+
+
+@dataclass
+class ExportReport:
+    model_class: str = ""
+    encoder_onnx: str = ""
+    ctc_decoder_onnx: str = ""
+    vocab_size: int = 0
+    num_languages: int = 0
+    languages: list[str] = field(default_factory=list)
+    parity_max_abs_delta: float | None = None
+    parity_pass: bool | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+# --- ONNX wrapper modules ---------------------------------------------------
+#
+# NeMo modules accept keyword-argument forwards (audio_signal=, length=) and
+# mix data/length tensors in ways torch.onnx.export can trip over. Thin
+# wrappers give the exporter positional signatures it can trace cleanly.
+
+def build_encoder_wrapper(torch, encoder):
+    class EncoderWrapper(torch.nn.Module):
+        def __init__(self, enc):
+            super().__init__()
+            self.enc = enc
+
+        def forward(self, features, features_lens):
+            # NeMo Conformer encoder returns (encoded, encoded_lens).
+            encoded, encoded_lens = self.enc(
+                audio_signal=features, length=features_lens
+            )
+            return encoded, encoded_lens
+
+    w = EncoderWrapper(encoder)
+    w.eval()
+    return w
+
+
+def build_ctc_decoder_wrapper(torch, ctc_decoder):
+    class CtcDecoderWrapper(torch.nn.Module):
+        def __init__(self, dec):
+            super().__init__()
+            self.dec = dec
+
+        def forward(self, encoded):
+            # ConvASRDecoder.forward expects keyword encoder_output= .
+            # It returns log-probs; we export the raw logits path by calling
+            # the underlying Conv1d directly so the C# side can decide
+            # whether to log_softmax.
+            logits = self.dec(encoder_output=encoded)
+            return logits
+
+    w = CtcDecoderWrapper(ctc_decoder)
+    w.eval()
+    return w
+
+
+# --- Export helpers ---------------------------------------------------------
+
+def export_encoder(torch, model, output_path: Path, opset: int, parity_seconds: float):
+    print(f"[encoder] exporting to {output_path}")
+    wrapper = build_encoder_wrapper(torch, model.encoder)
+    device = next(wrapper.parameters()).device
+
+    # Build a dummy log-mel-like feature tensor.
+    # NeMo preprocessor produces (batch, mel=80, frames). Frame rate is
+    # sample_rate / hop = 16000 / 160 = 100 frames/sec.
+    mel = int(model.cfg.preprocessor.features)
+    frames = max(int(parity_seconds * 100), 50)
+    features = torch.randn(1, mel, frames, dtype=torch.float32, device=device)
+    lens = torch.tensor([frames], dtype=torch.int64, device=device)
+
+    dynamic_axes = {
+        "features": {0: "batch", 2: "frames"},
+        "features_lens": {0: "batch"},
+        "encoded": {0: "batch", 2: "encoded_frames"},
+        "encoded_lens": {0: "batch"},
+    }
+
+    with torch.inference_mode():
+        torch.onnx.export(
+            wrapper,
+            (features, lens),
+            str(output_path),
+            input_names=["features", "features_lens"],
+            output_names=["encoded", "encoded_lens"],
+            dynamic_axes=dynamic_axes,
+            opset_version=opset,
+            dynamo=False,
+        )
+    print("[encoder] done")
+    return features, lens
+
+
+def export_ctc_decoder(torch, model, output_path: Path, opset: int,
+                       encoded_example) -> None:
+    print(f"[ctc_decoder] exporting to {output_path}")
+    wrapper = build_ctc_decoder_wrapper(torch, model.ctc_decoder)
+
+    dynamic_axes = {
+        "encoded": {0: "batch", 2: "encoded_frames"},
+        "logits": {0: "batch", 1: "encoded_frames"},
+    }
+
+    with torch.inference_mode():
+        torch.onnx.export(
+            wrapper,
+            (encoded_example,),
+            str(output_path),
+            input_names=["encoded"],
+            output_names=["logits"],
+            dynamic_axes=dynamic_axes,
+            opset_version=opset,
+            dynamo=False,
+        )
+    print("[ctc_decoder] done")
+
+
+# --- Sidecars ---------------------------------------------------------------
+
+def write_vocab(model, dst: Path) -> int:
+    """Flatten the 22 per-language SentencePiece vocabs into one file.
+
+    MultilingualTokenizer.ids_to_tokens takes (ids, lang_id), not a flat id —
+    so we walk the sub-tokenizers in offset order and stitch the result.
+    """
+    tok = model.tokenizer
+    lines: list[str | None] = [None] * tok.vocab_size
+    for lang in tok.langs:
+        offset = int(tok.token_id_offset[lang])
+        sub = tok.tokenizers_dict[lang]
+        n = sub.vocab_size
+        pieces = sub.ids_to_tokens(list(range(n)))
+        for local_id, piece in enumerate(pieces):
+            lines[offset + local_id] = piece
+    missing = [i for i, p in enumerate(lines) if p is None]
+    if missing:
+        raise RuntimeError(f"Vocab gaps at ids {missing[:10]} (total missing: {len(missing)})")
+    dst.write_text("\n".join(lines) + "\n")
+    print(f"[vocab] wrote {dst} ({len(lines)} lines)")
+    return len(lines)
+
+
+def write_language_spans(model, dst: Path) -> list[str]:
+    tok = model.tokenizer
+    offsets = tok.token_id_offset
+    spans = {}
+    for lang in tok.langs:
+        spans[lang] = {
+            "start": int(offsets[lang]),
+            "length": int(tok.tokenizers_dict[lang].vocab_size),
+        }
+    payload = {
+        "total_vocab_size": int(tok.vocab_size),
+        "blank_token_id": int(tok.vocab_size),  # CTC blank appended at the end
+        "languages": spans,
+    }
+    dst.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"[spans] wrote {dst} ({len(spans)} languages)")
+    return list(spans.keys())
+
+
+def write_config(model, dst: Path) -> None:
+    from omegaconf import OmegaConf
+    cfg = {
+        "preprocessor": OmegaConf.to_container(model.cfg.preprocessor, resolve=True),
+        "encoder": {
+            "feat_in": int(model.cfg.encoder.feat_in),
+            "n_layers": int(model.cfg.encoder.n_layers),
+            "d_model": int(model.cfg.encoder.d_model),
+        },
+        "sample_rate": 16000,
+    }
+    dst.write_text(json.dumps(cfg, indent=2))
+    print(f"[config] wrote {dst}")
+
+
+# --- Parity check -----------------------------------------------------------
+
+def parity_check(torch, model, encoder_onnx: Path, ctc_decoder_onnx: Path,
+                 parity_seconds: float, tolerance: float) -> tuple[float, bool]:
+    import numpy as np
+    import onnxruntime as ort
+
+    print("\n[parity] building synthetic input")
+    mel = int(model.cfg.preprocessor.features)
+    frames = max(int(parity_seconds * 100), 50)
+
+    # Seeded so re-runs are deterministic.
+    rng = np.random.default_rng(0)
+    feats_np = rng.standard_normal((1, mel, frames)).astype(np.float32)
+    lens_np = np.array([frames], dtype=np.int64)
+
+    # PyTorch reference: run encoder, then ctc_decoder.
+    print("[parity] PyTorch reference forward")
+    device = next(model.parameters()).device
+    feats_t = torch.from_numpy(feats_np).to(device)
+    lens_t = torch.from_numpy(lens_np).to(device)
+    with torch.inference_mode():
+        encoded_ref, encoded_lens_ref = model.encoder(audio_signal=feats_t, length=lens_t)
+        logits_ref = model.ctc_decoder(encoder_output=encoded_ref)
+    logits_ref_np = logits_ref.detach().cpu().numpy()
+    encoded_ref_np = encoded_ref.detach().cpu().numpy()
+
+    # ONNX Runtime: chain the two graphs the same way.
+    print("[parity] ORT encoder forward")
+    enc_sess = ort.InferenceSession(
+        str(encoder_onnx), providers=["CPUExecutionProvider"]
+    )
+    enc_out = enc_sess.run(None, {"features": feats_np, "features_lens": lens_np})
+    encoded_ort = enc_out[0]
+
+    print("[parity] ORT ctc_decoder forward")
+    dec_sess = ort.InferenceSession(
+        str(ctc_decoder_onnx), providers=["CPUExecutionProvider"]
+    )
+    dec_out = dec_sess.run(None, {"encoded": encoded_ort})
+    logits_ort = dec_out[0]
+
+    # Shapes should match exactly.
+    assert logits_ref_np.shape == logits_ort.shape, (
+        f"logits shape mismatch: ref {logits_ref_np.shape} vs ort {logits_ort.shape}"
+    )
+
+    # Compare on logits (the thing that matters for decoding).
+    delta = float(np.max(np.abs(logits_ref_np - logits_ort)))
+    enc_delta = float(np.max(np.abs(encoded_ref_np - encoded_ort)))
+    print(f"[parity] encoded max-abs delta:  {enc_delta:.6e}")
+    print(f"[parity] logits  max-abs delta:  {delta:.6e}")
+    print(f"[parity] tolerance:              {tolerance:.6e}")
+    passed = delta <= tolerance
+    print(f"[parity] {'PASS' if passed else 'FAIL'}")
+    return delta, passed
+
+
+# --- Main -------------------------------------------------------------------
+
+def main() -> None:
+    args = parse_args()
+
+    # Torch-level imports deferred so --help works without NeMo installed.
+    import torch
+    import nemo.collections.asr as nemo_asr
+
+    out_dir = Path(args.output_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    encoder_onnx = out_dir / "encoder-model.onnx"
+    ctc_decoder_onnx = out_dir / "ctc_decoder-model.onnx"
+    vocab_txt = out_dir / "vocab.txt"
+    spans_json = out_dir / "language_spans.json"
+    config_json = out_dir / "config.json"
+    report_json = out_dir / "export-report.json"
+
+    if not args.overwrite:
+        existing = [p for p in (encoder_onnx, ctc_decoder_onnx, vocab_txt,
+                                spans_json, config_json) if p.exists()]
+        if existing:
+            raise SystemExit(
+                "Output directory already contains export targets. "
+                "Re-run with --overwrite to replace them.\n"
+                f"Existing: {', '.join(p.name for p in existing)}"
+            )
+
+    # Device.
+    if args.device == "auto":
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        device = torch.device(args.device)
+    print(f"Using device: {device}")
+
+    print(f"Restoring: {args.nemo}")
+    model = nemo_asr.models.ASRModel.restore_from(args.nemo, map_location=device)
+    model.eval()
+    model.to(device)
+
+    # Inference-only: freeze the preprocessor's BN/running stats path.
+    model.freeze()
+
+    report = ExportReport(
+        model_class=type(model).__name__,
+        encoder_onnx=str(encoder_onnx),
+        ctc_decoder_onnx=str(ctc_decoder_onnx),
+    )
+
+    # 1. Encoder.
+    features_example, lens_example = export_encoder(
+        torch, model, encoder_onnx, args.opset, args.parity_seconds
+    )
+
+    # 2. Encoded example for the CTC decoder export (same shape the runtime sees).
+    with torch.inference_mode():
+        encoded_example, _ = model.encoder(
+            audio_signal=features_example, length=lens_example
+        )
+    export_ctc_decoder(torch, model, ctc_decoder_onnx, args.opset, encoded_example)
+
+    # 3. Sidecars.
+    vocab_size = write_vocab(model, vocab_txt)
+    langs = write_language_spans(model, spans_json)
+    write_config(model, config_json)
+    report.vocab_size = vocab_size
+    report.languages = langs
+    report.num_languages = len(langs)
+
+    # 4. Parity.
+    if not args.skip_parity:
+        delta, passed = parity_check(
+            torch, model, encoder_onnx, ctc_decoder_onnx,
+            args.parity_seconds, args.parity_tolerance,
+        )
+        report.parity_max_abs_delta = delta
+        report.parity_pass = passed
+    else:
+        report.notes.append("parity skipped by --skip-parity")
+
+    report_json.write_text(json.dumps(asdict(report), indent=2))
+    print(f"\n[report] wrote {report_json}")
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indicconformer_export/fetch_indic_test_audio.py
+++ b/scripts/indicconformer_export/fetch_indic_test_audio.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""
+fetch_indic_test_audio.py
+
+Pulls one short clip + ground-truth transcript per Indic language into
+~/Programming/test_audio/<locale>/, in the layout the rest of the
+test_audio library already uses (locale dir, <locale>_<source>_NN.wav,
+<locale>_<source>_NN.md with a single [speaker_0] block).
+
+Two sources:
+  - Fleurs (google/fleurs, CC-BY-4.0, not gated) for 14 languages:
+    hi, bn, ta, te, mr, gu, kn, ml, pa, or, as, ne, sd, ur
+  - IndicVoices-R (ai4bharat/indicvoices_r, gated) for 8 languages:
+    sa, ks, brx, doi, kok, mai, mni, sat
+    — model was trained on IndicVoices (sibling dataset), so these 8
+    are smoke-test material, not a rigorous WER benchmark.
+
+Resamples to 16 kHz mono. Idempotent: skips a language if a matching
+<source>_01.wav is already present.
+
+Usage:
+  # Fleurs 14 (no HF gate):
+  python scripts/indicconformer_export/fetch_indic_test_audio.py --source fleurs
+
+  # IndicVoices-R 8 (needs HF gate approval):
+  python scripts/indicconformer_export/fetch_indic_test_audio.py --source indicvoices_r
+
+  # Everything in one go:
+  python scripts/indicconformer_export/fetch_indic_test_audio.py --source all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+# BCP-47 locale → (HF config, transcript field, source tag).
+# Keep these aligned with the existing EU locale dir naming style.
+
+FLEURS_LANGS: dict[str, str] = {
+    # BCP-47 locale : Fleurs config code
+    "hi-IN": "hi_in",
+    "bn-IN": "bn_in",
+    "ta-IN": "ta_in",
+    "te-IN": "te_in",
+    "mr-IN": "mr_in",
+    "gu-IN": "gu_in",
+    "kn-IN": "kn_in",
+    "ml-IN": "ml_in",
+    "pa-IN": "pa_in",
+    "or-IN": "or_in",
+    "as-IN": "as_in",
+    "ne-NP": "ne_np",
+    "sd-IN": "sd_in",  # Fleurs has Indian Sindhi (not Pakistani)
+    "ur-PK": "ur_pk",  # Fleurs has Pakistani Urdu only
+}
+
+# IndicVoices-R config names are listed on the dataset card once accessed;
+# Sanskrit, Kashmiri, Bodo, Dogri, Konkani, Maithili, Manipuri, Santali.
+# The exact config keys will be filled in when we actually load the dataset
+# and inspect available configs — the webcard doesn't publish them.
+IV_R_LANGS: dict[str, str] = {
+    # BCP-47 locale : IndicVoices-R directory name (TitleCase)
+    "sa-IN": "Sanskrit",
+    "ks-IN": "Kashmiri",
+    "brx-IN": "Bodo",
+    "doi-IN": "Dogri",
+    "kok-IN": "Konkani",
+    "mai-IN": "Maithili",
+    "mni-IN": "Manipuri",
+    "sat-IN": "Santali",
+}
+
+# Max clip duration to keep things small; Fleurs clips are typically ~12s.
+MAX_SECONDS = 15.0
+MIN_SECONDS = 5.0
+
+
+@dataclass
+class WrittenClip:
+    locale: str
+    source: str
+    wav_path: Path
+    md_path: Path
+    duration_sec: float
+    transcript_preview: str
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--source",
+        choices=("fleurs", "indicvoices_r", "all"),
+        default="fleurs",
+        help="Which source to pull from.",
+    )
+    p.add_argument(
+        "--out-dir",
+        default=str(Path.home() / "Programming" / "test_audio"),
+        help="Root of the test_audio library.",
+    )
+    p.add_argument(
+        "--overwrite", action="store_true",
+        help="Re-download and replace existing clips.",
+    )
+    p.add_argument(
+        "--only-langs",
+        help="Comma-separated list of BCP-47 locales to restrict to, e.g. 'hi-IN,bn-IN'.",
+    )
+    return p.parse_args()
+
+
+def format_timestamp(seconds: float) -> str:
+    total = int(round(seconds))
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def write_transcript(
+    locale: str, source: str, duration: float, text: str, dst: Path
+) -> None:
+    """Write a .md in Vernacula.CLI's [speaker_N] [hh:mm:ss - hh:mm:ss] shape,
+    prefixed with a header that distinguishes these ground-truth transcripts
+    from leftover CLI output files."""
+    header = (
+        f"<!-- ground-truth transcript\n"
+        f"source: {source}\n"
+        f"locale: {locale}\n"
+        f"duration_sec: {duration:.2f}\n"
+        f"-->\n\n"
+    )
+    body = (
+        f"## [speaker_0] [00:00:00 - {format_timestamp(duration)}]\n"
+        f"\n"
+        f"{text.strip()}\n"
+    )
+    dst.write_text(header + body)
+
+
+def fetch_fleurs(
+    out_root: Path,
+    langs: dict[str, str],
+    overwrite: bool,
+) -> list[WrittenClip]:
+    """Direct HF Hub download — avoids the `datasets 2.14.4`/local-cache bug.
+
+    Fleurs layout:  data/<cfg>/audio/test.tar.gz  +  data/<cfg>/test.tsv
+    TSV columns:    id, filename, raw_transcription, transcription, phonetic, num_samples, gender
+    Audio is already 16 kHz mono .wav — no resampling needed.
+    """
+    target_min_samples = int(MIN_SECONDS * 16000)
+    target_max_samples = int(MAX_SECONDS * 16000)
+
+    written: list[WrittenClip] = []
+    for locale, fleurs_cfg in langs.items():
+        try:
+            clip = _fetch_one_fleurs(out_root, locale, fleurs_cfg,
+                                    overwrite, target_min_samples, target_max_samples)
+            if clip is not None:
+                written.append(clip)
+        except Exception as exc:
+            print(f"[{locale}] FAILED: {type(exc).__name__}: {exc}")
+    return written
+
+
+def _fetch_one_fleurs(
+    out_root: Path, locale: str, fleurs_cfg: str, overwrite: bool,
+    target_min_samples: int, target_max_samples: int,
+) -> "WrittenClip | None":
+    import csv
+    import tarfile
+    from huggingface_hub import hf_hub_download
+
+    dst_dir = out_root / locale
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    wav_path = dst_dir / f"{locale}_fleurs_01.wav"
+    md_path = dst_dir / f"{locale}_fleurs_01.md"
+
+    if wav_path.exists() and md_path.exists() and not overwrite:
+        print(f"[{locale}] already present — skipping")
+        return None
+
+    print(f"[{locale}] fetching test.tsv …")
+    tsv_path = hf_hub_download(
+        repo_id="google/fleurs",
+        repo_type="dataset",
+        filename=f"data/{fleurs_cfg}/test.tsv",
+    )
+
+    chosen = None
+    with open(tsv_path, encoding="utf-8") as fh:
+        reader = csv.reader(fh, delimiter="\t")
+        for row in reader:
+            if len(row) < 6:
+                continue
+            _id, filename, _raw, transcription, _phon, num_samples, *_ = row
+            ns = int(num_samples)
+            if (target_min_samples <= ns <= target_max_samples
+                    and transcription.strip()):
+                chosen = (filename, transcription, ns / 16000.0)
+                break
+
+    if chosen is None:
+        print(f"[{locale}] no clip in [{MIN_SECONDS}, {MAX_SECONDS}]s — skipping")
+        return None
+    target_filename, text, dur = chosen
+
+    print(f"[{locale}] fetching test.tar.gz (picking {target_filename}) …")
+    tar_path = hf_hub_download(
+        repo_id="google/fleurs",
+        repo_type="dataset",
+        filename=f"data/{fleurs_cfg}/audio/test.tar.gz",
+    )
+
+    with tarfile.open(tar_path, "r:gz") as tar:
+        # Fleurs tars put files at either <name>.wav or test/<name>.wav;
+        # walk the tar and match the filename tail.
+        member = None
+        for m in tar:
+            if m.name.endswith("/" + target_filename) or m.name == target_filename:
+                member = m
+                break
+        if member is None:
+            raise RuntimeError(f"{target_filename} not in {tar_path}")
+        src = tar.extractfile(member)
+        if src is None:
+            raise RuntimeError(f"Failed to open {target_filename} in tar")
+        wav_path.write_bytes(src.read())
+
+    write_transcript(locale, "fleurs", dur, text, md_path)
+    preview = text[:60] + ("…" if len(text) > 60 else "")
+    print(f"[{locale}] wrote {wav_path.name} ({dur:.1f}s) — {preview}")
+    return WrittenClip(locale, "fleurs", wav_path, md_path, dur, preview)
+
+
+def fetch_indicvoices_r(
+    out_root: Path,
+    langs: dict[str, str],
+    overwrite: bool,
+) -> list[WrittenClip]:
+    """Direct HF Hub download — sidesteps the datasets/local-cache bug.
+
+    IV-R layout:  <LanguageName>/test-0000N-of-000MM.parquet
+    Audio lives inline in each row as `{"bytes": <wav bytes>, "path": str}`.
+    Transcripts: prefer `verbatim`, fall back to `text` / `normalized`.
+
+    `langs` values must be the TitleCase language dir name (e.g., "Sanskrit").
+    """
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    all_files = api.list_repo_files("ai4bharat/indicvoices_r", repo_type="dataset")
+
+    written: list[WrittenClip] = []
+    for locale, dirname in langs.items():
+        try:
+            shards = sorted(
+                f for f in all_files
+                if f.startswith(dirname + "/") and "/test-" in f
+            )
+            if not shards:
+                print(f"[{locale}] no IV-R test shards found for '{dirname}' — skipping")
+                continue
+            clip = _fetch_one_iv_r(out_root, locale, shards[0], overwrite)
+            if clip is not None:
+                written.append(clip)
+        except Exception as exc:
+            print(f"[{locale}] FAILED: {type(exc).__name__}: {exc}")
+    return written
+
+
+def _fetch_one_iv_r(
+    out_root: Path, locale: str, shard_filename: str, overwrite: bool,
+) -> "WrittenClip | None":
+    import io as _io
+    from huggingface_hub import hf_hub_download
+    import pyarrow.parquet as pq
+    import soundfile as sf
+    import librosa
+
+    dst_dir = out_root / locale
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    wav_path = dst_dir / f"{locale}_indicvoices_r_01.wav"
+    md_path = dst_dir / f"{locale}_indicvoices_r_01.md"
+
+    if wav_path.exists() and md_path.exists() and not overwrite:
+        print(f"[{locale}] already present — skipping")
+        return None
+
+    print(f"[{locale}] fetching {shard_filename} …")
+    shard_path = hf_hub_download(
+        repo_id="ai4bharat/indicvoices_r",
+        repo_type="dataset",
+        filename=shard_filename,
+    )
+
+    table = pq.read_table(shard_path)
+    n = table.num_rows
+    print(f"[{locale}] shard has {n} rows; scanning for [{MIN_SECONDS}, {MAX_SECONDS}]s clip")
+
+    chosen = None
+    for row in table.to_pylist():
+        dur = float(row.get("duration") or 0.0)
+        text = (row.get("verbatim") or row.get("text") or row.get("normalized") or "").strip()
+        if MIN_SECONDS <= dur <= MAX_SECONDS and text:
+            chosen = (row, dur, text)
+            break
+    if chosen is None:
+        print(f"[{locale}] no clip in range found in first test shard — skipping")
+        return None
+    row, dur, text = chosen
+
+    wav_bytes = row["audio"]["bytes"]
+    arr, sr = sf.read(_io.BytesIO(wav_bytes), dtype="float32")
+    if arr.ndim > 1:
+        arr = arr.mean(axis=1)
+    if sr != 16000:
+        arr = librosa.resample(arr, orig_sr=sr, target_sr=16000)
+        sr = 16000
+    sf.write(str(wav_path), arr, sr, subtype="PCM_16")
+
+    write_transcript(locale, "indicvoices_r", dur, text, md_path)
+    preview = text[:60] + ("…" if len(text) > 60 else "")
+    print(f"[{locale}] wrote {wav_path.name} ({dur:.1f}s) — {preview}")
+    return WrittenClip(locale, "indicvoices_r", wav_path, md_path, dur, preview)
+
+
+def main() -> None:
+    args = parse_args()
+    out_root = Path(args.out_dir).expanduser()
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    only = None
+    if args.only_langs:
+        only = {s.strip() for s in args.only_langs.split(",") if s.strip()}
+
+    written: list[WrittenClip] = []
+    if args.source in ("fleurs", "all"):
+        langs = FLEURS_LANGS if only is None else {
+            k: v for k, v in FLEURS_LANGS.items() if k in only
+        }
+        if langs:
+            written += fetch_fleurs(out_root, langs, args.overwrite)
+
+    if args.source in ("indicvoices_r", "all"):
+        langs = IV_R_LANGS if only is None else {
+            k: v for k, v in IV_R_LANGS.items() if k in only
+        }
+        if langs:
+            written += fetch_indicvoices_r(out_root, langs, args.overwrite)
+
+    print(f"\nDone. {len(written)} clips written.")
+    summary_path = out_root / "indic_fetch_summary.json"
+    summary_path.write_text(json.dumps([
+        {
+            "locale": c.locale,
+            "source": c.source,
+            "duration_sec": c.duration_sec,
+            "wav": str(c.wav_path),
+            "md": str(c.md_path),
+            "transcript_preview": c.transcript_preview,
+        }
+        for c in written
+    ], indent=2, ensure_ascii=False))
+    print(f"Summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indicconformer_export/inspect_indicconformer.py
+++ b/scripts/indicconformer_export/inspect_indicconformer.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+inspect_indicconformer.py
+
+Phase 1 discovery script for IndicConformer. Loads a .nemo checkpoint via
+the AI4Bharat NeMo fork and dumps the information we need to decide:
+
+  1. Is there a usable CTC head (so we can skip RNNT export)?
+  2. Is this a single-language softmax, a multi-softmax, or a shared-vocab
+     single-softmax?
+  3. What do the vocab(s) look like per language?
+  4. What is the preprocessor configuration (so we can reuse the DFT
+     preprocessor from nemo_export/)?
+
+This script does NOT export anything. It only reads the checkpoint.
+
+Usage:
+    # Hindi-only checkpoint (simpler — use this for the initial spike)
+    python scripts/indicconformer_export/inspect_indicconformer.py \
+      --hf-repo ai4bharat/indicconformer_stt_hi_hybrid_ctc_rnnt_large
+
+    # Unified 22-language checkpoint (what we actually want to ship)
+    python scripts/indicconformer_export/inspect_indicconformer.py \
+      --hf-repo ai4bharat/IndicConformer
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--nemo", help="Path to a local .nemo file.")
+    group.add_argument("--hf-repo", help="HF repo id to pull from (e.g. ai4bharat/IndicConformer).")
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Optional path to write the full inspection report as JSON.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Imports deferred so --help works without NeMo installed.
+    import torch
+    import nemo.collections.asr as nemo_asr
+
+    if args.nemo:
+        print(f"Restoring from local checkpoint: {args.nemo}")
+        model = nemo_asr.models.ASRModel.restore_from(args.nemo, map_location="cpu")
+    else:
+        print(f"Downloading from HF: {args.hf_repo}")
+        model = nemo_asr.models.ASRModel.from_pretrained(args.hf_repo, map_location="cpu")
+
+    model.eval()
+
+    report: dict = {
+        "model_class": type(model).__name__,
+        "mro": [cls.__name__ for cls in type(model).__mro__],
+    }
+
+    # --- Decoders ------------------------------------------------------------
+    has_ctc = hasattr(model, "ctc_decoder") or hasattr(model, "decoder") and "CTC" in type(getattr(model, "decoder", None)).__name__
+    has_rnnt = hasattr(model, "decoding") and hasattr(model, "joint")
+    report["has_ctc_head"] = has_ctc
+    report["has_rnnt_head"] = has_rnnt
+    report["cfg_decoder"] = _safe_cfg(model, "cfg.decoder")
+    report["cfg_joint"] = _safe_cfg(model, "cfg.joint")
+    report["cfg_ctc_decoder"] = _safe_cfg(model, "cfg.ctc_decoder")
+    report["cfg_aux_ctc"] = _safe_cfg(model, "cfg.aux_ctc")
+
+    # --- Language heads / multi-softmax --------------------------------------
+    # AI4Bharat's fork advertises "multi-softmax" — look for per-language
+    # decoder state_dict keys or a `language_masking_prob` style config.
+    ctc_decoder = getattr(model, "ctc_decoder", None) or getattr(model, "decoder", None)
+    if ctc_decoder is not None:
+        report["ctc_decoder_class"] = type(ctc_decoder).__name__
+        # Flatten parameter names so we can see per-language keys if they exist.
+        param_names = [n for n, _ in ctc_decoder.named_parameters()]
+        report["ctc_decoder_param_names"] = param_names[:40]  # cap for sanity
+        report["ctc_decoder_param_count"] = len(param_names)
+
+    # --- Vocab(s) ------------------------------------------------------------
+    # Single-language CTC: model.decoder.vocabulary is a flat list
+    # Multi-softmax: vocabularies live per-language, possibly on a tokenizer
+    # with language_id indexing.
+    vocab = None
+    try:
+        vocab = ctc_decoder.vocabulary
+    except AttributeError:
+        pass
+    if vocab is not None:
+        report["ctc_vocab_size"] = len(vocab)
+        report["ctc_vocab_preview"] = list(vocab)[:20]
+
+    if hasattr(model, "tokenizer"):
+        tok = model.tokenizer
+        report["tokenizer_class"] = type(tok).__name__
+        report["tokenizer_attrs"] = [a for a in dir(tok) if not a.startswith("_")][:40]
+        # AggregateTokenizer (multi-lang) has .langs / .tokenizers_dict
+        if hasattr(tok, "langs"):
+            report["tokenizer_langs"] = list(tok.langs)
+
+    # --- Preprocessor --------------------------------------------------------
+    report["cfg_preprocessor"] = _safe_cfg(model, "cfg.preprocessor")
+
+    # --- CTC inference smoke (no audio) --------------------------------------
+    # Just confirm we can switch decoder modes without crashing.
+    try:
+        model.cur_decoder = "ctc"
+        report["can_set_cur_decoder_ctc"] = True
+    except Exception as exc:
+        report["can_set_cur_decoder_ctc"] = False
+        report["set_cur_decoder_ctc_error"] = repr(exc)
+
+    # --- Print ---------------------------------------------------------------
+    pretty = json.dumps(report, indent=2, default=str)
+    print("\n===== IndicConformer inspection report =====")
+    print(pretty)
+
+    if args.out:
+        Path(args.out).write_text(pretty)
+        print(f"\nWrote {args.out}")
+
+
+def _safe_cfg(model, dotted_path: str):
+    cur = model
+    for part in dotted_path.split("."):
+        cur = getattr(cur, part, None)
+        if cur is None:
+            return None
+    # OmegaConf DictConfig -> plain dict
+    try:
+        from omegaconf import OmegaConf
+        return OmegaConf.to_container(cur, resolve=True)
+    except Exception:
+        return str(cur)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indicconformer_export/probe_vocab_spans.py
+++ b/scripts/indicconformer_export/probe_vocab_spans.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+probe_vocab_spans.py
+
+Phase 1 follow-up. The checkpoint uses an AggregateTokenizer that unions 22
+per-language SentencePiece vocabs (256 tokens each) into a flat 5632-entry
+vocab. The "multi-softmax" design masks 5376 of those logits at decode time
+based on language_id. To decide what lives in the shipping package and what
+lives in C#, we need:
+
+  1. Are the 22 language blocks contiguous in the flat vocab?
+  2. Is there a per-language [start, length] table we can extract?
+  3. Does the model carry a prebuilt mask tensor (so we can bake it into
+     the exported artifact) or is the mask built on the fly?
+
+Outputs:
+  - /tmp/indicconformer_vocab.txt  (flat 5632-line vocab, one token per line)
+  - /tmp/indicconformer_language_spans.json  (22 entries, [start, length])
+
+Usage:
+  python scripts/indicconformer_export/probe_vocab_spans.py \
+    --nemo <path to downloaded .nemo>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--nemo", required=True, help="Path to a local .nemo file.")
+    p.add_argument("--vocab-out", default="/tmp/indicconformer_vocab.txt")
+    p.add_argument("--spans-out", default="/tmp/indicconformer_language_spans.json")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    import nemo.collections.asr as nemo_asr
+
+    print(f"Restoring: {args.nemo}")
+    model = nemo_asr.models.ASRModel.restore_from(args.nemo, map_location="cpu")
+    model.eval()
+
+    tok = model.tokenizer
+    print(f"\nTokenizer class: {type(tok).__name__}")
+    print(f"Languages: {list(tok.langs)}")
+    print(f"Total vocab size: {tok.vocab_size}")
+
+    # Offsets table — how the MultilingualTokenizer assigns a contiguous
+    # range in the flat id-space to each per-language SentencePiece.
+    offsets = getattr(tok, "token_id_offset", None)
+    print(f"\ntoken_id_offset keys: {list(offsets.keys()) if isinstance(offsets, dict) else offsets}")
+
+    tokenizers_dict = getattr(tok, "tokenizers_dict", None)
+    if tokenizers_dict is None:
+        raise RuntimeError("Expected `tokenizers_dict` on MultilingualTokenizer; layout changed?")
+
+    # Build per-language [start, length] from each sub-tokenizer's vocab_size
+    spans: dict[str, dict] = {}
+    for lang in tok.langs:
+        sub = tokenizers_dict[lang]
+        start = offsets[lang] if isinstance(offsets, dict) else None
+        length = sub.vocab_size
+        spans[lang] = {"start": start, "length": length}
+        print(f"  {lang:4s}  start={start:>5}  length={length:>4}")
+
+    # Contiguity check.
+    sorted_by_start = sorted(spans.items(), key=lambda kv: kv[1]["start"])
+    contiguous = True
+    expected = sorted_by_start[0][1]["start"]
+    for lang, s in sorted_by_start:
+        if s["start"] != expected:
+            contiguous = False
+            print(f"  GAP: {lang} starts at {s['start']}, expected {expected}")
+        expected = s["start"] + s["length"]
+    total = sum(s["length"] for s in spans.values())
+    print(f"\nContiguous: {contiguous}")
+    print(f"Sum of per-language lengths: {total}")
+    print(f"Matches vocab_size?: {total == tok.vocab_size}")
+
+    # Flat vocab dump. Each id -> its token string. For SentencePiece inside
+    # an aggregate this requires asking the per-language sub-tokenizer.
+    print("\nDumping flat vocab...")
+    vocab_lines: list[str] = []
+    for token_id in range(tok.vocab_size):
+        try:
+            piece = tok.ids_to_tokens([token_id])[0]
+        except Exception as exc:
+            piece = f"<err:{exc}>"
+        vocab_lines.append(piece)
+    Path(args.vocab_out).write_text("\n".join(vocab_lines) + "\n")
+    print(f"  wrote {args.vocab_out}  ({len(vocab_lines)} lines)")
+
+    # Spans JSON.
+    Path(args.spans_out).write_text(json.dumps(
+        {
+            "total_vocab_size": tok.vocab_size,
+            "languages": spans,
+        },
+        indent=2,
+        ensure_ascii=False,
+    ))
+    print(f"  wrote {args.spans_out}")
+
+    # Is there a prebuilt mask tensor on the ctc_decoder we can bake?
+    print("\nctc_decoder buffers / parameters:")
+    ctc = getattr(model, "ctc_decoder", None) or getattr(model, "decoder", None)
+    for name, buf in ctc.named_buffers():
+        print(f"  buf  {name}  shape={tuple(buf.shape)}  dtype={buf.dtype}")
+    for name, param in ctc.named_parameters():
+        print(f"  parm {name}  shape={tuple(param.shape)}  dtype={param.dtype}")
+
+    # Look for a language-mask attr on the model itself.
+    for attr in ("language_masks", "lang_masks", "masks", "softmax_masks"):
+        obj = getattr(model, attr, None)
+        if obj is not None:
+            print(f"\nmodel.{attr}: {type(obj).__name__}  "
+                  f"repr-preview={repr(obj)[:200]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indicconformer_export/repackage_600m_indicconformer.py
+++ b/scripts/indicconformer_export/repackage_600m_indicconformer.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+repackage_600m_indicconformer.py
+
+AI4Bharat ships the 600M IndicConformer as a pre-exported ONNX package at
+`ai4bharat/indic-conformer-600m-multilingual`. The architecture is identical
+to the 120M we exported in Phase 1/2 (same 22 × 256 CTC layout, same 80-mel
+Conformer frontend — verified byte-for-byte from their preprocessor.ts) but
+the shipping shape differs:
+
+  - Input/output tensor names: encoder uses `audio_signal/length` → `outputs/
+    encoded_lengths`, CTC uses `encoder_output → logprobs`. We rename to
+    `features/features_lens → encoded/encoded_lens` and `encoded → logits`
+    so one C# backend handles both 120M and 600M without per-model branches.
+  - Vocab: per-language dict of 257 tokens (first is `<unk>`, last is blank
+    at local id 256). We flatten to a 5632-line flat vocab.txt (drop each
+    language's `<unk>` and blank — shared CTC blank is implicit at id 5632).
+  - Masks: per-language 5633-long bool arrays. We convert to 22 × {start,
+    length} spans, matching our `language_spans.json` shape.
+  - Preprocessor: they ship TorchScript. We reuse our existing DFT-conv1d
+    `nemo128.onnx` from the 120M export because the frontend config is
+    identical (verified: sample_rate 16k, 80 mel, n_fft 512, hop 160, win
+    400, hann, preemph 0.97, log+add guard, per-feature normalize, mag² ).
+
+Usage:
+  python scripts/indicconformer_export/repackage_600m_indicconformer.py \\
+    --nemo128-from ~/models/indicconformer_onnx/nemo128.onnx \\
+    --output-dir ~/models/indicconformer_600m_onnx
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+# IO rename maps. Keys are AI4Bharat's names; values are ours.
+ENCODER_IO_RENAME = {
+    "audio_signal": "features",
+    "length": "features_lens",
+    "outputs": "encoded",
+    "encoded_lengths": "encoded_lens",
+}
+CTC_IO_RENAME = {
+    "encoder_output": "encoded",
+    "logprobs": "logits",
+}
+
+# BCP-47 ordering used on the 120M side; the AI4Bharat dict uses the same
+# keys but unordered. We keep this list so the span table and flat vocab
+# come out in a stable deterministic order.
+LANGS = [
+    "as", "bn", "brx", "doi", "kok", "gu", "hi", "kn", "ks", "mai",
+    "ml", "mr", "mni", "ne", "or", "pa", "sa", "sat", "sd", "ta", "te", "ur",
+]
+
+REPO_ID = "ai4bharat/indic-conformer-600m-multilingual"
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--output-dir", required=True,
+        help="Destination for the repackaged IndicConformer 600M package.",
+    )
+    p.add_argument(
+        "--nemo128-from", required=True,
+        help="Path to an existing nemo128.onnx from the 120M export (preprocessor is identical).",
+    )
+    p.add_argument(
+        "--overwrite", action="store_true",
+    )
+    return p.parse_args()
+
+
+def snapshot_600m_assets():
+    """Downloads (or reuses cached) 600M repo assets. Returns the snapshot root Path."""
+    from huggingface_hub import snapshot_download
+    p = snapshot_download(
+        repo_id=REPO_ID,
+        allow_patterns=[
+            "assets/encoder.onnx",
+            "assets/ctc_decoder.onnx",
+            "assets/vocab.json",
+            "assets/language_masks.json",
+            "assets/layers.*",
+            "assets/onnx__*",
+            "assets/pre_encode*",
+            "assets/Constant_*",
+        ],
+    )
+    return Path(p)
+
+
+def rename_and_consolidate_onnx(
+    src_path: Path, dst_path: Path, io_rename: dict[str, str],
+) -> None:
+    """Load ONNX with (possibly external) data, rename IO tensors, and
+    resave with single-file external data sidecar `<dst>.data`.
+
+    Note on symlinks: HF Hub stores blobs under cache/blobs/ and creates
+    relative symlinks in the snapshot dir pointing back to them. The
+    official onnx Python loader rejects symlinked external data as a
+    safety measure, so we load the graph without external data first and
+    manually populate each initializer's raw_data by reading the realpath
+    of its referenced external file."""
+    import onnx
+    from onnx import external_data_helper
+
+    print(f"  loading {src_path.name} (graph only; resolving external data manually)")
+    model = onnx.load(str(src_path), load_external_data=False)
+
+    base_dir = src_path.parent
+
+    def _resolve_tensor(t) -> bool:
+        if not external_data_helper.uses_external_data(t):
+            return False
+        loc = None
+        for kv in t.external_data:
+            if kv.key == "location":
+                loc = kv.value
+                break
+        if loc is None:
+            raise RuntimeError(f"Tensor {t.name!r} uses external data but has no 'location' key")
+        t.raw_data = (base_dir / loc).resolve().read_bytes()
+        t.data_location = onnx.TensorProto.DEFAULT
+        del t.external_data[:]
+        return True
+
+    resolved_tensors = 0
+    # Initializers.
+    for t in model.graph.initializer:
+        if _resolve_tensor(t):
+            resolved_tensors += 1
+    # Constant node attributes can also carry external data (AI4Bharat's
+    # encoder has a Constant_1970_attr__value of this form). Walk all nodes
+    # recursively in case any subgraphs exist (if/loop branches).
+    def _walk(graph):
+        nonlocal resolved_tensors
+        for node in graph.node:
+            for attr in node.attribute:
+                if attr.type == onnx.AttributeProto.TENSOR and attr.t:
+                    if _resolve_tensor(attr.t):
+                        resolved_tensors += 1
+                if attr.type == onnx.AttributeProto.TENSORS:
+                    for t in attr.tensors:
+                        if _resolve_tensor(t):
+                            resolved_tensors += 1
+                if attr.type == onnx.AttributeProto.GRAPH and attr.g:
+                    _walk(attr.g)
+                if attr.type == onnx.AttributeProto.GRAPHS:
+                    for g in attr.graphs:
+                        _walk(g)
+    _walk(model.graph)
+    print(f"    resolved {resolved_tensors} external tensors (initializers + attrs)")
+
+    # Rename graph inputs.
+    for inp in model.graph.input:
+        new = io_rename.get(inp.name)
+        if new is not None:
+            print(f"    rename input {inp.name} -> {new}")
+            inp.name = new
+    # Rename graph outputs.
+    for out in model.graph.output:
+        new = io_rename.get(out.name)
+        if new is not None:
+            print(f"    rename output {out.name} -> {new}")
+            out.name = new
+    # Rename references in node inputs/outputs.
+    renamed = 0
+    for node in model.graph.node:
+        for i, n in enumerate(node.input):
+            if n in io_rename:
+                node.input[i] = io_rename[n]
+                renamed += 1
+        for i, n in enumerate(node.output):
+            if n in io_rename:
+                node.output[i] = io_rename[n]
+                renamed += 1
+    print(f"    rewrote {renamed} node IO references")
+
+    sidecar = dst_path.name + ".data"
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    if dst_path.exists():
+        dst_path.unlink()
+    stale_sidecar = dst_path.parent / sidecar
+    if stale_sidecar.exists():
+        stale_sidecar.unlink()
+
+    # Decide whether to use external data: only if the model has large
+    # initializers. For ctc_decoder (~23 MB) we can inline; for encoder
+    # (~2.5 GB) we must externalize.
+    total_init_bytes = sum(len(t.raw_data) for t in model.graph.initializer)
+    if total_init_bytes > 500 * 1024 * 1024:
+        print(f"  saving {dst_path.name} with external data -> {sidecar}")
+        onnx.save_model(
+            model, str(dst_path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=sidecar,
+            size_threshold=0,
+        )
+    else:
+        print(f"  saving {dst_path.name} (inline, {total_init_bytes/1e6:.1f} MB)")
+        onnx.save_model(model, str(dst_path))
+
+
+def flatten_vocab(
+    per_lang_vocab: dict[str, list[str]], out_path: Path,
+) -> tuple[int, list[dict]]:
+    """Turn {lang: [<unk>, t1, t2, ..., t255, <blank>]} (length 257) into a flat
+    5632-line vocab.txt covering 22 × 256 real tokens. `<unk>` (local id 0) and
+    the per-language blank (local id 256) are both dropped — the CTC graph has
+    one shared blank at id 5632, implicit.
+
+    Returns (total_vocab_size, spans) where spans is a list of {language,
+    start, length} entries in LANGS order.
+    """
+    # AI4Bharat's per-language vocab has 257 entries: [<unk>, t1, ..., t256].
+    # The CTC softmax head emits 256 logits per language (the first 256 of
+    # the 257-dim per-lang output); the 257th output slot is the shared CTC
+    # blank, not a real token. So vocab[lang][0..255] are the 256 real
+    # entries (with <unk> at index 0) and vocab[lang][256] is unused padding
+    # (mirrors the RNNT head's 257-dim layout).
+    lines: list[str] = []
+    spans = []
+    cursor = 0
+    for lang in LANGS:
+        subvocab = per_lang_vocab[lang]
+        assert len(subvocab) == 257, f"{lang}: expected 257 entries, got {len(subvocab)}"
+        assert subvocab[0] in ("<unk>", "<UNK>", "unk"), f"{lang}[0]={subvocab[0]!r}"
+        real = subvocab[:256]
+        assert len(real) == 256, f"{lang}: first-256 slice is {len(real)} tokens"
+        lines.extend(real)
+        spans.append({"language": lang, "start": cursor, "length": 256})
+        cursor += 256
+    out_path.write_text("\n".join(lines) + "\n")
+    print(f"[vocab] wrote {out_path} ({len(lines)} lines)")
+    return len(lines), spans
+
+
+def write_language_spans(spans: list[dict], vocab_size: int, out_path: Path) -> None:
+    # Match the 120M schema: top-level has total_vocab_size, blank_token_id,
+    # and languages = {lang: {start, length}}.
+    payload = {
+        "total_vocab_size": int(vocab_size),
+        "blank_token_id": int(vocab_size),  # shared CTC blank at 5632
+        "languages": {s["language"]: {"start": s["start"], "length": s["length"]}
+                      for s in spans},
+    }
+    out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"[spans] wrote {out_path} ({len(spans)} languages)")
+
+
+def verify_masks_match_spans(
+    per_lang_masks: dict[str, list[bool]], spans: list[dict], vocab_size: int,
+) -> None:
+    """Cross-check: AI4Bharat's pre-materialized language_masks.json should
+    agree with the contiguous spans we derived from the per-language vocab
+    sizes. If they don't, our flattening is wrong."""
+    for s in spans:
+        lang = s["language"]
+        mask = per_lang_masks[lang]
+        expected_true = list(range(s["start"], s["start"] + s["length"])) + [vocab_size]
+        actual_true = [i for i, v in enumerate(mask) if v]
+        if actual_true != expected_true:
+            raise RuntimeError(
+                f"[{lang}] mask disagrees with span. expected True at "
+                f"{expected_true[:3]}..{expected_true[-3:]}, got "
+                f"{actual_true[:3]}..{actual_true[-3:]}"
+            )
+    print("[verify] masks match derived spans for all 22 languages")
+
+
+def write_config(out_path: Path) -> None:
+    # Minimal config — enough for the C# side to know the preprocessor
+    # contract and the blank id. Preprocessor params are the same as 120M.
+    cfg = {
+        "sample_rate": 16000,
+        "preprocessor": {
+            "features": 80,
+            "n_fft": 512,
+            "window_size": 0.025,
+            "window_stride": 0.01,
+            "window": "hann",
+            "normalize": "per_feature",
+            "preemph": 0.97,
+            "mag_power": 2.0,
+            "log_zero_guard_type": "add",
+            "log_zero_guard_value": 5.960464477539063e-08,
+        },
+        "encoder": {"d_model": 1024, "family": "indicconformer-600m"},
+        "ctc": {"blank_token_id": 5632, "logits_dim": 5633},
+    }
+    out_path.write_text(json.dumps(cfg, indent=2))
+    print(f"[config] wrote {out_path}")
+
+
+def main() -> None:
+    args = parse_args()
+    out_dir = Path(args.output_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    targets = {
+        "encoder": out_dir / "encoder-model.onnx",
+        "ctc_decoder": out_dir / "ctc_decoder-model.onnx",
+        "nemo128": out_dir / "nemo128.onnx",
+        "vocab": out_dir / "vocab.txt",
+        "spans": out_dir / "language_spans.json",
+        "config": out_dir / "config.json",
+    }
+
+    if not args.overwrite:
+        existing = [p for p in targets.values() if p.exists()]
+        if existing:
+            raise SystemExit(
+                "Output directory already contains target files. Re-run with "
+                "--overwrite to replace them.\n"
+                f"Existing: {', '.join(p.name for p in existing)}"
+            )
+
+    print("Snapshotting 600M ONNX assets (may be cached already) …")
+    snap = snapshot_600m_assets()
+    print(f"  {snap}")
+
+    # 1. Encoder: rename IO, consolidate external data into a single sidecar.
+    print("\n[encoder] repackaging")
+    rename_and_consolidate_onnx(
+        snap / "assets" / "encoder.onnx",
+        targets["encoder"],
+        ENCODER_IO_RENAME,
+    )
+
+    # 2. CTC decoder: rename IO, inline weights (small enough).
+    print("\n[ctc_decoder] repackaging")
+    rename_and_consolidate_onnx(
+        snap / "assets" / "ctc_decoder.onnx",
+        targets["ctc_decoder"],
+        CTC_IO_RENAME,
+    )
+
+    # 3. Preprocessor: reuse our 120M-era nemo128.onnx verbatim.
+    src_nemo128 = Path(args.nemo128_from).expanduser()
+    if not src_nemo128.exists():
+        raise SystemExit(f"nemo128 source not found: {src_nemo128}")
+    print(f"\n[nemo128] copying from {src_nemo128}")
+    shutil.copyfile(src_nemo128, targets["nemo128"])
+    print(f"[nemo128] wrote {targets['nemo128']}")
+
+    # 4. Vocab + spans (with cross-check against published masks).
+    per_lang_vocab = json.loads((snap / "assets" / "vocab.json").read_text())
+    per_lang_masks = json.loads((snap / "assets" / "language_masks.json").read_text())
+
+    vocab_size, spans = flatten_vocab(per_lang_vocab, targets["vocab"])
+    verify_masks_match_spans(per_lang_masks, spans, vocab_size)
+    write_language_spans(spans, vocab_size, targets["spans"])
+
+    # 5. Config.
+    write_config(targets["config"])
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indicconformer_export/requirements.txt
+++ b/scripts/indicconformer_export/requirements.txt
@@ -1,0 +1,20 @@
+# Deps for the IndicConformer ONNX export venv.
+#
+# NeMo is NOT listed here — it's installed from AI4Bharat's fork
+# (github.com/AI4Bharat/NeMo, branch nemo-v2) by setup_indicconformer_env.py.
+# Keep this file for the ancillary packages only.
+#
+# Use Python 3.10, 3.11, or 3.12. The AI4Bharat fork requires Python >= 3.10.
+
+onnx>=1.17,<2
+onnxscript>=0.3,<1
+huggingface_hub>=0.30,<1
+soundfile>=0.12,<1
+librosa>=0.10,<1
+
+# The AI4Bharat fork pins datasets==2.14.4, which uses pa.PyExtensionType —
+# removed in pyarrow 15. Must pin below that to keep NeMo imports working.
+pyarrow<15
+# pyarrow<15 wheels were compiled against NumPy 1.x, so numpy must be pinned
+# too. pyannote.core/metrics want numpy>=2 but we don't hit those paths.
+numpy<2

--- a/scripts/indicconformer_export/setup_indicconformer_env.py
+++ b/scripts/indicconformer_export/setup_indicconformer_env.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+setup_indicconformer_env.py
+
+Creates a Python virtual environment for IndicConformer ONNX export and
+installs AI4Bharat's NeMo fork (the nemo-v2 branch implements the
+multi-softmax ASR models used by IndicConformer).
+
+This env is deliberately separate from `.venv-nemo-export`: the AI4Bharat
+fork pins different versions of NeMo/PyTorch internals, and mixing them
+would break Parakeet export.
+
+Usage:
+    python scripts/indicconformer_export/setup_indicconformer_env.py
+    python scripts/indicconformer_export/setup_indicconformer_env.py --cuda-version cu121
+    python scripts/indicconformer_export/setup_indicconformer_env.py --cuda-version ""
+"""
+
+import argparse
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS = Path(__file__).resolve().parent / "requirements.txt"
+
+AI4BHARAT_NEMO_REPO = "https://github.com/AI4Bharat/NeMo.git"
+AI4BHARAT_NEMO_BRANCH = "nemo-v2"
+
+
+def run(*cmd: str) -> None:
+    print(f"+ {' '.join(cmd)}")
+    subprocess.run(list(cmd), check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create the IndicConformer export venv and install dependencies."
+    )
+    parser.add_argument(
+        "--python", default="python3",
+        help="Python interpreter to use for venv creation (default: python3)",
+    )
+    parser.add_argument(
+        "--venv-dir", default=str(REPO_ROOT / ".venv-indicconformer-export"),
+        help="Path to the virtual environment directory",
+    )
+    parser.add_argument(
+        "--cuda-version", default="cu128",
+        help="PyTorch CUDA build tag, e.g. cu121, cu128 (pass '' for CPU wheel)",
+    )
+    parser.add_argument(
+        "--nemo-clone-dir", default=str(REPO_ROOT / ".venv-indicconformer-export" / "_src" / "NeMo"),
+        help="Where to clone the AI4Bharat NeMo fork.",
+    )
+    args = parser.parse_args()
+
+    venv = Path(args.venv_dir)
+    python = str(venv / "bin" / "python")
+
+    run(args.python, "-m", "venv", str(venv))
+    run(python, "-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
+
+    if args.cuda_version:
+        torch_index = f"https://download.pytorch.org/whl/{args.cuda_version}"
+        print(f"\nInstalling PyTorch with CUDA ({args.cuda_version}) from {torch_index}")
+        run(python, "-m", "pip", "install", "torch", "--index-url", torch_index)
+        run(python, "-m", "pip", "install", "onnxruntime-gpu>=1.20,<2")
+    else:
+        run(python, "-m", "pip", "install", "onnxruntime>=1.20,<2")
+
+    run(python, "-m", "pip", "install", "-r", str(REQUIREMENTS))
+
+    # Clone AI4Bharat's NeMo fork (nemo-v2 branch) and install it editable.
+    clone_dir = Path(args.nemo_clone_dir)
+    if not clone_dir.exists():
+        clone_dir.parent.mkdir(parents=True, exist_ok=True)
+        run("git", "clone", "--branch", AI4BHARAT_NEMO_BRANCH, "--depth", "1",
+            AI4BHARAT_NEMO_REPO, str(clone_dir))
+    else:
+        print(f"\nAI4Bharat NeMo clone already present at {clone_dir}; skipping clone.")
+
+    # The fork's `./reinstall.sh` pulls NVIDIA Apex, Megatron, and other heavy
+    # training deps we don't need for inference+export. Use the documented
+    # lightweight path instead.
+    print("\nInstalling AI4Bharat NeMo fork (editable, ASR extras)")
+    run(python, "-m", "pip", "install", "-e", f"{clone_dir}[asr]")
+
+    print(f"\nEnvironment ready. Activate with:")
+    print(f"  source {venv}/bin/activate")
+    print(f"\nPhase 1 discovery:")
+    print(f"  python scripts/indicconformer_export/inspect_indicconformer.py \\")
+    print(f"    --hf-repo ai4bharat/indicconformer_stt_hi_hybrid_ctc_rnnt_large")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indicconformer_export/upload_indicconformer_600m_to_hf.py
+++ b/scripts/indicconformer_export/upload_indicconformer_600m_to_hf.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+upload_indicconformer_600m_to_hf.py
+
+Publishes the repackaged AI4Bharat IndicConformer 600M ONNX package to
+`christopherthompson81/indicconformer-600m-onnx` on the HF Hub so
+Vernacula's ModelManagerService can download it at runtime.
+
+What this uploads (from --package, default ~/models/indicconformer_600m_onnx/):
+  - encoder-model.onnx + encoder-model.onnx.data (consolidated external data)
+  - ctc_decoder-model.onnx
+  - nemo128.onnx (DFT-conv1d 80-mel preprocessor, verified byte-identical
+    to the upstream 600M preprocessor.ts config — see Phase 2 discovery)
+  - vocab.txt, language_spans.json, config.json
+
+Also generates and uploads:
+  - manifest.json — {"files": {name: {"md5": …}, …}} shape; matches the
+    other ModelManagerService manifests (ParseManifestHashes reads this).
+  - README.md — model card with AI4Bharat attribution, MIT license,
+    summary of the repackaging transformations so downstream users can
+    reproduce what we did.
+
+Usage:
+  python scripts/indicconformer_export/upload_indicconformer_600m_to_hf.py \\
+    [--package ~/models/indicconformer_600m_onnx] \\
+    [--repo-id christopherthompson81/indicconformer-600m-onnx] \\
+    [--private]   # default is public
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+FILES_TO_UPLOAD = [
+    "encoder-model.onnx",
+    "encoder-model.onnx.data",
+    "ctc_decoder-model.onnx",
+    "nemo128.onnx",
+    "vocab.txt",
+    "language_spans.json",
+    "config.json",
+]
+
+DEFAULT_REPO_ID = "christopherthompson81/indicconformer-600m-onnx"
+
+MODEL_CARD = """---
+license: mit
+tags:
+  - asr
+  - speech-recognition
+  - onnx
+  - indic
+language:
+  - as
+  - bn
+  - brx
+  - doi
+  - gu
+  - hi
+  - kn
+  - kok
+  - ks
+  - mai
+  - ml
+  - mni
+  - mr
+  - ne
+  - or
+  - pa
+  - sa
+  - sat
+  - sd
+  - ta
+  - te
+  - ur
+base_model: ai4bharat/indic-conformer-600m-multilingual
+library_name: onnxruntime
+---
+
+# IndicConformer 600M — ONNX (repackaged for Vernacula)
+
+This repo republishes AI4Bharat's 22-language
+[`ai4bharat/indic-conformer-600m-multilingual`](https://huggingface.co/ai4bharat/indic-conformer-600m-multilingual)
+as a single self-contained ONNX shipping package, in the shape the
+[Vernacula](https://github.com/christopherthompson81/vernacula) desktop ASR
+app expects its on-disk model directories to be. The CTC head only — the
+RNNT components from the source repo are not shipped here.
+
+All numerical behavior is identical to the upstream encoder+CTC graph; only
+the on-disk packaging differs.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `encoder-model.onnx` (+ `.data` sidecar) | Conformer encoder, `[features, features_lens] -> [encoded, encoded_lens]` |
+| `ctc_decoder-model.onnx` | Single `Conv1d` → 5633-dim logits (22 × 256 language tokens + 1 shared CTC blank at id 5632) |
+| `nemo128.onnx` | DFT-conv1d 80-mel preprocessor, `[waveforms, waveforms_lens] -> [features, features_lens]` |
+| `vocab.txt` | Flat 5632-line vocab, id = line index; shared CTC blank is implicit at id 5632 |
+| `language_spans.json` | 22 × `{start, length}` — which slice of `vocab.txt` each language's 256 tokens occupy |
+| `config.json` | Preprocessor frontend params + CTC blank id |
+| `manifest.json` | Per-file MD5 hashes (used by Vernacula's download verifier) |
+
+## Transformations applied vs upstream
+
+1. **Encoder ONNX**: consolidated the ~360 per-tensor external-data blob
+   files (HF's xet layout in the upstream repo) into a single
+   `encoder-model.onnx.data` sidecar so the file set is manageable. Also
+   resolved external data from Constant-node attributes as well as graph
+   initializers.
+2. **Renamed ONNX IO tensors** so one C# backend loads either this 600M
+   package or a NeMo-fork 120M export without branching:
+   - Encoder: `audio_signal → features`, `length → features_lens`,
+     `outputs → encoded`, `encoded_lengths → encoded_lens`.
+   - CTC decoder: `encoder_output → encoded`, `logprobs → logits`.
+3. **Vocab flatten**: upstream `vocab.json` is a 22-key dict with 257
+   entries each (`[<unk>, t1..t256]`). Flattened to a single 5632-line
+   `vocab.txt` keeping `<unk>` at local index 0 and the 255 real tokens
+   at 1..255 per language. The 257th upstream slot is unused padding
+   mirroring the RNNT head layout; it would never be decoded by the
+   256-dim CTC softmax.
+4. **Masks → spans**: upstream `language_masks.json` is 22 per-language
+   length-5633 boolean arrays. Verified they resolve to contiguous
+   256-token ranges, then compressed to `22 × {start, length}` entries.
+5. **Preprocessor**: upstream ships TorchScript (`preprocessor.ts`). We
+   replace it with a custom DFT-conv1d ONNX graph (no `STFT` op — ONNX
+   Runtime's STFT diverges from PyTorch's on current toolchains). The
+   frontend config is byte-identical to upstream: sample_rate 16 kHz,
+   80 mel, n_fft 512, hop 160, win 400, hann, preemph 0.97, log+add
+   guard, per-feature normalize, power spectrogram.
+6. Parity verified end-to-end against upstream on a Hindi Fleurs clip —
+   decodes to readable Devanagari with realistic WER; the full pipeline
+   (nemo128 → encoder → ctc_decoder) is numerically equivalent to
+   running AI4Bharat's reference model_onnx.py against the original
+   assets/*.onnx files.
+
+## Citation
+
+Original model by AI4Bharat. Please cite their work when using this
+repackaged copy; see their [model
+card](https://huggingface.co/ai4bharat/indic-conformer-600m-multilingual)
+for details.
+
+## License
+
+MIT, same as upstream.
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--package",
+        default=str(Path.home() / "models" / "indicconformer_600m_onnx"),
+        help="Directory holding the repackaged ONNX package.",
+    )
+    p.add_argument(
+        "--repo-id", default=DEFAULT_REPO_ID,
+        help="Destination HF repo id (created if missing).",
+    )
+    p.add_argument(
+        "--private", action="store_true",
+        help="Create the repo as private (default is public).",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help="Generate manifest.json + README.md locally; skip create/upload.",
+    )
+    return p.parse_args()
+
+
+def md5(path: Path, chunk: int = 1 << 20) -> str:
+    h = hashlib.md5()
+    with path.open("rb") as fh:
+        for block in iter(lambda: fh.read(chunk), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def main() -> None:
+    args = parse_args()
+    pkg = Path(args.package).expanduser()
+    if not pkg.is_dir():
+        raise SystemExit(f"--package dir not found: {pkg}")
+
+    for f in FILES_TO_UPLOAD:
+        if not (pkg / f).exists():
+            raise SystemExit(f"missing required file: {pkg / f}")
+
+    # Generate manifest.json with per-file MD5s. Written into the package
+    # itself so it's uploaded alongside the other files.
+    manifest = {
+        "files": {f: {"md5": md5(pkg / f)} for f in FILES_TO_UPLOAD}
+    }
+    manifest_path = pkg / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    print(f"wrote {manifest_path}")
+
+    # Write the model card next to the package — it gets uploaded too.
+    readme_path = pkg / "README.md"
+    readme_path.write_text(MODEL_CARD)
+    print(f"wrote {readme_path}")
+
+    if args.dry_run:
+        print("\n--dry-run: stopping before HF create/upload.")
+        return
+
+    from huggingface_hub import HfApi, create_repo
+
+    api = HfApi()
+    whoami = api.whoami()
+    print(f"\nauthenticated as: {whoami.get('name', '?')}")
+
+    print(f"creating repo {args.repo_id} (private={args.private}) …")
+    create_repo(
+        repo_id=args.repo_id,
+        repo_type="model",
+        private=args.private,
+        exist_ok=True,
+    )
+
+    # upload_folder with allow_patterns so we don't accidentally push
+    # any stray files a user left in the package dir.
+    allow = FILES_TO_UPLOAD + ["manifest.json", "README.md"]
+    print(f"uploading {len(allow)} files from {pkg} → {args.repo_id} …")
+    api.upload_folder(
+        repo_id=args.repo_id,
+        repo_type="model",
+        folder_path=str(pkg),
+        allow_patterns=allow,
+        commit_message="Initial upload: repackaged IndicConformer 600M ONNX",
+    )
+    print(f"\nDone. https://huggingface.co/{args.repo_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/indicconformer_export/validate_indicconformer_package.py
+++ b/scripts/indicconformer_export/validate_indicconformer_package.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+validate_indicconformer_package.py
+
+End-to-end smoke test for an IndicConformer ONNX package (either the
+120M home-exported shape or the repackaged 600M shape — both share the
+same on-disk contract now). Runs the full pipeline:
+
+  wav -> nemo128.onnx -> encoder-model.onnx -> ctc_decoder-model.onnx
+      -> language-mask argmax + dedup (drop shared blank)
+      -> lookup in flat vocab.txt via language_spans.json
+      -> SentencePiece-style detokenize ('▁' -> ' ')
+
+Also doubles as the Python reference for the C# decode path in Phase 3.
+
+Usage:
+  python scripts/indicconformer_export/validate_indicconformer_package.py \\
+    --package ~/models/indicconformer_600m_onnx \\
+    --wav ~/Programming/test_audio/hi-IN/hi-IN_fleurs_01.wav \\
+    --lang hi
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--package", required=True,
+                   help="Directory with encoder-model.onnx + ctc_decoder-model.onnx + nemo128.onnx + vocab.txt + language_spans.json")
+    p.add_argument("--wav", required=True, help="16 kHz mono .wav")
+    p.add_argument("--lang", required=True, help="BCP-47-ish code without region, e.g. 'hi', 'ta'")
+    p.add_argument("--expected", default=None,
+                   help="Optional expected reference transcript for informational diff.")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    import numpy as np
+    import onnxruntime as ort
+    import soundfile as sf
+
+    pkg = Path(args.package).expanduser()
+    preproc = pkg / "nemo128.onnx"
+    encoder = pkg / "encoder-model.onnx"
+    ctc = pkg / "ctc_decoder-model.onnx"
+    vocab_path = pkg / "vocab.txt"
+    spans_path = pkg / "language_spans.json"
+    for p in (preproc, encoder, ctc, vocab_path, spans_path):
+        if not p.exists():
+            raise SystemExit(f"missing: {p}")
+
+    spans = json.loads(spans_path.read_text())
+    langs = spans["languages"]
+    if args.lang not in langs:
+        raise SystemExit(f"language {args.lang!r} not in {sorted(langs)}")
+    lang = langs[args.lang]
+    start, length = int(lang["start"]), int(lang["length"])
+    blank_id = int(spans["blank_token_id"])  # 5632, shared
+
+    # Flat vocab (5632 lines, one token per id across all 22 langs).
+    vocab = vocab_path.read_text().splitlines()
+    assert len(vocab) == spans["total_vocab_size"], (
+        f"vocab.txt has {len(vocab)} lines, spans says {spans['total_vocab_size']}"
+    )
+
+    # Load audio.
+    arr, sr = sf.read(args.wav, dtype="float32")
+    if arr.ndim > 1:
+        arr = arr.mean(axis=1)
+    if sr != 16000:
+        raise SystemExit(f"wav must be 16 kHz; got {sr}")
+    waveforms = arr[None, :].astype(np.float32)
+    wav_lens = np.array([arr.shape[0]], dtype=np.int64)
+
+    cpu = ["CPUExecutionProvider"]
+    pre_sess = ort.InferenceSession(str(preproc), providers=cpu)
+    enc_sess = ort.InferenceSession(str(encoder), providers=cpu)
+    dec_sess = ort.InferenceSession(str(ctc), providers=cpu)
+
+    # 1. Preprocessor: wav -> features, features_lens.
+    feats, feats_lens = pre_sess.run(
+        None, {"waveforms": waveforms, "waveforms_lens": wav_lens}
+    )
+
+    # 2. Encoder: features -> encoded, encoded_lens.
+    encoded, encoded_lens = enc_sess.run(
+        None, {"features": feats, "features_lens": feats_lens}
+    )
+    T = int(encoded_lens[0])
+
+    # 3. CTC decoder: encoded -> logits [B, T, 5633] (or logprobs; either way argmax is equivalent).
+    logits = dec_sess.run(None, {"encoded": encoded})[0]
+
+    # 4. Language-masked argmax + dedup.
+    # Build the argmax over the 257 valid positions (256 lang tokens + 1 shared blank).
+    # Doing it as a gather on the sub-span keeps the blank at local position 256.
+    lang_slice = logits[0, :T, start:start + length]         # [T, 256]
+    blank_logit = logits[0, :T, blank_id:blank_id + 1]       # [T, 1]
+    sub = np.concatenate([lang_slice, blank_logit], axis=1)  # [T, 257]
+    local_blank_id = length  # = 256
+
+    indices = sub.argmax(axis=-1)
+    # Greedy CTC collapse: drop consecutive dupes, then drop blanks.
+    pieces: list[str] = []
+    prev = None
+    for idx in indices.tolist():
+        if idx == prev:
+            continue
+        prev = idx
+        if idx == local_blank_id:
+            continue
+        # Lookup: local id 0..255 -> global id start..start+255.
+        global_id = start + idx
+        piece = vocab[global_id]
+        pieces.append(piece)
+
+    # SentencePiece-style detokenize: '▁' at the head of a piece marks a word boundary.
+    text = "".join(pieces).replace("\u2581", " ").strip()
+
+    print(f"decoded ({args.lang}): {text}")
+    if args.expected is not None:
+        print(f"expected:         {args.expected}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
+++ b/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
@@ -34,6 +34,24 @@ This section manages the AI model files required for transcription.
 - **Download Missing Models** — downloads any model files not yet present on disk. A progress bar and status line track each file as it downloads.
 - **Check for Updates** — checks whether newer model weights are available. An update banner also appears on the home screen automatically when updated weights are detected.
 
+## ASR Backend
+
+Controls which speech-recognition model transcribes the audio. Each backend covers a different set of languages and has different tradeoffs.
+
+| Backend | Languages | Notes |
+|---|---|---|
+| **Parakeet** | 25 European | Default. Multilingual shared-vocab model; auto-detects language during decode. Optional KenLM shallow fusion for domain biasing. |
+| **Cohere Transcribe** | 14 | Whisper-family decoder path. Supports optional per-file forced language. |
+| **Qwen3-ASR 1.7B** | 29 | Batched decoder with the widest language coverage. Optional forced language; otherwise auto-detects. |
+| **VibeVoice-ASR** | 12 | Combined diarization + ASR in a single model pass. Requires a CUDA-capable GPU. |
+| **IndicConformer 600M** | 22 Indic | AI4Bharat's multilingual Indic model. Covers the 22 official Indian languages across multiple scripts (Devanagari, Bengali, Tamil, Arabic, Ol Chiki, etc.). Requires a language to be picked at inference — see below. |
+
+### IndicConformer language selection
+
+Unlike Parakeet's shared-vocab auto-routing, IndicConformer's 22 languages have disjoint per-language CTC heads. The decoder needs to be told which head to use, so the Settings page exposes a **Language** picker just below the backend radio group. Five languages use ISO 639-3 codes because they have no 639-1 assignment: `brx` (Bodo), `doi` (Dogri), `kok` (Konkani), `mai` (Maithili), `mni` (Manipuri), `sat` (Santali). The remaining 17 use their 639-1 codes.
+
+When **Language Identification** is enabled (see below), IndicConformer uses the detected language per segment and falls back to the manual picker for segments whose detected language isn't one of the 14 VoxLingua107 covers. The 8 languages LID cannot detect — `brx`, `doi`, `kok`, `ks`, `mai`, `mni`, `or`, `sat` — always require the manual picker for files whose primary language is one of them.
+
 ## Segmentation Mode
 
 Controls how the audio is divided into segments before speech recognition.

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -36,14 +36,12 @@ public class AppSettings
     // IndicConformer is strictly per-language at inference — the model has
     // 22 CTC heads and picking one is mandatory, so this is not optional
     // like Cohere/Qwen3 "auto". Default to Hindi (largest / most common).
+    // When the global LID switches (LidEnabled / LidPerSegment below) are
+    // on, IndicConformer uses LID's detected language per-segment and falls
+    // back to this manual pick for the 8 langs VoxLingua doesn't cover
+    // (brx, doi, kok, ks, mai, mni, or, sat). With LID off, every segment
+    // decodes in this language.
     public string             IndicConformerLanguage { get; set; } = "hi";
-    // When on, the IndicConformer branch uses per-segment LID results to
-    // pick the decoder span, falling back to IndicConformerLanguage above
-    // for segments LID doesn't classify as one of its 14 supported Indic
-    // langs (VoxLingua coverage: as, bn, gu, hi, kn, ml, mr, ne, pa, sa,
-    // sd, ta, te, ur). The 8 remaining IndicConformer langs — brx, doi,
-    // kok, ks, mai, mni, or, sat — require manual selection.
-    public bool               IndicConformerAutoLid { get; set; } = false;
     public DenoiserMode       Denoiser            { get; set; } = DenoiserMode.None;
     public PlaybackMode       EditorPlaybackMode  { get; set; } = PlaybackMode.Continuous;
     public string             ModelsDir           { get; set; } = "";

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -4,7 +4,9 @@ namespace Vernacula.App.Models;
 
 public enum AppTheme    { Dark, Light }
 public enum PlaybackMode { Single, AutoAdvance, Continuous }
-public enum AsrBackend { Parakeet, Cohere, Qwen3Asr, VibeVoice }
+// New enum values MUST be appended. Persisted settings store the integer
+// value, so inserting mid-enum silently re-interprets existing user state.
+public enum AsrBackend { Parakeet, Cohere, Qwen3Asr, VibeVoice, IndicConformer }
 
 public class AppSettings
 {
@@ -31,6 +33,10 @@ public class AppSettings
     public float              ParakeetLmLengthPenalty { get; set; } = 0.6f;
     public string             CohereLanguage      { get; set; } = "";
     public string             Qwen3AsrLanguage    { get; set; } = "";
+    // IndicConformer is strictly per-language at inference — the model has
+    // 22 CTC heads and picking one is mandatory, so this is not optional
+    // like Cohere/Qwen3 "auto". Default to Hindi (largest / most common).
+    public string             IndicConformerLanguage { get; set; } = "hi";
     public DenoiserMode       Denoiser            { get; set; } = DenoiserMode.None;
     public PlaybackMode       EditorPlaybackMode  { get; set; } = PlaybackMode.Continuous;
     public string             ModelsDir           { get; set; } = "";

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -37,6 +37,13 @@ public class AppSettings
     // 22 CTC heads and picking one is mandatory, so this is not optional
     // like Cohere/Qwen3 "auto". Default to Hindi (largest / most common).
     public string             IndicConformerLanguage { get; set; } = "hi";
+    // When on, the IndicConformer branch uses per-segment LID results to
+    // pick the decoder span, falling back to IndicConformerLanguage above
+    // for segments LID doesn't classify as one of its 14 supported Indic
+    // langs (VoxLingua coverage: as, bn, gu, hi, kn, ml, mr, ne, pa, sa,
+    // sd, ta, te, ur). The 8 remaining IndicConformer langs — brx, doi,
+    // kok, ks, mai, mni, or, sat — require manual selection.
+    public bool               IndicConformerAutoLid { get; set; } = false;
     public DenoiserMode       Denoiser            { get; set; } = DenoiserMode.None;
     public PlaybackMode       EditorPlaybackMode  { get; set; } = PlaybackMode.Continuous;
     public string             ModelsDir           { get; set; } = "";

--- a/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
+++ b/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
@@ -63,6 +63,19 @@ public static class AsrLanguageSupport
         "en", "fr", "de", "it", "ja", "ko", "pt", "ru", "es", "th", "vi", "zh",
     }.ToFrozenSet();
 
+    // AI4Bharat IndicConformer 600M — the 22 official Indian languages, mixed
+    // ISO 639-1 / 639-3 convention because five have no 639-1 assignment:
+    // brx (Bodo), doi (Dogri), kok (Konkani), mai (Maithili), mni (Manipuri),
+    // sat (Santali). The remaining seventeen use their 639-1 forms. The
+    // model's language_spans.json keys use the same convention, so matching
+    // is straightforward — we do not normalize between 639-1 / 639-3 here.
+    private static readonly FrozenSet<string> IndicConformerLangs = new HashSet<string>
+    {
+        "as", "bn", "brx", "doi", "gu", "hi", "kn", "kok",
+        "ks", "mai", "ml", "mni", "mr", "ne", "or", "pa",
+        "sa", "sat", "sd", "ta", "te", "ur",
+    }.ToFrozenSet();
+
     /// <summary>
     /// Map deprecated ISO 639-1 codes to their modern equivalents and
     /// lowercase the result. Used at every lookup boundary so the rest of
@@ -103,11 +116,12 @@ public static class AsrLanguageSupport
     /// </summary>
     public static FrozenSet<string> Get(AsrBackend backend) => backend switch
     {
-        AsrBackend.Parakeet  => ParakeetLangs,
-        AsrBackend.Cohere    => CohereLangs,
-        AsrBackend.Qwen3Asr  => Qwen3AsrLangs,
-        AsrBackend.VibeVoice => VibeVoiceLangs,
-        _                    => FrozenSet<string>.Empty,
+        AsrBackend.Parakeet       => ParakeetLangs,
+        AsrBackend.Cohere         => CohereLangs,
+        AsrBackend.Qwen3Asr       => Qwen3AsrLangs,
+        AsrBackend.VibeVoice      => VibeVoiceLangs,
+        AsrBackend.IndicConformer => IndicConformerLangs,
+        _                         => FrozenSet<string>.Empty,
     };
 
     // ── Cross-language fallback policy ───────────────────────────────────────
@@ -157,7 +171,18 @@ public static class AsrLanguageSupport
     {
         if (string.IsNullOrWhiteSpace(iso)) return Array.Empty<AsrBackend>();
         string code = NormalizeIso(iso);
-        var order = new[] { AsrBackend.Qwen3Asr, AsrBackend.Cohere, AsrBackend.Parakeet, AsrBackend.VibeVoice };
+        // IndicConformer leads the preference order but its 22-language set
+        // is disjoint from Parakeet/Cohere/VibeVoice and barely overlaps
+        // Qwen3-ASR ("hi" is the only overlap), so promoting it to first
+        // only effects Indic languages — other codes still pick the
+        // generalist backends in the usual order.
+        var order = new[] {
+            AsrBackend.IndicConformer,
+            AsrBackend.Qwen3Asr,
+            AsrBackend.Cohere,
+            AsrBackend.Parakeet,
+            AsrBackend.VibeVoice,
+        };
         return order.Where(b => Get(b).Contains(code)).ToArray();
     }
 
@@ -175,11 +200,12 @@ public static class AsrLanguageSupport
     /// <summary>Human-readable display name for a backend.</summary>
     public static string DisplayName(AsrBackend backend) => backend switch
     {
-        AsrBackend.Parakeet  => "Parakeet",
-        AsrBackend.Cohere    => "Cohere Transcribe",
-        AsrBackend.Qwen3Asr  => "Qwen3-ASR",
-        AsrBackend.VibeVoice => "VibeVoice-ASR",
-        _                    => backend.ToString(),
+        AsrBackend.Parakeet       => "Parakeet",
+        AsrBackend.Cohere         => "Cohere Transcribe",
+        AsrBackend.Qwen3Asr       => "Qwen3-ASR",
+        AsrBackend.VibeVoice      => "VibeVoice-ASR",
+        AsrBackend.IndicConformer => "IndicConformer",
+        _                         => backend.ToString(),
     };
 
     /// <summary>
@@ -188,20 +214,22 @@ public static class AsrLanguageSupport
     /// </summary>
     public static AsrBackend? BackendOf(string modelName) => modelName switch
     {
-        "nvidia/parakeet-tdt-0.6b-v3"          => AsrBackend.Parakeet,
-        "CohereLabs/cohere-transcribe-03-2026" => AsrBackend.Cohere,
-        "Qwen/Qwen3-ASR-1.7B"                  => AsrBackend.Qwen3Asr,
-        "vibevoice/vibevoice-asr"              => AsrBackend.VibeVoice,
-        _                                      => (AsrBackend?)null,
+        "nvidia/parakeet-tdt-0.6b-v3"                  => AsrBackend.Parakeet,
+        "CohereLabs/cohere-transcribe-03-2026"         => AsrBackend.Cohere,
+        "Qwen/Qwen3-ASR-1.7B"                          => AsrBackend.Qwen3Asr,
+        "vibevoice/vibevoice-asr"                      => AsrBackend.VibeVoice,
+        "ai4bharat/indic-conformer-600m-multilingual"  => AsrBackend.IndicConformer,
+        _                                              => (AsrBackend?)null,
     };
 
     /// <summary>Inverse of <see cref="BackendOf"/>: enum → pipeline model-name string.</summary>
     public static string ModelName(AsrBackend backend) => backend switch
     {
-        AsrBackend.Parakeet  => "nvidia/parakeet-tdt-0.6b-v3",
-        AsrBackend.Cohere    => "CohereLabs/cohere-transcribe-03-2026",
-        AsrBackend.Qwen3Asr  => "Qwen/Qwen3-ASR-1.7B",
-        AsrBackend.VibeVoice => "vibevoice/vibevoice-asr",
+        AsrBackend.Parakeet       => "nvidia/parakeet-tdt-0.6b-v3",
+        AsrBackend.Cohere         => "CohereLabs/cohere-transcribe-03-2026",
+        AsrBackend.Qwen3Asr       => "Qwen/Qwen3-ASR-1.7B",
+        AsrBackend.VibeVoice      => "vibevoice/vibevoice-asr",
+        AsrBackend.IndicConformer => "ai4bharat/indic-conformer-600m-multilingual",
         _ => throw new ArgumentOutOfRangeException(nameof(backend)),
     };
 
@@ -225,6 +253,15 @@ public static class AsrLanguageSupport
             ["sl"] = "Slovenian",   ["sv"] = "Swedish",    ["th"] = "Thai",
             ["tl"] = "Filipino",    ["tr"] = "Turkish",    ["uk"] = "Ukrainian",
             ["vi"] = "Vietnamese",  ["zh"] = "Chinese",
+            // IndicConformer — 22 official Indian languages. Five use 639-3
+            // because they have no 639-1 code; see IndicConformerLangs above.
+            ["as"] = "Assamese",    ["bn"] = "Bengali",    ["brx"] = "Bodo",
+            ["doi"] = "Dogri",      ["gu"] = "Gujarati",   ["kn"] = "Kannada",
+            ["kok"] = "Konkani",    ["ks"] = "Kashmiri",   ["mai"] = "Maithili",
+            ["ml"] = "Malayalam",   ["mni"] = "Manipuri",  ["mr"] = "Marathi",
+            ["ne"] = "Nepali",      ["or"] = "Odia",       ["pa"] = "Punjabi",
+            ["sa"] = "Sanskrit",    ["sat"] = "Santali",   ["sd"] = "Sindhi",
+            ["ta"] = "Tamil",       ["te"] = "Telugu",     ["ur"] = "Urdu",
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>

--- a/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
+++ b/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
@@ -264,6 +264,23 @@ public static class AsrLanguageSupport
             ["ta"] = "Tamil",       ["te"] = "Telugu",     ["ur"] = "Urdu",
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
+    // Right-to-left scripts. Keep tight — only codes whose *normal* writing
+    // direction is RTL. Urdu, Kashmiri and Sindhi all write in Perso-Arabic
+    // RTL in this model's training data. Arabic / Hebrew / Persian aren't
+    // in IndicConformer's set but are included so other backends (Cohere,
+    // Qwen3) benefit from the same helper.
+    private static readonly FrozenSet<string> RtlLangs = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "ar", "fa", "he", "iw", "ur", "ks", "sd",
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>True when the language's normal writing direction is
+    /// right-to-left. Used by the editor to flip FlowDirection on the
+    /// per-token ASR runs and the Edit box when rendering one of these
+    /// languages. Deprecated codes normalized via <see cref="NormalizeIso"/>.</summary>
+    public static bool IsRtl(string? iso) =>
+        !string.IsNullOrWhiteSpace(iso) && RtlLangs.Contains(NormalizeIso(iso));
+
     /// <summary>
     /// English display name for an ISO 639-1 code, or the code itself if
     /// no name is registered. Case-insensitive; deprecated codes are

--- a/src/Vernacula.Avalonia/Models/TranscriptEditorCardState.cs
+++ b/src/Vernacula.Avalonia/Models/TranscriptEditorCardState.cs
@@ -59,6 +59,13 @@ internal sealed partial class TranscriptEditorCardState : ObservableObject
     public ObservableCollection<TranscriptEditorTextRunState> AsrRuns { get; } = [];
     public ObservableCollection<TranscriptEditorTextRunState> AdjacentRuns { get; } = [];
 
+    /// <summary>Flow direction for the ASR/Edit columns in the focused card.
+    /// Set to RightToLeft for Urdu/Kashmiri/Sindhi (and other RTL codes from
+    /// non-Indic backends). Driven by the segment's language at build time,
+    /// so mixed-direction files where LID per-segment split languages across
+    /// scripts get each card rendered in the correct direction.</summary>
+    [ObservableProperty] private FlowDirection _asrFlowDirection = FlowDirection.LeftToRight;
+
     [ObservableProperty] private bool _isFocused;
     [ObservableProperty] private AsrLanguageOption? _selectedRedoLanguage;
     public bool ShowLanguageChip { get; set; }

--- a/src/Vernacula.Avalonia/Services/JobQueueService.cs
+++ b/src/Vernacula.Avalonia/Services/JobQueueService.cs
@@ -328,22 +328,35 @@ internal sealed class JobQueueService
 
     private string GetJobAsrModelName() => _settings.Current.AsrBackend switch
     {
-        AsrBackend.Cohere     => "CohereLabs/cohere-transcribe-03-2026",
-        AsrBackend.Qwen3Asr   => "Qwen/Qwen3-ASR-1.7B",
-        AsrBackend.VibeVoice  => "vibevoice/vibevoice-asr",
-        _                     => "nvidia/parakeet-tdt-0.6b-v3",
+        AsrBackend.Cohere         => "CohereLabs/cohere-transcribe-03-2026",
+        AsrBackend.Qwen3Asr       => "Qwen/Qwen3-ASR-1.7B",
+        AsrBackend.VibeVoice      => "vibevoice/vibevoice-asr",
+        AsrBackend.IndicConformer => "ai4bharat/indic-conformer-600m-multilingual",
+        _                         => "nvidia/parakeet-tdt-0.6b-v3",
     };
 
     private string GetJobAsrLanguageCode()
     {
-        return _settings.Current.AsrBackend switch
+        var backend = _settings.Current.AsrBackend;
+        // IndicConformer must pass a real code — "auto" would later resolve
+        // against the 22-head set and fail. When AutoLid is on, the service
+        // still receives the manual fallback here and consumes LID inside.
+        if (backend == AsrBackend.IndicConformer)
         {
-            AsrBackend.Cohere   => string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
-                                       ? "auto" : _settings.Current.CohereLanguage,
-            AsrBackend.Qwen3Asr => string.IsNullOrWhiteSpace(_settings.Current.Qwen3AsrLanguage)
-                                       ? "auto" : _settings.Current.Qwen3AsrLanguage,
-            _                   => "auto",
-        };
+            return string.IsNullOrWhiteSpace(_settings.Current.IndicConformerLanguage)
+                ? "hi" : _settings.Current.IndicConformerLanguage;
+        }
+        if (backend == AsrBackend.Cohere)
+        {
+            return string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
+                ? "auto" : _settings.Current.CohereLanguage;
+        }
+        if (backend == AsrBackend.Qwen3Asr)
+        {
+            return string.IsNullOrWhiteSpace(_settings.Current.Qwen3AsrLanguage)
+                ? "auto" : _settings.Current.Qwen3AsrLanguage;
+        }
+        return "auto";
     }
 
     private record QueueEntry(

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -38,6 +38,11 @@ internal class ModelManagerService
     private const string VoxLinguaManifestUrl =
         "https://huggingface.co/christopherthompson81/voxlingua107-lid-onnx/resolve/main/manifest.json";
 
+    private const string IndicConformerRepoBase =
+        "https://huggingface.co/christopherthompson81/indicconformer-600m-onnx/resolve/main";
+    private const string IndicConformerManifestUrl =
+        "https://huggingface.co/christopherthompson81/indicconformer-600m-onnx/resolve/main/manifest.json";
+
     private static readonly ModelAsset[] CoreDiarizationFiles =
         [
             new(Path.Combine(Config.SortformerSubDir, Config.SortformerFile), Config.SortformerFile),
@@ -101,6 +106,17 @@ internal class ModelManagerService
             new(Path.Combine(Config.VoxLinguaSubDir, Config.VoxLinguaLangMapFile), Config.VoxLinguaLangMapFile),
         ];
 
+    private static readonly ModelAsset[] IndicConformerFiles =
+        [
+            new(Path.Combine(Config.IndicConformerSubDir, Config.PreprocessorFile),        Config.PreprocessorFile),
+            new(Path.Combine(Config.IndicConformerSubDir, Config.EncoderFile),             Config.EncoderFile),
+            new(Path.Combine(Config.IndicConformerSubDir, $"{Config.EncoderFile}.data"),   $"{Config.EncoderFile}.data"),
+            new(Path.Combine(Config.IndicConformerSubDir, Config.CtcDecoderFile),          Config.CtcDecoderFile),
+            new(Path.Combine(Config.IndicConformerSubDir, Config.VocabFile),               Config.VocabFile),
+            new(Path.Combine(Config.IndicConformerSubDir, Config.IndicConformerLanguageSpansFile), Config.IndicConformerLanguageSpansFile),
+            new(Path.Combine(Config.IndicConformerSubDir, Config.AsrConfigFile),           Config.AsrConfigFile),
+        ];
+
     private static readonly ModelAsset[] VibeVoiceFiles =
         [
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.AudioEncoderFile),                       VibeVoiceAsr.AudioEncoderFile),
@@ -139,6 +155,11 @@ internal class ModelManagerService
             [
                 new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
                 new AssetRepo("", "", Qwen3AsrFiles),
+            ],
+            AsrBackend.IndicConformer =>
+            [
+                new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
+                new AssetRepo(IndicConformerRepoBase, IndicConformerManifestUrl, IndicConformerFiles),
             ],
             _ =>
             [

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -101,6 +101,9 @@ internal class SettingsService
     public string GetVibeVoiceModelsDir() =>
         Path.Combine(GetModelsDir(), "vibevoice_asr");
 
+    public string GetIndicConformerModelsDir() =>
+        Path.Combine(GetModelsDir(), Config.IndicConformerSubDir);
+
     public string GetVoxLinguaModelsDir() =>
         string.IsNullOrWhiteSpace(Current.VoxLinguaModelsDir)
             ? Path.Combine(GetModelsDir(), Config.VoxLinguaSubDir)

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -953,22 +953,17 @@ internal class TranscriptionService
             else if (useIndicConformerAsr)
             {
                 // IndicConformer has 22 per-language CTC heads; one must be
-                // chosen per segment. Two modes:
-                //
-                //   - AutoLid ON: use per-segment LID (if enabled, else the
-                //     file-level detected_language) to pick the head. Groups
-                //     detected as one of IndicConformer's 22 supported codes
-                //     decode in that language; everything else falls back to
-                //     the user's manual pick. VoxLingua covers 14 of 22 —
-                //     the other 8 (brx, doi, kok, ks, mai, mni, or, sat)
-                //     always go through the fallback.
-                //
-                //   - AutoLid OFF: current behavior — all segments decode in
-                //     the manual language.
+                // chosen per segment. LID drives per-segment language when
+                // the global LidEnabled / LidPerSegment switches are on
+                // (lidByRid populated above). Segments LID didn't classify
+                // — or ones LID detected as a language outside the 22 Indic
+                // heads, or as one of the 8 VoxLingua doesn't cover (brx,
+                // doi, kok, ks, mai, mni, or, sat) — fall back to the
+                // manual pick from settings.
                 //
                 // `asrLanguageCode` from the per-file override still wins
-                // either way. "auto"/"" from that field is normal — it just
-                // means "use settings".
+                // over the manual setting when present. "auto" / "" from
+                // that field mean "use settings".
                 string perFileLang = !string.IsNullOrWhiteSpace(asrLanguageCode)
                     && !string.Equals(asrLanguageCode, "auto", StringComparison.OrdinalIgnoreCase)
                         ? asrLanguageCode
@@ -980,13 +975,13 @@ internal class TranscriptionService
 
                 var indicSupported = AsrLanguageSupport.Get(AsrBackend.IndicConformer);
 
-                // When AutoLid is on we grouper per-segment via the existing
-                // LID plumbing. lidByRid was set up above for the Cohere/
-                // Qwen3 branches; reuse it here.
-                bool useAutoLid = _settings.Current.IndicConformerAutoLid;
-                var groups = useAutoLid
-                    ? GroupSegmentsByLidLanguage(unfilledResultIds, lidByRid, fallback: perFileLang)
-                    : [new LidLanguageGroup(perFileLang, Enumerable.Range(0, segsSubset.Count).ToList())];
+                // GroupSegmentsByLidLanguage handles all three states
+                // uniformly: when lidByRid is null and there's no fallback
+                // LID, every segment lands in one group using perFileLang;
+                // when per-segment LID populated it, segments split by
+                // detected language.
+                var groups = GroupSegmentsByLidLanguage(
+                    unfilledResultIds, lidByRid, fallback: perFileLang);
 
                 foreach (var group in groups)
                 {

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -108,9 +108,10 @@ internal class TranscriptionService
         var (rawSamples, sampleRate, channels) = AudioUtils.ReadAudio(audioPath, streamIndex);
 
         // ── ASR backend / segmentation flags ─────────────────────────────────
-        bool useVibeVoiceAsr  = string.Equals(asrModelName, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
-        bool useCohereAsr     = string.Equals(asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
-        bool useQwen3Asr      = string.Equals(asrModelName, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
+        bool useVibeVoiceAsr     = string.Equals(asrModelName, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+        bool useCohereAsr        = string.Equals(asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+        bool useQwen3Asr         = string.Equals(asrModelName, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
+        bool useIndicConformerAsr = string.Equals(asrModelName, "ai4bharat/indic-conformer-600m-multilingual", StringComparison.Ordinal);
         var  segmentationMode = _settings.Current.Segmentation;
         bool runVibeVoice     = useVibeVoiceAsr || segmentationMode == SegmentationMode.VibeVoiceBuiltin;
 
@@ -641,9 +642,10 @@ internal class TranscriptionService
                                 // be switched TO here because its diarization path
                                 // runs earlier; AsrLanguageSupport.PickBestBackend
                                 // prefers Qwen3-ASR/Cohere/Parakeet in that order.)
-                                useVibeVoiceAsr = string.Equals(asrModelName, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
-                                useCohereAsr    = string.Equals(asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
-                                useQwen3Asr     = string.Equals(asrModelName, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
+                                useVibeVoiceAsr      = string.Equals(asrModelName, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+                                useCohereAsr         = string.Equals(asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+                                useQwen3Asr          = string.Equals(asrModelName, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
+                                useIndicConformerAsr = string.Equals(asrModelName, "ai4bharat/indic-conformer-600m-multilingual", StringComparison.Ordinal);
                                 // Reflect the switch in the results DB so the
                                 // Results view reads the *effective* backend
                                 // (and so the mismatch banner doesn't appear
@@ -946,6 +948,60 @@ internal class TranscriptionService
                             result.Text,
                             overridePercent));
                     }
+                }
+            }
+            else if (useIndicConformerAsr)
+            {
+                // IndicConformer has 22 per-language CTC heads; callers must
+                // pick one. If the user hasn't set IndicConformerLanguage (or
+                // asrLanguageCode from the per-file override) points at
+                // something the package doesn't cover, fall back to the
+                // setting's default (Hindi).
+                string indicLang = !string.IsNullOrWhiteSpace(asrLanguageCode)
+                    && !string.Equals(asrLanguageCode, "auto", StringComparison.OrdinalIgnoreCase)
+                        ? asrLanguageCode
+                        : _settings.Current.IndicConformerLanguage;
+                if (string.IsNullOrWhiteSpace(indicLang)) indicLang = "hi";
+
+                string indicModelsDir = _settings.GetIndicConformerModelsDir();
+                using var indic = new IndicConformer(indicModelsDir);
+                foreach (var (segId, text, tokens, timestamps, durations, logprobs) in
+                    indic.Recognize(segsSubset, audio, indicLang))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    int rid   = unfilledResultIds[segId];
+                    int absId = rid - 1;
+                    completed++;
+
+                    db.UpdateResult(
+                        resultId:   rid,
+                        asrContent: text,
+                        content:    text,
+                        tokens:     JsonSerializer.Serialize(tokens),
+                        timestamps: JsonSerializer.Serialize(timestamps),
+                        logprobs:   JsonSerializer.Serialize(logprobs),
+                        durations:  durations.Count > 0 ? JsonSerializer.Serialize(durations) : null,
+                        language:   indicLang);
+
+                    onSegmentText(absId, text);
+
+                    string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
+                        ["i"]     = completed.ToString(),
+                        ["count"] = totalSegs.ToString() });
+                    double? overridePercent = segmentationMode == SegmentationMode.DiariZen
+                        ? ScaleOverallProgress(
+                            DiariZenDiarizationPercentWeight,
+                            100,
+                            totalSegs > 0 ? completed / (double)totalSegs : 1)
+                        : null;
+                    progress.Report(new TranscriptionProgress(
+                        TranscriptionPhase.Recognizing,
+                        completed,
+                        totalSegs,
+                        asrText,
+                        absId,
+                        text,
+                        overridePercent));
                 }
             }
             else

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -952,56 +952,94 @@ internal class TranscriptionService
             }
             else if (useIndicConformerAsr)
             {
-                // IndicConformer has 22 per-language CTC heads; callers must
-                // pick one. If the user hasn't set IndicConformerLanguage (or
-                // asrLanguageCode from the per-file override) points at
-                // something the package doesn't cover, fall back to the
-                // setting's default (Hindi).
-                string indicLang = !string.IsNullOrWhiteSpace(asrLanguageCode)
+                // IndicConformer has 22 per-language CTC heads; one must be
+                // chosen per segment. Two modes:
+                //
+                //   - AutoLid ON: use per-segment LID (if enabled, else the
+                //     file-level detected_language) to pick the head. Groups
+                //     detected as one of IndicConformer's 22 supported codes
+                //     decode in that language; everything else falls back to
+                //     the user's manual pick. VoxLingua covers 14 of 22 —
+                //     the other 8 (brx, doi, kok, ks, mai, mni, or, sat)
+                //     always go through the fallback.
+                //
+                //   - AutoLid OFF: current behavior — all segments decode in
+                //     the manual language.
+                //
+                // `asrLanguageCode` from the per-file override still wins
+                // either way. "auto"/"" from that field is normal — it just
+                // means "use settings".
+                string perFileLang = !string.IsNullOrWhiteSpace(asrLanguageCode)
                     && !string.Equals(asrLanguageCode, "auto", StringComparison.OrdinalIgnoreCase)
                         ? asrLanguageCode
                         : _settings.Current.IndicConformerLanguage;
-                if (string.IsNullOrWhiteSpace(indicLang)) indicLang = "hi";
+                if (string.IsNullOrWhiteSpace(perFileLang)) perFileLang = "hi";
 
                 string indicModelsDir = _settings.GetIndicConformerModelsDir();
                 using var indic = new IndicConformer(indicModelsDir);
-                foreach (var (segId, text, tokens, timestamps, durations, logprobs) in
-                    indic.Recognize(segsSubset, audio, indicLang))
+
+                var indicSupported = AsrLanguageSupport.Get(AsrBackend.IndicConformer);
+
+                // When AutoLid is on we grouper per-segment via the existing
+                // LID plumbing. lidByRid was set up above for the Cohere/
+                // Qwen3 branches; reuse it here.
+                bool useAutoLid = _settings.Current.IndicConformerAutoLid;
+                var groups = useAutoLid
+                    ? GroupSegmentsByLidLanguage(unfilledResultIds, lidByRid, fallback: perFileLang)
+                    : [new LidLanguageGroup(perFileLang, Enumerable.Range(0, segsSubset.Count).ToList())];
+
+                foreach (var group in groups)
                 {
-                    ct.ThrowIfCancellationRequested();
-                    int rid   = unfilledResultIds[segId];
-                    int absId = rid - 1;
-                    completed++;
+                    // Normalise the group's language through IndicConformer's
+                    // supported set. If LID produced something outside the 22
+                    // (or a code IndicConformer doesn't expose, like "en"),
+                    // fall back to the manual choice.
+                    string groupLang = group.ForceLanguage ?? perFileLang;
+                    if (!indicSupported.Contains(AsrLanguageSupport.NormalizeIso(groupLang)))
+                        groupLang = perFileLang;
 
-                    db.UpdateResult(
-                        resultId:   rid,
-                        asrContent: text,
-                        content:    text,
-                        tokens:     JsonSerializer.Serialize(tokens),
-                        timestamps: JsonSerializer.Serialize(timestamps),
-                        logprobs:   JsonSerializer.Serialize(logprobs),
-                        durations:  durations.Count > 0 ? JsonSerializer.Serialize(durations) : null,
-                        language:   indicLang);
+                    var groupSegs = group.LocalIndices.Select(i => segsSubset[i]).ToList();
+                    if (groupSegs.Count == 0) continue;
 
-                    onSegmentText(absId, text);
+                    foreach (var (segId, text, tokens, timestamps, durations, logprobs) in
+                        indic.Recognize(groupSegs, audio, groupLang))
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        int localIdx = group.LocalIndices[segId];
+                        int rid      = unfilledResultIds[localIdx];
+                        int absId    = rid - 1;
+                        completed++;
 
-                    string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
-                        ["i"]     = completed.ToString(),
-                        ["count"] = totalSegs.ToString() });
-                    double? overridePercent = segmentationMode == SegmentationMode.DiariZen
-                        ? ScaleOverallProgress(
-                            DiariZenDiarizationPercentWeight,
-                            100,
-                            totalSegs > 0 ? completed / (double)totalSegs : 1)
-                        : null;
-                    progress.Report(new TranscriptionProgress(
-                        TranscriptionPhase.Recognizing,
-                        completed,
-                        totalSegs,
-                        asrText,
-                        absId,
-                        text,
-                        overridePercent));
+                        db.UpdateResult(
+                            resultId:   rid,
+                            asrContent: text,
+                            content:    text,
+                            tokens:     JsonSerializer.Serialize(tokens),
+                            timestamps: JsonSerializer.Serialize(timestamps),
+                            logprobs:   JsonSerializer.Serialize(logprobs),
+                            durations:  durations.Count > 0 ? JsonSerializer.Serialize(durations) : null,
+                            language:   groupLang);
+
+                        onSegmentText(absId, text);
+
+                        string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
+                            ["i"]     = completed.ToString(),
+                            ["count"] = totalSegs.ToString() });
+                        double? overridePercent = segmentationMode == SegmentationMode.DiariZen
+                            ? ScaleOverallProgress(
+                                DiariZenDiarizationPercentWeight,
+                                100,
+                                totalSegs > 0 ? completed / (double)totalSegs : 1)
+                            : null;
+                        progress.Report(new TranscriptionProgress(
+                            TranscriptionPhase.Recognizing,
+                            completed,
+                            totalSegs,
+                            asrText,
+                            absId,
+                            text,
+                            overridePercent));
+                    }
                 }
             }
             else

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -13,7 +13,7 @@ namespace Vernacula.App.Services;
 /// </summary>
 internal class VocabService
 {
-    private enum VocabKind { Parakeet, Cohere, Qwen3Asr, VibeVoice }
+    private enum VocabKind { Parakeet, Cohere, Qwen3Asr, VibeVoice, IndicConformer }
 
     private readonly Dictionary<int, string> _vocab;
     private readonly VocabKind _kind;
@@ -39,11 +39,40 @@ internal class VocabService
             (_vocab, _addedContent) = LoadVibeVoiceVocab(Path.Combine(modelsDir, Config.Qwen3AsrSubDir, Qwen3Asr.TokenizerFile));
             _byteLevelDecode = BuildByteLevelDecode();
         }
+        else if (string.Equals(asrModel, "ai4bharat/indic-conformer-600m-multilingual", StringComparison.Ordinal))
+        {
+            _kind = VocabKind.IndicConformer;
+            _vocab = LoadIndicConformerVocab(Path.Combine(modelsDir, Config.IndicConformerSubDir, Config.VocabFile));
+        }
         else
         {
             _kind = VocabKind.Parakeet;
             _vocab = LoadParakeetVocab(Path.Combine(modelsDir, Config.VocabFile));
         }
+    }
+
+    /// <summary>
+    /// IndicConformer's vocab.txt is one token per line (id = line index),
+    /// no trailing blank row. SentencePiece-style: pieces starting with
+    /// U+2581 (▁) mark word boundaries. Replace at load time so concat in
+    /// GetTokenRuns yields space-separated words, matching the Parakeet
+    /// decoder's convention. Blank line tolerant only at EOF — mid-file
+    /// blanks would mis-align ids and are silently skipped (load will
+    /// still produce a working vocab with holes rather than a shifted one).
+    /// </summary>
+    private static Dictionary<int, string> LoadIndicConformerVocab(string vocabPath)
+    {
+        var vocab = new Dictionary<int, string>();
+        if (!File.Exists(vocabPath)) return vocab;
+
+        int id = 0;
+        foreach (var rawLine in File.ReadLines(vocabPath))
+        {
+            if (!string.IsNullOrEmpty(rawLine))
+                vocab[id] = rawLine.Replace("\u2581", " ");
+            id++;
+        }
+        return vocab;
     }
 
     // ── Vocab loading (mirrors Parakeet.GetVocab) ────────────────────────────
@@ -204,7 +233,7 @@ internal class VocabService
         if (!_vocab.TryGetValue(token, out var value))
             return "";
 
-        if (_kind == VocabKind.Parakeet)
+        if (_kind == VocabKind.Parakeet || _kind == VocabKind.IndicConformer)
             return value;
 
         if (_kind == VocabKind.VibeVoice)

--- a/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
@@ -82,6 +82,8 @@ internal partial class HomeViewModel : ObservableObject
         else if (_settings.Current.AsrBackend == AsrBackend.VibeVoice ||
                  _settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.VibeVoiceBuiltin)
             ModelStatusText = $"VibeVoice-ASR weights are missing. Use Download Missing Models, or place them in {_settings.GetVibeVoiceModelsDir()}.";
+        else if (_settings.Current.AsrBackend == AsrBackend.IndicConformer)
+            ModelStatusText = $"IndicConformer weights are missing. Place them in {_settings.GetIndicConformerModelsDir()}.";
         else if (_settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen)
             ModelStatusText = "DiariZen external weights are missing. Open Settings to review the notice and import or download them.";
         else

--- a/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
@@ -109,10 +109,11 @@ internal partial class MainViewModel : ObservableObject
         {
             string asrModelName = backend switch
             {
-                AsrBackend.Parakeet  => "nvidia/parakeet-tdt-0.6b-v3",
-                AsrBackend.Cohere    => "CohereLabs/cohere-transcribe-03-2026",
-                AsrBackend.Qwen3Asr  => "Qwen/Qwen3-ASR-1.7B",
-                AsrBackend.VibeVoice => "vibevoice/vibevoice-asr",
+                AsrBackend.Parakeet       => "nvidia/parakeet-tdt-0.6b-v3",
+                AsrBackend.Cohere         => "CohereLabs/cohere-transcribe-03-2026",
+                AsrBackend.Qwen3Asr       => "Qwen/Qwen3-ASR-1.7B",
+                AsrBackend.VibeVoice      => "vibevoice/vibevoice-asr",
+                AsrBackend.IndicConformer => "ai4bharat/indic-conformer-600m-multilingual",
                 _ => throw new ArgumentOutOfRangeException(nameof(backend)),
             };
             controlDb.UpdateJobAsr(jobId, asrModelName, detectedIso);

--- a/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/ProgressViewModel.cs
@@ -346,19 +346,32 @@ internal partial class ProgressViewModel : ObservableObject
 
     private string GetJobAsrModelName() => _settings.Current.AsrBackend switch
     {
-        AsrBackend.Cohere => "CohereLabs/cohere-transcribe-03-2026",
-        AsrBackend.Qwen3Asr => "Qwen/Qwen3-ASR-1.7B",
-        _                 => "nvidia/parakeet-tdt-0.6b-v3",
+        AsrBackend.Cohere         => "CohereLabs/cohere-transcribe-03-2026",
+        AsrBackend.Qwen3Asr       => "Qwen/Qwen3-ASR-1.7B",
+        AsrBackend.VibeVoice      => "vibevoice/vibevoice-asr",
+        AsrBackend.IndicConformer => "ai4bharat/indic-conformer-600m-multilingual",
+        _                         => "nvidia/parakeet-tdt-0.6b-v3",
     };
 
     private string GetJobAsrLanguageCode()
     {
-        if (_settings.Current.AsrBackend != AsrBackend.Cohere)
-            return "auto";
-
-        return string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
-            ? "auto"
-            : _settings.Current.CohereLanguage;
+        // IndicConformer requires a language at inference and stores the
+        // chosen code (not "auto"); Cohere stores a code or empty for
+        // auto-detect. Every other backend uses "auto" for the pipeline.
+        var backend = _settings.Current.AsrBackend;
+        if (backend == AsrBackend.IndicConformer)
+        {
+            return string.IsNullOrWhiteSpace(_settings.Current.IndicConformerLanguage)
+                ? "hi"
+                : _settings.Current.IndicConformerLanguage;
+        }
+        if (backend == AsrBackend.Cohere)
+        {
+            return string.IsNullOrWhiteSpace(_settings.Current.CohereLanguage)
+                ? "auto"
+                : _settings.Current.CohereLanguage;
+        }
+        return "auto";
     }
 
     // ── Shared helpers ────────────────────────────────────────────────────────

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -31,7 +31,7 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrIndicConformer), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker), nameof(ShowIndicConformerAutoLidWarning))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrIndicConformer), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -102,10 +102,6 @@ internal partial class SettingsViewModel : ObservableObject
     private AsrLanguageOption? _selectedIndicConformerLanguage;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(ShowIndicConformerAutoLidWarning), nameof(IndicConformerLanguagePickerLabel), nameof(IndicConformerLanguagePickerDescription))]
-    private bool _useIndicConformerAutoLid;
-
-    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDenoiserNone), nameof(IsDenoiserDfn3))]
     private DenoiserMode _selectedDenoiser;
 
@@ -144,18 +140,6 @@ internal partial class SettingsViewModel : ObservableObject
     public bool ShowCohereLanguagePicker         => SelectedAsrBackend == AsrBackend.Cohere;
     public bool ShowQwen3AsrLanguagePicker       => SelectedAsrBackend == AsrBackend.Qwen3Asr;
     public bool ShowIndicConformerLanguagePicker => SelectedAsrBackend == AsrBackend.IndicConformer;
-    public bool ShowIndicConformerAutoLidWarning =>
-        SelectedAsrBackend == AsrBackend.IndicConformer && UseIndicConformerAutoLid;
-
-    /// <summary>Label flips between "Language" (manual) and "Manual fallback
-    /// language" (auto mode) so the picker's role is obvious when LID is
-    /// driving most of the choice.</summary>
-    public string IndicConformerLanguagePickerLabel =>
-        UseIndicConformerAutoLid ? "Manual fallback language" : "Language";
-
-    public string IndicConformerLanguagePickerDescription => UseIndicConformerAutoLid
-        ? "Used for segments whose language wasn't detected, or when the detected language isn't one of the 14 LID-supported Indic languages."
-        : "Required. IndicConformer has 22 per-language CTC heads and needs one selected at inference.";
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
     public bool ShowStandardSegmentationOptions => SelectedAsrBackend != AsrBackend.VibeVoice;
@@ -331,7 +315,6 @@ internal partial class SettingsViewModel : ObservableObject
         _selectedIndicConformerLanguage = IndicConformerLanguages.FirstOrDefault(l => l.Code == svc.Current.IndicConformerLanguage)
                                         ?? IndicConformerLanguages.FirstOrDefault(l => l.Code == "hi")
                                         ?? IndicConformerLanguages[0];
-        _useIndicConformerAutoLid     = svc.Current.IndicConformerAutoLid;
         _parakeetBeamWidth            = Math.Max(1, svc.Current.ParakeetBeamWidth);
         _selectedLmOption             = KenLmCatalog.Find(svc.Current.ParakeetLmSelection) ?? KenLmCatalog.All[0];
         // If the user's saved selection is a built-in option whose file isn't
@@ -448,12 +431,6 @@ internal partial class SettingsViewModel : ObservableObject
         // No "auto" entry for IndicConformer — if someone binds null through a
         // cleared combo, fall back to the last good code rather than persist "".
         _svc.Current.IndicConformerLanguage = value?.Code ?? _svc.Current.IndicConformerLanguage;
-        _svc.Save();
-    }
-
-    partial void OnUseIndicConformerAutoLidChanged(bool value)
-    {
-        _svc.Current.IndicConformerAutoLid = value;
         _svc.Save();
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -31,7 +31,7 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrIndicConformer), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrIndicConformer), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker), nameof(ShowIndicConformerAutoLidWarning))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -102,6 +102,10 @@ internal partial class SettingsViewModel : ObservableObject
     private AsrLanguageOption? _selectedIndicConformerLanguage;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowIndicConformerAutoLidWarning), nameof(IndicConformerLanguagePickerLabel), nameof(IndicConformerLanguagePickerDescription))]
+    private bool _useIndicConformerAutoLid;
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDenoiserNone), nameof(IsDenoiserDfn3))]
     private DenoiserMode _selectedDenoiser;
 
@@ -140,6 +144,18 @@ internal partial class SettingsViewModel : ObservableObject
     public bool ShowCohereLanguagePicker         => SelectedAsrBackend == AsrBackend.Cohere;
     public bool ShowQwen3AsrLanguagePicker       => SelectedAsrBackend == AsrBackend.Qwen3Asr;
     public bool ShowIndicConformerLanguagePicker => SelectedAsrBackend == AsrBackend.IndicConformer;
+    public bool ShowIndicConformerAutoLidWarning =>
+        SelectedAsrBackend == AsrBackend.IndicConformer && UseIndicConformerAutoLid;
+
+    /// <summary>Label flips between "Language" (manual) and "Manual fallback
+    /// language" (auto mode) so the picker's role is obvious when LID is
+    /// driving most of the choice.</summary>
+    public string IndicConformerLanguagePickerLabel =>
+        UseIndicConformerAutoLid ? "Manual fallback language" : "Language";
+
+    public string IndicConformerLanguagePickerDescription => UseIndicConformerAutoLid
+        ? "Used for segments whose language wasn't detected, or when the detected language isn't one of the 14 LID-supported Indic languages."
+        : "Required. IndicConformer has 22 per-language CTC heads and needs one selected at inference.";
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
     public bool ShowStandardSegmentationOptions => SelectedAsrBackend != AsrBackend.VibeVoice;
@@ -315,6 +331,7 @@ internal partial class SettingsViewModel : ObservableObject
         _selectedIndicConformerLanguage = IndicConformerLanguages.FirstOrDefault(l => l.Code == svc.Current.IndicConformerLanguage)
                                         ?? IndicConformerLanguages.FirstOrDefault(l => l.Code == "hi")
                                         ?? IndicConformerLanguages[0];
+        _useIndicConformerAutoLid     = svc.Current.IndicConformerAutoLid;
         _parakeetBeamWidth            = Math.Max(1, svc.Current.ParakeetBeamWidth);
         _selectedLmOption             = KenLmCatalog.Find(svc.Current.ParakeetLmSelection) ?? KenLmCatalog.All[0];
         // If the user's saved selection is a built-in option whose file isn't
@@ -431,6 +448,12 @@ internal partial class SettingsViewModel : ObservableObject
         // No "auto" entry for IndicConformer — if someone binds null through a
         // cleared combo, fall back to the last good code rather than persist "".
         _svc.Current.IndicConformerLanguage = value?.Code ?? _svc.Current.IndicConformerLanguage;
+        _svc.Save();
+    }
+
+    partial void OnUseIndicConformerAutoLidChanged(bool value)
+    {
+        _svc.Current.IndicConformerAutoLid = value;
         _svc.Save();
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -31,7 +31,7 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrIndicConformer), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -99,6 +99,9 @@ internal partial class SettingsViewModel : ObservableObject
     private AsrLanguageOption? _selectedQwen3AsrLanguage;
 
     [ObservableProperty]
+    private AsrLanguageOption? _selectedIndicConformerLanguage;
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDenoiserNone), nameof(IsDenoiserDfn3))]
     private DenoiserMode _selectedDenoiser;
 
@@ -128,13 +131,15 @@ internal partial class SettingsViewModel : ObservableObject
     public bool IsAsrCohere         => SelectedAsrBackend == AsrBackend.Cohere;
     public bool IsAsrQwen3Asr       => SelectedAsrBackend == AsrBackend.Qwen3Asr;
     public bool IsAsrVibeVoice      => SelectedAsrBackend == AsrBackend.VibeVoice;
+    public bool IsAsrIndicConformer => SelectedAsrBackend == AsrBackend.IndicConformer;
     public bool CanUseVibeVoiceAsr  => CudaEpWorking;
     public string VibeVoiceAsrLabel => CanUseVibeVoiceAsr ? "VibeVoice-ASR" : "VibeVoice-ASR (Unavailable - CUDA Missing)";
     public string VibeVoiceAsrDescription => CanUseVibeVoiceAsr
         ? "Whole-recording ASR with built-in diarization. Downloads into the vibevoice_asr models folder."
         : "Unavailable because the CUDA execution provider check did not pass.";
-    public bool ShowCohereLanguagePicker   => SelectedAsrBackend == AsrBackend.Cohere;
-    public bool ShowQwen3AsrLanguagePicker => SelectedAsrBackend == AsrBackend.Qwen3Asr;
+    public bool ShowCohereLanguagePicker         => SelectedAsrBackend == AsrBackend.Cohere;
+    public bool ShowQwen3AsrLanguagePicker       => SelectedAsrBackend == AsrBackend.Qwen3Asr;
+    public bool ShowIndicConformerLanguagePicker => SelectedAsrBackend == AsrBackend.IndicConformer;
     public bool IsDenoiserNone      => SelectedDenoiser == DenoiserMode.None;
     public bool IsDenoiserDfn3      => SelectedDenoiser == DenoiserMode.DeepFilterNet3;
     public bool ShowStandardSegmentationOptions => SelectedAsrBackend != AsrBackend.VibeVoice;
@@ -200,6 +205,37 @@ internal partial class SettingsViewModel : ObservableObject
         new("th", "Thai"),
         new("tr", "Turkish"),
         new("vi", "Vietnamese"),
+    ];
+
+    // AI4Bharat IndicConformer 600M — the 22 official Indian languages.
+    // Unlike Cohere/Qwen3 there is no "auto-detect" option: the model has
+    // 22 distinct per-language CTC heads and picking one is required at
+    // inference. Five codes use ISO 639-3 because they have no 639-1
+    // assignment (brx, doi, kok, mai, mni, sat); seventeen use 639-1.
+    public static readonly IReadOnlyList<AsrLanguageOption> IndicConformerLanguages =
+    [
+        new("as",  "Assamese"),
+        new("bn",  "Bengali"),
+        new("brx", "Bodo"),
+        new("doi", "Dogri"),
+        new("gu",  "Gujarati"),
+        new("hi",  "Hindi"),
+        new("kn",  "Kannada"),
+        new("kok", "Konkani"),
+        new("ks",  "Kashmiri"),
+        new("mai", "Maithili"),
+        new("ml",  "Malayalam"),
+        new("mni", "Manipuri"),
+        new("mr",  "Marathi"),
+        new("ne",  "Nepali"),
+        new("or",  "Odia"),
+        new("pa",  "Punjabi"),
+        new("sa",  "Sanskrit"),
+        new("sat", "Santali"),
+        new("sd",  "Sindhi"),
+        new("ta",  "Tamil"),
+        new("te",  "Telugu"),
+        new("ur",  "Urdu"),
     ];
 
     // ── Hardware check state ─────────────────────────────────────────────────
@@ -276,6 +312,9 @@ internal partial class SettingsViewModel : ObservableObject
                                         ?? CohereLanguages[0];
         _selectedQwen3AsrLanguage     = Qwen3AsrLanguages.FirstOrDefault(l => l.Code == svc.Current.Qwen3AsrLanguage)
                                         ?? Qwen3AsrLanguages[0];
+        _selectedIndicConformerLanguage = IndicConformerLanguages.FirstOrDefault(l => l.Code == svc.Current.IndicConformerLanguage)
+                                        ?? IndicConformerLanguages.FirstOrDefault(l => l.Code == "hi")
+                                        ?? IndicConformerLanguages[0];
         _parakeetBeamWidth            = Math.Max(1, svc.Current.ParakeetBeamWidth);
         _selectedLmOption             = KenLmCatalog.Find(svc.Current.ParakeetLmSelection) ?? KenLmCatalog.All[0];
         // If the user's saved selection is a built-in option whose file isn't
@@ -384,6 +423,14 @@ internal partial class SettingsViewModel : ObservableObject
     partial void OnSelectedQwen3AsrLanguageChanged(AsrLanguageOption? value)
     {
         _svc.Current.Qwen3AsrLanguage = value?.Code ?? "";
+        _svc.Save();
+    }
+
+    partial void OnSelectedIndicConformerLanguageChanged(AsrLanguageOption? value)
+    {
+        // No "auto" entry for IndicConformer — if someone binds null through a
+        // cleared combo, fall back to the last good code rather than persist "".
+        _svc.Current.IndicConformerLanguage = value?.Code ?? _svc.Current.IndicConformerLanguage;
         _svc.Save();
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1011,6 +1011,13 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     public void RefreshFocusedCardAsrHighlighting(TranscriptEditorCardState card, VocabService? vocab,
         Color confidenceLowColor, Color accentColor, IBrush textBrush, int highlightedToken)
     {
+        // Set direction once per focus refresh. Prefer the segment's stored
+        // `language` (what the ASR pass decoded against), fall back to the
+        // LID-detected language if the ASR pass didn't persist one.
+        string? dirLang = card.Segment.Language ?? card.Segment.LidLanguage;
+        card.AsrFlowDirection = AsrLanguageSupport.IsRtl(dirLang)
+            ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+
         if (vocab == null || card.Segment.Tokens.Count == 0)
         {
             card.RebuildAsrRuns([(card.Segment.AsrContent, Colors.Transparent)], textBrush);

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -488,6 +488,24 @@
                             </StackPanel>
                         </RadioButton>
 
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+
+                        <RadioButton GroupName="AsrBackend"
+                                     IsChecked="{Binding IsAsrIndicConformer, Mode=OneWay}"
+                                     Command="{Binding SetAsrBackendCommand}"
+                                     CommandParameter="IndicConformer"
+                                     Foreground="{DynamicResource TextBrush}">
+                            <StackPanel>
+                                <TextBlock Text="IndicConformer 600M"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextBrush}" />
+                                <TextBlock Text="AI4Bharat's 22-language Indic ASR (Hindi, Bengali, Tamil, Telugu, Marathi, …). Place the exported package in the indicconformer models folder. A per-file language must be selected below — there's no auto-detect."
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </RadioButton>
+
                         <StackPanel Margin="24,10,0,0"
                                     IsVisible="{Binding IsAsrParakeet}">
                             <TextBlock Text="TDT beam width"
@@ -646,6 +664,32 @@
                                        Margin="0,0,0,8" />
                             <ComboBox ItemsSource="{x:Static vm:SettingsViewModel.Qwen3AsrLanguages}"
                                       SelectedItem="{Binding SelectedQwen3AsrLanguage}"
+                                      Background="{DynamicResource OverlayBrush}"
+                                      Foreground="{DynamicResource TextBrush}"
+                                      BorderBrush="{DynamicResource OverlayBrush}"
+                                      HorizontalAlignment="Left"
+                                      MinWidth="220">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+
+                        <StackPanel Margin="24,10,0,0"
+                                    IsVisible="{Binding ShowIndicConformerLanguagePicker}">
+                            <TextBlock Text="Language"
+                                       Foreground="{DynamicResource TextBrush}"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,0,6" />
+                            <TextBlock Text="Required. IndicConformer has 22 per-language CTC heads and needs one selected at inference."
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <ComboBox ItemsSource="{x:Static vm:SettingsViewModel.IndicConformerLanguages}"
+                                      SelectedItem="{Binding SelectedIndicConformerLanguage}"
                                       Background="{DynamicResource OverlayBrush}"
                                       Foreground="{DynamicResource TextBrush}"
                                       BorderBrush="{DynamicResource OverlayBrush}"

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -679,45 +679,18 @@
 
                         <StackPanel Margin="24,10,0,0"
                                     IsVisible="{Binding ShowIndicConformerLanguagePicker}">
-                            <CheckBox IsChecked="{Binding UseIndicConformerAutoLid}"
-                                      Content="LID-driven auto (pick language per segment)"
-                                      Foreground="{DynamicResource TextBrush}"
-                                      Margin="0,0,0,4" />
-                            <TextBlock Text="When on, VoxLingua107 picks the decoder language per segment. Requires language identification to be enabled below."
-                                       Foreground="{DynamicResource SubtextBrush}"
-                                       FontSize="11"
-                                       TextWrapping="Wrap"
-                                       Margin="24,0,0,8" />
-
-                            <Border IsVisible="{Binding ShowIndicConformerAutoLidWarning}"
-                                    Background="{DynamicResource OverlayBrush}"
-                                    BorderBrush="{DynamicResource SubtextBrush}"
-                                    BorderThickness="1"
-                                    CornerRadius="4"
-                                    Padding="10"
-                                    Margin="0,0,0,10">
-                                <StackPanel>
-                                    <TextBlock Text="LID covers 14 of 22 IndicConformer languages"
-                                               Foreground="{DynamicResource TextBrush}"
-                                               FontWeight="SemiBold"
-                                               FontSize="12" />
-                                    <TextBlock Text="VoxLingua107 cannot identify these eight. Segments whose language LID can't detect — or ones that come back as one of these — use the manual fallback below: Bodo, Dogri, Konkani, Kashmiri, Maithili, Manipuri, Odia, Santali."
-                                               Foreground="{DynamicResource SubtextBrush}"
-                                               FontSize="11"
-                                               TextWrapping="Wrap"
-                                               Margin="0,4,0,0" />
-                                </StackPanel>
-                            </Border>
-
-                            <TextBlock Text="{Binding IndicConformerLanguagePickerLabel}"
+                            <TextBlock Text="Language"
                                        Foreground="{DynamicResource TextBrush}"
                                        FontWeight="SemiBold"
                                        Margin="0,0,0,6" />
-                            <TextBlock Text="{Binding IndicConformerLanguagePickerDescription}"
+                            <TextBlock TextWrapping="Wrap"
                                        Foreground="{DynamicResource SubtextBrush}"
                                        FontSize="11"
-                                       TextWrapping="Wrap"
-                                       Margin="0,0,0,8" />
+                                       Margin="0,0,0,8">
+                                <Run Text="Required. IndicConformer has 22 per-language CTC heads and needs one selected at inference." />
+                                <LineBreak />
+                                <Run Text="When Language Identification is enabled below, LID picks the decoder language per segment; this setting is the fallback for the 8 languages VoxLingua doesn't cover (Bodo, Dogri, Konkani, Kashmiri, Maithili, Manipuri, Odia, Santali)." />
+                            </TextBlock>
                             <ComboBox ItemsSource="{x:Static vm:SettingsViewModel.IndicConformerLanguages}"
                                       SelectedItem="{Binding SelectedIndicConformerLanguage}"
                                       Background="{DynamicResource OverlayBrush}"

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -679,11 +679,41 @@
 
                         <StackPanel Margin="24,10,0,0"
                                     IsVisible="{Binding ShowIndicConformerLanguagePicker}">
-                            <TextBlock Text="Language"
+                            <CheckBox IsChecked="{Binding UseIndicConformerAutoLid}"
+                                      Content="LID-driven auto (pick language per segment)"
+                                      Foreground="{DynamicResource TextBrush}"
+                                      Margin="0,0,0,4" />
+                            <TextBlock Text="When on, VoxLingua107 picks the decoder language per segment. Requires language identification to be enabled below."
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11"
+                                       TextWrapping="Wrap"
+                                       Margin="24,0,0,8" />
+
+                            <Border IsVisible="{Binding ShowIndicConformerAutoLidWarning}"
+                                    Background="{DynamicResource OverlayBrush}"
+                                    BorderBrush="{DynamicResource SubtextBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4"
+                                    Padding="10"
+                                    Margin="0,0,0,10">
+                                <StackPanel>
+                                    <TextBlock Text="LID covers 14 of 22 IndicConformer languages"
+                                               Foreground="{DynamicResource TextBrush}"
+                                               FontWeight="SemiBold"
+                                               FontSize="12" />
+                                    <TextBlock Text="VoxLingua107 cannot identify these eight. Segments whose language LID can't detect — or ones that come back as one of these — use the manual fallback below: Bodo, Dogri, Konkani, Kashmiri, Maithili, Manipuri, Odia, Santali."
+                                               Foreground="{DynamicResource SubtextBrush}"
+                                               FontSize="11"
+                                               TextWrapping="Wrap"
+                                               Margin="0,4,0,0" />
+                                </StackPanel>
+                            </Border>
+
+                            <TextBlock Text="{Binding IndicConformerLanguagePickerLabel}"
                                        Foreground="{DynamicResource TextBrush}"
                                        FontWeight="SemiBold"
                                        Margin="0,0,0,6" />
-                            <TextBlock Text="Required. IndicConformer has 22 per-language CTC heads and needs one selected at inference."
+                            <TextBlock Text="{Binding IndicConformerLanguagePickerDescription}"
                                        Foreground="{DynamicResource SubtextBrush}"
                                        FontSize="11"
                                        TextWrapping="Wrap"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml
@@ -544,7 +544,8 @@
                                                               MaxHeight="214"
                                                               VerticalScrollBarVisibility="Auto"
                                                               HorizontalScrollBarVisibility="Disabled">
-                                                    <ItemsControl ItemsSource="{Binding AsrRuns}">
+                                                    <ItemsControl ItemsSource="{Binding AsrRuns}"
+                                                                  FlowDirection="{Binding AsrFlowDirection}">
                                                         <ItemsControl.ItemsPanel>
                                                             <ItemsPanelTemplate>
                                                                 <WrapPanel />
@@ -576,6 +577,7 @@
                                                          Text="{Binding DraftContent, Mode=TwoWay}"
                                                          AcceptsReturn="True"
                                                          TextWrapping="Wrap"
+                                                         FlowDirection="{Binding AsrFlowDirection}"
                                                          VerticalContentAlignment="Top"
                                                          MinHeight="84"
                                                          MaxHeight="214"

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -98,9 +98,10 @@ public partial class TranscriptEditorWindow : Window
         _jobAsrLanguageCode = string.IsNullOrWhiteSpace(asrLanguageCode)
             ? "auto"
             : asrLanguageCode;
-        bool isCohere    = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
-        bool isQwen3Asr  = string.Equals(_jobAsrModel, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
-        bool isVibeVoice = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+        bool isCohere         = string.Equals(_jobAsrModel, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
+        bool isQwen3Asr       = string.Equals(_jobAsrModel, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
+        bool isVibeVoice      = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
+        bool isIndicConformer = string.Equals(_jobAsrModel, "ai4bharat/indic-conformer-600m-multilingual", StringComparison.Ordinal);
         _isQwen3Asr = isQwen3Asr;
         _showApproximateTimingNotice = isCohere || isQwen3Asr || isVibeVoice;
         _approximateTimingNoticeText = isCohere
@@ -117,11 +118,14 @@ public partial class TranscriptEditorWindow : Window
                 ? Path.Combine(modelsDir, Config.Qwen3AsrSubDir, Qwen3Asr.TokenizerFile)
             : isVibeVoice
                 ? Path.Combine(modelsDir, Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile)
+            : isIndicConformer
+                ? Path.Combine(modelsDir, Config.IndicConformerSubDir, Config.VocabFile)
                 : Path.Combine(parakeetModelsDir, Config.VocabFile);
         if (vocabPath is not null && File.Exists(vocabPath))
         {
             _vocab = new VocabService(
-                isCohere || isQwen3Asr || isVibeVoice ? App.Current.Settings.GetModelsDir() : parakeetModelsDir,
+                isCohere || isQwen3Asr || isVibeVoice || isIndicConformer
+                    ? App.Current.Settings.GetModelsDir() : parakeetModelsDir,
                 _jobAsrModel);
         }
 

--- a/src/Vernacula.Base/Config.cs
+++ b/src/Vernacula.Base/Config.cs
@@ -247,6 +247,11 @@ public static class Config
     public const string DecoderJointFileInt8 = "decoder_joint-model.int8.onnx";
     public const string VocabFile            = "vocab.txt";
     public const string AsrConfigFile        = "config.json";
+
+    // ── ASR (IndicConformer) ────────────────────────────────────────────────
+    public const string IndicConformerSubDir             = "indicconformer";
+    public const string CtcDecoderFile                   = "ctc_decoder-model.onnx";
+    public const string IndicConformerLanguageSpansFile  = "language_spans.json";
     public const int    MaxTokensPerStep     = 10;
     public const int    MaxBatchSize         = 32;
 

--- a/src/Vernacula.Base/IndicConformer.cs
+++ b/src/Vernacula.Base/IndicConformer.cs
@@ -1,0 +1,577 @@
+using System.Text.Json;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Models;
+
+namespace Vernacula.Base;
+
+/// <summary>
+/// AI4Bharat IndicConformer (Hybrid CTC-RNNT, CTC head only) — C# port of
+/// the validate_indicconformer_package.py reference decoder, matching the
+/// ONNX shipping package produced by scripts/indicconformer_export/ and
+/// scripts/indicconformer_export/repackage_600m_indicconformer.py.
+///
+/// Mirrors <see cref="Parakeet"/>'s public surface so
+/// <c>TranscriptionService</c> can swap backends without special-casing,
+/// but the decoder runs a shared-encoder + per-language-span greedy CTC
+/// collapse instead of an RNNT loop. Blank is implicit at id = vocab
+/// size; the shared CTC dim is vocab_size + 1 (5633 for the published
+/// 22-language checkpoint). Per-call <c>lang</c> picks which 256-token
+/// span to decode into.
+///
+/// Helpers like <see cref="PadList"/>, <see cref="SegmentWaveform"/>, and
+/// the VRAM-bounded batcher are duplicated verbatim from
+/// <see cref="Parakeet"/> on this first pass; extracting them into a
+/// shared <c>AsrUtils</c> is follow-up work.
+/// </summary>
+public sealed class IndicConformer : IDisposable
+{
+    private readonly string _modelPath;
+
+    private readonly InferenceSession _preprocessor;
+    private readonly InferenceSession _encoder;
+    private readonly InferenceSession _ctcDecoder;
+
+    /// <summary>Flat vocab, index-addressed (ids 0..vocab_size-1).</summary>
+    private readonly string[] _vocab;
+
+    /// <summary>Per-language [start, length] into the flat vocab.</summary>
+    private readonly Dictionary<string, (int start, int length)> _langSpans;
+
+    /// <summary>CTC blank token id — always equals <see cref="_vocab"/>.Length.</summary>
+    private readonly int _blankIdx;
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    public IndicConformer(string modelPath)
+        : this(modelPath, Config.EncoderFile, Config.CtcDecoderFile) { }
+
+    public IndicConformer(
+        string modelPath,
+        string encoderFile,
+        string ctcDecoderFile,
+        ExecutionProvider ep = ExecutionProvider.Auto)
+    {
+        _modelPath = modelPath;
+
+        var cpuOpts = new SessionOptions();
+        _preprocessor = new InferenceSession(
+            Path.Combine(modelPath, Config.PreprocessorFile), cpuOpts);
+
+        var gpuOpts = MakeSessionOptions(ep);
+        _encoder    = new InferenceSession(Path.Combine(modelPath, encoderFile),    gpuOpts);
+        _ctcDecoder = new InferenceSession(Path.Combine(modelPath, ctcDecoderFile), gpuOpts);
+
+        _vocab     = LoadFlatVocab(Path.Combine(modelPath, Config.VocabFile));
+        _langSpans = LoadLanguageSpans(Path.Combine(modelPath, Config.IndicConformerLanguageSpansFile));
+        _blankIdx  = _vocab.Length;
+    }
+
+    private static SessionOptions MakeSessionOptions(ExecutionProvider ep)
+    {
+        var opts = new SessionOptions();
+        switch (ep)
+        {
+            case ExecutionProvider.Auto:
+                if (HardwareInfo.CanProbeCudaExecutionProvider())
+                {
+                    try { opts.AppendExecutionProvider_CUDA(0); } catch { }
+                }
+                try { opts.AppendExecutionProvider_DML(0); } catch { }
+                break;
+            case ExecutionProvider.Cuda:
+                try { opts.AppendExecutionProvider_CUDA(0); }
+                catch (EntryPointNotFoundException)
+                { throw new InvalidOperationException("CUDA EP not available in current OnnxRuntime build."); }
+                break;
+            case ExecutionProvider.DirectML:
+                try { opts.AppendExecutionProvider_DML(0); }
+                catch (EntryPointNotFoundException)
+                { throw new InvalidOperationException("DirectML EP not available. Build with -p:UseDirectML=true."); }
+                break;
+            case ExecutionProvider.Cpu:
+                break;
+        }
+        return opts;
+    }
+
+    // ── Vocab + language spans ───────────────────────────────────────────────
+
+    private static string[] LoadFlatVocab(string path)
+    {
+        var raw = File.ReadAllLines(path);
+        // Shipping vocab.txt is one token per line with id = line index, no
+        // trailing blank row. A final empty line from newline-terminated
+        // writes is tolerated by dropping blanks at the end only — mid-file
+        // blanks would shift ids and are rejected.
+        int end = raw.Length;
+        while (end > 0 && string.IsNullOrEmpty(raw[end - 1])) end--;
+        for (int i = 0; i < end; i++)
+            if (string.IsNullOrEmpty(raw[i]))
+                throw new InvalidDataException(
+                    $"{path}: empty line at id {i}. Vocab format is one token per line, " +
+                    "no gaps — blank lines would misalign the CTC output.");
+        var clean = new string[end];
+        Array.Copy(raw, clean, end);
+        return clean;
+    }
+
+    private static Dictionary<string, (int start, int length)> LoadLanguageSpans(string path)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllBytes(path));
+        var root = doc.RootElement;
+        var spans = new Dictionary<string, (int, int)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var prop in root.GetProperty("languages").EnumerateObject())
+        {
+            int start  = prop.Value.GetProperty("start").GetInt32();
+            int length = prop.Value.GetProperty("length").GetInt32();
+            spans[prop.Name] = (start, length);
+        }
+        return spans;
+    }
+
+    // ── Array helpers (duplicated from Parakeet; candidate for AsrUtils) ─────
+
+    public static (float[,] padded, long[] lens) PadList(IReadOnlyList<float[]> arrays)
+    {
+        if (arrays.Count == 0)
+            return (new float[0, 0], Array.Empty<long>());
+
+        var lens   = new long[arrays.Count];
+        long maxLen = 0;
+        for (int i = 0; i < arrays.Count; i++)
+        {
+            lens[i] = arrays[i].Length;
+            if (lens[i] > maxLen) maxLen = lens[i];
+        }
+
+        var padded = new float[arrays.Count, maxLen];
+        for (int i = 0; i < arrays.Count; i++)
+        {
+            int len = (int)Math.Min(lens[i], maxLen);
+            for (int j = 0; j < len; j++)
+                padded[i, j] = arrays[i][j];
+        }
+        return (padded, lens);
+    }
+
+    public static List<float[]> SegmentWaveform(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio)
+    {
+        var results = new List<float[]>(segs.Count);
+        foreach (var (start, end, _) in segs)
+        {
+            int startFrame = Math.Max((int)(start * Config.SampleRate), 0);
+            int endFrame   = Math.Min((int)(end   * Config.SampleRate), audio.Length);
+            int len        = Math.Max(endFrame - startFrame, 0);
+            var seg        = new float[len];
+            if (len > 0)
+                Array.Copy(audio, startFrame, seg, 0, len);
+            results.Add(seg);
+        }
+        return results;
+    }
+
+    private static float[] Flatten2D(float[,] a, int d0, int d1)
+    {
+        var flat = new float[d0 * d1];
+        for (int i = 0; i < d0; i++)
+            for (int j = 0; j < d1; j++)
+                flat[i * d1 + j] = a[i, j];
+        return flat;
+    }
+
+    private static float[] Flatten3D(float[,,] a, int d0, int d1, int d2)
+    {
+        var flat = new float[d0 * d1 * d2];
+        for (int i = 0; i < d0; i++)
+            for (int j = 0; j < d1; j++)
+                for (int k = 0; k < d2; k++)
+                    flat[i * d1 * d2 + j * d2 + k] = a[i, j, k];
+        return flat;
+    }
+
+    // ── ONNX inference helpers ───────────────────────────────────────────────
+
+    private (float[,,] features, long[] featLens) PreprocessFeatures(
+        float[,] waveforms, long[] waveformsLens)
+    {
+        int B = waveforms.GetLength(0);
+        int T = waveforms.GetLength(1);
+
+        var waveT = new DenseTensor<float>(Flatten2D(waveforms, B, T), new[] { B, T });
+        var waveL = new DenseTensor<long>(waveformsLens, new[] { B });
+
+        using var results = _preprocessor.Run(new List<NamedOnnxValue>
+        {
+            NamedOnnxValue.CreateFromTensor("waveforms",      waveT),
+            NamedOnnxValue.CreateFromTensor("waveforms_lens", waveL),
+        });
+
+        var featT  = results.First(r => r.Name == "features").AsTensor<float>();
+        var featLT = results.First(r => r.Name == "features_lens").AsTensor<long>();
+
+        int D2 = featT.Dimensions[1];
+        int T2 = featT.Dimensions[2];
+        var features = new float[B, D2, T2];
+        for (int b = 0; b < B; b++)
+            for (int d = 0; d < D2; d++)
+                for (int t = 0; t < T2; t++)
+                    features[b, d, t] = featT[b, d, t];
+
+        var featLens = new long[B];
+        for (int b = 0; b < B; b++)
+            featLens[b] = featLT[b];
+
+        return (features, featLens);
+    }
+
+    private (float[,,] encoded, long[] encodedLens) Encode(float[,,] features, long[] lens)
+    {
+        int B = features.GetLength(0);
+        int D = features.GetLength(1);
+        int T = features.GetLength(2);
+
+        var featT = new DenseTensor<float>(Flatten3D(features, B, D, T), new[] { B, D, T });
+        var lenT  = new DenseTensor<long>(lens, new[] { B });
+
+        using var results = _encoder.Run(new List<NamedOnnxValue>
+        {
+            NamedOnnxValue.CreateFromTensor("features",      featT),
+            NamedOnnxValue.CreateFromTensor("features_lens", lenT),
+        });
+
+        var outT  = results.First(r => r.Name == "encoded").AsTensor<float>();
+        var outLT = results.First(r => r.Name == "encoded_lens").AsTensor<long>();
+
+        // Encoder emits [B, D, T]; transpose to [B, T, D] so the CTC
+        // session and downstream argmax operate over contiguous time.
+        int D2 = outT.Dimensions[1];
+        int T2 = outT.Dimensions[2];
+        var encoded = new float[B, T2, D2];
+        for (int b = 0; b < B; b++)
+            for (int d = 0; d < D2; d++)
+                for (int t = 0; t < T2; t++)
+                    encoded[b, t, d] = outT[b, d, t];
+
+        var encodedLens = new long[B];
+        for (int b = 0; b < B; b++)
+            encodedLens[b] = outLT[b];
+
+        return (encoded, encodedLens);
+    }
+
+    private float[,,] RunCtcDecoder(float[,,] encoded)
+    {
+        int B = encoded.GetLength(0);
+        int T = encoded.GetLength(1);
+        int D = encoded.GetLength(2);
+
+        // ctc_decoder.onnx expects [B, D, T] (ConvASRDecoder convention),
+        // same layout the encoder emits natively. Re-transpose before
+        // feeding.
+        var encBDT = new float[B * D * T];
+        for (int b = 0; b < B; b++)
+            for (int t = 0; t < T; t++)
+                for (int d = 0; d < D; d++)
+                    encBDT[((b * D) + d) * T + t] = encoded[b, t, d];
+
+        var encT = new DenseTensor<float>(encBDT, new[] { B, D, T });
+
+        using var results = _ctcDecoder.Run(new List<NamedOnnxValue>
+        {
+            NamedOnnxValue.CreateFromTensor("encoded", encT),
+        });
+
+        var logitsT = results.First(r => r.Name == "logits").AsTensor<float>();
+        // Graph returns [B, T, V]. Copy into a managed 3D array so callers
+        // don't have to hold an InferenceSession result alive.
+        int V = logitsT.Dimensions[2];
+        var logits = new float[B, T, V];
+        for (int b = 0; b < B; b++)
+            for (int t = 0; t < T; t++)
+                for (int v = 0; v < V; v++)
+                    logits[b, t, v] = logitsT[b, t, v];
+        return logits;
+    }
+
+    // ── CTC greedy decode ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Masked greedy CTC. For each frame: argmax over the (span-length + 1)
+    /// positions that belong to the requested language plus the shared
+    /// blank. Collapse runs of the same token, drop blanks, return emitted
+    /// global token ids with per-token timestamps, durations, and
+    /// log-softmax scores over the masked subspace.
+    /// </summary>
+    private (List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs)
+        GreedyCtcDecode(
+            float[,,] logits, int batchIdx, int T,
+            int spanStart, int spanLength)
+    {
+        int localBlankId = spanLength;       // masked-subspace index of blank
+        int vocabDim     = logits.GetLength(2);
+
+        var tokens     = new List<int>();
+        var timestamps = new List<int>();
+        var durations  = new List<int>();
+        var logprobs   = new List<float>();
+
+        // State across frames: currentLocalId is what we last emitted (or
+        // localBlankId when in blank); startFrame is where the current run
+        // began; bestLogprob tracks the tightest log-prob during the run.
+        int currentLocalId = -1;
+        int startFrame     = 0;
+        float bestLogprob  = float.NegativeInfinity;
+
+        void Emit(int endFrameExclusive)
+        {
+            if (currentLocalId < 0 || currentLocalId == localBlankId) return;
+            int globalId = spanStart + currentLocalId;
+            tokens.Add(globalId);
+            timestamps.Add(startFrame);
+            durations.Add(endFrameExclusive - startFrame);
+            logprobs.Add(bestLogprob);
+        }
+
+        for (int t = 0; t < T; t++)
+        {
+            // Argmax in the masked subspace without materializing a copy.
+            int   bestLocal  = -1;
+            float bestLogit  = float.NegativeInfinity;
+            for (int i = 0; i < spanLength; i++)
+            {
+                float v = logits[batchIdx, t, spanStart + i];
+                if (v > bestLogit) { bestLogit = v; bestLocal = i; }
+            }
+            float blankLogit = logits[batchIdx, t, _blankIdx];
+            if (blankLogit > bestLogit) { bestLogit = blankLogit; bestLocal = localBlankId; }
+
+            if (bestLocal == currentLocalId)
+            {
+                // Extend the current run. Update bestLogprob with a fresh
+                // log-softmax over the masked subspace at this frame.
+                float lp = LogSoftmaxSelected(
+                    logits, batchIdx, t, spanStart, spanLength, _blankIdx, bestLocal);
+                if (lp > bestLogprob) bestLogprob = lp;
+                continue;
+            }
+
+            // Run boundary: emit the outgoing run (if not blank), then start
+            // a new one.
+            Emit(endFrameExclusive: t);
+            currentLocalId = bestLocal;
+            startFrame     = t;
+            bestLogprob    = LogSoftmaxSelected(
+                logits, batchIdx, t, spanStart, spanLength, _blankIdx, bestLocal);
+        }
+        Emit(endFrameExclusive: T);
+
+        _ = vocabDim; // silence analyser; keep the variable for future-prefix debugging
+        return (tokens, timestamps, durations, logprobs);
+    }
+
+    /// <summary>
+    /// log-softmax over the 257-dim subspace (span of <paramref name="spanLength"/>
+    /// language tokens + the shared blank at <paramref name="blankIdx"/>),
+    /// returning the value at <paramref name="localIdx"/>.
+    /// </summary>
+    private static float LogSoftmaxSelected(
+        float[,,] logits, int b, int t,
+        int spanStart, int spanLength, int blankIdx, int localIdx)
+    {
+        // Two-pass stable log-softmax: first find max for numerical stability,
+        // then accumulate log-sum-exp.
+        float max = float.NegativeInfinity;
+        for (int i = 0; i < spanLength; i++)
+        {
+            float v = logits[b, t, spanStart + i];
+            if (v > max) max = v;
+        }
+        float blankV = logits[b, t, blankIdx];
+        if (blankV > max) max = blankV;
+
+        double sum = 0.0;
+        for (int i = 0; i < spanLength; i++)
+            sum += Math.Exp(logits[b, t, spanStart + i] - max);
+        sum += Math.Exp(blankV - max);
+
+        float chosen = localIdx == spanLength ? blankV : logits[b, t, spanStart + localIdx];
+        return (float)(chosen - max - Math.Log(sum));
+    }
+
+    // ── VRAM-bounded batching (duplicated from Parakeet) ─────────────────────
+
+    private static long ComputeMaxFrames()
+    {
+        var (_, freeMb) = HardwareInfo.GetGpuMemoryMb();
+        if (freeMb <= 0) return Config.FallbackMaxFrames;
+
+        double available = freeMb - Config.VramSafetyMb;
+        if (available <= 0) return Config.FallbackMaxFrames;
+
+        long frames = (long)((available - Config.VramInterceptMb) / Config.VramSlopePerSample);
+        return frames > 0 ? frames : Config.FallbackMaxFrames;
+    }
+
+    private static IEnumerable<List<float[]>> MakeBatches(
+        List<float[]> sorted, int maxBatchSize, long maxFrames)
+    {
+        var current    = new List<float[]>();
+        long currentMax = 0;
+
+        foreach (var wave in sorted)
+        {
+            long newMax    = Math.Max(currentMax, wave.Length);
+            long projected = (current.Count + 1) * newMax;
+            bool sizeLimit  = current.Count >= maxBatchSize;
+            bool frameLimit = current.Count > 0 && projected > maxFrames;
+
+            if (sizeLimit || frameLimit)
+            {
+                yield return current;
+                current    = new List<float[]>();
+                currentMax = 0;
+                newMax     = wave.Length;
+            }
+
+            current.Add(wave);
+            currentMax = Math.Max(currentMax, wave.Length);
+        }
+
+        if (current.Count > 0)
+            yield return current;
+    }
+
+    // ── Public recognition API ───────────────────────────────────────────────
+
+    public IndicConformerPreparedBatch? PrepareBatch(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio)
+    {
+        var waveforms = SegmentWaveform(segs, audio);
+        if (waveforms.Count == 0) return null;
+
+        var sorted = waveforms
+            .Select((w, i) => (w, origIdx: i))
+            .OrderBy(x => x.w.Length)
+            .ToList();
+
+        long maxFrames   = ComputeMaxFrames();
+        var sortedWaves  = sorted.Select(x => x.w).ToList();
+        var batchedWaves = MakeBatches(sortedWaves, Config.MaxBatchSize, maxFrames).ToList();
+
+        var batches = new List<(float[,,] features, long[] featLens, int segCount)>(batchedWaves.Count);
+        foreach (var batch in batchedWaves)
+        {
+            var (padded, lens)       = PadList(batch);
+            var (features, featLens) = PreprocessFeatures(padded, lens);
+            batches.Add((features, featLens, batch.Count));
+        }
+
+        return new IndicConformerPreparedBatch(
+            sorted.Select(x => x.origIdx).ToList(), batches);
+    }
+
+    /// <summary>
+    /// GPU phase: encode and CTC-decode a batch already preprocessed by
+    /// <see cref="PrepareBatch"/>. Results are yielded in original segment
+    /// order. <paramref name="lang"/> selects which 256-token span the
+    /// language mask will expose before argmax (BCP-47 primary subtag —
+    /// e.g. "hi", "bn", "ta"; case-insensitive).
+    /// </summary>
+    public IEnumerable<(int segId, string text, List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs)>
+        RecognizePrepared(IndicConformerPreparedBatch prepared, string lang)
+    {
+        if (!_langSpans.TryGetValue(lang, out var span))
+            throw new ArgumentException(
+                $"Unknown language '{lang}'. Supported: " +
+                string.Join(", ", _langSpans.Keys.OrderBy(k => k)),
+                nameof(lang));
+
+        int sortedPos = 0;
+        foreach (var (features, featLens, segCount) in prepared.Batches)
+        {
+            var (encoded, encodedLens) = Encode(features, featLens);
+            var logits = RunCtcDecoder(encoded);
+            int B = logits.GetLength(0);
+
+            for (int b = 0; b < B; b++)
+            {
+                int T = (int)encodedLens[b];
+                var (tokens, timestamps, durations, logprobs) = GreedyCtcDecode(
+                    logits, b, T, span.start, span.length);
+
+                string text = Detokenize(tokens);
+                int origIdx = prepared.OriginalIndices[sortedPos + b];
+                yield return (origIdx, text, tokens, timestamps, durations, logprobs);
+            }
+            sortedPos += segCount;
+        }
+    }
+
+    /// <summary>
+    /// Convenience wrapper: CPU preprocess then GPU encode+decode in one call.
+    /// </summary>
+    public IEnumerable<(int segId, string text, List<int> tokens, List<int> timestamps, List<int> durations, List<float> logprobs)>
+        Recognize(
+            IReadOnlyList<(double start, double end, string spk)> segs,
+            float[] audio,
+            string lang)
+    {
+        var prepared = PrepareBatch(segs, audio);
+        if (prepared == null) yield break;
+        foreach (var result in RecognizePrepared(prepared, lang))
+            yield return result;
+    }
+
+    /// <summary>
+    /// SentencePiece-style detokenize: each piece with a leading `▁`
+    /// (U+2581) marks a word boundary in the language-specific tokenizer.
+    /// Trim edge whitespace; the first emission usually starts with the
+    /// marker and would otherwise leave a leading space.
+    /// </summary>
+    private string Detokenize(List<int> tokenIds)
+    {
+        var sb = new System.Text.StringBuilder(tokenIds.Count * 2);
+        foreach (int id in tokenIds)
+        {
+            if (id < 0 || id >= _vocab.Length) continue;
+            string piece = _vocab[id];
+            if (piece.Length == 0) continue;
+            if (piece[0] == '\u2581') { sb.Append(' '); sb.Append(piece.AsSpan(1)); }
+            else sb.Append(piece);
+        }
+        return sb.ToString().Trim();
+    }
+
+    // ── Supported languages ──────────────────────────────────────────────────
+
+    /// <summary>BCP-47 primary subtags this package can decode (22 for the
+    /// published IndicConformer).</summary>
+    public IReadOnlyCollection<string> SupportedLanguages => _langSpans.Keys;
+
+    // ── IDisposable ──────────────────────────────────────────────────────────
+
+    public void Dispose()
+    {
+        _preprocessor.Dispose();
+        _encoder.Dispose();
+        _ctcDecoder.Dispose();
+    }
+}
+
+/// <summary>
+/// CPU-preprocessed features ready for GPU encoding.
+/// Separate type from <c>PreparedBatch</c> so the two backends can evolve
+/// independently. TranscriptionService branches by backend already, so
+/// sharing the wrapper type offers no reduction in branches.
+/// </summary>
+public sealed class IndicConformerPreparedBatch(
+    IReadOnlyList<int> originalIndices,
+    IReadOnlyList<(float[,,] features, long[] featLens, int segCount)> batches)
+{
+    public IReadOnlyList<int> OriginalIndices { get; } = originalIndices;
+    public IReadOnlyList<(float[,,] features, long[] featLens, int segCount)> Batches { get; } = batches;
+}

--- a/tests/IndicConformerTest/IndicConformerSmokeTests.cs
+++ b/tests/IndicConformerTest/IndicConformerSmokeTests.cs
@@ -1,0 +1,240 @@
+using System.Globalization;
+using System.Text;
+using Vernacula.Base;
+using Xunit;
+
+namespace Vernacula.Tests.IndicConformerTest;
+
+/// <summary>
+/// Smoke tests for the IndicConformer ONNX package + C# decode path.
+///
+/// Runs each of the 22 language test clips through
+/// <see cref="IndicConformer.Recognize"/> and asserts the output is
+/// non-trivial and composed primarily of characters in the expected
+/// script family. Not a WER benchmark — golden-substring assertions
+/// against the Fleurs / IndicVoices-R references would be too brittle
+/// against ordinary ASR word errors. The regression we actually want
+/// to catch is the Parakeet-vocab-fallback / wrong-language-head / IO-
+/// rename-broken kind of failure, where output either vanishes or
+/// comes back in the wrong script. Script-block fraction is a robust
+/// signal for that.
+///
+/// Discovery:
+///   - IndicConformer ONNX package: env VERNACULA_INDIC_MODELS_DIR,
+///     else ~/.local/share/Vernacula/models/indicconformer/,
+///     else ~/models/indicconformer_600m_onnx/.
+///   - Test audio library: env VERNACULA_TEST_AUDIO_DIR,
+///     else ~/Programming/test_audio/.
+/// Each test skips (Assert.Skip) if the needed asset is absent, so a
+/// machine without the 2.4 GB package still shows green but reports
+/// what was skipped.
+/// </summary>
+public class IndicConformerSmokeTests : IDisposable
+{
+    private static readonly Lazy<IndicConformer?> SharedModel = new(LoadSharedModel);
+    private static readonly string? AudioRoot = DiscoverAudioRoot();
+    private static readonly string? SkipReason = BuildSkipReason();
+
+    // Per-language test data. `scriptRanges` lists the Unicode blocks where
+    // legitimate output for the language should live; the decode must put
+    // at least `minScriptFraction` of non-whitespace characters into one of
+    // these blocks (combined) to pass. Ranges are inclusive on both ends.
+    private sealed record Lang(
+        string Iso,
+        string LocaleDir,
+        string AudioFile,
+        (int lo, int hi)[] ScriptRanges);
+
+    // Script block reference:
+    //   Devanagari    U+0900–U+097F (hi, mr, sa, ne, kok, mai, doi, sd)
+    //   Bengali       U+0980–U+09FF (bn, as)
+    //   Gurmukhi      U+0A00–U+0A7F (pa)
+    //   Gujarati      U+0A80–U+0AFF (gu)
+    //   Odia          U+0B00–U+0B7F (or)
+    //   Tamil         U+0B80–U+0BFF (ta)
+    //   Telugu        U+0C00–U+0C7F (te)
+    //   Kannada       U+0C80–U+0CFF (kn)
+    //   Malayalam     U+0D00–U+0D7F (ml)
+    //   Ol Chiki      U+1C50–U+1C7F (sat)
+    //   Meitei Mayek  U+ABC0–U+ABFF (mni)
+    //   Arabic        U+0600–U+06FF (ur, ks, sd)
+    //   Arabic Supp   U+0750–U+077F
+    //   Arabic Ext-A  U+08A0–U+08FF
+    //   Bengali supp  (as)/brx may land in extended Bengali ranges
+    //
+    // Bodo (brx) can use Devanagari or Bengali historically; AI4Bharat's
+    // tokenizer appears to be Devanagari-based, so accept both.
+    // Kashmiri (ks), Sindhi (sd) primarily use Perso-Arabic script in
+    // AI4Bharat's tokenizer; accept Arabic ranges.
+    public static IEnumerable<TheoryDataRow<string>> LanguageCodes =>
+        Langs.Select(l => new TheoryDataRow<string>(l.Iso));
+
+    private static readonly Lang[] Langs =
+    [
+        new("hi",  "hi-IN", "hi-IN_fleurs_01.wav",        [(0x0900, 0x097F)]),
+        new("bn",  "bn-IN", "bn-IN_fleurs_01.wav",        [(0x0980, 0x09FF)]),
+        new("ta",  "ta-IN", "ta-IN_fleurs_01.wav",        [(0x0B80, 0x0BFF)]),
+        new("te",  "te-IN", "te-IN_fleurs_01.wav",        [(0x0C00, 0x0C7F)]),
+        new("mr",  "mr-IN", "mr-IN_fleurs_01.wav",        [(0x0900, 0x097F)]),
+        new("gu",  "gu-IN", "gu-IN_fleurs_01.wav",        [(0x0A80, 0x0AFF)]),
+        new("kn",  "kn-IN", "kn-IN_fleurs_01.wav",        [(0x0C80, 0x0CFF)]),
+        new("ml",  "ml-IN", "ml-IN_fleurs_01.wav",        [(0x0D00, 0x0D7F)]),
+        new("pa",  "pa-IN", "pa-IN_fleurs_01.wav",        [(0x0A00, 0x0A7F)]),
+        new("or",  "or-IN", "or-IN_fleurs_01.wav",        [(0x0B00, 0x0B7F)]),
+        new("as",  "as-IN", "as-IN_fleurs_01.wav",        [(0x0980, 0x09FF)]),
+        new("ne",  "ne-NP", "ne-NP_fleurs_01.wav",        [(0x0900, 0x097F)]),
+        new("sd",  "sd-IN", "sd-IN_fleurs_01.wav",        [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF), (0x0900, 0x097F)]),
+        new("ur",  "ur-PK", "ur-PK_fleurs_01.wav",        [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF)]),
+        new("sa",  "sa-IN", "sa-IN_indicvoices_r_01.wav", [(0x0900, 0x097F)]),
+        new("ks",  "ks-IN", "ks-IN_indicvoices_r_01.wav", [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF), (0x0900, 0x097F)]),
+        new("brx", "brx-IN","brx-IN_indicvoices_r_01.wav",[(0x0900, 0x097F), (0x0980, 0x09FF)]),
+        new("doi", "doi-IN","doi-IN_indicvoices_r_01.wav",[(0x0900, 0x097F)]),
+        new("kok", "kok-IN","kok-IN_indicvoices_r_01.wav",[(0x0900, 0x097F)]),
+        new("mai", "mai-IN","mai-IN_indicvoices_r_01.wav",[(0x0900, 0x097F)]),
+        new("mni", "mni-IN","mni-IN_indicvoices_r_01.wav",[(0xABC0, 0xABFF), (0x0980, 0x09FF)]),
+        new("sat", "sat-IN","sat-IN_indicvoices_r_01.wav",[(0x1C50, 0x1C7F)]),
+    ];
+
+    private const double MinScriptFraction = 0.70;
+    private const int    MinCharacters     = 3;
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(LanguageCodes))]
+    public void Decodes_InExpectedScript(string iso)
+    {
+        if (SkipReason is not null) Assert.Skip(SkipReason);
+        var model = SharedModel.Value!;
+
+        var lang = Langs.First(l => l.Iso == iso);
+        string wavPath = Path.Combine(AudioRoot!, lang.LocaleDir, lang.AudioFile);
+        if (!File.Exists(wavPath)) Assert.Skip($"missing test audio: {wavPath}");
+
+        var (samples, sampleRate, channels) = AudioUtils.ReadAudio(wavPath);
+        Assert.Equal(Config.SampleRate, sampleRate);
+        Assert.Equal(1, channels);
+
+        // Single whole-clip segment. Diarization is out of scope for the
+        // smoke test — we just want to prove the ASR graph + C# decoder
+        // produce the expected script family.
+        var segs = new List<(double start, double end, string spk)>
+        {
+            (0.0, samples.Length / (double)sampleRate, "speaker_0"),
+        };
+
+        var results = model.Recognize(segs, samples, iso).ToList();
+        Assert.Single(results);
+        string text = results[0].text;
+        Assert.False(string.IsNullOrWhiteSpace(text),
+            $"[{iso}] decode produced empty output");
+
+        string nfc = text.Normalize(NormalizationForm.FormC);
+        int inScript = 0, nonWs = 0;
+        foreach (Rune r in nfc.EnumerateRunes())
+        {
+            if (Rune.IsWhiteSpace(r)) continue;
+            nonWs++;
+            int cp = r.Value;
+            foreach (var (lo, hi) in lang.ScriptRanges)
+                if (cp >= lo && cp <= hi) { inScript++; break; }
+        }
+
+        Assert.True(nonWs >= MinCharacters,
+            $"[{iso}] decode too short: {nonWs} non-whitespace chars in {text.q()}");
+
+        double fraction = nonWs == 0 ? 0.0 : (double)inScript / nonWs;
+        Assert.True(fraction >= MinScriptFraction,
+            $"[{iso}] only {fraction:P0} of chars in expected script " +
+            $"ranges {FormatRanges(lang.ScriptRanges)}; got {nonWs} chars total: " +
+            $"{Preview(nfc)}");
+    }
+
+    [Fact]
+    public void PackageIsLoadable()
+    {
+        if (SkipReason is not null) Assert.Skip(SkipReason);
+        var model = SharedModel.Value!;
+
+        Assert.NotNull(model);
+        Assert.Contains("hi", model.SupportedLanguages);
+        Assert.Equal(22, model.SupportedLanguages.Count);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static IndicConformer? LoadSharedModel()
+    {
+        string? dir = DiscoverModelsDir();
+        if (dir is null) return null;
+        try { return new IndicConformer(dir); }
+        catch { return null; }
+    }
+
+    private static string? DiscoverModelsDir()
+    {
+        string? envDir = Environment.GetEnvironmentVariable("VERNACULA_INDIC_MODELS_DIR");
+        if (!string.IsNullOrWhiteSpace(envDir) && HasPackage(envDir)) return envDir;
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string[] candidates =
+        [
+            Path.Combine(home, ".local", "share", "Vernacula", "models", Config.IndicConformerSubDir),
+            Path.Combine(home, "models", "indicconformer_600m_onnx"),
+        ];
+        foreach (var c in candidates)
+            if (HasPackage(c)) return c;
+        return null;
+    }
+
+    private static bool HasPackage(string dir) =>
+        Directory.Exists(dir) &&
+        File.Exists(Path.Combine(dir, Config.EncoderFile)) &&
+        File.Exists(Path.Combine(dir, Config.CtcDecoderFile)) &&
+        File.Exists(Path.Combine(dir, Config.PreprocessorFile)) &&
+        File.Exists(Path.Combine(dir, Config.VocabFile)) &&
+        File.Exists(Path.Combine(dir, Config.IndicConformerLanguageSpansFile));
+
+    private static string? DiscoverAudioRoot()
+    {
+        string? envDir = Environment.GetEnvironmentVariable("VERNACULA_TEST_AUDIO_DIR");
+        if (!string.IsNullOrWhiteSpace(envDir) && Directory.Exists(envDir)) return envDir;
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        string def = Path.Combine(home, "Programming", "test_audio");
+        return Directory.Exists(def) ? def : null;
+    }
+
+    private static string? BuildSkipReason()
+    {
+        if (SharedModel.Value is null)
+            return "IndicConformer ONNX package not found. Set VERNACULA_INDIC_MODELS_DIR, " +
+                   "or place the package at ~/.local/share/Vernacula/models/indicconformer/ " +
+                   "or ~/models/indicconformer_600m_onnx/.";
+        if (AudioRoot is null)
+            return "Test audio library not found. Set VERNACULA_TEST_AUDIO_DIR, " +
+                   "or place the test_audio/ tree at ~/Programming/test_audio/.";
+        return null;
+    }
+
+    private static string FormatRanges((int lo, int hi)[] ranges) =>
+        "[" + string.Join(", ", ranges.Select(r => $"U+{r.lo:X4}-{r.hi:X4}")) + "]";
+
+    private static string Preview(string s) =>
+        s.Length <= 80 ? s : s[..80] + "…";
+
+    public void Dispose()
+    {
+        // Class-level Lazy<> holds the model; per-test disposal isn't right
+        // here (it'd break the next test in the theory). The model is
+        // disposed implicitly when the test host tears down AppDomain.
+        GC.SuppressFinalize(this);
+    }
+}
+
+internal static class StringFormatExtension
+{
+    // Short repr-like helper — wraps text in quotes for readable failure
+    // messages without pulling in a full Debug.Print dependency.
+    internal static string q(this string? s) => s is null ? "null" : $"\"{s}\"";
+}

--- a/tests/IndicConformerTest/IndicConformerTest.csproj
+++ b/tests/IndicConformerTest/IndicConformerTest.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- Tests run on CPU only. Deterministic across machines and avoids
+         a hard dep on a CUDA/DirectML driver matching the dev box.
+         The Vernacula.Base ProjectReference pulls in the OnnxRuntime.Gpu
+         runtime chosen at its build time; add an explicit CPU package
+         here so InferenceSession(..., new SessionOptions()) in the test
+         host resolves cleanly without a GPU. -->
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit.v3" Version="1.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
+      <!-- Base normally bakes in OnnxRuntime.Gpu via its consumer's EP prop.
+           For the test host we want the CPU package above to be the only
+           runtime in the output directory, so suppress Base's transitive
+           EP selection by passing EP=Cpu down the build graph. -->
+      <Private>true</Private>
+      <SetConfiguration>EP=Cpu</SetConfiguration>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds AI4Bharat's [IndicConformer 600M](https://huggingface.co/ai4bharat/indic-conformer-600m-multilingual) as a fifth ASR backend alongside Parakeet, Cohere, Qwen3-ASR, and VibeVoice. Covers the 22 official Indian languages across Devanagari, Bengali, Gurmukhi, Gujarati, Odia, Tamil, Telugu, Kannada, Malayalam, Perso-Arabic, Ol Chiki, and Meitei Mayek scripts.

Delivers all six phases from the original plan (`data/IndicConformer_plan.md` in `parakeet_csharp`), plus the UX polish that surfaced during testing.

## What ships

- **ONNX shipping package**: [christopherthompson81/indicconformer-600m-onnx](https://huggingface.co/christopherthompson81/indicconformer-600m-onnx) — repackaged from AI4Bharat's distribution with consolidated external-data sidecar, renamed IO tensors to match Parakeet's contract, flat 5632-line vocab + 22 × `{start, length}` language spans, and our DFT-conv1d preprocessor (same config as upstream `preprocessor.ts`).
- **New C# backend** [`src/Vernacula.Base/IndicConformer.cs`](../blob/indicconformer/src/Vernacula.Base/IndicConformer.cs) — CTC greedy decode with per-language span masking, mirrors `Parakeet.cs`'s public surface so `TranscriptionService` swaps backends without branching.
- **Settings UI**: new radio entry below VibeVoice, a 22-row language picker, and a short help section explaining the LID interaction.
- **LID integration**: global Language Identification now drives per-segment decoder-head selection for IndicConformer too; the manual picker is the fallback for the 8 Indic languages VoxLingua107 can't detect (`brx, doi, kok, ks, mai, mni, or, sat`).
- **Smoke tests**: first `dotnet test` project in the repo — `tests/IndicConformerTest/` with a 22-row theory that asserts each language decodes in the correct Unicode script block. 23/23 pass on CPU ORT in ~9s. Auto-skips when the 2.4 GB package isn't on disk.

## Why the 600M and not the 120M

The plan originally targeted the 120M variant and did export it (Phase 1/2 artifacts at `scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py`). We pivoted to the 600M mid-way for parameter parity with Parakeet TDT 0.6B; AI4Bharat publishes that one as an already-exported ONNX package, so Phase 2 for 600M is a repackage job (`scripts/indicconformer_export/repackage_600m_indicconformer.py`). The 120M export pipeline is still in the tree and working — useful as a fallback and as a reference for future re-exports.

## Fixes picked up during testing

- **Jobs queued from Home ran as Parakeet** even when IndicConformer was selected. Two copies of the backend-to-model-name resolver had diverged; fixed in `35eb790` and filed as [#23](https://github.com/christopherthompson81/vernacula/issues/23) for the broader refactor.
- **Transcript editor showed Latin/Greek mojibake** on IndicConformer transcripts. Editor's `VocabService` had no IndicConformer branch and fell through to Parakeet vocab on the shared integer token ids. Fixed in `5b15181`.
- **RTL languages (Urdu, Kashmiri, Sindhi) rendered left-to-right** in the editor's per-token ASR panel. Added `IsRtl` helper + bound `FlowDirection` on the WrapPanel and Edit TextBox. Fixed in `0a5fd38`.

## Files of interest for review

- **Exporter logic**: [`scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py`](../blob/indicconformer/scripts/indicconformer_export/export_indicconformer_nemo_to_onnx.py) (120M hand-rolled export) and [`scripts/indicconformer_export/repackage_600m_indicconformer.py`](../blob/indicconformer/scripts/indicconformer_export/repackage_600m_indicconformer.py) (600M repackage).
- **C# backend**: [`src/Vernacula.Base/IndicConformer.cs`](../blob/indicconformer/src/Vernacula.Base/IndicConformer.cs).
- **Routing + resolver changes**: [`src/Vernacula.Avalonia/Services/TranscriptionService.cs`](../blob/indicconformer/src/Vernacula.Avalonia/Services/TranscriptionService.cs), [`src/Vernacula.Avalonia/Services/JobQueueService.cs`](../blob/indicconformer/src/Vernacula.Avalonia/Services/JobQueueService.cs), [`src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs`](../blob/indicconformer/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs).
- **Full chronological history of decisions, dead ends, and run-by-run findings**: [`docs/indicconformer_investigation.md`](../blob/indicconformer/docs/indicconformer_investigation.md) — worth skimming for the architectural-discovery arc (especially the multi-softmax → span-mask realization) before the code review.

## Follow-up

- [#23](https://github.com/christopherthompson81/vernacula/issues/23) — duplicated resolver logic + Settings-to-runtime propagation gaps (surfaced by this PR, not made worse by it).
- 26 non-en help locales are stale on `first_steps/settings_window.md`. Run `python scripts/update_help_files.py --files first_steps/settings_window.md` whenever the translation pass is desired.
- `AsrUtils` extraction (flagged in `IndicConformer.cs`'s class doc) — duplicated `PadList` / `SegmentWaveform` / `MakeBatches` between `Parakeet.cs` and `IndicConformer.cs` for now.

## Test plan

- [x] All 22 Indic test clips decode in the correct script (automated: `dotnet test tests/IndicConformerTest/`)
- [x] Full solution builds clean (`dotnet build Vernacula.slnx`)
- [x] End-to-end manual test: select IndicConformer in Settings, download models, transcribe a Hindi Fleurs clip → correct Devanagari output
- [x] Editor RTL verified on `ur-PK_fleurs_01.wav`
- [x] Editor ASR column matches Edit column (no Parakeet-vocab mojibake) on a freshly-transcribed IndicConformer job
- [ ] Reviewer: build + run on a fresh checkout, confirm Download Missing Models pulls the HF repo correctly