### PR TITLE
Granite Speech 4.1 GUI integration (#33)

### DIFF
--- a/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
+++ b/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
@@ -46,6 +46,7 @@ Controls which speech-recognition model transcribes the audio. Each backend cove
 | **VibeVoice-ASR** | 12 | Combined diarization + ASR in a single model pass. Requires a CUDA-capable GPU. |
 | **IndicConformer 600M** | 22 Indic | AI4Bharat's multilingual Indic model. Covers the 22 official Indian languages across multiple scripts (Devanagari, Bengali, Tamil, Arabic, Ol Chiki, etc.). Requires a language to be picked at inference — see below. |
 | **Whisper large-v3-turbo** | 99 | OpenAI Whisper (turbo-distilled decoder, full large-v3 encoder). Widest multilingual coverage of any Vernacula backend by a long margin — includes Arabic, Japanese, Korean, Vietnamese, Swahili, Tagalog, Cantonese, and many low-resource languages no other backend covers. Auto-detects language by default via Whisper's `<\|lang\|>` prefix token; forced language available for files where auto-detect confuses similar languages (e.g. Croatian vs Serbian, Norwegian Bokmål vs Nynorsk). |
+| **Granite Speech 4.1** | 6 | IBM's 1.84 B Granite-4 LLM decoder fused with a Conformer audio encoder. English-first; secondary support for French, German, Spanish, Portuguese, Japanese. No language picker. Auto-selects the BF16 mixed-precision bundle on Ampere+ NVIDIA GPUs (faster, smaller); falls back to FP32 on older GPUs and CPU-only systems. |
 
 ### IndicConformer language selection
 

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -6,7 +6,7 @@ public enum AppTheme    { Dark, Light }
 public enum PlaybackMode { Single, AutoAdvance, Continuous }
 // New enum values MUST be appended. Persisted settings store the integer
 // value, so inserting mid-enum silently re-interprets existing user state.
-public enum AsrBackend { Parakeet, Cohere, Qwen3Asr, VibeVoice, IndicConformer, WhisperTurbo }
+public enum AsrBackend { Parakeet, Cohere, Qwen3Asr, VibeVoice, IndicConformer, WhisperTurbo, GraniteSpeech }
 
 public class AppSettings
 {

--- a/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
+++ b/src/Vernacula.Avalonia/Models/AsrLanguageSupport.cs
@@ -46,6 +46,16 @@ public static class AsrLanguageSupport
         "ko", "nl", "pl", "pt", "vi", "zh",
     }.ToFrozenSet();
 
+    // IBM Granite Speech 4.1 — 6 languages from the upstream model card
+    // (https://huggingface.co/ibm-granite/granite-speech-4.1-2b). The base
+    // model targets English; the other five are evaluated but secondary.
+    // Vernacula treats it as English-first since the audio prompt template
+    // only fires for English ASR; force-language routing is not exposed.
+    private static readonly FrozenSet<string> GraniteSpeechLangs = new HashSet<string>
+    {
+        "en", "fr", "de", "es", "pt", "ja",
+    }.ToFrozenSet();
+
     // Official Qwen3-ASR 1.7B supported languages (https://github.com/QwenLM/Qwen3-ASR).
     // "tl" (Tagalog) covers the officially listed "Filipino". Cantonese (yue) omitted
     // pending token-ID support in Qwen3Asr.IsoToLanguageName.
@@ -147,6 +157,7 @@ public static class AsrLanguageSupport
         AsrBackend.VibeVoice      => VibeVoiceLangs,
         AsrBackend.IndicConformer => IndicConformerLangs,
         AsrBackend.WhisperTurbo   => WhisperTurboLangs,
+        AsrBackend.GraniteSpeech  => GraniteSpeechLangs,
         _                         => FrozenSet<string>.Empty,
     };
 
@@ -213,6 +224,7 @@ public static class AsrLanguageSupport
             AsrBackend.WhisperTurbo,
             AsrBackend.Qwen3Asr,
             AsrBackend.Cohere,
+            AsrBackend.GraniteSpeech,
             AsrBackend.Parakeet,
             AsrBackend.VibeVoice,
         };
@@ -239,6 +251,7 @@ public static class AsrLanguageSupport
         AsrBackend.VibeVoice      => "VibeVoice-ASR",
         AsrBackend.IndicConformer => "IndicConformer",
         AsrBackend.WhisperTurbo   => "Whisper Turbo",
+        AsrBackend.GraniteSpeech  => "Granite Speech 4.1",
         _                         => backend.ToString(),
     };
 
@@ -254,6 +267,7 @@ public static class AsrLanguageSupport
         "vibevoice/vibevoice-asr"                      => AsrBackend.VibeVoice,
         "ai4bharat/indic-conformer-600m-multilingual"  => AsrBackend.IndicConformer,
         "openai/whisper-large-v3-turbo"                => AsrBackend.WhisperTurbo,
+        "ibm-granite/granite-speech-4.1-2b"            => AsrBackend.GraniteSpeech,
         _                                              => (AsrBackend?)null,
     };
 
@@ -266,6 +280,7 @@ public static class AsrLanguageSupport
         AsrBackend.VibeVoice      => "vibevoice/vibevoice-asr",
         AsrBackend.IndicConformer => "ai4bharat/indic-conformer-600m-multilingual",
         AsrBackend.WhisperTurbo   => "openai/whisper-large-v3-turbo",
+        AsrBackend.GraniteSpeech  => "ibm-granite/granite-speech-4.1-2b",
         _ => throw new ArgumentOutOfRangeException(nameof(backend)),
     };
 

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -43,6 +43,19 @@ internal class ModelManagerService
     private const string IndicConformerManifestUrl =
         "https://huggingface.co/christopherthompson81/indicconformer-600m-onnx/resolve/main/manifest.json";
 
+    // Granite Speech 4.1 ships as two sibling bundles. Mixed-precision (BF16
+    // decoder, FP32 encoder/projector) is preferred on Ampere+ NVIDIA GPUs;
+    // FP32 is the safe default everywhere else (CPU, pre-Ampere, AMD).
+    // ActiveRepos picks one or the other via HardwareInfo.SupportsBf16Acceleration.
+    private const string GraniteSpeechFp32RepoBase =
+        "https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx/resolve/main";
+    private const string GraniteSpeechFp32ManifestUrl =
+        "https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx/resolve/main/manifest.json";
+    private const string GraniteSpeechBf16RepoBase =
+        "https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx-bf16/resolve/main";
+    private const string GraniteSpeechBf16ManifestUrl =
+        "https://huggingface.co/christopherthompson81/granite-speech-4-1-2b-onnx-bf16/resolve/main/manifest.json";
+
     // Whisper turbo pulls directly from the onnx-community pre-exported repo
     // (no re-hosting). No manifest: onnx-community doesn't ship our format, so
     // the MD5 update-check pass silently skips this repo (per
@@ -154,6 +167,48 @@ internal class ModelManagerService
             new(Path.Combine(Config.IndicConformerSubDir, Config.AsrConfigFile),           Config.AsrConfigFile),
         ];
 
