### PR TITLE
Granite Speech BF16 mixed-precision bundle (#32)

### DIFF
--- a/docs/dev/granite_speech_bf16_investigation.md
+++ b/docs/dev/granite_speech_bf16_investigation.md
@@ -111,6 +111,32 @@ practice**. Hardware auto-detection should require CUDA EP (Ampere+
 preferred), not just `avx512_bf16`. CPU users — including the laptop
 target with native CPU BF16 — get the FP32 bundle.
 
+### Verified directly: C# CPU EP fails identically (2026-05-08)
+
+Built `Vernacula.CLI` with `-p:EP=Cpu` and ran the BF16 bundle on the
+6.4 s VCTK clip. Same error at `InferenceSession` construction:
+
+```
+Microsoft.ML.OnnxRuntime.OnnxRuntimeException:
+  [ErrorCode:NotImplemented] Could not find an implementation for
+  Where(16) node with name 'node_where_1'
+```
+
+This is an ORT op-kernel **registry** miss, not a runtime hardware
+gate. The CPU EP's BF16 op coverage is decided at ORT build time;
+`avx512_bf16` controls SIMD dispatch *within* an existing kernel,
+which means it can speed up a BF16 kernel that ships but cannot
+materialise one that doesn't. So:
+
+- `avx512_bf16` in `/proc/cpuinfo` is **not sufficient** for the BF16
+  bundle to load on CPU EP.
+- Auto-detect must gate on CUDA EP availability with Ampere+ tensor
+  cores — period — until ORT closes the CPU op-kernel gaps for
+  `Where` and the rest of the LM ops the decoder graph uses.
+- The 7840U laptop will use the FP32 bundle today even though its CPU
+  has native BF16 in hardware. That capability is wasted on this
+  model with current ORT.
+
 ## Run 3 — 2026-05-08 — Bundle size and per-stage profile
 
 **Setup:** Mixed-precision export at `--dtype bfloat16 --opset 18`.

--- a/docs/dev/granite_speech_bf16_investigation.md
+++ b/docs/dev/granite_speech_bf16_investigation.md
@@ -1,0 +1,183 @@
+# Granite Speech 4.1 → BF16 export & inference investigation
+
+Tracking issue: [#32](https://github.com/christopherthompson81/vernacula/issues/32).
+
+Goal: ship a `granite-speech-4-1-2b-onnx-bf16` HF bundle for hardware
+that has native BF16 (Ampere+ NVIDIA tensor cores, AMD Zen 4+
+`avx512_bf16`, Intel SPR+ `amx_bf16`). Auto-detect at runtime; FP32
+remains the default for hardware without BF16.
+
+The FP32 baseline shipped in PR #31: 10-min en-US clip RTF 0.043 on
+RTX 3090. Targets — RTF 0.025–0.030 if BF16 tensor cores hit on GPU,
+~0.035 otherwise (faster on CPU only on machines with avx512_bf16).
+
+Each entry is one run or experiment, stamped with local date/time.
+
+## Run 1 — 2026-05-08 — Plumbing audit
+
+**Question:** What hard-coded dtype assumptions block `--dtype bfloat16`
+in `export_granite_speech_to_onnx.py`?
+
+**Setup:** Reading the script before running anything.
+
+**Findings:**
+
+- Model loads with the user-selected dtype via `dtype=torch.bfloat16`
+  in `load_model_and_processor` (line 189). Encoder/projector/decoder
+  weights are BF16.
+- **`processor` is loaded without dtype** — its mel/audio_processor
+  stays fp32. `make_dummy_processor_inputs` returns `input_features`
+  in fp32.
+- Hard-coded `torch.float32` survives in two places that participate in
+  trace:
+  - Lines 1240/1241: `dummy_full`, `dummy_half` — pre-mel waveform
+    samples fed to `mel_wrapper`. Mel is DSP-only with no learnable
+    params; fp32 in/fp32 out is fine here regardless of model dtype.
+  - Lines 1309/1313: `u_past_keys`, `u_past_values` — past-KV dummies
+    fed to the unified decoder wrapper. The decoder's projection
+    matmuls expect input dtype = weight dtype = BF16 when model is
+    BF16, so these MUST follow `args.dtype`.
+- `np.float32` audio buffers in `make_dummy_processor_inputs` (lines
+  218/219): same story as mel dummies — these go through the
+  fp32 audio_processor and never touch BF16 weights. Keep as fp32.
+
+Per-graph dtype boundaries we expect to need:
+
+| Graph | Input | Internal | Output |
+|---|---|---|---|
+| `mel.onnx` | fp32 audio | fp32 (DSP) | fp32 features |
+| `encoder.onnx` | fp32 features | BF16 (with `Cast` at input) | fp32 (with `Cast` at output) — keeps C# side fp32 |
+| `projector.onnx` | fp32 enc hidden | BF16 (with `Cast` at input) | fp32 (with `Cast` at output) |
+| `decoder.onnx` | int64 ids/masks/cache_pos, **fp32** audio_embeds, **BF16** past_kv | BF16 | **fp32** logits (with `Cast`), **BF16** present_kv |
+
+The "BF16 past_kv" choice on the decoder is load-bearing: keeping KV
+BF16 across the chained `Run` steps preserves half the per-step memory
+bandwidth and concat cost on KV (Run 7 of the perf doc identified
+concat as the #1 ORT op cost). The only consequence on the C# side is
+that the *empty-prefill* past-KV OrtValues at the start of decode need
+to be created with BF16 dtype rather than the current
+`OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(), ...)`. ORT
+C# exposes `Microsoft.ML.OnnxRuntime.BFloat16` for that. Roughly 5
+lines of C# change.
+
+**Implication for the next run:** start with the minimal plumbing fix
+(past-KV dummies follow `args.dtype`), attempt the trace, then add
+`Cast` nodes inside the encoder/projector/decoder wrappers as failures
+surface.
+
+## Run 2 — 2026-05-08 — Conv/Where BF16 gaps force mixed precision
+
+**Question:** Will full BF16 export (encoder + projector + decoder)
+load and run on ORT?
+
+**Setup:** With past-KV dummies routed through `args.dtype` (Run 1) and
+fp32 round-trip Casts removed from the encoder→projector and
+projector→decoder boundaries (per the user's "no double-cast" pushback —
+BF16↔fp32 is bit-preserving for BF16 values, so any internal round-trip
+is pure bandwidth waste, not a correctness issue), full BF16 export
+**traces successfully**. Bundle drops from 8.7 GB to 4.4 GB.
+
+ORT load-time errors block the runtime path:
+
+1. **Encoder Conv at opset 18:** `Type 'tensor(bfloat16)' of input
+   parameter (permute_1) of operator (Conv) ... is invalid.` ONNX
+   added BF16 to Conv's type constraint at opset 22.
+2. **Encoder Conv at opset 22:** `Type parameter (T) of Optype (Conv)
+   bound to different types (tensor(bfloat16) and tensor(float))`. The
+   Conformer's depthwise convs end up with mixed-dtype inputs/weights
+   in the trace — not a single-graph type error but a deeper
+   ONNX/PyTorch interaction.
+3. **Decoder unified `Where` on CPU EP:** `Could not find an
+   implementation for Where(16) node`. ORT CPU EP does not implement
+   Where for BF16. The audio merge (`torch.where`) needs Where to
+   support BF16 to run on CPU at all.
+
+**Decision:** Mixed precision —
+- `model.encoder.to(torch.float32)` and
+  `model.projector.to(torch.float32)` after load (encoder accounts for
+  ~25% of wall time vs decoder's 60%+; projector is ~0.2%).
+- LM decoder stays in `args.dtype`. Audio_embeds boundary cast inside
+  `DecoderUnifiedWrapper`: fp32 in → BF16 internal. Logits boundary
+  cast: BF16 internal → fp32 out (CPU argmax stays cheap).
+- Past-KV stays in `args.dtype` across the chained `Run` loop —
+  GPU-resident, never read on the host. C# detects the dtype from the
+  decoder's `InputMetadata["past_key_0"].ElementDataType` at construction
+  and creates the empty-prefill OrtValues via a small
+  `CreateEmptyPastKv(shape)` helper that switches on `Float / BFloat16
+  / Float16`.
+
+The CPU `Where(BF16)` gap means **the BF16 bundle is GPU-only in
+practice**. Hardware auto-detection should require CUDA EP (Ampere+
+preferred), not just `avx512_bf16`. CPU users — including the laptop
+target with native CPU BF16 — get the FP32 bundle.
+
+## Run 3 — 2026-05-08 — Bundle size and per-stage profile
+
+**Setup:** Mixed-precision export at `--dtype bfloat16 --opset 18`.
+
+**Bundle layout:**
+
+```
+mel.onnx              124 KB    (unchanged DSP)
+encoder.onnx          2.2 MB    (graph)
+encoder.onnx.data     1.7 GB    (fp32 weights, unchanged)
+projector.onnx        137 MB    (fp32 weights, inline)
+decoder.onnx          7.1 MB    (graph)
+decoder.onnx.data     3.5 GB    (BF16 weights — half of fp32's 6.9 GB)
+                      ────
+total                 5.3 GB    (vs 8.7 GB FP32 → 39% smaller)
+```
+
+**C# pipeline change (one helper):**
+
+```csharp
+private OrtValue CreateEmptyPastKv(long[] shape) => _pastKvDtype switch
+{
+    TensorElementType.Float    => OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(),    shape),
+    TensorElementType.BFloat16 => OrtValue.CreateTensorValueFromMemory(Array.Empty<BFloat16>(), shape),
+    TensorElementType.Float16  => OrtValue.CreateTensorValueFromMemory(Array.Empty<Float16>(),  shape),
+    _ => throw new InvalidOperationException(...),
+};
+```
+
+`_pastKvDtype` is read once at session load from
+`_decoder.InputMetadata["past_key_0"].ElementDataType`. The chained
+Run-with-OrtValue loop is otherwise unchanged — KV OrtValues come back
+from `_decoder.Run` in whatever dtype the graph emits and feed back as
+inputs to the next Run without C# ever seeing the data.
+
+## Run 4 — 2026-05-08 — End-to-end RTF on 10 min en-US clip
+
+**Test:** 600 s en-US clip, VAD-segmented to 159 segments, batched
+greedy decode through `--asr granite` on RTX 3090.
+
+| Bundle | ASR wall | RTF | Step-loop | Encoder | KV bytes per token (B=16) |
+|---|---:|---:|---:|---:|---:|
+| FP32 (baseline) | 23.9 s | 0.043 | 13.0 s (60%) | 5.4 s (25%) | 167 MB |
+| **BF16 mixed**  | **17.4 s** | **0.032** | **7.8 s** (50%) | 5.2 s (33%) | **84 MB** |
+
+**Step-loop dropped 41%** (13.0 s → 7.8 s) — the dominant LM cost is
+where BF16 tensor cores hit hardest. Encoder unchanged at ~5.2 s
+(intentional — kept fp32). Combined ASR wall is **27% faster** despite
+encoder being unchanged.
+
+Word count: 1514 (FP32) → 1521 (BF16) — within 0.5%. Spot-check diff:
+small word-level variations on ~15 lines (e.g. `"Oh, yeah."` vs
+`"Uh, uh."`, `"Fred and Nena's"` vs `"Fred and Nanette's"`) typical of
+greedy argmax at lower mantissa precision. No catastrophic
+regressions, no runaway-loop reappearance, no semantic divergence on
+spot-checked passages.
+
+**VRAM-for-batches lever (response to user's concern):** decoder KV
+halves at BF16 (167 MB → 84 MB per token at B=16). The cost-model in
+`GraniteBatchCostModel.EstimatePeakBytes` still uses
+`bytesPerFloat = 4L` — overestimates KV when KV is BF16 — so on a
+3090 with 16 hard-cap we're not seeing the unlock yet. On smaller GPUs
+the BF16 bundle would actually allow a higher batch cap. Cost model
+update to read `_pastKvDtype` and use 2 bytes for BF16 is a follow-up.
+
+**Implication:** ship the BF16 bundle as a sibling HF repo
+(`granite-speech-4-1-2b-onnx-bf16`) for hardware that has CUDA EP.
+Vernacula's downloader picks one based on hardware capability —
+gating on "Ampere+ NVIDIA GPU detected" rather than `avx512_bf16`,
+because the CPU `Where(BF16)` gap blocks CPU EP entirely.

--- a/scripts/granite_export/export_granite_speech_to_onnx.py
+++ b/scripts/granite_export/export_granite_speech_to_onnx.py
@@ -459,6 +459,12 @@ def make_encoder_wrapper(torch: Any, model: Any) -> Any:
     The encoder forward is single-input single-output, but the per-layer
     attention uses 5D SDPA which the dynamo->ONNX converter does not
     support; see _patch_encoder_attention_for_export.
+
+    Encoder always runs at fp32 — ONNX Conv only added BF16 type support at
+    opset 22, and even there the export hits dtype-binding errors at Conv
+    nodes where input/weight don't agree. Encoder is ~25% of wall time vs
+    decoder's 60%+, so keeping it fp32 sacrifices a modest fraction of the
+    BF16 win to avoid a deep ONNX/Conv compatibility hunt.
     """
     nn = torch.nn
     _patch_encoder_attention_for_export(torch, model.encoder)
@@ -477,7 +483,12 @@ def make_encoder_wrapper(torch: Any, model: Any) -> Any:
 def make_projector_wrapper(torch: Any, model: Any) -> Any:
     """Projector: pads to multiple of window_size=15, runs Q-Former with 3 queries
     per 15-frame block, downsamples 5x, projects to LLM hidden dim 2048.
-    Single-input single-output."""
+    Single-input single-output.
+
+    Projector also stays fp32 — same Conv compatibility caveat as encoder
+    applies (Q-Former blocks include conv-flavoured ops). The decoder is
+    where BF16 yields the dominant win, so projector stays at native dtype.
+    """
     nn = torch.nn
 
     class ProjectorWrapper(nn.Module):
@@ -605,11 +616,14 @@ def make_decoder_unified_wrapper(torch: Any, model: Any) -> Any:
     nn = torch.nn
     from transformers.cache_utils import DynamicCache
 
+    weight_dtype = next(model.language_model.parameters()).dtype
+
     class DecoderUnifiedWrapper(nn.Module):
         def __init__(self, m: Any) -> None:
             super().__init__()
             self.language_model = m.language_model
             self.audio_token_id = m.config.audio_token_id
+            self._weight_dtype = weight_dtype
 
         def forward(
             self,
@@ -619,6 +633,11 @@ def make_decoder_unified_wrapper(torch: Any, model: Any) -> Any:
             cache_position: Any,
             *past_kv: Any,
         ) -> Any:
+            # audio_embeds arrives as fp32 (projector stays fp32; see
+            # make_projector_wrapper). Cast to LM weight dtype at the
+            # boundary so all internal matmuls stay in weight dtype.
+            audio_embeds = audio_embeds.to(self._weight_dtype)
+
             # Audio merge — same cumsum-gather-where as the prefill-only
             # wrapper. Collapses to a no-op at step time because no audio
             # tokens appear in the next-token input.
@@ -634,7 +653,10 @@ def make_decoder_unified_wrapper(torch: Any, model: Any) -> Any:
 
             # Build a DynamicCache from the past_kv inputs. At prefill the
             # caller supplies zero-length tensors; HF treats this as an
-            # empty cache and runs prefill normally.
+            # empty cache and runs prefill normally. past_kv stays in the
+            # weight dtype across the chain — ORT chains them between
+            # `Run` calls without ever materialising on the host, so a
+            # BF16 KV is half the memory bandwidth and concat cost vs fp32.
             n = NUM_DECODER_LAYERS
             past_keys = list(past_kv[:n])
             past_values = list(past_kv[n:])
@@ -650,7 +672,9 @@ def make_decoder_unified_wrapper(torch: Any, model: Any) -> Any:
             )
             new_keys = [layer.keys for layer in out.past_key_values.layers]
             new_values = [layer.values for layer in out.past_key_values.layers]
-            return (out.logits, *new_keys, *new_values)
+            # Logits → fp32 boundary so C# argmax stays unchanged. KV stays
+            # in weight dtype (uncast).
+            return (out.logits.to(torch.float32), *new_keys, *new_values)
 
     return DecoderUnifiedWrapper(model)
 
@@ -1202,6 +1226,17 @@ def main() -> int:
         args.model_repo, args.revision, args.device, dtype, torch
     )
 
+    # Mixed-precision policy: when --dtype is BF16 (or fp16), only the
+    # language-model decoder runs in the reduced precision. Encoder and
+    # projector are cast back to fp32 because ONNX Conv has historically
+    # patchy reduced-precision support (BF16 added at opset 22 but with
+    # type-binding errors on the Conformer's depthwise convs at trace),
+    # and they account for ~25% of inference time vs the decoder's 60%+.
+    if dtype != torch.float32:
+        print(f"  Casting encoder + projector back to fp32 (mixed-precision policy)")
+        model.encoder = model.encoder.to(torch.float32)
+        model.projector = model.projector.to(torch.float32)
+
     inputs = make_dummy_processor_inputs(
         torch, processor, args.dummy_seconds, args.device
     )
@@ -1305,12 +1340,15 @@ def main() -> int:
         u_cache_position = torch.arange(
             past_dummy, past_dummy + seq_dummy, dtype=torch.long, device=input_ids.device
         )
+        # Past-KV must match decoder weight dtype — the LM's K/V projection
+        # outputs land in `dtype`, and the in-graph concat across the past_len
+        # axis fails if the supplied past tensor doesn't match.
         u_past_keys = [
-            torch.zeros((bsz, NUM_KV_HEADS, past_dummy, HEAD_DIM), dtype=torch.float32, device=input_ids.device)
+            torch.zeros((bsz, NUM_KV_HEADS, past_dummy, HEAD_DIM), dtype=dtype, device=input_ids.device)
             for _ in range(NUM_DECODER_LAYERS)
         ]
         u_past_values = [
-            torch.zeros((bsz, NUM_KV_HEADS, past_dummy, HEAD_DIM), dtype=torch.float32, device=input_ids.device)
+            torch.zeros((bsz, NUM_KV_HEADS, past_dummy, HEAD_DIM), dtype=dtype, device=input_ids.device)
             for _ in range(NUM_DECODER_LAYERS)
         ]
         unified_inputs = {

--- a/scripts/granite_export/test_parity_unified.py
+++ b/scripts/granite_export/test_parity_unified.py
@@ -96,7 +96,13 @@ def main() -> int:
 
     so = ort.SessionOptions()
     so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
-    providers = ["CPUExecutionProvider"]
+    available = ort.get_available_providers()
+    providers = (
+        ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        if "CUDAExecutionProvider" in available
+        else ["CPUExecutionProvider"]
+    )
+    print(f"  ORT providers: {providers}")
 
     enc_sess = ort.InferenceSession(str(args.onnx_dir / "encoder.onnx"), so, providers=providers)
     proj_sess = ort.InferenceSession(str(args.onnx_dir / "projector.onnx"), so, providers=providers)
@@ -107,16 +113,40 @@ def main() -> int:
     print(f"  encoder out: {enc_out.shape}")
     print(f"  projector out: {proj_out.shape}")
 
+    # Detect decoder past-KV dtype — for the BF16 mixed-precision bundle the
+    # decoder's K/V tensors are bfloat16, so the empty-past dummies and the
+    # populated past_kv at step time must match.
+    past_kv_dtype = next(
+        i.type for i in dec_sess.get_inputs() if i.name == "past_key_0"
+    )
+    np_past_dtype = {
+        "tensor(float)": np.float32,
+        "tensor(float16)": np.float16,
+        "tensor(bfloat16)": "bfloat16",  # numpy lacks bfloat16; sentinel handled below
+    }[past_kv_dtype]
+    print(f"  decoder past_kv dtype: {past_kv_dtype} -> numpy={np_past_dtype}")
+
+    def to_past_dtype(arr):
+        """Cast numpy array (or torch tensor) to the decoder's past-KV
+        dtype. For bfloat16 we use ml_dtypes.bfloat16 since numpy proper
+        has no native bfloat16; ORT accepts arrays with that dtype."""
+        if isinstance(arr, torch.Tensor):
+            arr = arr.cpu().numpy()
+        if np_past_dtype == "bfloat16":
+            from ml_dtypes import bfloat16 as _bf16
+            return arr.astype(_bf16)
+        return arr.astype(np_past_dtype)
+
     # ── Mode A: prefill (past_kv zero-length) ────────────────────────────
     section("Mode A: prefill via unified decoder (past_kv zero-length)")
     B, S = input_ids.shape
     cache_position = np.arange(S, dtype=np.int64)
     empty_keys = [
-        np.zeros((B, NUM_KV_HEADS, 0, HEAD_DIM), dtype=np.float32)
+        to_past_dtype(np.zeros((B, NUM_KV_HEADS, 0, HEAD_DIM), dtype=np.float32))
         for _ in range(NUM_DECODER_LAYERS)
     ]
     empty_values = [
-        np.zeros((B, NUM_KV_HEADS, 0, HEAD_DIM), dtype=np.float32)
+        to_past_dtype(np.zeros((B, NUM_KV_HEADS, 0, HEAD_DIM), dtype=np.float32))
         for _ in range(NUM_DECODER_LAYERS)
     ]
 
@@ -173,8 +203,8 @@ def main() -> int:
         "cache_position": cache_position,
     }
     for L in range(NUM_DECODER_LAYERS):
-        feed[f"past_key_{L}"] = ref_keys[L].cpu().numpy().astype(np.float32)
-        feed[f"past_value_{L}"] = ref_values[L].cpu().numpy().astype(np.float32)
+        feed[f"past_key_{L}"] = to_past_dtype(ref_keys[L])
+        feed[f"past_value_{L}"] = to_past_dtype(ref_values[L])
     t0 = time.time()
     step_out = dec_sess.run(None, feed)
     print(f"  unified step: logits={step_out[0].shape}, kv0={step_out[1].shape}  ({time.time()-t0:.2f}s)")

--- a/scripts/hf_readmes/README.md
+++ b/scripts/hf_readmes/README.md
@@ -17,6 +17,7 @@ directory.
 | [`voxlingua107-lid-onnx`](https://huggingface.co/christopherthompson81/voxlingua107-lid-onnx) | [`voxlingua107-lid-onnx/`](voxlingua107-lid-onnx/) | Apache-2.0 | needs upload |
 | [`indicconformer-600m-onnx`](https://huggingface.co/christopherthompson81/indicconformer-600m-onnx) | [`indicconformer-600m-onnx/`](indicconformer-600m-onnx/) | MIT | needs upload |
 | [`granite-speech-4-1-2b-onnx`](https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx) | [`granite-speech-4-1-2b-onnx/`](granite-speech-4-1-2b-onnx/) | Apache-2.0 | needs upload |
+| [`granite-speech-4-1-2b-onnx-bf16`](https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx-bf16) | [`granite-speech-4-1-2b-onnx-bf16/`](granite-speech-4-1-2b-onnx-bf16/) | Apache-2.0 | needs upload |
 
 ## What each card includes
 

--- a/scripts/hf_readmes/granite-speech-4-1-2b-onnx-bf16/README.md
+++ b/scripts/hf_readmes/granite-speech-4-1-2b-onnx-bf16/README.md
@@ -1,0 +1,178 @@
+---
+license: apache-2.0
+library_name: onnxruntime
+pipeline_tag: automatic-speech-recognition
+tags:
+  - onnx
+  - onnxruntime
+  - automatic-speech-recognition
+  - granite
+  - granite-speech
+  - bfloat16
+  - vernacula
+base_model: ibm-granite/granite-speech-4.1-2b
+language:
+  - en
+  - fr
+  - de
+  - es
+  - pt
+  - ja
+---
+
+# IBM Granite Speech 4.1 (2B) — BF16 mixed-precision ONNX export for Vernacula
+
+ONNX export of [`ibm-granite/granite-speech-4.1-2b`](https://huggingface.co/ibm-granite/granite-speech-4.1-2b)
+with the 1.84 B-parameter Granite-4.0 LLM decoder in **bfloat16**, packaged
+for use with [Vernacula](https://github.com/christopherthompson81/vernacula)
+and ONNX Runtime on hardware with native BF16 acceleration.
+
+- **Conversion script:** [`scripts/granite_export/`](https://github.com/christopherthompson81/vernacula/tree/main/scripts/granite_export)
+- **Vernacula:** [github.com/christopherthompson81/vernacula](https://github.com/christopherthompson81/vernacula)
+- **Upstream model:** [`ibm-granite/granite-speech-4.1-2b`](https://huggingface.co/ibm-granite/granite-speech-4.1-2b)
+- **FP32 sibling bundle (default):** [`christopherthompson81/granite-speech-4-1-2b-onnx`](https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx)
+
+## When to use this bundle
+
+This is the **GPU bundle** for hardware with NVIDIA Ampere or newer
+(compute capability ≥ 8.0). On those parts the LM decoder runs through
+BF16 tensor cores and the ASR loop is meaningfully faster than the FP32
+sibling. On older GPUs and on CPU-only systems use the FP32 bundle —
+ORT's CPU EP currently lacks a `Where(BF16)` kernel that this graph
+needs at the audio merge, so the BF16 bundle does not load on CPU
+regardless of whether the host CPU has `avx512_bf16` or `amx_bf16` in
+hardware. See the FP32 sibling bundle linked above for that path.
+
+Vernacula auto-detects this with `HardwareInfo.SupportsBf16Acceleration`
+and pulls whichever bundle is appropriate.
+
+## Highlights
+
+- **31× realtime on RTX 3090 (RTF 0.032)**, up from 23× (RTF 0.043) on the FP32 sibling on the same 10-min English clip — **1.37× faster end-to-end** despite encoder + projector staying FP32.
+- **LM decoder ~1.7× faster.** Step-loop drops 40% (13.0 s → 7.8 s) and prefill drops 26% (2.3 s → 1.7 s) — the BF16-affected portion of the pipeline (prefill + step-loop) runs 38% faster overall. Encoder + projector are unchanged at ~5.2 s by design (see Mixed-precision design below).
+- **KV cache memory halved.** Per-token KV at B=16 drops from 167 MB (FP32) to 84 MB (BF16). On smaller GPUs this unlocks higher batch caps; on a 3090 we already saturate the 16-row hard cap before the VRAM budget bites.
+- **Bundle 39% smaller (5.3 GB vs 8.7 GB).** Decoder weights: 6.9 GB → 3.5 GB. Encoder/projector unchanged from the FP32 sibling.
+- **Greedy-argmax fidelity preserved.** Word count on the 10 min en-US benchmark: 1521 (BF16) vs 1514 (FP32) — within 0.5%. Spot-checks find only minor word-level variations consistent with BF16 mantissa truncation; no semantic drift, no runaway-loop reappearance.
+
+## Contents
+
+| File | Purpose | Precision |
+|---|---|---|
+| `mel.onnx` | Log-Mel spectrogram frontend (16 kHz waveform → mel features) | FP32 (DSP, dtype-invariant) |
+| `encoder.onnx` (+ `.data`) | Conformer acoustic encoder, full-attention rewrite | FP32 |
+| `projector.onnx` | BLIP-2 Q-Former audio-to-text projector | FP32 |
+| `decoder.onnx` (+ `.data`) | Unified prefill + step Granite-4.0 LM decoder with cumsum-gather audio merge; **BF16 weights and KV** | BF16 (FP32 audio_embeds in, FP32 logits out) |
+| `tokenizer.json`, `vocab.json`, `merges.txt`, `added_tokens.json`, `special_tokens_map.json`, `tokenizer_config.json` | GPT-2-family ByteLevel BPE tokenizer assets | text |
+| `chat_template.jinja` | Chat template (used to construct the ASR prompt) | text |
+| `preprocessor_config.json`, `processor_config.json` | Mel/preprocessor parameters from upstream | text |
+| `export-report.json` | Per-stage export timings + dtype/opset metadata | text |
+| `manifest.json` | Per-file MD5 hashes (used by Vernacula's download verifier) | text |
+
+## Mixed-precision design
+
+The ONNX export traces the model loaded at BF16 then casts the encoder
+and projector back to FP32 before tracing those graphs:
+
+```python
+model = GraniteSpeechForConditionalGeneration.from_pretrained(repo, dtype=torch.bfloat16)
+model.encoder = model.encoder.to(torch.float32)
+model.projector = model.projector.to(torch.float32)
+```
+
+Two ORT BF16 gaps drove the encoder/projector → FP32 carve-out:
+
+1. **Conv at opset 18** has no BF16 type binding; opset 22 added it but
+   fails type-binding on the Conformer's depthwise convs at trace time.
+2. **CPU EP `Where`** has no BF16 kernel registered — the audio merge
+   uses `torch.where` and would fail to load even on hardware that has
+   AVX-512 BF16 support, because the kernel isn't built into ORT's CPU EP
+   regardless of host capability.
+
+The decoder graph has FP32 boundary casts at exactly two places:
+
+- **Input:** `audio_embeds` arrives as FP32 (projector output) and is cast to BF16 inside the decoder graph before the audio merge.
+- **Output:** `logits` is cast back to FP32 so the C# argmax stays cheap and dtype-uniform with the FP32 bundle.
+
+Past-KV stays in BF16 across the chained `Run` loop — GPU-resident, never read on the host. The C# side detects the dtype from the decoder's `InputMetadata["past_key_0"].ElementDataType` at session construction and creates the empty-prefill OrtValues via a switch on `Float / BFloat16 / Float16`.
+
+## Performance
+
+Measured on an RTX 3090 with Vernacula's batched ONNX pipeline:
+
+| Workload | Mode | FP32 wall | **BF16 wall** | FP32 RTF | **BF16 RTF** |
+|---|---|---:|---:|---:|---:|
+| 6.4 s VCTK clip | B=1 | 3.25 s | 2.50 s | 0.508 | 0.392 |
+| 600 s (10 min) VAD-segmented | mixed B (≤16) | 23.9 s | **17.4 s** | 0.043 | **0.032** |
+
+Per-stage breakdown on the 10-min run (BF16):
+
+| Stage | ms | % |
+|---|---:|---:|
+| mel | 534 | 3.4% |
+| encoder | 5,191 | 33.4% |
+| projector | 42 | 0.3% |
+| prefill | 1,723 | 11.1% |
+| step-loop | **7,755** | **49.9%** |
+| overhead | 300 | 1.9% |
+
+Encoder is unchanged from FP32 (intentional — see Mixed-precision design above). The win is concentrated in prefill + step-loop, which together account for ~60% of total ASR time at this precision.
+
+## License
+
+[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0), inherited from the upstream [`ibm-granite/granite-speech-4.1-2b`](https://huggingface.co/ibm-granite/granite-speech-4.1-2b) model. Permissive — commercial use is allowed with attribution.
+
+## Using these files
+
+In Vernacula, the auto-detect picks this bundle when both bundles are present on disk and the host has CUDA EP available with an Ampere+ GPU. The CLI flag is `--asr granite`; force a specific bundle with `--granite-model <path>` if you need to override the heuristic.
+
+Outside Vernacula, pull with `huggingface_hub` and load the four graphs with `onnxruntime`:
+
+```python
+from huggingface_hub import snapshot_download
+path = snapshot_download(repo_id="christopherthompson81/granite-speech-4-1-2b-onnx-bf16")
+```
+
+The contract on the decoder graph differs from the FP32 sibling in two places that callers need to handle:
+
+- **`audio_embeds` is still declared as FP32** at the graph boundary (cast to BF16 internally). No caller change needed there.
+- **`past_key_<L>` and `past_value_<L>` are declared as BF16.** The empty-prefill tensors at the start of decode must be BF16, not FP32. ORT C# exposes this via `Microsoft.ML.OnnxRuntime.BFloat16`; ORT Python's BF16-numpy round-trip is unhelpful (numpy lacks a native BF16 dtype) and ML callers should keep KV as `OrtValue` objects without ever materialising on the host.
+
+See [`scripts/granite_export/`](https://github.com/christopherthompson81/vernacula/tree/main/scripts/granite_export) for the full input/output tensor names and shapes, and [`docs/dev/granite_speech_bf16_investigation.md`](https://github.com/christopherthompson81/vernacula/blob/main/docs/dev/granite_speech_bf16_investigation.md) for the run-by-run journey including the ORT compatibility gaps that shaped the mixed-precision policy.
+
+## Limitations
+
+- **Hardware required: NVIDIA Ampere or newer (compute capability ≥ 8.0).** Older GPUs may load the bundle but fall back to slower BF16 emulation; CPU-only systems do not load at all due to the `Where(BF16)` kernel gap. For those use the FP32 sibling bundle.
+- **Audio segments capped at ~6.7 minutes per call** by the decoder's 4096-token context (with `max_new_tokens=256`). Pre-segment longer audio with VAD or diarization.
+- **Greedy decode loops on near-silence segments** — same model property as the FP32 bundle. Vernacula mitigates with a runtime period-1..4 loop detector that forces EOS on stuck rows. Non-Vernacula consumers should replicate that pattern or pre-filter silent VAD chunks.
+- **No speaker attribution or word-level timestamps** — those are in the upstream `granite-speech-4.1-2b-plus` variant, which has not been exported.
+
+## Citation
+
+```bibtex
+@misc{granite-speech-4-1,
+    author       = { IBM Granite Team },
+    title        = { Granite Speech 4.1 (2B) },
+    year         = 2025,
+    url          = { https://huggingface.co/ibm-granite/granite-speech-4.1-2b },
+    publisher    = { Hugging Face }
+}
+```
+
+## Acknowledgments
+
+- Original model: [IBM Granite Team](https://www.ibm.com/granite)
+- ONNX repackaging: [Chris Thompson](https://github.com/christopherthompson81) for [Vernacula](https://github.com/christopherthompson81/vernacula)
+
+Issues with the ONNX export specifically: open an issue on
+[the Vernacula repo](https://github.com/christopherthompson81/vernacula/issues).
+Issues with the underlying model: see the upstream
+[`ibm-granite/granite-speech-4.1-2b`](https://huggingface.co/ibm-granite/granite-speech-4.1-2b)
+model card.
+
+## See also
+
+- [Vernacula on GitHub](https://github.com/christopherthompson81/vernacula) — the speech pipeline app this package is built for
+- [`granite-speech-4-1-2b-onnx`](https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx) — FP32 sibling bundle (default for non-Ampere GPUs and CPU)
+- [Conversion script (`scripts/granite_export/`)](https://github.com/christopherthompson81/vernacula/tree/main/scripts/granite_export) — the export pipeline that produced these files
+- [`ibm-granite/granite-speech-4.1-2b`](https://huggingface.co/ibm-granite/granite-speech-4.1-2b) — upstream model card
+- [Other Vernacula model packages](https://huggingface.co/christopherthompson81)

--- a/scripts/hf_readmes/granite-speech-4-1-2b-onnx/README.md
+++ b/scripts/hf_readmes/granite-speech-4-1-2b-onnx/README.md
@@ -31,6 +31,7 @@ ONNX Runtime.
 - **Conversion script:** [`scripts/granite_export/`](https://github.com/christopherthompson81/vernacula/tree/main/scripts/granite_export)
 - **Vernacula:** [github.com/christopherthompson81/vernacula](https://github.com/christopherthompson81/vernacula)
 - **Upstream model:** [`ibm-granite/granite-speech-4.1-2b`](https://huggingface.co/ibm-granite/granite-speech-4.1-2b)
+- **BF16 sibling bundle (Ampere+ GPUs):** [`christopherthompson81/granite-speech-4-1-2b-onnx-bf16`](https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx-bf16) — same content with the LM decoder in BF16, ~39% smaller and ~27% faster end-to-end on hardware with BF16 tensor cores. CPU and pre-Ampere GPU users should stay on this FP32 bundle.
 
 ## Highlights
 

--- a/src/Vernacula.Base/Config.cs
+++ b/src/Vernacula.Base/Config.cs
@@ -182,6 +182,7 @@ public static class Config
 
     // ── ASR (Granite Speech 4.1) ─────────────────────────────────────────────
     public const string GraniteSpeechSubDir = "granite_speech_4_1_2b";
+    public const string GraniteSpeechBf16SubDir = "granite_speech_4_1_2b_bf16";
 
     // ── Language identification (VoxLingua107 ECAPA-TDNN) ────────────────────
     /// <summary>

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -196,7 +196,7 @@ public sealed class GraniteSpeech : IDisposable
 
         var plan = BatchSizer.Plan(
             durations,
-            new GraniteBatchCostModel(maxNewTokens),
+            new GraniteBatchCostModel(maxNewTokens, KvBytesPerElement),
             _vramBudgetForKvBytes,
             MaxBatchSize);
 
@@ -814,14 +814,31 @@ public sealed class GraniteSpeech : IDisposable
     }
 
     /// <summary>
+    /// Bytes per KV-cache element — 4 for FP32 bundles, 2 for the BF16
+    /// mixed-precision bundle. Derived once from <see cref="_pastKvDtype"/>
+    /// and passed into the cost model so smaller GPUs unlock a higher
+    /// batch cap on the BF16 bundle.
+    /// </summary>
+    private long KvBytesPerElement => _pastKvDtype switch
+    {
+        TensorElementType.BFloat16 => 2L,
+        TensorElementType.Float16  => 2L,
+        _                          => 4L,
+    };
+
+    /// <summary>
     /// Peak-VRAM cost model for batched Granite Speech decode. Compares
     /// three transient allocations and returns the worst case:
-    ///   1. Decoder KV at end of decode  (B × 80 × 4 × seqLen × 128 × 4 bytes)
-    ///   2. Prefill logits spike         (B × promptLen × VocabSize × 4 bytes)
-    ///   3. Encoder full-attention bias  (num_heads × T_enc² × 4 bytes, B=1 because
-    ///      mel/encoder/projector run serially)
+    ///   1. Decoder KV at end of decode  (B × 80 × 4 × seqLen × 128 × kvBytes)
+    ///   2. Prefill logits spike         (B × promptLen × VocabSize × 4 bytes
+    ///      — logits are always fp32 on the C# boundary regardless of
+    ///      bundle precision; the decoder graph casts BF16 → fp32 on
+    ///      output for CPU argmax)
+    ///   3. Encoder full-attention bias  (num_heads × T_enc² × 4 bytes, B=1
+    ///      — mel/encoder/projector run serially and stay fp32 in both
+    ///      bundles)
     /// </summary>
-    private sealed class GraniteBatchCostModel(int maxNewTokens) : IBatchCostModel
+    private sealed class GraniteBatchCostModel(int maxNewTokens, long kvBytesPerElement) : IBatchCostModel
     {
         public long EstimatePeakBytes(int batchSize, double maxDurationSec)
         {
@@ -830,11 +847,13 @@ public sealed class GraniteSpeech : IDisposable
             int seqLen    = promptLen + maxNewTokens;
             int encFrames = EstimateEncoderFrames(maxDurationSec);
 
-            // KV cache: 2 (K+V) × 40 layers × B × 4 KV-heads × seqLen × 128 head dim
+            // KV cache: 2 (K+V) × 40 layers × B × 4 KV-heads × seqLen × 128 head dim.
+            // BF16 bundle halves this — the dominant per-row cost on long decodes,
+            // so on smaller GPUs the BF16 bundle unlocks meaningfully higher B.
             long kvBytes = 2L * NumDecoderLayers * batchSize * NumKvHeads
-                         * seqLen * HeadDim * bytesPerFloat;
+                         * seqLen * HeadDim * kvBytesPerElement;
 
-            // Prefill logits: B × promptLen × VocabSize × float — peaks at start of decode
+            // Prefill logits: B × promptLen × VocabSize × float — peaks at start of decode.
             long logitsBytes = (long)batchSize * promptLen * VocabSize * bytesPerFloat;
 
             // Encoder full-attention bias [H, T, T] — runs serially per row so B=1.

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -97,6 +97,14 @@ public sealed class GraniteSpeech : IDisposable
     private readonly InferenceSession _projector;
     private readonly InferenceSession _decoder;
 
+    // Past-KV dtype detected from the decoder's input metadata. The fp32
+    // bundle uses tensor(float); the BF16 mixed-precision bundle uses
+    // tensor(bfloat16) for KV across the chained Run loop. We need this
+    // to construct the empty-prefill past_kv OrtValues in the right
+    // dtype — KV inputs and outputs across step calls are otherwise
+    // GPU-resident and never touch managed memory.
+    private readonly TensorElementType _pastKvDtype;
+
     private readonly string?[] _idToToken;
     private readonly Dictionary<int, string> _addedTokens;
     private readonly Dictionary<char, byte> _byteLevelDecode;
@@ -113,6 +121,10 @@ public sealed class GraniteSpeech : IDisposable
 
         (_idToToken, _addedTokens) = LoadTokenizerVocab(Path.Combine(modelPath, TokenizerFile));
         _byteLevelDecode = BuildByteLevelDecodeTable();
+
+        _pastKvDtype = _decoder.InputMetadata.TryGetValue("past_key_0", out var pkMeta)
+            ? pkMeta.ElementDataType
+            : TensorElementType.Float;
 
         _vramBudgetForKvBytes = QueryVramBudget();
     }
@@ -418,14 +430,11 @@ public sealed class GraniteSpeech : IDisposable
             var emptyPasts = new List<OrtValue>(2 * NumDecoderLayers);
             var prefillInputs = new List<OrtValue>(4 + 2 * NumDecoderLayers)
             { inputIdsVal, audioVal, attnVal, cpVal };
+            long[] emptyPastShape = { B, NumKvHeads, 0, HeadDim };
             for (int L = 0; L < NumDecoderLayers; L++)
             {
-                var k = OrtValue.CreateTensorValueFromMemory(
-                    Array.Empty<float>(),
-                    new long[] { B, NumKvHeads, 0, HeadDim });
-                var v = OrtValue.CreateTensorValueFromMemory(
-                    Array.Empty<float>(),
-                    new long[] { B, NumKvHeads, 0, HeadDim });
+                var k = CreateEmptyPastKv(emptyPastShape);
+                var v = CreateEmptyPastKv(emptyPastShape);
                 emptyPasts.Add(k);
                 emptyPasts.Add(v);
                 prefillInputs.Add(k);
@@ -627,6 +636,29 @@ public sealed class GraniteSpeech : IDisposable
         var seg = new float[e - s];
         Array.Copy(audio, s, seg, 0, e - s);
         return seg;
+    }
+
+    /// <summary>
+    /// Creates a zero-length past-KV OrtValue in the dtype the decoder
+    /// expects. The fp32 bundle uses Float; the BF16 mixed-precision
+    /// bundle uses BFloat16. ORT requires the dtype on the input
+    /// OrtValue to match the graph's declared type — mismatched fp32
+    /// fed to a BF16 graph fails with "Unexpected input data type"
+    /// before the run starts.
+    /// </summary>
+    private OrtValue CreateEmptyPastKv(long[] shape)
+    {
+        return _pastKvDtype switch
+        {
+            TensorElementType.Float    => OrtValue.CreateTensorValueFromMemory(
+                Array.Empty<float>(), shape),
+            TensorElementType.BFloat16 => OrtValue.CreateTensorValueFromMemory(
+                Array.Empty<BFloat16>(), shape),
+            TensorElementType.Float16  => OrtValue.CreateTensorValueFromMemory(
+                Array.Empty<Float16>(), shape),
+            _ => throw new InvalidOperationException(
+                $"Unsupported past_kv dtype {_pastKvDtype}. Decoder bundle should be Float, BFloat16, or Float16."),
+        };
     }
 
     /// <summary>

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -56,6 +56,12 @@ public static class HardwareInfo
     [DllImport("libnvidia-ml.so.1", EntryPoint = "nvmlDeviceGetMemoryInfo")]
     private static extern int NvmlDeviceGetMemoryInfoLinux(IntPtr device, out NvmlMemory memory);
 
+    [DllImport("nvml.dll", EntryPoint = "nvmlDeviceGetCudaComputeCapability")]
+    private static extern int NvmlDeviceGetCudaComputeCapabilityWindows(IntPtr device, out int major, out int minor);
+
+    [DllImport("libnvidia-ml.so.1", EntryPoint = "nvmlDeviceGetCudaComputeCapability")]
+    private static extern int NvmlDeviceGetCudaComputeCapabilityLinux(IntPtr device, out int major, out int minor);
+
     // ── GPU memory ────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -239,6 +245,50 @@ public static class HardwareInfo
 
         var (totalMb, _) = GetGpuMemoryMb();
         return totalMb > 0;
+    }
+
+    /// <summary>
+    /// Returns (major, minor) CUDA compute capability of <paramref name="gpuId"/>,
+    /// or (0, 0) if NVML is unavailable or the query fails. Compute capability ≥ 8.0
+    /// indicates an Ampere-class or newer architecture with hardware BF16 tensor
+    /// cores; older parts (Volta/Turing 7.x, Pascal 6.x) lack accelerated BF16 and
+    /// will run BF16 ops via slower fallback paths.
+    /// </summary>
+    public static (int Major, int Minor) GetCudaComputeCapability(int gpuId = 0)
+    {
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
+            return (0, 0);
+
+        try
+        {
+            if (NvmlInitPlatform() != 0) return (0, 0);
+            try
+            {
+                if (NvmlDeviceGetHandleByIndexPlatform((uint)gpuId, out var device) != 0) return (0, 0);
+                int rc = OperatingSystem.IsWindows()
+                    ? NvmlDeviceGetCudaComputeCapabilityWindows(device, out int major, out int minor)
+                    : NvmlDeviceGetCudaComputeCapabilityLinux(device, out major, out minor);
+                if (rc != 0) return (0, 0);
+                return (major, minor);
+            }
+            finally { NvmlShutdownPlatform(); }
+        }
+        catch { return (0, 0); }
+    }
+
+    /// <summary>
+    /// True if the system has CUDA available AND a GPU with hardware-accelerated
+    /// BF16 (Ampere or newer, compute capability ≥ 8.0). Used to gate selection of
+    /// BF16 ONNX bundles like Granite Speech 4.1: on hardware that lacks BF16
+    /// tensor cores the BF16 kernels fall back to slower paths or are unavailable
+    /// (the LM decoder ops, the encoder Conv, and ORT's CPU EP <c>Where(BF16)</c>
+    /// all have known coverage gaps), so the FP32 bundle is the safe default.
+    /// </summary>
+    public static bool SupportsBf16Acceleration()
+    {
+        if (!CanProbeCudaExecutionProvider()) return false;
+        var (major, _) = GetCudaComputeCapability();
+        return major >= 8;
     }
 
     private static int NvmlInitPlatform() =>

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -583,10 +583,26 @@ try
     }
     else if (asrBackend == "granite")
     {
-        string graniteDir = graniteModelDir
-            ?? (Directory.Exists(Path.Combine(modelDir, Config.GraniteSpeechSubDir))
-                ? Path.Combine(modelDir, Config.GraniteSpeechSubDir)
-                : modelDir);
+        // Bundle selection: when the user did not pass --granite-model, prefer
+        // the BF16 mixed-precision bundle if both (a) it's present on disk and
+        // (b) the host has CUDA EP with Ampere+ tensor cores. Otherwise fall
+        // back to the FP32 bundle. The BF16 bundle's CPU path is blocked by
+        // ORT's missing Where(BF16) kernel, so a non-Ampere or CPU-only host
+        // must use FP32 even if both bundles are downloaded.
+        string graniteDir;
+        if (graniteModelDir is not null)
+        {
+            graniteDir = graniteModelDir;
+        }
+        else
+        {
+            string bf16Dir = Path.Combine(modelDir, Config.GraniteSpeechBf16SubDir);
+            string fp32Dir = Path.Combine(modelDir, Config.GraniteSpeechSubDir);
+            bool bf16Available = Directory.Exists(bf16Dir) && HardwareInfo.SupportsBf16Acceleration();
+            graniteDir = bf16Available ? bf16Dir
+                : (Directory.Exists(fp32Dir) ? fp32Dir : modelDir);
+            Console.WriteLine($"Granite Speech bundle: {Path.GetFileName(graniteDir)}");
+        }
 
         if (!File.Exists(Path.Combine(graniteDir, GraniteSpeech.MelFile)))
         {


### PR DESCRIPTION
## Summary

- Mixed-precision Granite Speech 4.1 ONNX export: LM decoder in BF16, encoder + projector in FP32. ORT's CPU \`Where(BF16)\` kernel and the Conformer's depthwise Conv at opset 22 don't accept BF16 cleanly, so encoder/projector stay FP32 and we get the BF16 win where it matters most (the dominant 60% LM decoder forward).
- C# pickup is dtype-agnostic: read \`InputMetadata[\"past_key_0\"].ElementDataType\` once at session load, create empty-prefill OrtValues via a switch on \`Float / BFloat16 / Float16\`. Past-KV chains through \`Run\` calls in whatever dtype the graph emits without C# ever materialising on the host.
- Hardware-detect (\`HardwareInfo.SupportsBf16Acceleration\`) gates on NVML compute capability ≥ 8.0 (Ampere+) AND \`CanProbeCudaExecutionProvider\`. CPU users — including those with native CPU BF16 in \`/proc/cpuinfo\` — get the FP32 bundle, because ORT's CPU EP lacks the BF16 kernels regardless of host capability. Verified directly with \`-p:EP=Cpu\` builds.
- CLI auto-picks \`granite_speech_4_1_2b_bf16/\` over \`granite_speech_4_1_2b/\` when both are present and the host qualifies; \`--granite-model\` overrides.
- \`GraniteBatchCostModel\` takes a \`kvBytesPerElement\` arg (4 / 2) sourced from the detected past-KV dtype; on smaller GPUs this unlocks a higher batch cap before the VRAM budget bites.
- HF bundle uploaded: [\`christopherthompson81/granite-speech-4-1-2b-onnx-bf16\`](https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx-bf16). FP32 sibling card updated to cross-reference.

## Performance (RTX 3090, CUDA EP)

| Workload | FP32 wall | **BF16 wall** | FP32 RTF | **BF16 RTF** |
|---|---:|---:|---:|---:|
| 6.4 s VCTK clip | 3.25 s | 2.50 s | 0.508 | 0.392 |
| 600 s VAD-segmented | 23.9 s | **17.4 s** | 0.043 | **0.032** |

LM decoder (prefill + step-loop) runs ~38% faster (1.6×). Encoder unchanged at ~5.2 s by design. Bundle 5.3 GB vs 8.7 GB FP32. Word count within 0.5% of FP32 baseline; spot-checks find only minor word-level variations consistent with BF16 mantissa truncation, no semantic drift.

## Test plan

- [x] Python export at \`--dtype bfloat16 --opset 18 --unified-decoder\` succeeds; mixed-precision policy applied automatically when dtype != fp32
- [x] C# CLI smoke on 6.4 s VCTK with B=1: text matches FP32 exactly
- [x] C# CLI smoke on 10 min en-US clip with VAD-segmented batched decode: RTF 0.032; 1521 words vs 1514 (FP32)
- [x] Auto-detect picks BF16 on RTX 3090, FP32 on Pascal/Volta or CPU-only (NVML compute-cap probe)
- [x] CPU EP fails identically in C# and Python with \`Where(16)\` kernel-registry miss — confirmed; no false-positive load attempts
- [x] HF model card uploaded; FP32 card updated with sibling cross-reference
- [x] Investigation doc (\`docs/dev/granite_speech_bf16_investigation.md\`) covers Runs 1-4 end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)