+    // Granite Speech 4.1 — FP32 bundle. Both encoder (1.7 GB) and decoder
+    // (6.9 GB) ship with external .data sidecars; mel + projector are
+    // inline. Tokenizer assets follow the GPT-2 ByteLevel BPE convention
+    // (tokenizer.json, vocab.json, merges.txt, added_tokens.json,
+    // special_tokens_map.json, tokenizer_config.json).
+    private static readonly ModelAsset[] GraniteSpeechFp32Files =
+        [
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.MelFile),                    GraniteSpeech.MelFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.EncoderFile),                GraniteSpeech.EncoderFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, $"{GraniteSpeech.EncoderFile}.data"),     $"{GraniteSpeech.EncoderFile}.data"),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.ProjectorFile),              GraniteSpeech.ProjectorFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.DecoderFile),                GraniteSpeech.DecoderFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, $"{GraniteSpeech.DecoderFile}.data"),     $"{GraniteSpeech.DecoderFile}.data"),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile),              GraniteSpeech.TokenizerFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, "vocab.json"),                             "vocab.json"),
+            new(Path.Combine(Config.GraniteSpeechSubDir, "merges.txt"),                             "merges.txt"),
+            new(Path.Combine(Config.GraniteSpeechSubDir, "added_tokens.json"),                      "added_tokens.json"),
+            new(Path.Combine(Config.GraniteSpeechSubDir, "special_tokens_map.json"),                "special_tokens_map.json"),
+            new(Path.Combine(Config.GraniteSpeechSubDir, "tokenizer_config.json"),                  "tokenizer_config.json"),
+        ];
+
+    // Granite Speech 4.1 — BF16 mixed-precision bundle. Encoder weights at
+    // BF16 fit inline (843 MB, below ORT's 2 GB external-data threshold),
+    // so there is no encoder.onnx.data; only the decoder retains its
+    // sidecar (3.5 GB). Local subdir differs to keep both bundles installable
+    // side by side; SettingsService.GetGraniteSpeechModelsDir picks the
+    // active one at runtime.
+    private static readonly ModelAsset[] GraniteSpeechBf16Files =
+        [
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.MelFile),                GraniteSpeech.MelFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.EncoderFile),            GraniteSpeech.EncoderFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.ProjectorFile),          GraniteSpeech.ProjectorFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.DecoderFile),            GraniteSpeech.DecoderFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, $"{GraniteSpeech.DecoderFile}.data"), $"{GraniteSpeech.DecoderFile}.data"),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile),          GraniteSpeech.TokenizerFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "vocab.json"),                         "vocab.json"),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "merges.txt"),                         "merges.txt"),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "added_tokens.json"),                  "added_tokens.json"),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "special_tokens_map.json"),            "special_tokens_map.json"),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "tokenizer_config.json"),              "tokenizer_config.json"),
+        ];
+
     private static readonly ModelAsset[] VibeVoiceFiles =
         [
             new(Path.Combine(Config.VibeVoiceSubDir, VibeVoiceAsr.AudioEncoderFile),                       VibeVoiceAsr.AudioEncoderFile),
@@ -204,6 +259,23 @@ internal class ModelManagerService
                 new AssetRepo(WhisperTurboRepoBase, "", WhisperTurboFiles),
                 new AssetRepo("", "", WhisperTurboAuxFiles),
             ],
+            // Granite Speech: pick BF16 sibling repo + bundle when the host
+            // qualifies (Ampere+ NVIDIA + working CUDA EP), else FP32. The
+            // local install dir differs between the two — see
+            // GraniteSpeechBf16Files / GraniteSpeechFp32Files — so a previously
+            // downloaded FP32 bundle is preserved if BF16 later becomes the
+            // active choice (e.g. user moved to a newer GPU).
+            AsrBackend.GraniteSpeech => HardwareInfo.SupportsBf16Acceleration()
+                ?
+                [
+                    new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
+                    new AssetRepo(GraniteSpeechBf16RepoBase, GraniteSpeechBf16ManifestUrl, GraniteSpeechBf16Files),
+                ]
+                :
+                [
+                    new AssetRepo(CoreRepoBase, CoreManifestUrl, CoreDiarizationFiles),
+                    new AssetRepo(GraniteSpeechFp32RepoBase, GraniteSpeechFp32ManifestUrl, GraniteSpeechFp32Files),
+                ],
             _ =>
             [
                 new AssetRepo(CoreRepoBase, CoreManifestUrl, [.. CoreDiarizationFiles, .. AsrFilesFp32]),

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -181,11 +181,11 @@ internal class ModelManagerService
             new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.DecoderFile),                GraniteSpeech.DecoderFile),
             new(Path.Combine(Config.GraniteSpeechSubDir, $"{GraniteSpeech.DecoderFile}.data"),     $"{GraniteSpeech.DecoderFile}.data"),
             new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile),              GraniteSpeech.TokenizerFile),
-            new(Path.Combine(Config.GraniteSpeechSubDir, "vocab.json"),                             "vocab.json"),
-            new(Path.Combine(Config.GraniteSpeechSubDir, "merges.txt"),                             "merges.txt"),
-            new(Path.Combine(Config.GraniteSpeechSubDir, "added_tokens.json"),                      "added_tokens.json"),
-            new(Path.Combine(Config.GraniteSpeechSubDir, "special_tokens_map.json"),                "special_tokens_map.json"),
-            new(Path.Combine(Config.GraniteSpeechSubDir, "tokenizer_config.json"),                  "tokenizer_config.json"),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.VocabFile),                  GraniteSpeech.VocabFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.MergesFile),                 GraniteSpeech.MergesFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.AddedTokensFile),            GraniteSpeech.AddedTokensFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.SpecialTokensFile),          GraniteSpeech.SpecialTokensFile),
+            new(Path.Combine(Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerCfgFile),           GraniteSpeech.TokenizerCfgFile),
         ];
 
     // Granite Speech 4.1 — BF16 mixed-precision bundle. Encoder weights at
@@ -202,11 +202,11 @@ internal class ModelManagerService
             new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.DecoderFile),            GraniteSpeech.DecoderFile),
             new(Path.Combine(Config.GraniteSpeechBf16SubDir, $"{GraniteSpeech.DecoderFile}.data"), $"{GraniteSpeech.DecoderFile}.data"),
             new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile),          GraniteSpeech.TokenizerFile),
-            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "vocab.json"),                         "vocab.json"),
-            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "merges.txt"),                         "merges.txt"),
-            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "added_tokens.json"),                  "added_tokens.json"),
-            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "special_tokens_map.json"),            "special_tokens_map.json"),
-            new(Path.Combine(Config.GraniteSpeechBf16SubDir, "tokenizer_config.json"),              "tokenizer_config.json"),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.VocabFile),              GraniteSpeech.VocabFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.MergesFile),             GraniteSpeech.MergesFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.AddedTokensFile),        GraniteSpeech.AddedTokensFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.SpecialTokensFile),      GraniteSpeech.SpecialTokensFile),
+            new(Path.Combine(Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerCfgFile),       GraniteSpeech.TokenizerCfgFile),
         ];
 
     private static readonly ModelAsset[] VibeVoiceFiles =

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -104,6 +104,22 @@ internal class SettingsService
     public string GetWhisperTurboModelsDir() =>
         Path.Combine(GetModelsDir(), Config.WhisperTurboSubDir);
 
+    /// <summary>
+    /// Resolves the active Granite Speech 4.1 bundle directory: prefers
+    /// the BF16 mixed-precision bundle when present on disk and the host
+    /// has CUDA EP with Ampere+ tensor cores; otherwise falls back to the
+    /// FP32 bundle. Mirrors the CLI's selection logic so editor and CLI
+    /// pick the same bundle on the same machine.
+    /// </summary>
+    public string GetGraniteSpeechModelsDir()
+    {
+        string bf16Dir = Path.Combine(GetModelsDir(), Config.GraniteSpeechBf16SubDir);
+        string fp32Dir = Path.Combine(GetModelsDir(), Config.GraniteSpeechSubDir);
+        if (Directory.Exists(bf16Dir) && HardwareInfo.SupportsBf16Acceleration())
+            return bf16Dir;
+        return fp32Dir;
+    }
+
     public string GetVoxLinguaModelsDir() =>
         string.IsNullOrWhiteSpace(Current.VoxLinguaModelsDir)
             ? Path.Combine(GetModelsDir(), Config.VoxLinguaSubDir)

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -110,6 +110,12 @@ internal class SettingsService
     /// has CUDA EP with Ampere+ tensor cores; otherwise falls back to the
     /// FP32 bundle. Mirrors the CLI's selection logic so editor and CLI
     /// pick the same bundle on the same machine.
+    ///
+    /// Implicit invariant with <c>ModelManagerService.ActiveRepos</c>:
+    /// both consult <see cref="HardwareInfo.SupportsBf16Acceleration"/> to
+    /// decide which bundle to fetch (manager) vs load (this). The result
+    /// is cached process-wide on the first call, so the two call sites
+    /// always agree within a single run.
     /// </summary>
     public string GetGraniteSpeechModelsDir()
     {

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -126,6 +126,25 @@ internal class SettingsService
         return fp32Dir;
     }
 
+    /// <summary>
+    /// Returns the path to a Granite Speech tokenizer.json from whichever
+    /// sibling bundle is actually installed (BF16 preferred, FP32 fallback),
+    /// or null when neither bundle is present. The two bundles ship
+    /// identical tokenizer.json content, so file-presence — not hardware
+    /// capability — is the right gate here: the editor's vocab loader and
+    /// any other consumer that needs the tokenizer should be able to find
+    /// it regardless of whether the user is on the "right" hardware for
+    /// the bundle they happened to download.
+    /// </summary>
+    public string? TryGetGraniteSpeechTokenizerPath()
+    {
+        string bf16Path = Path.Combine(GetModelsDir(), Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile);
+        if (File.Exists(bf16Path)) return bf16Path;
+        string fp32Path = Path.Combine(GetModelsDir(), Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile);
+        if (File.Exists(fp32Path)) return fp32Path;
+        return null;
+    }
+
     public string GetVoxLinguaModelsDir() =>
         string.IsNullOrWhiteSpace(Current.VoxLinguaModelsDir)
             ? Path.Combine(GetModelsDir(), Config.VoxLinguaSubDir)

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -118,6 +118,7 @@ internal class TranscriptionService
         bool useQwen3Asr         = string.Equals(asrModelName, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
         bool useIndicConformerAsr = string.Equals(asrModelName, "ai4bharat/indic-conformer-600m-multilingual", StringComparison.Ordinal);
         bool useWhisperTurboAsr   = string.Equals(asrModelName, "openai/whisper-large-v3-turbo", StringComparison.Ordinal);
+        bool useGraniteSpeechAsr  = string.Equals(asrModelName, "ibm-granite/granite-speech-4.1-2b", StringComparison.Ordinal);
         var  segmentationMode = _settings.Current.Segmentation;
         bool runVibeVoice     = useVibeVoiceAsr || segmentationMode == SegmentationMode.VibeVoiceBuiltin;
 
@@ -634,6 +635,7 @@ internal class TranscriptionService
                                 useCohereAsr         = string.Equals(asrModelName, "CohereLabs/cohere-transcribe-03-2026", StringComparison.Ordinal);
                                 useQwen3Asr          = string.Equals(asrModelName, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
                                 useIndicConformerAsr = string.Equals(asrModelName, "ai4bharat/indic-conformer-600m-multilingual", StringComparison.Ordinal);
+                                useGraniteSpeechAsr  = string.Equals(asrModelName, "ibm-granite/granite-speech-4.1-2b", StringComparison.Ordinal);
                                 // Reflect the switch in the results DB so the
                                 // Results view reads the *effective* backend
                                 // (and so the mismatch banner doesn't appear
@@ -1120,6 +1122,61 @@ internal class TranscriptionService
                             result.Text,
                             overridePercent));
                     }
+                }
+            }
+            else if (useGraniteSpeechAsr)
+            {
+                // Granite Speech 4.1 — encoder + Q-Former projector + 1.84B
+                // Granite-4 LM decoder. Recognize returns just (segId, text,
+                // speaker); the C# backend doesn't surface token IDs from the
+                // greedy decode, so we store empty token/logprob arrays and
+                // synthesize timestamps from the audio duration + word count.
+                // Word-level highlighting in the editor will be a no-op for
+                // Granite-transcribed segments — adding it would require
+                // exposing the greedy tokens from GraniteSpeech.Recognize.
+                string graniteDir = _settings.GetGraniteSpeechModelsDir();
+                using var granite = new GraniteSpeech(graniteDir);
+
+                foreach (var (segId, text, _) in granite.Recognize(segsSubset, audio))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    int rid   = unfilledResultIds[segId];
+                    int absId = rid - 1;
+                    completed++;
+
+                    int wordCount = string.IsNullOrWhiteSpace(text)
+                        ? 0
+                        : text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
+                    var syntheticTimestamps = BuildSyntheticTokenTimestamps(
+                        segsSubset[segId].end - segsSubset[segId].start,
+                        wordCount);
+
+                    db.UpdateResult(
+                        resultId:   rid,
+                        asrContent: text,
+                        content:    text,
+                        tokens:     JsonSerializer.Serialize(Array.Empty<int>()),
+                        timestamps: JsonSerializer.Serialize(syntheticTimestamps),
+                        logprobs:   JsonSerializer.Serialize(Array.Empty<float>()),
+                        language:   "en");
+
+                    onSegmentText(absId, text);
+
+                    string asrText = Loc.Instance.T("progress_recognizing_segment", new() {
+                        ["i"]     = completed.ToString(),
+                        ["count"] = totalSegs.ToString() });
+                    double? overridePercent = ScaleOverallProgress(
+                        diarizationEndPercent,
+                        100,
+                        totalSegs > 0 ? completed / (double)totalSegs : 1);
+                    progress.Report(new TranscriptionProgress(
+                        TranscriptionPhase.Recognizing,
+                        completed,
+                        totalSegs,
+                        asrText,
+                        absId,
+                        text,
+                        overridePercent));
                 }
             }
             else

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -1127,35 +1127,43 @@ internal class TranscriptionService
             else if (useGraniteSpeechAsr)
             {
                 // Granite Speech 4.1 — encoder + Q-Former projector + 1.84B
-                // Granite-4 LM decoder. Recognize returns just (segId, text,
-                // speaker); the C# backend doesn't surface token IDs from the
-                // greedy decode, so we store empty token/logprob arrays and
-                // synthesize timestamps from the audio duration + word count.
-                // Word-level highlighting in the editor will be a no-op for
-                // Granite-transcribed segments — adding it would require
-                // exposing the greedy tokens from GraniteSpeech.Recognize.
+                // Granite-4 LM decoder. RecognizeDetailed surfaces the
+                // post-trim BPE token IDs alongside the decoded text so the
+                // editor's word-sync UI gets per-token synthetic linear
+                // timestamps (Cohere/Qwen3 use the same scheme). Token count
+                // matches the visible text's information content because the
+                // backend has already stripped trailing EOS and any
+                // detected-runaway-loop tail before yielding.
+                //
+                // Logprobs aren't surfaced by the backend (greedy argmax
+                // discards them); stored as empty arrays. Word-level
+                // alignment beyond synthetic-linear is tracked in #36.
                 string graniteDir = _settings.GetGraniteSpeechModelsDir();
                 using var granite = new GraniteSpeech(graniteDir);
 
-                foreach (var (segId, text, _) in granite.Recognize(segsSubset, audio))
+                foreach (var (segId, text, tokens, _) in granite.RecognizeDetailed(segsSubset, audio))
                 {
                     ct.ThrowIfCancellationRequested();
                     int rid   = unfilledResultIds[segId];
                     int absId = rid - 1;
                     completed++;
 
-                    int wordCount = string.IsNullOrWhiteSpace(text)
-                        ? 0
-                        : text.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length;
                     var syntheticTimestamps = BuildSyntheticTokenTimestamps(
                         segsSubset[segId].end - segsSubset[segId].start,
-                        wordCount);
+                        tokens.Count);
+
+                    // Cast long-typed BPE IDs to int for DB storage (Granite's
+                    // vocab is 100353, well under int range). Matches Cohere's
+                    // List<int> token-storage shape so downstream readers don't
+                    // need a backend-specific path.
+                    var tokensInt = new int[tokens.Count];
+                    for (int i = 0; i < tokens.Count; i++) tokensInt[i] = (int)tokens[i];
 
                     db.UpdateResult(
                         resultId:   rid,
                         asrContent: text,
                         content:    text,
-                        tokens:     JsonSerializer.Serialize(Array.Empty<int>()),
+                        tokens:     JsonSerializer.Serialize(tokensInt),
                         timestamps: JsonSerializer.Serialize(syntheticTimestamps),
                         logprobs:   JsonSerializer.Serialize(Array.Empty<float>()),
                         language:   "en");

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -60,6 +60,22 @@ internal class VocabService
         }
         else
         {
+            // Default to Parakeet for null/empty asrModel — that's the
+            // legitimate "no specific backend known" caller (e.g. a fresh
+            // editor before the job's asr_model row has been written). For
+            // an UNRECOGNISED non-null string, log a warning so the
+            // dispatch-fan-out gap is visible at startup instead of silently
+            // mis-loading a vocab. This is what bit Granite Speech the first
+            // time around: missing case here → Parakeet text-format loader
+            // hit a JSON file → empty vocab → editor rendered raw GPT-2
+            // ByteLevel chars instead of decoded text.
+            if (!string.IsNullOrWhiteSpace(asrModel))
+            {
+                Console.Error.WriteLine(
+                    $"[VocabService] WARNING: unrecognised asrModel '{asrModel}'. " +
+                    $"Falling back to Parakeet vocab loader; tokens may render incorrectly. " +
+                    $"Add a VocabKind case for this backend.");
+            }
             _kind = VocabKind.Parakeet;
             _vocab = LoadParakeetVocab(Path.Combine(modelsDir, Config.VocabFile));
         }
@@ -232,7 +248,7 @@ internal class VocabService
     {
         var bytes = new List<byte>(tokens.Count * 4);
         foreach (int token in tokens)
-            bytes.AddRange(GetVibeVoiceTokenBytes(token));
+            bytes.AddRange(GetByteLevelTokenBytes(token));
         return TrimVibeVoiceBoundaryQuotes(Encoding.UTF8.GetString(bytes.ToArray()));
     }
 
@@ -245,7 +261,7 @@ internal class VocabService
         // GraniteSpeech.DecodeTokens in Vernacula.Base.
         var bytes = new List<byte>(tokens.Count * 4);
         foreach (int token in tokens)
-            bytes.AddRange(GetVibeVoiceTokenBytes(token));
+            bytes.AddRange(GetByteLevelTokenBytes(token));
         return Encoding.UTF8.GetString(bytes.ToArray());
     }
 
@@ -262,7 +278,7 @@ internal class VocabService
 
         for (int i = 0; i < tokens.Count; i++)
         {
-            byte[] tokenBytes = GetVibeVoiceTokenBytes(tokens[i]);
+            byte[] tokenBytes = GetByteLevelTokenBytes(tokens[i]);
             string runText;
             if (tokenBytes.Length == 0)
             {
@@ -301,7 +317,7 @@ internal class VocabService
             return value;
 
         if (_kind == VocabKind.VibeVoice)
-            return Encoding.UTF8.GetString(GetVibeVoiceTokenBytes(token));
+            return Encoding.UTF8.GetString(GetByteLevelTokenBytes(token));
         if (_kind == VocabKind.Qwen3Asr)
             return Encoding.UTF8.GetString(GetQwen3AsrTokenBytes(token));
         if (_kind == VocabKind.GraniteSpeech)
@@ -309,7 +325,7 @@ internal class VocabService
             // (special tokens render as their content; regular tokens decode
             // through _byteLevelDecode). Reusing the helper here means the
             // single-token decode stays in lock-step with DecodeGraniteSpeechTokens.
-            return Encoding.UTF8.GetString(GetVibeVoiceTokenBytes(token));
+            return Encoding.UTF8.GetString(GetByteLevelTokenBytes(token));
 
         if (value.Length == 6 && value[0] == '<' && value[1] == '0' && value[2] == 'x' && value[5] == '>')
         {
@@ -366,7 +382,7 @@ internal class VocabService
 
         for (int i = 0; i < tokens.Count; i++)
         {
-            byte[] tokenBytes = GetVibeVoiceTokenBytes(tokens[i]);
+            byte[] tokenBytes = GetByteLevelTokenBytes(tokens[i]);
             string runText;
             if (tokenBytes.Length == 0)
             {
@@ -423,7 +439,15 @@ internal class VocabService
         return runs;
     }
 
-    private byte[] GetVibeVoiceTokenBytes(int token)
+    /// <summary>
+    /// Resolves a token id to its underlying byte sequence under the GPT-2
+    /// ByteLevel BPE convention: each char in the raw vocab string maps to
+    /// one byte via <see cref="_byteLevelDecode"/>; added (special) tokens
+    /// render as their literal content as UTF-8. Used by every kind that
+    /// loads its vocab through HF tokenizer.json — VibeVoice, Qwen3, and
+    /// GraniteSpeech.
+    /// </summary>
+    private byte[] GetByteLevelTokenBytes(int token)
     {
         if (_addedContent.TryGetValue(token, out var special))
             return Encoding.UTF8.GetBytes(special);

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -13,7 +13,7 @@ namespace Vernacula.App.Services;
 /// </summary>
 internal class VocabService
 {
-    private enum VocabKind { Parakeet, Cohere, Qwen3Asr, VibeVoice, IndicConformer }
+    private enum VocabKind { Parakeet, Cohere, Qwen3Asr, VibeVoice, IndicConformer, GraniteSpeech }
 
     private readonly Dictionary<int, string> _vocab;
     private readonly VocabKind _kind;
@@ -43,6 +43,20 @@ internal class VocabService
         {
             _kind = VocabKind.IndicConformer;
             _vocab = LoadIndicConformerVocab(Path.Combine(modelsDir, Config.IndicConformerSubDir, Config.VocabFile));
+        }
+        else if (string.Equals(asrModel, "ibm-granite/granite-speech-4.1-2b", StringComparison.Ordinal))
+        {
+            // Granite ships in two sibling bundles (FP32 / BF16 mixed-precision).
+            // The tokenizer.json is identical between them; pick whichever one is
+            // installed. Decode path mirrors Qwen3 / VibeVoice (HF-style
+            // tokenizer.json + GPT-2 ByteLevel BPE), which matches what
+            // GraniteSpeech.DecodeTokens does in Vernacula.Base.
+            _kind = VocabKind.GraniteSpeech;
+            string bf16TokPath = Path.Combine(modelsDir, Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile);
+            string fp32TokPath = Path.Combine(modelsDir, Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile);
+            string tokPath = File.Exists(bf16TokPath) ? bf16TokPath : fp32TokPath;
+            (_vocab, _addedContent) = LoadVibeVoiceVocab(tokPath);
+            _byteLevelDecode = BuildByteLevelDecode();
         }
         else
         {
@@ -135,10 +149,11 @@ internal class VocabService
     {
         return _kind switch
         {
-            VocabKind.Cohere   => DecodeCohereTokens(tokens),
-            VocabKind.Qwen3Asr => DecodeQwen3AsrTokens(tokens),
-            VocabKind.VibeVoice => DecodeVibeVoiceTokens(tokens),
-            _                  => DecodeParakeetTokens(tokens),
+            VocabKind.Cohere        => DecodeCohereTokens(tokens),
+            VocabKind.Qwen3Asr      => DecodeQwen3AsrTokens(tokens),
+            VocabKind.VibeVoice     => DecodeVibeVoiceTokens(tokens),
+            VocabKind.GraniteSpeech => DecodeGraniteSpeechTokens(tokens),
+            _                       => DecodeParakeetTokens(tokens),
         };
     }
 
@@ -152,6 +167,8 @@ internal class VocabService
             return GetQwen3AsrTokenRuns(tokens, logprobs);
         if (_kind == VocabKind.VibeVoice)
             return GetVibeVoiceTokenRuns(tokens, logprobs, targetText);
+        if (_kind == VocabKind.GraniteSpeech)
+            return GetGraniteSpeechTokenRuns(tokens, logprobs);
 
         var runs = new List<(string, float)>(tokens.Count);
         for (int i = 0; i < tokens.Count; i++)
@@ -219,6 +236,53 @@ internal class VocabService
         return TrimVibeVoiceBoundaryQuotes(Encoding.UTF8.GetString(bytes.ToArray()));
     }
 
+    private string DecodeGraniteSpeechTokens(IReadOnlyList<int> tokens)
+    {
+        // Same byte resolution as VibeVoice (HF tokenizer.json + GPT-2 ByteLevel
+        // BPE) but no boundary-quote trim — Granite is plain ASR, not a
+        // JSON-mode model, so leading/trailing quotes in the output are real
+        // content if they appear and shouldn't be stripped. Mirrors
+        // GraniteSpeech.DecodeTokens in Vernacula.Base.
+        var bytes = new List<byte>(tokens.Count * 4);
+        foreach (int token in tokens)
+            bytes.AddRange(GetVibeVoiceTokenBytes(token));
+        return Encoding.UTF8.GetString(bytes.ToArray());
+    }
+
+    private IReadOnlyList<(string text, float logprob)> GetGraniteSpeechTokenRuns(
+        IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
+    {
+        // Per-token UTF-8 decode using a streaming Decoder so multi-byte
+        // characters split across consecutive BPE tokens render at the byte
+        // boundary they actually finish at. Matches the Qwen3 / VibeVoice
+        // pattern; no leading-space-strip or quote-trim because Granite's
+        // raw decode already lines up with Content (no prefix-quote artefact).
+        var runs = new List<(string, float)>(tokens.Count);
+        Decoder decoder = Encoding.UTF8.GetDecoder();
+
+        for (int i = 0; i < tokens.Count; i++)
+        {
+            byte[] tokenBytes = GetVibeVoiceTokenBytes(tokens[i]);
+            string runText;
+            if (tokenBytes.Length == 0)
+            {
+                runText = "";
+            }
+            else
+            {
+                int charCount = decoder.GetCharCount(tokenBytes, 0, tokenBytes.Length, flush: false);
+                char[] chars = new char[charCount];
+                decoder.GetChars(tokenBytes, 0, tokenBytes.Length, chars, 0, flush: false);
+                runText = new string(chars);
+            }
+
+            float lp = i < logprobs.Count ? logprobs[i] : 0f;
+            runs.Add((runText, lp));
+        }
+
+        return runs;
+    }
+
     private string DecodeQwen3AsrTokens(IReadOnlyList<int> tokens)
     {
         var bytes = new List<byte>(tokens.Count * 4);
@@ -240,6 +304,12 @@ internal class VocabService
             return Encoding.UTF8.GetString(GetVibeVoiceTokenBytes(token));
         if (_kind == VocabKind.Qwen3Asr)
             return Encoding.UTF8.GetString(GetQwen3AsrTokenBytes(token));
+        if (_kind == VocabKind.GraniteSpeech)
+            // Granite shares VibeVoice's GPT-2-ByteLevel byte resolution path
+            // (special tokens render as their content; regular tokens decode
+            // through _byteLevelDecode). Reusing the helper here means the
+            // single-token decode stays in lock-step with DecodeGraniteSpeechTokens.
+            return Encoding.UTF8.GetString(GetVibeVoiceTokenBytes(token));
 
         if (value.Length == 6 && value[0] == '<' && value[1] == '0' && value[2] == 'x' && value[5] == '>')
         {

--- a/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
@@ -7,6 +7,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Vernacula.App.Models;
 using Vernacula.App.Services;
+using Vernacula.Base;
+using Vernacula.Base.Models;
 
 namespace Vernacula.App.ViewModels;
 
@@ -85,7 +87,16 @@ internal partial class HomeViewModel : ObservableObject
         else if (_settings.Current.AsrBackend == AsrBackend.IndicConformer)
             ModelStatusText = $"IndicConformer weights are missing. Place them in {_settings.GetIndicConformerModelsDir()}.";
         else if (_settings.Current.AsrBackend == AsrBackend.GraniteSpeech)
-            ModelStatusText = $"Granite Speech weights are missing. Use Download Missing Models, or place them in {_settings.GetGraniteSpeechModelsDir()}.";
+            // Two install paths exist (granite_speech_4_1_2b/ and
+            // granite_speech_4_1_2b_bf16/); GetGraniteSpeechModelsDir
+            // returns the auto-pick for the current hardware. Tell the
+            // user that path explicitly — it's the one Download Missing
+            // Models would populate — but mention the sibling so a
+            // manual install ends up where the loader will look on
+            // hardware where the auto-pick differs.
+            ModelStatusText = HardwareInfo.SupportsBf16Acceleration()
+                ? $"Granite Speech weights are missing. Use Download Missing Models, or place them in {_settings.GetGraniteSpeechModelsDir()} (FP32 sibling: {Config.GraniteSpeechSubDir}/)."
+                : $"Granite Speech weights are missing. Use Download Missing Models, or place them in {_settings.GetGraniteSpeechModelsDir()}.";
         else if (_settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen)
             ModelStatusText = "DiariZen external weights are missing. Open Settings to review the notice and import or download them.";
         else

--- a/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/HomeViewModel.cs
@@ -84,6 +84,8 @@ internal partial class HomeViewModel : ObservableObject
             ModelStatusText = $"VibeVoice-ASR weights are missing. Use Download Missing Models, or place them in {_settings.GetVibeVoiceModelsDir()}.";
         else if (_settings.Current.AsrBackend == AsrBackend.IndicConformer)
             ModelStatusText = $"IndicConformer weights are missing. Place them in {_settings.GetIndicConformerModelsDir()}.";
+        else if (_settings.Current.AsrBackend == AsrBackend.GraniteSpeech)
+            ModelStatusText = $"Granite Speech weights are missing. Use Download Missing Models, or place them in {_settings.GetGraniteSpeechModelsDir()}.";
         else if (_settings.Current.Segmentation == Vernacula.Base.Models.SegmentationMode.DiariZen)
             ModelStatusText = "DiariZen external weights are missing. Open Settings to review the notice and import or download them.";
         else

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -31,7 +31,7 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrIndicConformer), nameof(IsAsrWhisperTurbo), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker), nameof(ShowWhisperTurboLanguagePicker))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrIndicConformer), nameof(IsAsrWhisperTurbo), nameof(IsAsrGraniteSpeech), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker), nameof(ShowWhisperTurboLanguagePicker))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -138,6 +138,7 @@ internal partial class SettingsViewModel : ObservableObject
     public bool IsAsrVibeVoice      => SelectedAsrBackend == AsrBackend.VibeVoice;
     public bool IsAsrIndicConformer => SelectedAsrBackend == AsrBackend.IndicConformer;
     public bool IsAsrWhisperTurbo   => SelectedAsrBackend == AsrBackend.WhisperTurbo;
+    public bool IsAsrGraniteSpeech  => SelectedAsrBackend == AsrBackend.GraniteSpeech;
     public bool CanUseVibeVoiceAsr  => CudaEpWorking;
     public string VibeVoiceAsrLabel => CanUseVibeVoiceAsr ? "VibeVoice-ASR" : "VibeVoice-ASR (Unavailable - CUDA Missing)";
     public string VibeVoiceAsrDescription => CanUseVibeVoiceAsr

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -603,6 +603,24 @@
                             </StackPanel>
                         </RadioButton>
 
+                        <Separator Background="{DynamicResource OverlayBrush}" Margin="0,8,0,8" />
+
+                        <RadioButton GroupName="AsrBackend"
+                                     IsChecked="{Binding IsAsrGraniteSpeech, Mode=OneWay}"
+                                     Command="{Binding SetAsrBackendCommand}"
+                                     CommandParameter="GraniteSpeech"
+                                     Foreground="{DynamicResource TextBrush}">
+                            <StackPanel>
+                                <TextBlock Text="Granite Speech 4.1 (2B)"
+                                           FontWeight="SemiBold"
+                                           Foreground="{DynamicResource TextBrush}" />
+                                <TextBlock Text="IBM's 1.84B Granite-4 LLM decoder with a Conformer audio encoder. English-first; supports French, German, Spanish, Portuguese, Japanese. Downloads into granite_speech_4_1_2b/ (FP32) or granite_speech_4_1_2b_bf16/ (BF16, auto-selected on Ampere+ NVIDIA GPUs)."
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap" />
+                            </StackPanel>
+                        </RadioButton>
+
                         <Expander Margin="24,10,0,0"
                                   IsExpanded="False"
                                   IsVisible="{Binding IsAsrParakeet}">

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -115,19 +115,14 @@ public partial class TranscriptEditorWindow : Window
                 ? "Granite Speech: no word-level timing; token sync is approximate."
                 : "";
 
-        // Granite ships in two sibling bundles (FP32 / BF16 mixed-precision).
-        // Tokenizer.json is identical between them; pick whichever one is
-        // installed on disk — the BF16 dir takes precedence to match
-        // SettingsService.GetGraniteSpeechModelsDir's auto-pick.
-        string? graniteVocabPath = null;
-        if (isGraniteSpeech)
-        {
-            string bf16TokPath = Path.Combine(modelsDir, Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile);
-            string fp32TokPath = Path.Combine(modelsDir, Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile);
-            graniteVocabPath = File.Exists(bf16TokPath) ? bf16TokPath
-                : File.Exists(fp32TokPath) ? fp32TokPath
-                : null;
-        }
+        // Granite ships in two sibling bundles (FP32 / BF16 mixed-precision)
+        // with identical tokenizer.json content;
+        // SettingsService.TryGetGraniteSpeechTokenizerPath does the BF16-first
+        // probe so the editor and any other tokenizer consumer share the
+        // same resolution.
+        string? graniteVocabPath = isGraniteSpeech
+            ? App.Current.Settings.TryGetGraniteSpeechTokenizerPath()
+            : null;
 
         string? vocabPath = isCohere
             ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)

--- a/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
+++ b/src/Vernacula.Avalonia/Views/TranscriptEditorWindow.axaml.cs
@@ -102,15 +102,32 @@ public partial class TranscriptEditorWindow : Window
         bool isQwen3Asr       = string.Equals(_jobAsrModel, "Qwen/Qwen3-ASR-1.7B", StringComparison.Ordinal);
         bool isVibeVoice      = string.Equals(_jobAsrModel, "vibevoice/vibevoice-asr", StringComparison.Ordinal);
         bool isIndicConformer = string.Equals(_jobAsrModel, "ai4bharat/indic-conformer-600m-multilingual", StringComparison.Ordinal);
+        bool isGraniteSpeech  = string.Equals(_jobAsrModel, "ibm-granite/granite-speech-4.1-2b", StringComparison.Ordinal);
         _isQwen3Asr = isQwen3Asr;
-        _showApproximateTimingNotice = isCohere || isQwen3Asr || isVibeVoice;
+        _showApproximateTimingNotice = isCohere || isQwen3Asr || isVibeVoice || isGraniteSpeech;
         _approximateTimingNoticeText = isCohere
             ? "Cohere Transcribe: no word-level timing; token sync is approximate."
             : isQwen3Asr
                 ? "Qwen3-ASR: no word-level timing; token sync is approximate."
             : isVibeVoice
                 ? "VibeVoice-ASR: no token-level timing; token sync is approximate."
+            : isGraniteSpeech
+                ? "Granite Speech: no word-level timing; token sync is approximate."
                 : "";
+
+        // Granite ships in two sibling bundles (FP32 / BF16 mixed-precision).
+        // Tokenizer.json is identical between them; pick whichever one is
+        // installed on disk — the BF16 dir takes precedence to match
+        // SettingsService.GetGraniteSpeechModelsDir's auto-pick.
+        string? graniteVocabPath = null;
+        if (isGraniteSpeech)
+        {
+            string bf16TokPath = Path.Combine(modelsDir, Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile);
+            string fp32TokPath = Path.Combine(modelsDir, Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile);
+            graniteVocabPath = File.Exists(bf16TokPath) ? bf16TokPath
+                : File.Exists(fp32TokPath) ? fp32TokPath
+                : null;
+        }
 
         string? vocabPath = isCohere
             ? Path.Combine(modelsDir, "cohere_transcribe", CohereTranscribe.VocabFile)
@@ -120,11 +137,13 @@ public partial class TranscriptEditorWindow : Window
                 ? Path.Combine(modelsDir, Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile)
             : isIndicConformer
                 ? Path.Combine(modelsDir, Config.IndicConformerSubDir, Config.VocabFile)
+            : isGraniteSpeech
+                ? graniteVocabPath
                 : Path.Combine(parakeetModelsDir, Config.VocabFile);
         if (vocabPath is not null && File.Exists(vocabPath))
         {
             _vocab = new VocabService(
-                isCohere || isQwen3Asr || isVibeVoice || isIndicConformer
+                isCohere || isQwen3Asr || isVibeVoice || isIndicConformer || isGraniteSpeech
                     ? App.Current.Settings.GetModelsDir() : parakeetModelsDir,
                 _jobAsrModel);
         }

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -36,11 +36,16 @@ namespace Vernacula.Base;
 /// </summary>
 public sealed class GraniteSpeech : IDisposable
 {
-    public const string MelFile       = "mel.onnx";
-    public const string EncoderFile   = "encoder.onnx";
-    public const string ProjectorFile = "projector.onnx";
-    public const string DecoderFile   = "decoder.onnx";
-    public const string TokenizerFile = "tokenizer.json";
+    public const string MelFile           = "mel.onnx";
+    public const string EncoderFile       = "encoder.onnx";
+    public const string ProjectorFile     = "projector.onnx";
+    public const string DecoderFile       = "decoder.onnx";
+    public const string TokenizerFile     = "tokenizer.json";
+    public const string VocabFile         = "vocab.json";
+    public const string MergesFile        = "merges.txt";
+    public const string AddedTokensFile   = "added_tokens.json";
+    public const string SpecialTokensFile = "special_tokens_map.json";
+    public const string TokenizerCfgFile  = "tokenizer_config.json";
 
     // ── Architecture constants ──────────────────────────────────────────
     // Mirror what the Python export wrote into config.json. Hardcoded here

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -180,16 +180,43 @@ public sealed class GraniteSpeech : IDisposable
     /// labels are passed through from the input segments — Granite Speech
     /// itself doesn't do speaker diarization.
     ///
+    /// Thin wrapper over <see cref="RecognizeDetailed"/> that drops the
+    /// per-segment token IDs. Callers that want token-level data — for
+    /// editor word-sync via synthetic linear timestamps, or for any
+    /// per-token UI — should use <see cref="RecognizeDetailed"/> directly.
+    /// </summary>
+    /// <param name="segs">Segment list as <c>(start_seconds, end_seconds, speaker_label)</c>.</param>
+    /// <param name="audio">Mono 16 kHz waveform covering all segments.</param>
+    /// <param name="maxNewTokens">Cap on generated tokens per segment.</param>
+    public IEnumerable<(int segId, string text, string speaker)> Recognize(
+        IReadOnlyList<(double start, double end, string spk)> segs,
+        float[] audio,
+        int maxNewTokens = 256)
+    {
+        foreach (var (segId, text, _, speaker) in RecognizeDetailed(segs, audio, maxNewTokens))
+            yield return (segId, text, speaker);
+    }
+
+    /// <summary>
+    /// Like <see cref="Recognize"/> but also surfaces the post-trim BPE token
+    /// IDs that produced the text. Used by the GUI's transcript editor to
+    /// drive word-level click-to-position via <c>BuildSyntheticTokenTimestamps</c>:
+    /// per-token linear timestamps over the segment duration give finer
+    /// granularity than per-word splitting and match what Cohere/Qwen3
+    /// surface today.
+    ///
+    /// Tokens are the same sequence used to produce the text: trailing EOS
+    /// stripped, periodic-loop tail trimmed when the runaway-loop detector
+    /// fired. Token count therefore matches the visible text's information
+    /// content, not the raw decode length.
+    ///
     /// Segments are sorted by ascending duration and packed into VRAM-budgeted
     /// batches via <see cref="BatchSizer.Plan"/>. Within a batch, all segments
     /// run through a single batched forward of mel + encoder + projector +
     /// unified decoder; per-row EOS tracking lets shorter segments stop while
     /// the longest finishes its decode.
     /// </summary>
-    /// <param name="segs">Segment list as <c>(start_seconds, end_seconds, speaker_label)</c>.</param>
-    /// <param name="audio">Mono 16 kHz waveform covering all segments.</param>
-    /// <param name="maxNewTokens">Cap on generated tokens per segment.</param>
-    public IEnumerable<(int segId, string text, string speaker)> Recognize(
+    public IEnumerable<(int segId, string text, IReadOnlyList<long> tokens, string speaker)> RecognizeDetailed(
         IReadOnlyList<(double start, double end, string spk)> segs,
         float[] audio,
         int maxNewTokens = 256)
@@ -211,7 +238,7 @@ public sealed class GraniteSpeech : IDisposable
             int[] segIds = batch.SegmentIndices;
 
             // Extract waveforms; mark short ones to skip without dropping the
-            // batch slot (we yield an empty string for them).
+            // batch slot (we yield an empty result for them).
             var waveforms = new float[B][];
             var skipped = new bool[B];
             for (int b = 0; b < B; b++)
@@ -227,28 +254,30 @@ public sealed class GraniteSpeech : IDisposable
             for (int b = 0; b < B; b++)
                 if (!skipped[b]) { realIdx.Add(b); realWaves.Add(waveforms[b]); }
 
-            string[] realTexts = realWaves.Count > 0
+            (string text, long[] tokens)[] realRows = realWaves.Count > 0
                 ? TranscribeBatch(realWaves.ToArray(), maxNewTokens)
-                : Array.Empty<string>();
+                : Array.Empty<(string, long[])>();
 
             // Yield in the batch order; reinflate the skipped slots.
             for (int b = 0; b < B; b++)
             {
                 int segId = segIds[b];
                 string text = string.Empty;
+                IReadOnlyList<long> tokens = Array.Empty<long>();
                 if (!skipped[b])
                 {
                     int realPos = realIdx.IndexOf(b);
-                    text = realTexts[realPos];
+                    text = realRows[realPos].text;
+                    tokens = realRows[realPos].tokens;
                 }
-                yield return (segId, text, segs[segId].spk);
+                yield return (segId, text, tokens, segs[segId].spk);
             }
         }
     }
 
     /// <summary>Convenience entry point for transcribing a single waveform.</summary>
     public string Transcribe(float[] audio16kMono, int maxNewTokens = 256)
-        => TranscribeBatch(new[] { audio16kMono }, maxNewTokens)[0];
+        => TranscribeBatch(new[] { audio16kMono }, maxNewTokens)[0].text;
 
     // ── Batched pipeline ────────────────────────────────────────────────
 
@@ -283,10 +312,10 @@ public sealed class GraniteSpeech : IDisposable
     internal static int MaxBatchSeen;
     private static readonly object _profileLock = new();
 
-    private string[] TranscribeBatch(float[][] waveforms, int maxNewTokens)
+    private (string text, long[] tokens)[] TranscribeBatch(float[][] waveforms, int maxNewTokens)
     {
         int B = waveforms.Length;
-        if (B == 0) return Array.Empty<string>();
+        if (B == 0) return Array.Empty<(string, long[])>();
 
         var swBatch = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
         long melLocal = 0, encLocal = 0, projLocal = 0;
@@ -572,7 +601,11 @@ public sealed class GraniteSpeech : IDisposable
         // tail on rows where the runtime detector classified the row as a
         // runaway. Otherwise natural emphatic repetition (e.g. a speaker
         // saying "no, no, no!") would be silently truncated.
-        var texts = new string[B];
+        // Both the decoded text AND the trimmed token list are surfaced so
+        // the GUI's synthetic-linear-timestamp logic in TranscriptionService
+        // can use real BPE tokens for editor word-sync (token count drives
+        // BuildSyntheticTokenTimestamps' interpolation granularity).
+        var rows = new (string text, long[] tokens)[B];
         for (int b = 0; b < B; b++)
         {
             var toks = generated[b];
@@ -581,8 +614,13 @@ public sealed class GraniteSpeech : IDisposable
             int trimmed = loopDetected[b]
                 ? TrimRepetitionTail(toks, realCount)
                 : realCount;
-            if (trimmed == toks.Count) texts[b] = DecodeTokens(toks);
-            else texts[b] = DecodeTokens(toks.GetRange(0, trimmed));
+            if (trimmed == toks.Count)
+                rows[b] = (DecodeTokens(toks), toks.ToArray());
+            else
+            {
+                var trimmedToks = toks.GetRange(0, trimmed);
+                rows[b] = (DecodeTokens(trimmedToks), trimmedToks.ToArray());
+            }
         }
 
         if (swBatch != null)
@@ -603,7 +641,7 @@ public sealed class GraniteSpeech : IDisposable
               + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
               + $"overhead={overhead}ms)");
         }
-        return texts;
+        return rows;
     }
 
     /// <summary>Print accumulated profile stats and reset. Returns true if profiling was on.</summary>

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -283,13 +283,20 @@ public static class HardwareInfo
     /// tensor cores the BF16 kernels fall back to slower paths or are unavailable
     /// (the LM decoder ops, the encoder Conv, and ORT's CPU EP <c>Where(BF16)</c>
     /// all have known coverage gaps), so the FP32 bundle is the safe default.
+    ///
+    /// Result is cached after the first call: the answer is fixed for the
+    /// lifetime of the process (GPUs don't hot-swap), and the underlying
+    /// NVML init/get/shutdown cycle is non-trivial when called repeatedly
+    /// from settings/UI flows.
     /// </summary>
-    public static bool SupportsBf16Acceleration()
+    public static bool SupportsBf16Acceleration() => _bf16Cache.Value;
+
+    private static readonly Lazy<bool> _bf16Cache = new(() =>
     {
         if (!CanProbeCudaExecutionProvider()) return false;
         var (major, _) = GetCudaComputeCapability();
         return major >= 8;
-    }
+    });
 
     private static int NvmlInitPlatform() =>
         OperatingSystem.IsWindows() ? NvmlInitWindows() : NvmlInitLinux();


### PR DESCRIPTION
## Summary

Wires Granite Speech 4.1 into the Avalonia GUI alongside the other ASR backends. Integration is structurally simpler than Cohere/Qwen3 because Granite is English-first with no per-file language picker, no LID grouping, and no token surface from \`Recognize\`.

- **Settings UI**: new \"Granite Speech 4.1 (2B)\" radio button at the end of the ASR backend list with a one-line description.
- **Model manager**: registers both HF bundles (\`granite-speech-4-1-2b-onnx\` FP32 and \`granite-speech-4-1-2b-onnx-bf16\`); \`ActiveRepos\` picks one or the other at runtime via \`HardwareInfo.SupportsBf16Acceleration()\`. The two bundles install into separate local subdirs (\`granite_speech_4_1_2b/\` vs \`granite_speech_4_1_2b_bf16/\`) so a downloaded FP32 bundle is preserved if the user later upgrades to an Ampere+ GPU.
- **Transcribe dispatch**: \`useGraniteSpeechAsr\` branch in \`TranscriptionService\` calls \`GraniteSpeech.Recognize\` and writes results to the DB. Tokens/logprobs are stored as empty arrays (Granite's Recognize doesn't surface them); timestamps synthesised from word count.
- **Bundle selection mirrors the CLI** so editor and CLI agree on which bundle to load on a given host. \`SettingsService.GetGraniteSpeechModelsDir\` is the single source of truth.
- **HomeViewModel**: model-status warning when the bundle's missing.

## Limitations / known gaps

- **No word-level highlighting in the editor** for Granite-transcribed segments — \`GraniteSpeech.Recognize\` only returns \`(segId, text, speaker)\`. Surfacing greedy tokens would let the editor light up token-level UI; deferred.
- **No language picker** — Granite is English-first; the upstream model card lists fr/de/es/pt/ja as secondary but the ASR prompt template targets English. Force-language UI would require additional prompt-template plumbing in the backend; not in this PR.

## Test plan

- [x] Build (Vernacula.Avalonia + Vernacula.CLI) clean, 0 warnings
- [x] CLI smoke (\`--asr granite\` on VCTK 6.4 s) still works after the GUI changes — same bundle auto-detect output, same transcript
- [x] Reviewer: launch the GUI, pick Granite Speech in Settings, run \"Download Missing Models\" against an empty models dir, transcribe a test clip end-to-end via the editor
- [x] Reviewer: confirm hardware auto-pick selects the BF16 bundle on a 3090 and the FP32 bundle on a CPU-only or pre-Ampere host
- [x] Reviewer: confirm empty-segment behaviour (a 0-duration VAD chunk produces an empty transcript without crashing the editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)