### PR TITLE
Granite Speech: fused-attention investigation and dynamic-shape decoder path (closes #43 with negative findings)

### DIFF
--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2475,13 +2475,268 @@ function. The answer changes which iter-5 plan is correct:
   the recon phase are reproducible if you need to re-verify GQA's
   left-alignment or MHA's mask semantics.
 
+## Run 19 — 2026-05-10 11:51 — ORT MHA semantics ground-truthed
 
+**Goal of this run:** before writing any iter-5 code, verify the
+iter-4 speculative claim that ORT's `relative_position_bias` is
+"relative-position-style only" (and therefore that iter-2's
+where_2-as-RPB wiring couldn't have been semantically correct).
 
+**Method:** read the authoritative ORT contrib op spec
+(`docs/ContribOperators.md`) plus the CUDA op implementation
+(`onnxruntime/contrib_ops/cuda/bert/multihead_attention.cc`) and
+the kernel scale path (`attention_impl.cu`) on `main`.
 
+### Findings (verbatim from ORT main)
 
+1. **The input is no longer named `relative_position_bias`** — it
+   was renamed to `attention_bias` in current ORT. The contrib spec
+   says:
 
+   > **`attention_bias`** (optional) : T — bias added to QxK' with
+   > shape `(batch_size or 1, num_heads or 1, sequence_length,
+   > total_sequence_length)`
 
+   "Bias added to QxK'" is a literal element-wise additive bias.
+   No relative-position indexing; broadcast over batch and heads
+   is supported via the `or 1` dims.
 
+2. **Kernel data flow is a literal pointer assign**, not a
+   computed function:
+
+   ```cpp
+   data.attention_bias = reinterpret_cast<const CudaT*>(
+       attention_bias->Data<T>());
+   ```
+
+   It is forwarded into `QkvToContext` and added element-wise to
+   scores before softmax. (Default scale 1/sqrt(head_size) is
+   confirmed in `attention_impl.cu`; matches Granite's
+   head_size=128.)
+
+3. **`unidirectional` is a flat causal-mask attribute** —
+   "Whether every token can only attend to previous tokens.
+   Default 0." When `past_key`/`past_value` are also provided,
+   MHA concatenates internally and `total_sequence_length =
+   past_sequence_length + sequence_length`; the present_key
+   output shape is `(B, num_heads, total_sequence_length,
+   head_size)`, confirming internal concat. The ORT-side
+   causal mask therefore covers the new query positions
+   correctly relative to the cached past — i.e., iter 3's
+   "Q[s] only sees [0,s]" symptom only happens when you
+   pre-concat K *and* set `unidirectional=1` (no `past_key`
+   input given). With proper `past_key` plumbing, causal would
+   be applied with the right offset.
+
+4. **`key` accepts a (B, num_heads, kv_seq_len, head_size)
+   layout** — per the spec, the `key` input may be in
+   "past_key with shape (batch_size, num_heads,
+   kv_sequence_length, head_size)" form. **This means we can
+   feed K (and V) directly in the post-Transpose layout
+   without a Transpose+Reshape adapter**, which the rewriter
+   currently uses. Same for `value`. (Q is still required as
+   `(B, S, hidden_size)`.) Big simplification for the rewrite.
+
+5. **`key_padding_mask` shapes** include `(batch_size,
+   sequence_length, total_sequence_length)` — a 3D per-(q,k)
+   binary mask. Type constraint M is `tensor(int32)`, so it
+   can't carry the float `-inf` of where_2 directly; it would
+   have to be derived as a binary causal+padding mask. Likely
+   not needed if `attention_bias` works.
+
+6. **Restrictions when `attention_bias` is non-null**:
+   Flash Attention, Lean Attention, fused cross-attention, and
+   fused TRT self-attention paths are disabled. cuDNN SDPA and
+   memory-efficient attention remain available (with alignment
+   constraints). So feeding where_2 as `attention_bias` *does*
+   prevent the most aggressive fast paths — but cuDNN SDPA is
+   still on the table and is typically the winner on Hopper-
+   class hardware for our shape regime.
+
+### Implication — iter-4's hypothesis is DISPROVEN
+
+`attention_bias` is a literal additive mask. Iter-2's wiring
+(feeding where_2 as RPB) was **semantically correct** for the
+mask semantics. The partial-correct ("Garrett, of course none
+of them") output therefore came from a *different* bug, not
+from RPB being misinterpreted. Candidate bugs, in priority
+order, given what we now know:
+
+a. **Q/K/V head-layout adapter in the rewriter.** Iter 2 wraps
+   the existing Transpose+Reshape pair to produce `(B, S,
+   hidden_size)` for all three of MHA's `query/key/value`
+   inputs. If the head ordering inside `hidden_size` doesn't
+   match MHA's internal `(num_heads, head_size)` interpretation,
+   per-head outputs would be permuted — exactly the kind of
+   "almost right tokens, mostly wrong" output we saw. **This is
+   the most likely root cause.** It's also testable cheaply: feed
+   K and V in the new spec-supported `(B, num_heads, S, head_size)`
+   layout directly, eliminating the K/V adapter entirely.
+
+b. **Numerical drift.** Original computes scores in fp32 with bf16
+   K/V dequantized at the matmul. MHA may accumulate in bf16. We
+   should be able to bound this by comparing per-layer attention
+   output L2 deltas; if drift compounds across 40 layers it could
+   produce iter-2-style output, but a 16-tap GEMM in bf16 is
+   typically <1e-3 relative error, which shouldn't garble decoding.
+
+c. **Scale.** Default `1/sqrt(head_size)` matches Granite. Unless
+   the original graph hides a non-default scale upstream of the
+   QK matmul (e.g., a `Mul(0.125)` we mis-attributed as the
+   1/sqrt scale when actually it's a separate logit_scaling),
+   this isn't the bug. Worth a 5-min audit of the unfused graph
+   structure around the QK matmul to confirm.
+
+### Iter-5 plan (revised, grounded in spec)
+
+The hand-off recommended either "stick with iter 2 if RPB is
+literal" OR "do past_key plumbing if RPB is relative-position-
+only". Given finding 1 above, the answer is **option A — stick
+with iter-2-style wiring** and fix the layout bug, not option B
+(past_kv plumbing). But the spec (finding 4) lets us simplify
+iter 2 in a way that *also* eliminates the most likely bug:
+
+1. Revert `scripts/granite_export/rewrite_attention_to_mha.py`
+   to iter-2 (`b9246cf`).
+2. Change K and V wiring: instead of the Transpose+Reshape pair
+   that produces `(B, S, hidden_size)`, feed K and V as `(B,
+   num_heads, S, head_size)` directly into MHA's `key`/`value`.
+   This is what the spec calls the "past_key shape" form and is
+   accepted natively.
+3. Keep `where_2` as `attention_bias` (rename in code from RPB).
+4. Build a per-layer parity harness: dump attention output of
+   layer 0 from both unfused-static and rewritten bundles on the
+   same input, diff. Walk layers 1..N if 0 matches.
+5. Only if a→b doesn't close the gap, consider past_kv plumbing.
+   It's now a fallback, not the primary plan.
+
+### Hand-off note for the next investigator
+
+**Don't** revert the iter-4 commit (`e8ed2ad`) — its dtype-
+rejection finding is still useful for ruling out the cast
+approach. Just branch from `b9246cf` (iter 2) for the actual
+rewriter changes, and treat this Run 19 entry as the spec
+ground truth that supersedes iter 4's speculative diagnosis.
+
+The single highest-value thing to do first is to compare a
+single rewritten layer's attention output against unfused on
+identical Q/K/V inputs. If they match bitwise (or to fp32 noise
+floor), the wiring is right and we just had a layout bug; if
+they don't, the diff is the next clue.
+
+## Run 19 — 2026-05-10 12:34 — Parity achieved (Granite scale = 1/head_dim)
+
+Implemented the iter-5 plan (drop K/V Transpose+Reshape adapter,
+feed K/V in (B, num_heads, T, head_dim) directly into MHA's
+`key`/`value`; keep `where_2` as `attention_bias`; drop the
+iter-4 fp32 cast on the bias). Output bundles staged at
+`/tmp/granite_iter5_*_bundle/` with hardlinked `decoder.onnx.data`
+to avoid duplicating the 3.6 GB sidecar.
+
+### Layer-by-layer bisect (e2e on `/tmp/run15_short_60s.wav`)
+
+| Layers rewritten | First-segment transcript |
+|---|---|
+| 0 only | "all kinds of telephone calls of course none of them were Garrett and so I mean I was just getting more and more as I would answer the phone it would not be Garrett I" — **matches baseline** |
+| 0–1 | mostly correct, "I'm saying" instead of "and so I mean" |
+| 0–9 | correct words, lower-case "garret", doubled "as as" |
+| 0–19 | derails partway: "none of them are gar- i- i mean i-" |
+| 0–39 | fully derailed: "all kinds of garret's of course none of them would be as i- as a as" — same as iter 2 |
+
+The progressive degradation pattern was the smoking gun: per-layer
+rewrite is geometrically correct, but error compounds across layers.
+
+### Root cause — Granite uses `attention_multiplier = 1/head_dim`, not `1/sqrt(head_dim)`
+
+Direct inspection of the unfused graph initializers:
+
+  scalar_tensor_default_2 = 0.0078125  # = 1/128 = 1/head_dim
+  clone_80                = 0.0
+  scalar_tensor_default_1 = -3.39e+38   # bf16 -inf
+
+`scalar_tensor_default_2` is the multiplicand of the per-layer
+score-scale Mul (`node_mul_313 = matmul_1 * scalar_tensor_default_2`).
+It is `1/head_dim`, not `1/sqrt(head_dim) ≈ 0.0884`. This is IBM
+Granite's `attention_multiplier` hyperparameter — the architecture
+intentionally diverges from the standard scaled-dot-product norm.
+
+The rewriter was passing `scale = 1/sqrt(head_dim)` to MHA, making
+attention 11.3× too peaky per layer. One layer is recoverable; 40
+layers compounds catastrophically.
+
+### Fix
+
+`scripts/granite_export/rewrite_attention_to_mha.py`:
+
+  scale = 1.0 / HEAD_DIM    # was 1.0 / (HEAD_DIM ** 0.5)
+
+### Verification (3 runs each on `/tmp/run15_short_60s.wav`, --benchmark)
+
+| Bundle | ASR wall (median) | Transcript |
+|---|---|---|
+| `granite_speech_4_1_2b_static_bf16` (unfused) | 13.29 s | baseline |
+| `granite_iter5_all_bundle_v2` (MHA fused, scale=1/128) | 13.55 s | exact match to baseline through full 60 s clip |
+
+Parity holds across all 18 segments and through long-context
+prefill. The transcript matches the unfused-static baseline at the
+visible-output level.
+
+### Perf result — fusion does not improve wall time
+
+MHA fusion is roughly at parity with the unfused-static path (+2%,
+within noise). The dynamic-shape baseline (~3.4 s) remains
+unbeaten. Possible explanations:
+
+- The static-shape padding of `seq + 512` to a fixed length is
+  the dominant cost; fusing the inner attention loop saves a
+  small fraction of total compute.
+- ORT's MHA CUDA kernel may not select the most optimal path
+  for our shape regime (S typically tiny during decode, T = past
+  + 1 up to 512, num_heads = 16, head_dim = 128). Flash and
+  fused TRT paths are disabled because we feed `attention_bias`.
+- The Q-side Transpose+Reshape adapter introduces small overhead;
+  K and V are fed natively now but Q can't be rank-4 per spec.
+
+### Implications
+
+- **Phase B's fusion goal is met for correctness** — the rewriter
+  produces a graph that loads on CUDA EP, runs end-to-end, and
+  produces parity transcripts. This is reusable for other
+  Granite-family models with the same scaling convention.
+- **Phase B does NOT close the perf gap to dynamic.** The static-
+  shape contract is the binding cost, not the per-layer attention
+  fusion. Future perf work should focus on: (a) reducing padding,
+  e.g. bucketed past_seq lengths; (b) IOBinding to keep K/V on
+  device between steps; (c) cuDNN attention path with attention_bias
+  support if available.
+- **The K/V (B, H, T, D) simplification is a real win** even at
+  perf parity: the rewriter is shorter and the graph has 80 fewer
+  Transpose+Reshape pairs (2 per layer × 40 layers).
+
+### Artifacts
+
+- Rewriter at `scripts/granite_export/rewrite_attention_to_mha.py`
+  with iter-5 wiring (drop K/V adapter, scale=1/128).
+- Working bundle at `/tmp/granite_iter5_all_bundle_v2/` (symlinks
+  to encoder/projector/mel/tokenizer files; hardlink to .data
+  sidecar; only `decoder.onnx` is new).
+- `/tmp/probe_iter5_load.py` — verbose-load probe; useful when
+  iterating on the rewriter to verify MHA placement.
+
+### Next investigator: where to go from here
+
+The parity bug is closed. The fusion is a wash for perf. Open
+questions for whoever picks this up:
+
+1. Is the static-shape contract still worth keeping? The 4× perf
+   gap to dynamic suggests the static path may not justify the
+   complexity, unless it unlocks something elsewhere (DirectML?
+   Specific deployment constraints?).
+2. If we keep static, the next perf lever is reducing the padded
+   T length. Bucketed past_seq (e.g. round up to multiples of 64
+   instead of always padding to 512) could reclaim a lot.
+3. The MHA-fused graph is reusable for any Granite model variant.
+   Apply the rewriter to Granite 8B / instruct / etc. as needed.
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -3033,6 +3033,81 @@ called out three suspects worth a look:
    cost. ORT-genai's continuous-batching pattern amortises this
    across many tokens.
 
+## Run 20 phase 4 — 2026-05-10 15:00 — Dynamic-shape GQA, drop static padding
+
+User pointed out: "We picked GQA because we didn't need to pad."
+Phases 1–3 still paid the static-shape pads (B=16 dummies, A=192
+audio, S=max(realLen) prompt). Phase 4 drops them.
+
+### Plan
+
+1. Default `else` branch of `export_decoder_unified` now accepts
+   `--unified-position-ids`, threading the new input through
+   `dynamic_axes` and `dyn_shapes` (variadic-merge same as the
+   static-shapes-unified branch).
+2. Rewriter's `find_kv_chain_for_gqa` now handles the case where
+   `present_key_<L>` is the Concat output directly (no Slice
+   between Concat and graph output) — that's how the dynamic
+   export emits it.
+3. Rewriter's adapter Reshape constants change from
+   `[16, -1, HIDDEN]` to `[0, -1, HIDDEN]` (ONNX-spec '0 means
+   preserve input dim'), so the batch dim stays symbolic.
+4. Rewriter's `add_gqa_graph_inputs` now accepts either an int
+   or a symbol name for `seqlens_k`'s batch dim, copying it
+   straight from `past_key_0`'s first dim.
+5. C# adds `_isDynamicGqaBundle` detection (GQA bundle whose
+   `past_key_0[0]` is symbolic/non-positive). Dispatch routes
+   each segment through a new `TranscribeDynamicGqaSingle`:
+   B = 1 per call, audio_embeds sized to actual audio tokens,
+   input_ids to actual prompt length, past_kv starts empty
+   `[1, 4, 0, 128]` and grows by 1 per step. No padding
+   anywhere.
+
+### Results (3 runs each on `/tmp/run15_short_60s.wav`)
+
+| Bundle | ASR median |
+|---|---|
+| unfused-static | 13.29 s |
+| MHA-fused (Run 19) | 13.55 s |
+| GQA phase 2 (no IOBinding) | 13.58 s |
+| GQA phase 3 (IOBinding) | 13.27 s |
+| **GQA phase 4 (Dynamic)** | **5.23 s** ← 2.5× faster |
+| dynamic baseline (legacy unfused) | ~3.4 s |
+
+Transcript exact match through all 18 segments.
+
+### What this confirms
+
+The user's reframing was correct: the static-shape padding was
+the real ceiling, not anything in attention math or KV traffic.
+Phases 1–3 of Run 20 chased percent-level wins inside the static
+contract; phase 4 dropped the contract and gave the 2.5× drop.
+
+The original GQA pitch — "no padding needed" — was true *only*
+once we stopped doing the other padding too. Within the static
+contract, GQA's seqlens_k was being used to mask off 432 padded
+slots per layer; but the same call was still running B=16 (15
+dummies) and A=192 audio (mostly zeros). The biggest wins came
+from dropping those, not from how attention was fused.
+
+### Remaining gap to dynamic baseline (~1.8 s)
+
+Still 1.8 s behind the legacy dynamic decoder. Plausible causes:
+
+- The legacy baseline batched multiple segments per call; we
+  serialise (one segment per `_decoder.Run`). 18 calls × ~280 ms
+  vs N batched calls — fixed per-call overhead matters.
+- The legacy baseline used eager attention, not GQA-fused. For
+  small shapes (B=1, S~80) the kernel-launch saving from fusion
+  may be smaller than batching saves.
+- Per-call OrtValue allocation overhead for `stepInputIds`,
+  `stepMask`, etc. adds up across hundreds of step iterations.
+
+A first try at closing this: batched dynamic-GQA with right-
+padded prompts + per-row position_ids (same trick that worked in
+phase 2 batched, now without the static-shape outer wrapper).
+That would let us amortise per-call overhead across segments.
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2738,6 +2738,92 @@ questions for whoever picks this up:
 3. The MHA-fused graph is reusable for any Granite model variant.
    Apply the rewriter to Granite 8B / instruct / etc. as needed.
 
+## Run 20 — 2026-05-10 — GQA + cache-layout migration (plan)
+
+MHA fusion at parity but no perf win (Run 19). The static-shape
+padding to `seq+512` is the dominant cost: every layer recomputes
+attention over 512 cached positions even when only a fraction are
+real. **GQA** is the standard ORT op that fixes this — its
+`seqlens_k` per-batch input tells the kernel where the real K
+ends, and compute past that point is skipped (not zeroed).
+
+### Why GQA, not MHA + tighter padding
+
+A bucketed-past_seq scheme (multiple sessions for 64/128/256/512)
+works but multiplies graph load time and resident memory by N. GQA
+does compute-skip in a single static graph, which is what we want.
+
+### The coordinated change (3 surfaces)
+
+The migration touches export, rewriter, and C# driver because the
+cache layout itself must change from right-aligned-with-sliding-
+window (today) to **left-aligned max-sized buffer** (GQA's required
+layout):
+
+  - past_kv buffer: `[B, kv_num_heads=4, max_seq=512, 128]`.
+  - real data at `[0, current_seq_len)` per batch row.
+  - zero/garbage at `[current_seq_len, max_seq)`.
+  - `seqlens_k[b] = total_seq[b] - 1` written as graph input each step.
+
+### Stage A — Rewriter (`--mode gqa`)
+
+Most of the work happens here. The rewriter:
+
+1. Adds two new graph inputs: `seqlens_k` (int32, shape `[B]`) and
+   `total_sequence_length` (int32, scalar).
+2. For each layer, walks the existing chain back through Expand
+   (4→16) and Concat to find:
+   - the `past_key_<L>` graph input (already exists),
+   - the **fresh K** tensor (post-RoPE, pre-Concat, shape `[B, 4,
+     S, 128]`).
+3. Replaces the unfused attention block with a GroupQueryAttention
+   node:
+   - inputs: `[query (B,S,2048), key (B,S,512), value (B,S,512),
+     past_key_<L>, past_value_<L>, seqlens_k, total_sequence_length]`
+   - outputs: `[output, present_key, present_value]`
+   - attrs: `num_heads=16, kv_num_heads=4, scale=1/128, do_rotary=0`
+4. Adapter shape ops:
+   - Q: existing Transpose+Reshape (B,16,S,128)→(B,S,2048).
+   - K, V: new Transpose+Reshape (B,4,S,128)→(B,S,512).
+5. Rewires `present_key_<L>` graph output to GQA's `present_key`
+   (the existing Concat→Slice chain becomes dead).
+
+### Stage B — C# driver
+
+1. Switch from left-padded prompts to **right-padded** so real
+   tokens occupy `[0, realLen[b])` of the prefill K input. (This
+   is what GQA expects in `key`.) Argmax position becomes
+   `realLen[b]-1` per batch row instead of `S-1`.
+2. Allocate past_kv buffers at `[B, 4, max_seq=P, 128]` and bind
+   them via IOBinding so present_key writes happen in place.
+3. Compute `seqlens_k` and `total_sequence_length` per call:
+   - prefill: `seqlens_k[b] = realLen[b] - 1`,
+     `total_sequence_length = max(realLen)`.
+   - step: `seqlens_k[b] = realLen[b] + step`,
+     `total_sequence_length = max(realLen) + step + 1`.
+4. cache_position: change from "starts at P" to "starts at 0"
+   (left-aligned cache, position N is the Nth real token).
+
+### Stage C — End-to-end test + benchmark
+
+Same `/tmp/run15_short_60s.wav` clip and the unfused-static
+baseline (~13.3 s) as the parity reference. Goal: close as much
+of the 13.3 s → 3.4 s gap as possible.
+
+### Risk / unknowns
+
+- Whether GQA on CUDA EP supports bf16 K/V cache as effectively
+  as the unfused path. (T_CACHE constraint includes bfloat16, so
+  yes, but kernel selection might prefer fp16.)
+- Whether the right-padding switch in C# breaks any existing
+  parity test in `tests/GraniteSpeechSmoke`. Likely needs a
+  fixture rebuild.
+- IOBinding correctness for the in-place present_key write across
+  step iterations. We currently use chained OrtValue passing
+  rather than IOBinding (deliberately, after Run 7); GQA may
+  force a switch.
+
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2142,6 +2142,93 @@ Granite-style model, the answer is documented.
 per-layer attention subgraph with `com.microsoft.GroupQueryAttention`
 nodes. Detailed plan in #43.
 
+## Run 18 — 2026-05-10 — Phase B reconnaissance: pattern map + alignment probes
+
+Phase B starts with reconnaissance, not engineering. Three concrete
+probes before committing to multi-day implementation:
+
+### Probe 1 — Granite's per-layer attention pattern
+
+Walked the eager+static decoder.onnx, anchored on the 40 Softmax
+nodes (one per layer). Each layer's attention block is uniform:
+
+```
+output_proj ← Reshape ← Transpose ← MatMul(softmax_out, V_full)
+                                    ↑
+                                   Softmax ← Add(scores, mask) ← Mul(scale, ·) ← MatMul(Q, K_full^T)
+                                                                                  ↑       ↑
+                                                                                  Q       K_full = Concat(past_K, new_K)
+```
+
+40 / 40 layers match this exact pattern — the rewriter target is
+clean. Anchor: walk back from each Softmax to its parent MatMul
+(scores), and forward to its child MatMul (× V).
+
+### Probe 2 — GQA cache-alignment
+
+Built a minimal `com.microsoft.GroupQueryAttention` graph with two
+test cache layouts: left-aligned (real KV at slots `[0, seqlens_k)`,
+padding after) vs right-aligned (zeros at `[0, P-real)`, real after).
+Compared GQA's output to a hand-rolled reference for each.
+
+| Configuration                            | GQA mean abs | Reference mean abs | Match? |
+|------------------------------------------|-------------:|-------------------:|:------:|
+| Left-aligned cache, seqlens_k=4          |     0.036117 |           0.036117 | **✓ exact** |
+| Right-aligned cache, seqlens_k=4         |     0.016493 |           0.032659 | ✗      |
+
+**GQA assumes left-aligned cache.** Granite's existing static-shape
+export uses right-aligned (slice `[-P:]`). Using GQA would require
+re-architecting the cache layout: re-export wrapper without the
+`[-P:]` slice, C# tracks per-row cache lengths and writes new K/V
+at the next slot, no slicing needed if we never exceed `P`. That's
+substantial extra scope (5-7 days) on top of the rewriter.
+
+### Probe 3 — MHA with custom mask
+
+Built a minimal `com.microsoft.MultiHeadAttention` graph with a
+`(B, T)` `key_padding_mask` and the same right-aligned cache
+configuration:
+
+| Probe                                         | mean abs | Reference matches? |
+|-----------------------------------------------|---------:|:------------------:|
+| MHA with mask convention `1=pad, 0=attend`    | 0.000000 | ✗ (all zeros)      |
+| MHA with mask convention `1=attend, 0=pad`    | 0.035227 | **✓ exact**        |
+
+**MHA accepts a custom `(B, T)` mask** with convention `1=attend,
+0=ignore` (standard HF transformers convention). Right-aligned cache
+just works — the mask gates whatever's in the cache, regardless of
+where the real KV sits. **No re-architecture needed.**
+
+### Implication
+
+**MHA is the right fused op for Granite, not GQA.** The phase B
+plan changes:
+
+- Replace each attention block with `com.microsoft.MultiHeadAttention`
+  (not GroupQueryAttention).
+- Keep the existing 80 Expand ops (4 KV heads → 16 heads); MHA
+  wants K/V already broadcast to 16 heads.
+- Feed the existing attention_mask through unchanged (just cast
+  to int32 if needed).
+- Past_kv keeps right-aligned layout. No C# rearchitecture.
+- C# side: minimal change — perhaps just one `Cast` from int64 mask
+  to int32, or re-shape into `seqlens_k` if MHA needs it. TBD on
+  closer look.
+
+Phase B effort revised back down to **3-4 days**:
+
+- Day 1: pattern matcher; replace one layer's attention with MHA;
+  verify it loads.
+- Day 2: extend to all 40 layers; per-layer parity vs unfused.
+- Day 3: end-to-end smoke test + minor C# mask conversion.
+- Day 4: perf benchmark.
+
+Bonus: MHA fusion generalizes to other transformer backends
+(Qwen3, VibeVoice) where the GQA-with-left-align approach was
+Granite-specific.
+
+
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -3193,6 +3193,72 @@ Three forks:
 The user is asking us to keep going; option 1 is the obvious
 next experiment.
 
+## Run 20 phase 6 — 2026-05-10 15:15 — MHA-fused dynamic batched works
+
+Re-rewrote the dynamic export with `--mode mha` instead of `gqa`.
+MHA's CUDA kernel implements `attention_bias` (Run 19 used it),
+so the same right-padded variable-length batching that CUDA GQA
+rejected now works.
+
+### C# wiring
+
+Generalised the legacy `TranscribeBatch` (dynamic path) to pass
+`position_ids` when the graph signature includes it
+(`_hasPositionIdsInput`). Per-row position_ids map left-padded
+slot s to semantic position `max(0, s - padLen[b])`, and step
+k's new token gets `realLen[b] + step`. No other changes — the
+existing left-padded prompt layout, attention_mask, and dynamic
+past_kv flow all work unchanged because MHA fusion only replaces
+the inner attention compute, not the surrounding plumbing.
+
+### Results (3 runs each on `/tmp/run15_short_60s.wav`)
+
+| Bundle | ASR median |
+|---|---|
+| unfused-static (Run 18 baseline) | 13.29 s |
+| MHA-fused static (Run 19) | 13.55 s |
+| GQA static phase 3 (IOBinding) | 13.27 s |
+| GQA dynamic phase 4 (B=1 serial) | 5.23 s |
+| **MHA-fused dynamic batched (this run)** | **4.76 s** |
+| legacy dynamic baseline (~Run 16) | ~3.4 s |
+
+Transcript exact match through all 18 segments.
+
+Profile shows the BatchSizer-grouped batches were sized
+`B=16, ~2.36 s` and `B=2, ~0.95 s` — the bulk amortisation
+happened in the first batch. ~280 ms/segment in the B=16 batch
+(vs ~280 ms/segment in B=1 GQA phase 4); the per-call overhead
+saving is real but small.
+
+### Why MHA-dynamic isn't far ahead of GQA-dynamic B=1
+
+The 0.5 s edge from batching is modest because the dominant
+per-token cost is FFN, not attention or per-call dispatch.
+Batched dispatch can't reduce FFN compute per token; it only
+amortises fixed per-call costs (binding setup, kernel launch
+counts on small ops). For our shapes, those fixed costs are
+already small.
+
+### Remaining gap to the legacy dynamic baseline (~1.4 s)
+
+Likely candidates, none of which our attention work touches:
+
+- The legacy baseline is unfused — every layer issues separate
+  MatMul/Mul/Add/Softmax kernels. MHA fusion saves kernel
+  launches, but for our small per-token shapes that's offset by
+  the extra Transpose+Reshape adapters our rewriter inserts.
+- Per-segment encoder/projector are serial in both paths. Mel
+  takes ~40 ms, encoder ~540 ms, projector ~10 ms across the
+  18-segment run; encoder dominates and could parallelise.
+- ORT may be choosing different decoder kernels for the fused
+  vs unfused graphs.
+
+A direct test: run the un-rewritten dynamic decoder against the
+same `TranscribeBatch` path and benchmark. If it matches the
+3.4 s baseline, MHA fusion is a net regression in dynamic mode;
+if it matches the 4.76 s phase-6 number, the gap is elsewhere
+(encoder, kernel selection).
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2298,6 +2298,62 @@ as starting points. The rewriter itself is committed; future
 investigators can iterate on the wiring without re-deriving the
 pattern map.
 
+### Iteration 3 (key_padding_mask + is_unidirectional)
+
+Sharper diagnosis after the user observed the perf regression
+wasn't expected as a parity-debugging artifact: the
+`relative_position_bias` path is **purely additive** — added to
+attention scores after they've been computed over all positions.
+ORT MHA can only skip masked positions in COMPUTE via
+`key_padding_mask` + `is_unidirectional`, not via RPB. So the
+parity bug and the perf regression were likely the same bug.
+
+Switched the rewriter to feed the graph's raw `attention_mask`
+(cast to int32) as `key_padding_mask`, and set
+`is_unidirectional=1` for causal handling. End-to-end on the 60 s
+clip:
+
+- Output: **"all kinds of telephone calls, of course, none of them"**
+  — first ~12 words match the baseline almost perfectly, then
+  derails into a repetition loop ("would get more as i would
+  answer would i would i would..."). Not parity yet.
+- Wall: **19.7 s** (worse than iter 2's 8.98 s) — but this is
+  because derailment inflates step count from 36 to 98. Per-step
+  time is hard to compare across runs with different convergence
+  behaviour.
+
+**Diagnosis (clearer now):** with `is_unidirectional=1` AND
+pre-concatenated K (no `past_key` argument to MHA), MHA applies
+causal masking as if the entire K is "new tokens". So Q at position
+`s` only attends to K at `[0, s]` — completely missing the cached
+positions `[0, P)`. The first prefill token sees nothing, the
+second sees only the first, etc. After prefill, the cache has very
+little useful context, so the model can decode a few tokens from
+limited state and then derails.
+
+**Architectural fix (next iteration):** feed `past_key` /
+`past_value` via MHA's dedicated past inputs, NOT pre-concatenated.
+MHA then knows there's an offset of length P, and applies causal
+correctly: `Q[s]` attends to past `[0, P)` + new `[P, P+s]`. This
+requires:
+
+- Bypass the existing `Concat(past_key_0, new_K)` chain. Instead,
+  feed `past_key_0` graph input directly to MHA's `past_key` input
+  (after Expand from 4 to 16 heads to match `num_heads`).
+- Feed the new step's K (post-RoPE, pre-Concat) as MHA's `key`
+  input, also Expanded to 16 heads.
+- The Expand needs to happen before MHA, which currently happens
+  AFTER the Concat in the unfused graph. Rewrite reorder.
+- MHA outputs `present_key` directly at the post-concat shape,
+  which then needs the wrapper-level slice to match the
+  static-shape contract. May need a separate Slice node after MHA.
+
+This is a ~1-day refactor of the rewriter, not a 30-min tweak.
+Same scope as a fresh-session day-2-follow-up. Pausing iteration
+loop here so it doesn't blur into a multi-day session.
+
+
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -3453,6 +3453,87 @@ Remaining levers, in order of decreasing realism:
 
 This is a good place to call the perf arc done.
 
+## Run 20 phase 9 — 2026-05-10 15:55 — GPU-side argmax (negative result, lever preserved)
+
+Phase 8's profile showed GPU at peak 90 % with the remaining
+host-side cost being the per-step logits transfer
+(`[B, 1, V]` = ~6 MB GPU→CPU per step). The thinking: append
+`Slice(last position) → ArgMax(V)` to the LM head so the head
+output becomes `next_token` (int64 [B, 1]) — 8 bytes per row
+instead of 400 KB. Greedy decoding doesn't need the raw logits.
+
+### Implementation
+
+Two pieces:
+
+  - **Rewriter** (`rewrite_attention_to_mha.py`): new `--add-argmax`
+    flag. Appends two nodes — `Slice` (axes=[1], starts=[-1],
+    ends=[INT_MAX]) and `ArgMax` (axis=2, keepdims=0) — and
+    removes `logits` from the graph outputs in favour of
+    `next_token` ([B, 1] int64). The Slice runs first so the
+    ArgMax operates on a `[B, 1, V]` tensor regardless of S
+    (prefill or step).
+  - **C# driver** (`GraniteSpeech.cs`): new `_hasNextTokenOutput`
+    flag detected from the decoder's `OutputMetadata`. When set,
+    `decOutputNames[0]` is `"next_token"`; prefill reads tokens
+    via `GetTensorDataAsSpan<long>()`; the step loop binds
+    `next_token` to a pre-allocated `long[B]` buffer via
+    `BindOutput`, skipping the CPU-side argmax entirely.
+
+Both pieces auto-detect from graph metadata, so the same C#
+binary handles bundles with or without argmax.
+
+### Results (3 runs each on `/tmp/run15_short_60s.wav`)
+
+| Bundle | ASR median |
+|---|---|
+| MHA dynamic + IOBinding (phase 8) | 3.61 s |
+| **MHA dynamic + IOBinding + GPU argmax (this run)** | **3.78 s** |
+
+A ~5 % regression. Per-batch stage breakdown (from `granite-prof`):
+
+| Phase | B=16 prefill | B=16 step (25 iter) | B=2 prefill | B=2 step (35 iter) |
+|---|---|---|---|---|
+| With argmax | **236 ms** | 627 ms (25 ms/step) | **56 ms** | 684 ms (20 ms/step) |
+| Without | 444 ms | 428 ms (17 ms/step) | 98 ms | 470 ms (13 ms/step) |
+| Δ | −208 ms | **+199 ms** | −42 ms | **+214 ms** |
+
+### Interpretation
+
+The argmax pass wins at **prefill** and loses at **step**:
+
+  - Prefill: logits is `[B, S, V]`; for B=16, S~85 that's ~545 MB
+    of GPU→CPU traffic *without* argmax. Replacing with `[B, 1]`
+    int64 eliminates almost all of it. Saved ~250 ms total.
+  - Step: logits is `[B, 1, V]`; for B=16 that's ~6 MB per step.
+    Transfer cost is ~1 ms. But the CUDA `ArgMax` kernel over
+    100 353 vocab × 16 rows costs ~6 ms per step — more than it
+    saves. Lost ~360 ms across the 60-step run.
+
+The step kernel cost dominates a 60-step-heavy workload. For a
+prompt-heavy / low-generation profile (e.g. transcript summary
+prompts) the prefill saving could win.
+
+### Decision
+
+Keep both the rewriter flag and C# detection — they're plumbing
+that's correct and tested, and the right answer for some
+workloads. Default to NOT adding argmax for our ASR profile;
+the MHA-fused dynamic + IOBinding bundle (phase 8) stays the
+recommended path at 3.61 s median.
+
+### What this taught us about the remaining slack
+
+The "12 MB per step transfer" worry was already addressed by
+phase 8's `BindOutput(logits, cpu_buffer)` — that bind is fast
+because ORT does a single DMA into our pre-allocated buffer.
+The remaining step-time cost is overwhelmingly **GPU compute
+time** (now ~17 ms/step for B=16, near our ~5 ms theoretical
+floor with realistic kernel-launch overhead). There isn't a big
+software lever left in the per-step loop; the next 2-3× would
+need quantisation (ruled out by user) or a different runtime
+(TRT-LLM, ruled out by repo scope).
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -3108,6 +3108,91 @@ padded prompts + per-row position_ids (same trick that worked in
 phase 2 batched, now without the static-shape outer wrapper).
 That would let us amortise per-call overhead across segments.
 
+## Run 20 phase 5 — 2026-05-10 15:05 — Batched dynamic GQA blocked by CUDA kernel
+
+Tried the obvious next step: TranscribeDynamicGqaBatch with B=N
+where the BatchSizer-grouped segments are right-padded to
+S = max(realLen) within the batch. With attention_bias = where_2
+wired through (the rewriter auto-detects past_seq dynamic and
+threads `mask` into GQA input slot 10), small intra-batch pad
+should be masked just like MHA Run 19 did.
+
+### What broke
+
+ORT runtime error on the first GQA node:
+
+```
+Non-zero status code returned while running GroupQueryAttention
+node. Name:'gqa_l0_node' Status Message:
+attention_bias is not supported in GroupQueryAttention cuda
+kernel.
+```
+
+`attention_bias` IS in the contrib op spec for
+`com.microsoft.GroupQueryAttention` (input slot 10), but the
+CUDA kernel hasn't implemented it yet. The CPU implementation
+probably has it; we'd hit a Memcpy fallback if we forced CPU,
+which would erase any perf win.
+
+### Why per-row seqlens_k can't substitute
+
+In dynamic / non-buffer-sharing mode, GQA's write region is
+uniform across batch: new K appends at past_seq..past_seq+new_S
+for every row. So even though `seqlens_k` is per-row (it controls
+per-row attention bound), it cannot reroute the WRITE.
+
+Concrete example with batch realLens = [99, 95, 90], S = 99:
+After prefill, the cache has past_seq = S = 99 (uniform), with
+real K at [0, realLen[b]) and pad K at [realLen[b], 99) for
+shorter rows. Step 0's new K lands at slot 99 for every row.
+Row 1 (realLen = 95): its generated tokens are at slots [99, …),
+but the slot [95] in cache still holds prefill pad K. Any
+per-row attention bound that's contiguous from 0 either includes
+slot 95 (poisoning the score with pad K) or skips slot 99 (which
+holds the actual generated K). There's no clean cut.
+
+This is the same constraint that made phase 2 static GQA need
+buffer-sharing mode + per-row write positions — non-buffer mode
+loses that lever.
+
+### Quick attempt without attention_bias
+
+Tried it anyway: removed the attention_bias wiring, accepted
+that BatchSizer-sorted segments would have small intra-batch
+pad. Result: transcript broke ("all the new York, and 'The new
+York Timescale 2'" instead of "all kinds of telephone calls of
+course…"). Even a few pad K slots within `seqlens_k+1`
+contaminate softmax enough to derail decoding.
+
+### Revert
+
+`TranscribeDynamicGqaBatch` reverts to looping
+`TranscribeDynamicGqaSingle` per segment — back to the phase-4
+working state at 5.23 s. The plumbing for the batched path is
+left in `rewrite_attention_to_mha.py` (auto-wires
+attention_bias when past_seq is dynamic) for the day the CUDA
+kernel grows the input.
+
+### Where this leaves us
+
+Three forks:
+
+1. **MHA-fused dynamic + batched.** MHA's CUDA kernel DOES
+   support `attention_bias` (Run 19 used it). Re-rewriting the
+   dynamic export with `--mode mha` should give a batched-capable
+   dynamic path. Fused attention, with per-row pad masking via
+   where_2. Likely the cleanest next step.
+2. **Exact-realLen binning.** Only batch segments with
+   identical realLen, fall back to B=1 otherwise. Bin sizes will
+   often be small (1–3) on real audio, so the amortisation win
+   is limited.
+3. **Stop here.** 5.23 s / 0.09 RTF is well under real-time and
+   the user-visible feature works. The legacy 3.4 s baseline is
+   nice but not a feature blocker.
+
+The user is asking us to keep going; option 1 is the obvious
+next experiment.
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2057,6 +2057,93 @@ needs static shapes to make GQA's `seqlens_k` input meaningful.
 The follow-up issue should bake in this feasibility data so the
 next investigator doesn't re-derive it.
 
+## Run 17 phase A — 2026-05-10 — SDPA spike (closed: dead)
+
+**Setup:** Issue #43, 1-day timebox. Hypothesis: switching the
+language model's attention to `attn_implementation="sdpa"` on the
+static-shape export emits a pattern ORT's `AttentionFusion` /
+`GroupQueryAttentionFusion` passes recognize, giving us fused
+attention without writing a custom graph rewriter.
+
+Implementation: added `--sdpa-attention` flag in
+`scripts/granite_export/export_granite_speech_to_onnx.py`. Granite's
+audio Q-former (`Blip2QFormerModel`) doesn't have an SDPA
+implementation, so `attn_implementation="sdpa"` at the top-level
+constructor errors. The flag instead loads with `eager` and post-load
+sets `model.language_model.config._attn_implementation = "sdpa"` —
+surgical override that leaves the audio path untouched.
+
+**Result — A1 (SDPA + dynamic shapes):** trace fails. Confirms the
+comment in the existing `load_model_and_processor` that flagged this
+path as broken. Specific error:
+
+```
+Could not guard on data-dependent expression Ne(u0, 4) (unhinted: Ne(u0, 4)).
+... attention_mask.shape[3] != 4 ...
+```
+
+PyTorch 2.11 / transformers 4.57 still hits this in dynamo-mode
+export. The original objection holds.
+
+**Result — A2 (SDPA + static shapes):** trace succeeds. ORT verbose
+load reports:
+
+| Metric                         | eager + static | **SDPA + static** |
+|--------------------------------|---------------:|------------------:|
+| Memcpy warnings                |              0 |                 0 |
+| CPU-fallback ops               |             10 |           **210** |
+|   Slice                        |              0 |               120 |
+|   Concat                       |              7 |                87 |
+|   sym_size_int                 |              1 |                 1 |
+|   add                          |              1 |                 1 |
+|   Reshape                      |              1 |                 1 |
+| `AttentionFusion modified`     |              0 |             **0** |
+| `GroupQueryAttentionFusion`    |              0 |             **0** |
+
+**SDPA + static is strictly worse than eager + static.** The pattern
+torch.onnx.export emits for SDPA at static shapes contains 200+ extra
+Slice / Concat ops (the GQA Expand+Repeat dance and KV-cache slicing
+were materialised as explicit graph nodes), AND ORT's pattern matcher
+*still* doesn't recognize the result.
+
+**Implication:** Path A is dead. The cheap `attn_implementation="sdpa"`
+shortcut doesn't auto-fuse Granite's attention pattern — neither at
+runtime-dynamic shapes (where it doesn't trace) nor at static shapes
+(where it traces a worse graph). Auto-fusion via ORT's built-in
+transformer passes is not reachable for Granite without rewriting
+either the attention module's PyTorch source or the exported ONNX
+graph directly.
+
+**Pivot:** Path B (custom graph rewriter). The earlier feasibility
+spike already confirmed `com.microsoft.GroupQueryAttention` runs on
+CUDA EP for Granite's exact config (16/4/128, BF16, do_rotary,
+past_len=768, batch=16). The remaining work is the pattern-matcher
+itself, applied to the **eager + static** export (which has cleaner
+per-layer structure than SDPA's traced output — the 200 extra
+Slice/Concat ops in SDPA's graph would make the matcher harder, not
+easier).
+
+**Honest retrospective on Phase A:** the asymmetric value-of-information
+argument from the path-comparison still held — A's failure was cheap
+(<1 day) and it gave us concrete data: we now know SDPA isn't a free
+shortcut on Granite, and we know the eager export is the cleaner
+target for path B. Next time someone proposes "just use SDPA" on a
+Granite-style model, the answer is documented.
+
+**Useful artifacts kept from Phase A:**
+
+- `--sdpa-attention` flag and the per-submodule override pattern in
+  `load_model_and_processor`. Future spikes on other transformers
+  models can reuse this.
+- The probe scripts (`/tmp/probe_ort_load.py` updated to grep
+  `AttentionFusion modified > 0` lines).
+
+**Next:** open phase B — custom graph rewriter to replace the
+per-layer attention subgraph with `com.microsoft.GroupQueryAttention`
+nodes. Detailed plan in #43.
+
+
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2947,6 +2947,92 @@ where to focus next:
   `/tmp/granite_gqa_all_bundle/` — serial-single-segment path,
   retained for fallback testing only.
 
+## Run 20 phase 3 — 2026-05-10 14:35 — IOBinding for in-place K/V
+
+User question: "We thought GQA would eliminate per-step KV memcpy
+without ballooning VRAM. Theory vs. result?"
+
+Honest contrast in the doc above. Phase 2's step loop used plain
+`_decoder.Run(...)` which allocates a FRESH `present_kv` buffer per
+call — same memcpy pattern as MHA. The buffer-sharing win that GQA
+documents was theoretically available but not yet realised in the
+C# driver. Phase 3 wires it via `OrtIoBinding`.
+
+### The wire change
+
+In `TranscribeStaticGqaBatched`'s step loop, replace the plain
+`Run(...)` with `RunWithBinding(...)`. Per layer:
+
+  - `BindInput("past_key_<L>", pastKvs[2*L])`
+  - `BindOutput("present_key_<L>", pastKvs[2*L])` — **same
+    `OrtValue`**. GQA detects same memory address and writes in
+    place, skipping the past → present copy.
+
+Plus a small extra: `BindOutput("logits", stepLogitsVal)` to a
+pre-allocated CPU buffer, so argmax reads native float without an
+extra `GetTensorDataAsSpan` round-trip. (Pattern lifted from
+`Qwen3Asr.cs:665` — the same in-place idiom that was discovered
+in that ASR backend's Phase-6 work.)
+
+### Results (3 runs each on `/tmp/run15_short_60s.wav`)
+
+| Bundle | ASR median |
+|---|---|
+| unfused-static (Run 18 baseline) | 13.29 s |
+| MHA-fused (Run 19) | 13.55 s |
+| GQA Phase 2 (no IOBinding) | 13.58 s |
+| **GQA Phase 3 (IOBinding, this run)** | **13.27 s** |
+| dynamic (Run 16) | ~3.4 s |
+
+Transcript still matches the unfused-static baseline through all
+18 segments.
+
+### Theory contrast
+
+The Run 20 phase 2 doc estimated ~6.4 GB of memcpy elimination
+per step (40 layers × 16 × 4 × 512 × 128 × 2 bytes × 2 for K+V).
+At ~1 TB/s HBM bandwidth that would be ~640 ms saved across 100
+steps — about 5 % of wall time.
+
+We observed ~300 ms saved (~2 %), about half the upper-bound
+estimate. Two likely explanations:
+
+1. **ORT's GQA without buffer sharing already does a partial
+   copy, not a full one.** The kernel probably memcopies only the
+   `[0, seqlens_k+1)` slice of past_kv into present_kv, then
+   writes the new K at the tail. With `realLen ≈ 80` and
+   `max_seq = 512`, that's ~16 % of the buffer, i.e. ~1 GB per
+   step instead of 6.4 GB. Saving 300 ms on ~1 GB of avoided
+   traffic is consistent with that.
+2. **FFN-bound layers don't benefit.** Even with KV write
+   eliminated, the GEMMs that follow are the bottleneck. We're
+   bandwidth-limited on the FFN, not the cache append.
+
+Either way: the theory was directionally right (memcpy
+elimination is a real lever) but the magnitude was overstated.
+This is the first time the GQA path has gone *below* the MHA
+path's wall time — a confirmation that buffer sharing works as
+claimed, just not as dramatically as the unconstrained
+back-of-envelope suggested.
+
+### Where the dynamic baseline's 4× lead still hides
+
+We've now closed the gap GQA was supposed to close (~2 %). The
+remaining 10 s of static-vs-dynamic delta is NOT in attention
+fusion, NOT in compute-skip, and NOT in KV memcpy. Run 20 phase 2
+called out three suspects worth a look:
+
+1. **`A = 192` audio pinning.** Encoder runs over 192 frames per
+   segment regardless of actual audio length. Most real segments
+   have far fewer.
+2. **Static-shape kernel selection.** ORT's graph optimizer can't
+   pick small-shape kernels when the signature pins B=16, S<=512.
+3. **Step-loop CPU overhead.** Even with IOBinding, building the
+   IO binding object, allocating per-step `stepMaskBatch`
+   buffers, and running the Python-style per-step loop has fixed
+   cost. ORT-genai's continuous-batching pattern amortises this
+   across many tokens.
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2227,6 +2227,79 @@ Bonus: MHA fusion generalizes to other transformer backends
 (Qwen3, VibeVoice) where the GQA-with-left-align approach was
 Granite-specific.
 
+## Run 18 phase B day 1+ — Rewriter implemented, partial parity (WIP)
+
+**Setup:** Wrote `scripts/granite_export/rewrite_attention_to_mha.py`.
+Anchors on each Softmax node, walks back/forward to identify the 7
+unfused-attention nodes (MatMul + Mul-scale + Add-mask + Softmax +
+MatMul + Transpose + Reshape), and replaces them with a single
+`com.microsoft.MultiHeadAttention` node fed via Q/K/V Transpose+Reshape
+adapters. The rewriter operates on the static-shape eager-export
+decoder.onnx as a post-export step.
+
+**Iteration 1 — naive raw-mask wiring:** Initial implementation passed
+the graph's `attention_mask` input (cast to int32) as MHA's
+`key_padding_mask`. Result: graph loaded cleanly, zero new CPU
+fallbacks vs unfused baseline, MHA placed on CUDA EP. End-to-end
+smoke: **garbage transcript** ("`<|fim_middle|>-- --  - -s,`").
+
+Diagnosis: by feeding only the raw (B, T) attention_mask, we lost
+the **causal masking** that the original graph's per-layer Add node
+applied. Granite's exported graph computes a single shared
+`(B, 1, S, T)` additive mask (`where_2`) that encodes both key-padding
+*and* causal triangulation; this mask is reused across all 40 layers'
+attention Add nodes.
+
+**Iteration 2 — feed `where_2` as `relative_position_bias`:** Updated
+the rewriter to pass `where_2` (the original shared additive mask)
+to MHA's `relative_position_bias` input. This is added to attention
+scores before softmax — the exact semantics of the original Add. End
+to end on the 60s clip:
+
+- Output: **partially correct**. "all kinds of garret's of course
+  none of them would be as i- as a as" vs the correct baseline
+  "all kinds of telephone calls of course none of them were Garrett
+  and so I mean...". "Garrett" + "of course none of them" match
+  approximately; the rest is mangled.
+- Wall: **8.98 s** (vs unfused-static 12.1 s, dynamic 3.4 s). MHA +
+  where_2 is faster than unfused-static but still 2.6× slower than
+  dynamic.
+
+**Implication:** Iteration 2 moved us from "complete garbage" to
+"garbled but recognizable" output. The mask wiring is on the right
+track but there's at least one more bug in the rewrite, and the
+compute regression hasn't been eliminated.
+
+**Possible remaining bugs (in priority order):**
+
+1. **Head layout in the adapter.** The Transpose+Reshape pair is
+   supposed to convert `(B, num_heads, S, head_dim)` to
+   `(B, S, num_heads × head_dim)` with heads-outer flattening. May
+   not match MHA's internal interpretation.
+2. **`relative_position_bias` shape mismatch.** ORT MHA expects this
+   tensor in `(B or 1, num_heads, S, T)` layout. Our `where_2` is
+   `(B, 1, S, T)` which should broadcast across heads — but if MHA
+   treats the second dim as actual head index rather than broadcast,
+   we'd have a layout mismatch.
+3. **`is_unidirectional` attribute** — MHA may apply implicit causal
+   masking; explicitly setting `is_unidirectional=0` to disable it
+   could matter.
+4. **Numerical drift.** Original computes attention in fp32 (with bf16
+   K/V dequantized at the matmul); MHA may use bf16 accumulators
+   internally. Could explain partial-correctness.
+
+**Decision: pause and ship the partial work as a checkpoint.** Phase B
+day 2 was meant to be "extend matcher + parity test"; we got
+"matcher implemented + partial parity". Closing the remaining gap is
+plausibly another day of debugging, but the agent-loop time spent
+here suggests it's worth handing the next iteration to a fresh
+session with the partial-output diff and the four hypotheses above
+as starting points. The rewriter itself is committed; future
+investigators can iterate on the wiring without re-deriving the
+pattern map.
+
+
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2400,6 +2400,83 @@ dedicated past inputs. Requires:
 This is a coordinated re-export + rewriter change. ~1-day fresh-
 session work; won't fit in this agent-loop session.
 
+---
+
+## For the next investigator (start here)
+
+The iter-1-to-iter-4 evidence is in the Run 18 entries above. **Don't
+build on iter-4's speculative claim that ORT's
+`relative_position_bias` is "relative-position-style only" — that
+was a guess from this session, not a verified fact.** The first move
+should be to ground-truth what ORT MHA actually does with its
+inputs.
+
+**Before writing any code, read these two ORT source files:**
+
+- `onnxruntime/contrib_ops/cuda/bert/multihead_attention.cc` — the
+  CUDA implementation. Specifically how `relative_position_bias`,
+  `key_padding_mask`, and `unidirectional` are combined.
+- `onnxruntime/contrib_ops/cpu/bert/multihead_attention_helper.h`
+  — input validation and shape semantics.
+
+These tell you definitively whether RPB is treated as a literal
+additive `(B, num_heads, S, T)` mask or as a relative-position
+function. The answer changes which iter-5 plan is correct:
+
+- **If RPB is literal additive:** iter 2's wiring should have worked.
+  The bug is somewhere else (head layout? scale? something we
+  missed). Re-examine the rewriter's adapter Transpose+Reshape
+  geometry. Add intermediate-tensor inspection (run unfused vs
+  rewritten on the same inputs, compare logits at each layer's
+  attention output).
+- **If RPB is relative-position-only:** iter 5's past_key plumbing
+  is the right path. Coordinated change to (a) the export
+  wrapper to declare past_kv as 16-head, (b) the rewriter to
+  feed MHA's past_key directly, (c) C# adaptation if cache shape
+  changes.
+
+**Fast feedback loop for iter 5:**
+
+1. Modify only ONE layer in the rewriter (`--layers 0`).
+2. End-to-end transcribe via the C# CLI on
+   `/tmp/run15_short_60s.wav` with bundle pointing at
+   `~/.local/share/Vernacula/models/granite_speech_4_1_2b_static_mha_bf16`
+   (the existing test bundle; copy your new layer-0 decoder.onnx in).
+3. If the output is identical to the unfused-static run on the same
+   clip, the wiring is right; extend to all 40 layers.
+4. If the output diverges, you've narrowed the bug to one layer's
+   wiring at the C# observable level — easier to debug than a
+   garbled cascade across 40 layers.
+
+**Branch state:**
+
+- `43-granite-fused-attention` (pushed). 8 commits.
+- The C# static-shape adaptation is cherry-picked from PR #44's
+  reverted phase 2c (commit `87b6c2c`). It's needed to test the
+  rewritten bundle end-to-end.
+- The rewriter is at `scripts/granite_export/rewrite_attention_to_mha.py`.
+  Currently in iter-4 wiring (RPB cast, dtype-rejected). Revert
+  that file to iter-2's commit (`b9246cf`) for the cleanest
+  starting point if pursuing the "RPB is literal" branch.
+
+**Tooling reminders:**
+
+- `--static-shapes-unified` flag in the export script gives you a
+  Granite decoder.onnx with seq dynamic and other dims pinned. The
+  iter-5 work probably wants `--static-shapes-unified --sdpa-attention`
+  (still eager unless you have a reason to test sdpa); past_kv is
+  declared 4-head currently, that's the dim you'd change for iter 5.
+- `VERNACULA_ORT_VERBOSE=1` env var (in `OrtSessionBuilder`)
+  enables ORT INFO-level logging across sessions. Use to verify
+  MHA placement on CUDA EP and check fusion-modified counts.
+- `/tmp/probe_ort_load.py` is a quick verbose-load probe — point it
+  at any decoder.onnx to see CPU fallbacks + Memcpy warnings.
+- `/tmp/probe_gqa_alignment.py` and `/tmp/probe_mha_mask.py` from
+  the recon phase are reproducible if you need to re-verify GQA's
+  left-alignment or MHA's mask semantics.
+
+
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2352,6 +2352,56 @@ This is a ~1-day refactor of the rewriter, not a 30-min tweak.
 Same scope as a fresh-session day-2-follow-up. Pausing iteration
 loop here so it doesn't blur into a multi-day session.
 
+### Iteration 4 (where_2 as RPB cast to fp32)
+
+Quick experiment to rule out dtype precision as the iter-2 bug
+cause. Cast where_2 (bf16) to fp32 before feeding as RPB.
+
+Result: ORT MHA rejects with `Type Error: Type parameter (T) of
+Optype (MultiHeadAttention) bound to different types (tensor(bfloat16)
+and tensor(float))`. ORT enforces RPB dtype to match Q/K/V dtype.
+Can't promote the mask cleanly without converting Q/K/V too.
+
+Implication: iter 2's "garbled but recognizable" output wasn't a
+dtype precision issue. Most likely root cause is that ORT MHA's
+`relative_position_bias` is intended for *relative* position
+encodings (T5/ALiBi style) and may not interpret arbitrary
+additive masks literally. The semantics of "RPB[s, t] is added
+to attention_scores[s, t]" sounds simple, but the implementation
+might index it as "RPB[s - t]" or similar relative-position
+function. This would explain why iter 2 produced output that
+*almost* matched (relative positions in the unmasked region behave
+similarly across q-positions) but with subtle drift.
+
+Full evidence-based diagnosis at this point:
+- iter 1 (raw KPM, no causal): garbage. Missing causal entirely.
+- iter 2 (where_2 as RPB): garbled. RPB likely interpreted
+  relative-position-style, not as literal additive mask.
+- iter 3 (KPM + unidirectional, pre-concat K): correct ~12 tokens
+  then derails. Causal applied as if K is all "new" — misses
+  cached past positions [0, P).
+- iter 4 (where_2 as RPB cast to fp32): dtype-rejected.
+
+The PATH FORWARD is iter 5: feed past_key/past_value via MHA's
+dedicated past inputs. Requires:
+
+1. Re-export with past_key/past_value declared as 16-head (Expand
+   from 4 to 16 heads at export time, before the wrapper-level
+   slice). Cache memory grows 4× but still fits comfortably
+   (~168 MB for 16 KV heads × 512 past × 128 head_dim × 80
+   tensors at bf16).
+2. Rewriter consumes past_key_<L> graph input directly as MHA's
+   past_key (not the post-concat tensor).
+3. New_K post-RoPE → MHA's key input (after Expand to 16 heads).
+4. unidirectional=1 + key_padding_mask for causal + masking.
+5. MHA's present_key output replaces the wrapper-level slice path
+   (or composes with it; depends on shape conventions).
+
+This is a coordinated re-export + rewriter change. ~1-day fresh-
+session work; won't fit in this agent-loop session.
+
+
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -2823,6 +2823,130 @@ of the 13.3 s → 3.4 s gap as possible.
   rather than IOBinding (deliberately, after Run 7); GQA may
   force a switch.
 
+## Run 20 phase 2 — 2026-05-10 14:23 — Batched GQA via per-row position_ids
+
+Phase 1's serial-single-segment fallback regressed wall time to
+35.7 s — far worse than MHA's 13.5 s. The user correctly pointed
+out the regression was the loss of batched parallelism, not GQA
+itself. Phase 2 restores batched dispatch.
+
+### Plan
+
+To batch variable-length prompts under GQA, each row's RoPE
+positions need to track its own real prompt length. The fix is a
+new `position_ids` graph input ([B, S], int64) that the C# driver
+fills per-row, plus right-padded prompts so GQA's write slots
+align with the real-vs-pad boundary per row.
+
+Three coordinated changes:
+
+1. **Export wrapper.** New `--unified-position-ids` flag adds a
+   `position_ids` arg to `DecoderUnifiedWrapper.forward` and
+   forwards it to `language_model(position_ids=...)`. HF then
+   uses per-row positions for RoPE instead of deriving them from
+   `cache_position`. `dynamic_shapes` is updated to thread
+   `position_ids` into the variadic `*rest` so torch.export
+   accepts the signature.
+
+2. **Rewriter.** No change — GQA only consumes past_kv, fresh
+   K/V, seqlens_k, total_sequence_length. cache_position and
+   position_ids flow through unmodified upstream nodes.
+
+3. **C# driver.** New `_hasPositionIdsInput` flag detects the
+   phase-2 bundle via decoder input metadata. New
+   `TranscribeStaticGqaBatched` method:
+   - right-pads all rows to `S = max(realLen)` (real prompt at
+     `[0, realLen[b])`, PAD at `[realLen[b], S)`),
+   - sets `seqlens_k` uniformly to `S - 1` at prefill (GQA's
+     write region is derived from `seqlens_k - new_S + 1` and
+     won't accept per-row write positions in one call),
+   - switches `seqlens_k` to per-row `realLen[b] + step` at step
+     time, so step k overwrites the first un-written pad slot
+     `past_kv[b, realLen[b]+k]`,
+   - sets `position_ids` per-row: real positions get
+     `[0..realLen[b])`, pad positions continue
+     `[realLen[b]..S)` (RoPE stable through prefill→step), and
+     step k's new token uses position `realLen[b]+k`.
+
+The pad K written at prefill into `past_kv[b, realLen[b]..S)`
+gets overwritten as step k progresses; per-row `seqlens_k` means
+the attention bound `[0..realLen[b]+k+1)` never reaches an
+un-overwritten pad slot. Step-time attention is clean despite
+the pad contamination paid during prefill.
+
+### Results (3 runs each on `/tmp/run15_short_60s.wav`, --benchmark)
+
+| Bundle | ASR median | Transcript |
+|---|---|---|
+| unfused-static | 13.29 s | baseline |
+| MHA-fused (Run 19) | 13.55 s | exact match |
+| **GQA + position_ids batched (Run 20 phase 2)** | **13.58 s** | **exact match** |
+| Phase 1 serial-single-segment | 35.7 s | parity but slow |
+| dynamic | ~3.4 s | (unbeaten) |
+
+Batched GQA closes the Phase 1 regression and lands at MHA
+parity. Architecturally cleaner than MHA: left-aligned cache,
+GQA's in-place writes, no `where_2` mask path.
+
+### Why the compute-skip didn't show up
+
+The original Run 20 plan called out FFN dominance as a risk;
+profiling confirms it. Per-layer cost breakdown at B=1, S=1
+decode step with our shape regime (D=2048, D_ffn≈8192,
+num_heads=16, head_dim=128, max_seq=512):
+
+  - QKV proj: ~6 M ops
+  - Attention (full 512 cache): ~2 M ops
+  - Attention (realLen ≈ 80 cache): ~0.3 M ops
+  - O proj: ~4 M ops
+  - FFN (gate + up + down): ~50 M ops
+  - **Total**: ~62 M full vs ~60 M with compute-skip — 3% delta.
+
+The dynamic baseline's 4× lead over static-shape is therefore
+NOT about attention fusion or compute-skip. Likely candidates:
+
+- The pinned `A = 192` audio dim forces the encoder to process
+  192 frames every call even for short segments (most real
+  segments have ≪ 192 frames).
+- Static-shape kernel selection. The graph optimizer can't pick
+  small-shape kernels for B=1, S=1 actual workload when the
+  graph signature says B=16, A=192.
+- ORT's `present_key` allocation and `cache_position`/RoPE
+  computation per-call has CPU overhead that doesn't amortize
+  the way dynamic does.
+
+### Implications for future perf work
+
+Attention fusion (MHA or GQA) is a structural win — cleaner
+graph, better tooling support, foundation for KV quantization —
+but is not the perf lever. The static-shape padding costs are
+where to focus next:
+
+1. **Reduce the audio_embeds pinning.** `A = 192` forces 30 s of
+   audio compute per call. Bucketed exports at `A ∈ {32, 96,
+   192}` would let short segments use a smaller graph.
+2. **Per-segment session selection.** Multiple decoder
+   `InferenceSession`s pinned at different `past_len` values
+   (`{64, 128, 256, 512}`), dispatch by current cache length.
+3. **Drop static shape entirely for the decoder.** The
+   ORT-genai/vLLM pattern of fully dynamic + IOBinding +
+   continuous batching is the production answer; our static
+   path was always a stepping stone.
+
+### Artifacts
+
+- New export: `/tmp/granite_export_phase2/decoder.onnx`
+  (with `--unified-position-ids --static-shapes-unified
+  --static-batch 16 --static-past-len 512 --static-audio-len
+  192`). Encoder/projector/mel are symlinked from the original
+  bundle (unchanged).
+- GQA-rewritten v2 bundle:
+  `/tmp/granite_gqa_v2_bundle/` — production-shaped test bundle
+  for the phase-2 C# code path.
+- Phase 1 GQA bundle still present:
+  `/tmp/granite_gqa_all_bundle/` — serial-single-segment path,
+  retained for fallback testing only.
+
 
 
 

--- a/docs/dev/granite_speech_perf_investigation.md
+++ b/docs/dev/granite_speech_perf_investigation.md
@@ -3259,6 +3259,200 @@ same `TranscribeBatch` path and benchmark. If it matches the
 if it matches the 4.76 s phase-6 number, the gap is elsewhere
 (encoder, kernel selection).
 
+## Run 20 phase 7 — 2026-05-10 15:20 — Tracing the gap: it doesn't exist
+
+User question: "We should trace a run and figure out where the
+opportunity exists (if there is one)." Followed by: "Might be
+we're counting VAD or something?"
+
+Both prompts pointed at the same suspicion: the comparison
+target (3.4 s) was wrong somehow.
+
+### Two tests
+
+**Test 1 — Same C# path, un-rewritten dynamic decoder.** Used
+`/tmp/granite_export_dynamic/decoder.onnx` as-is (no MHA
+fusion, no GQA rewriter, just the dynamic export with
+`--unified-position-ids`). Three trials:
+
+  - ASR median: **4.71 s** (vs MHA-fused 4.76 s)
+
+Unfused and MHA-fused dynamic are identical within noise. So
+MHA fusion isn't adding any cost OR any benefit in dynamic
+mode — the kernel launch saving from fusion is offset by the
+adapter Transpose+Reshape overhead. **MHA fusion is irrelevant
+to wall time in dynamic mode.**
+
+**Test 2 — Decompose the 4.7 s.** Audit the swAsr stopwatch:
+
+  - swAsr starts at Program.cs:410, AFTER swDiar.Stop(). So
+    diarization / VAD is NOT in ASR.
+  - swAsr stops after the Recognize enumeration completes.
+  - Between start and the granite branch: bundle selection
+    branching only, no model work.
+
+So the swAsr stopwatch covers:
+
+  - GraniteSpeech ctor (loads decoder.onnx + ~3.5 GB weights
+    onto GPU, plus mel/encoder/projector sessions).
+  - The Recognize call (TranscribeBatch + yields).
+
+Instrumented the ctor directly:
+
+  [granite-prof] session load: 1387 ms
+  [granite-prof] B=16 total=2336 ms (mel=41 enc=521 proj=7 prefill=442 step=1294 x25 overhead=31)
+  [granite-prof] B=2  total= 954 ms (mel=25 enc=110 proj=3 prefill= 55 step= 755 x35 overhead= 6)
+  ASR: 4685 ms
+
+  → session load 1387 ms + batches 3290 ms + dispatch ~10 ms ≈ 4685 ms
+
+### Conclusion
+
+The "1.4 s residual gap to the 3.4 s legacy baseline" is
+entirely the cold-start `new GraniteSpeech(...)` session-load
+cost. **Subtracting that, our actual decode work is 3.29 s —
+essentially at the legacy baseline.**
+
+The "3.4 s baseline" in the doc was almost certainly measured
+without ctor cost (likely a warm session, or the baseline run
+just happened to start with a primed disk cache). It is NOT a
+target our attention work missed.
+
+### What this means for the perf investigation
+
+We're at the floor. The Run 20 perf arc closes here:
+
+  - GQA static phases (1–3): 13.27 s. Capped by static-shape
+    padding.
+  - GQA dynamic phase 4 (B=1): 5.23 s. Dropped static-shape
+    padding, gained ~2.5×.
+  - GQA dynamic phase 5 (batched): blocked by CUDA kernel
+    missing attention_bias.
+  - MHA dynamic phase 6 (batched): 4.76 s. Marginal win over
+    phase 4. Same as un-rewritten dynamic, confirming fusion is
+    neutral here.
+  - Phase 7 (this entry): the residual gap to the cited 3.4 s
+    baseline is cold-start ctor cost, not perf opportunity.
+
+If there's still a perf lever, it's in the encoder
+(~540 ms/run, serial across segments) or in eliminating
+cold-start (preloaded singleton GraniteSpeech in the GUI/server
+context). The decoder itself is not the bottleneck.
+
+### Final state of the branch
+
+The MHA-fused dynamic bundle (this phase) is the recommended
+production path: clean fusion, dynamic shapes, batched dispatch.
+It's not faster than un-rewritten dynamic, but it's also not
+slower, and the rewriter scaffolding will become useful again
+when ORT's CUDA GQA grows `attention_bias` support (at which
+point the same export can be re-rewritten to GQA for whatever
+kernel-launch savings exist in larger-shape workloads).
+
+## Run 20 phase 8 — 2026-05-10 15:38 — IOBinding for the dynamic step loop
+
+GPU sampling at phase 7 showed 65 % idle and mean 18 % during
+the run. The biggest user-side lever was the per-step
+`GetTensorDataAsSpan<float>()` on the logits OrtValue — an
+implicit GPU→CPU copy that synchronises and stalls the host
+between iterations. Binding logits to a pre-allocated CPU buffer
+via `OrtIoBinding.BindOutput(name, ortValue)` writes the result
+directly into our .NET array and skips the round-trip.
+
+### Change
+
+In `TranscribeBatch` (the dynamic-MHA path), pre-allocate the
+constant-shape inputs (input_ids, audio_embeds, cache_position,
+position_ids) and the logits output buffer once. Each step
+constructs only the attention_mask OrtValue (whose shape grows)
+and a fresh `OrtIoBinding`, binds the pre-allocated inputs and
+the logits output, then calls `RunWithBinding`. present_kv
+OrtValues come back from `GetOutputValues()` and feed forward via
+the prev/cur collection-disposal pattern lifted from
+`WhisperTurbo.cs` — `pastKvs` holds borrowed references into the
+previous step's collection until the next step's binding has
+consumed them.
+
+Two bugs surfaced during development and were worth recording:
+
+1. **Disposal of the `GetOutputValues()` collection** — wrapping
+   it in `using var` disposes the inner OrtValues at end of
+   scope, which invalidates the `pastKvs` references that the
+   next iteration's binding needs. Fix: hold the collection in
+   `prevStepOutputs` and `Dispose()` it AFTER the next iteration
+   has swapped `pastKvs` off it (matches WhisperTurbo's pattern).
+2. **Output-bind index mismatch** — I bound outputs interleaved
+   (key_0, value_0, key_1, value_1, …) but indexed
+   `pastKvs[2L] = curOutputs[1+L]` as if all keys came first.
+   Symptom: transcript decoded as plausible bytes but semantically
+   garbage ("all kinds of 'ss<|fim_suffix|> been [aa…"). Fix: bind
+   outputs in the same order as `decOutputNames` — logits, then
+   all present_key in layer order, then all present_value.
+
+### Results (3 runs each on `/tmp/run15_short_60s.wav`)
+
+| Bundle | ASR median | Δ vs Phase 6 |
+|---|---|---|
+| MHA-fused dynamic (Phase 6, no IOBinding) | 4.76 s | baseline |
+| **MHA-fused dynamic + IOBinding (this run)** | **3.61 s** | **−24 %** |
+| legacy unfused dynamic reference | ~3.4 s | parity |
+
+Transcript exact match through all 18 segments.
+
+### GPU utilization comparison
+
+Sampled with `nvidia-smi -lms 30` during a full ASR run:
+
+| Phase | Mean GPU | Max GPU | 0-9 % bin |
+|---|---|---|---|
+| Phase 6 (4.76 s) | 18 % | 82 % | 65 % |
+| Phase 8 (3.61 s) | 14 % | 90 % | 72 % |
+
+Mean went down because the run completes faster, so the fixed
+cold-start cost is a bigger fraction of the sampled window. But
+the PEAKS went up (82 → 90 %) — when the GPU is actually doing
+decode work, it's now driven harder per second of wall time.
+
+### Where the wall time goes now
+
+Total ASR: 3.61 s
+  - cold-start session load: ~1.4 s (decoder.onnx + 3.5 GB weights
+    onto GPU, plus mel/encoder/projector sessions).
+  - actual decode work: ~2.2 s (warm-equivalent).
+
+For long-running deployments (GUI, server) where the GraniteSpeech
+instance is created once and reused, the relevant number is the
+~2.2 s warm decode — about **35 % faster than the legacy dynamic
+baseline** if that baseline included session load, or **at
+parity** if it didn't.
+
+### What's left on the GPU floor
+
+GPU still idle 72 % of wall time in this run, but most of that
+is the cold-start phase. Within the decode portion, peaks reach
+90 % so utilisation during compute is healthy.
+
+Remaining levers, in order of decreasing realism:
+
+1. **Pinned (page-locked) CPU memory for logits.** Current
+   `BindOutput` with a regular .NET array still does a
+   pageable-host copy. Pinned host memory enables async cudaMemcpy
+   that overlaps with the next step's kernel launches. Modest win
+   (~5-10 %) but achievable.
+2. **Encoder parallelism.** Encoder takes ~540 ms across the
+   18-segment run, serially per segment. Batched encoder call
+   would amortise this. Encoder/projector aren't the wall-time
+   bottleneck anymore so this is small.
+3. **Pre-loaded singleton GraniteSpeech.** Move the ~1.4 s
+   ctor cost out of the user-perceived ASR window. This is an
+   app-architecture change (long-running session vs per-CLI-call
+   reload), not a Granite kernel change.
+4. **CUDA graph capture.** Requires re-pinning shapes, regressing
+   to the slower static-shape contract. Not worth it given that
+   path was 13.3 s.
+
+This is a good place to call the perf arc done.
+
 
 
 

--- a/scripts/granite_export/export_granite_speech_to_onnx.py
+++ b/scripts/granite_export/export_granite_speech_to_onnx.py
@@ -160,6 +160,18 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--unified-position-ids",
+        action="store_true",
+        help=(
+            "Run 20 phase 2: add `position_ids` (int64, [B, S]) as a new "
+            "graph input to the unified decoder, and pass it to "
+            "language_model(position_ids=...). This lets the C# driver "
+            "feed per-row RoPE positions, which the GQA-rewritten bundle "
+            "needs to support batched variable-length prompts without "
+            "going serial. Only meaningful with --static-shapes-unified."
+        ),
+    )
+    parser.add_argument(
         "--sdpa-attention",
         action="store_true",
         help=(
@@ -648,7 +660,12 @@ def make_decoder_init_wrapper(torch: Any, model: Any) -> Any:
     return DecoderInitWrapper(model)
 
 
-def make_decoder_unified_wrapper(torch: Any, model: Any, static_past_len: int | None = None) -> Any:
+def make_decoder_unified_wrapper(
+    torch: Any,
+    model: Any,
+    static_past_len: int | None = None,
+    position_ids_input: bool = False,
+) -> Any:
     """One ONNX graph that handles BOTH prefill and step.
 
     Eliminates the duplicate LM-weight copy that the split init/step pair
@@ -699,6 +716,13 @@ def make_decoder_unified_wrapper(torch: Any, model: Any, static_past_len: int | 
             # past_kv inputs without a CPU-side slice. Used by the
             # --static-shapes-unified export (Run 15 phase 2c, issue #41).
             self._static_past_len = static_past_len
+            # When True, the wrapper takes `position_ids` ([B, S], int64)
+            # as a new positional input between cache_position and past_kv,
+            # and forwards it to language_model(position_ids=...). HF then
+            # uses per-row positions for RoPE, which lets the C# driver
+            # batch variable-length prompts without a shared-position
+            # contortion. See --unified-position-ids (Run 20 phase 2).
+            self._position_ids_input = position_ids_input
 
         def forward(
             self,
@@ -706,8 +730,14 @@ def make_decoder_unified_wrapper(torch: Any, model: Any, static_past_len: int | 
             audio_embeds: Any,
             attention_mask: Any,
             cache_position: Any,
-            *past_kv: Any,
+            *rest: Any,
         ) -> Any:
+            if self._position_ids_input:
+                position_ids = rest[0]
+                past_kv = rest[1:]
+            else:
+                position_ids = None
+                past_kv = rest
             # audio_embeds arrives as fp32 (projector stays fp32; see
             # make_projector_wrapper). Cast to LM weight dtype at the
             # boundary so all internal matmuls stay in weight dtype.
@@ -740,6 +770,7 @@ def make_decoder_unified_wrapper(torch: Any, model: Any, static_past_len: int | 
             out = self.language_model(
                 inputs_embeds=embeds,
                 attention_mask=attention_mask,
+                position_ids=position_ids,
                 past_key_values=cache,
                 cache_position=cache_position,
                 use_cache=True,
@@ -1115,6 +1146,7 @@ def export_decoder_unified(
     legacy: bool,
     static_shapes_probe: bool = False,
     static_shapes_unified: bool = False,
+    position_ids_input: bool = False,
 ) -> None:
     """Export the unified prefill+step graph.
 
@@ -1136,11 +1168,17 @@ def export_decoder_unified(
     attention_mask = inputs["attention_mask"]
     audio_embeds = inputs["audio_embeds"]
     cache_position = inputs["cache_position"]
+    position_ids = inputs.get("position_ids")
     keys = inputs["past_keys"]
     values = inputs["past_values"]
 
     with torch.no_grad():
-        out = wrapper(input_ids, audio_embeds, attention_mask, cache_position, *keys, *values)
+        if position_ids_input:
+            out = wrapper(input_ids, audio_embeds, attention_mask, cache_position,
+                          position_ids, *keys, *values)
+        else:
+            out = wrapper(input_ids, audio_embeds, attention_mask, cache_position,
+                          *keys, *values)
     print(f"  PyTorch logits shape: {tuple(out[0].shape)}, "
           f"present_key_0 shape: {tuple(out[1].shape)}")
 
@@ -1149,8 +1187,11 @@ def export_decoder_unified(
         + _kv_names("present_key")
         + _kv_names("present_value")
     )
+    base_inputs = ["input_ids", "audio_embeds", "attention_mask", "cache_position"]
+    if position_ids_input:
+        base_inputs = base_inputs + ["position_ids"]
     input_names = (
-        ["input_ids", "audio_embeds", "attention_mask", "cache_position"]
+        base_inputs
         + _kv_names("past_key")
         + _kv_names("past_value")
     )
@@ -1180,16 +1221,31 @@ def export_decoder_unified(
             "cache_position": {0: "seq"},
             "logits":         {1: "seq"},
         }
+        if position_ids_input:
+            dynamic_axes["position_ids"] = {1: "seq"}
         # past_kv / audio_embeds / batch all static — no dynamic_axes entry.
 
         past_kv_shapes = tuple({} for _ in range(2 * NUM_DECODER_LAYERS))
-        dyn_shapes = (
-            {1: seq},                    # input_ids
-            {},                          # audio_embeds (fully static)
-            {1: total},                  # attention_mask
-            {0: seq},                    # cache_position
-            past_kv_shapes,              # past_kv (all static)
-        )
+        if position_ids_input:
+            # The wrapper's *rest captures (position_ids, *past_kv) as one
+            # variadic, so dyn_shapes' last entry must be the merged tuple
+            # — not a separate top-level entry.
+            rest_shapes = ({1: seq},) + past_kv_shapes
+            dyn_shapes = (
+                {1: seq},                # input_ids
+                {},                      # audio_embeds (fully static)
+                {1: total},              # attention_mask
+                {0: seq},                # cache_position
+                rest_shapes,             # *rest = (position_ids, *past_kv)
+            )
+        else:
+            dyn_shapes = (
+                {1: seq},                # input_ids
+                {},                      # audio_embeds (fully static)
+                {1: total},              # attention_mask
+                {0: seq},                # cache_position
+                past_kv_shapes,          # past_kv (all static)
+            )
     else:
         batch = _make_dim(torch, "batch", min=1, max=65535)
         seq = _auto_dim(torch)         # input_ids[1] / cache_position[0] / new positions
@@ -1219,10 +1275,16 @@ def export_decoder_unified(
             past_kv_shapes,              # *past_kv
         )
 
+    if position_ids_input:
+        trace_args = (input_ids, audio_embeds, attention_mask, cache_position,
+                      position_ids, *keys, *values)
+    else:
+        trace_args = (input_ids, audio_embeds, attention_mask, cache_position,
+                      *keys, *values)
     _run_torch_export(
         torch,
         wrapper,
-        (input_ids, audio_embeds, attention_mask, cache_position, *keys, *values),
+        trace_args,
         output_path,
         input_names=input_names,
         output_names=output_names,
@@ -1460,7 +1522,12 @@ def main() -> int:
         # When --static-shapes-unified is set, the wrapper slices KV outputs
         # to past_len so present_kv is directly chainable as next past_kv.
         unified_static_past_len = args.static_past_len if args.static_shapes_unified else None
-        unified_wrapper = make_decoder_unified_wrapper(torch, model, static_past_len=unified_static_past_len)
+        unified_position_ids = bool(getattr(args, "unified_position_ids", False))
+        unified_wrapper = make_decoder_unified_wrapper(
+            torch, model,
+            static_past_len=unified_static_past_len,
+            position_ids_input=unified_position_ids,
+        )
         # Trace-dummy strategy varies by export mode:
         # - default: B=input_ids.shape[0], S=2 (mid-prompt), past=2 (mid-cache);
         #   both non-zero so dynamo doesn't specialise either.
@@ -1526,6 +1593,12 @@ def main() -> int:
             "past_keys": u_past_keys,
             "past_values": u_past_values,
         }
+        if unified_position_ids:
+            # Per-row positions. At trace time, all rows share the same
+            # seq_dummy positions; at runtime the C# driver fills per-row.
+            unified_inputs["position_ids"] = torch.arange(
+                seq_dummy, dtype=torch.long, device=input_ids.device
+            ).unsqueeze(0).expand(bsz, -1).contiguous()
         t0 = time.time()
         export_decoder_unified(
             torch,
@@ -1536,6 +1609,7 @@ def main() -> int:
             args.legacy_exporter,
             static_shapes_probe=args.static_shapes_probe,
             static_shapes_unified=args.static_shapes_unified,
+            position_ids_input=unified_position_ids,
         )
         report["stages"]["decoder_unified"] = {"seconds": round(time.time() - t0, 2)}
         if args.static_shapes_probe:

--- a/scripts/granite_export/export_granite_speech_to_onnx.py
+++ b/scripts/granite_export/export_granite_speech_to_onnx.py
@@ -1261,19 +1261,33 @@ def export_decoder_unified(
             "cache_position": {0: "seq"},
             "logits":         {0: "batch", 1: "seq"},
         }
+        if position_ids_input:
+            dynamic_axes["position_ids"] = {0: "batch", 1: "seq"}
         for name in _kv_names("past_key") + _kv_names("past_value"):
             dynamic_axes[name] = {0: "batch", 2: "past_len"}
         for name in _kv_names("present_key") + _kv_names("present_value"):
             dynamic_axes[name] = {0: "batch", 2: "total_len"}
 
         past_kv_shapes = tuple({0: batch, 2: past} for _ in range(2 * NUM_DECODER_LAYERS))
-        dyn_shapes = (
-            {0: batch, 1: seq},          # input_ids
-            {0: batch, 1: audio_len},    # audio_embeds
-            {0: batch, 1: total},        # attention_mask
-            {0: seq},                    # cache_position
-            past_kv_shapes,              # *past_kv
-        )
+        if position_ids_input:
+            # Variadic *rest captures (position_ids, *past_kv) as a single
+            # tuple — dyn_shapes' last entry must merge them.
+            rest_shapes = ({0: batch, 1: seq},) + past_kv_shapes
+            dyn_shapes = (
+                {0: batch, 1: seq},          # input_ids
+                {0: batch, 1: audio_len},    # audio_embeds
+                {0: batch, 1: total},        # attention_mask
+                {0: seq},                    # cache_position
+                rest_shapes,                 # *rest = (position_ids, *past_kv)
+            )
+        else:
+            dyn_shapes = (
+                {0: batch, 1: seq},          # input_ids
+                {0: batch, 1: audio_len},    # audio_embeds
+                {0: batch, 1: total},        # attention_mask
+                {0: seq},                    # cache_position
+                past_kv_shapes,              # *past_kv
+            )
 
     if position_ids_input:
         trace_args = (input_ids, audio_embeds, attention_mask, cache_position,

--- a/scripts/granite_export/export_granite_speech_to_onnx.py
+++ b/scripts/granite_export/export_granite_speech_to_onnx.py
@@ -160,6 +160,20 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--sdpa-attention",
+        action="store_true",
+        help=(
+            "Run 17 phase A spike (issue #43): load the model with "
+            "attn_implementation=sdpa instead of eager, with the goal of "
+            "letting torch.onnx.export emit a pattern ORT's "
+            "AttentionFusion / GroupQueryAttentionFusion passes recognize. "
+            "Previously gated off because SDPA's data-dependent branch on "
+            "attention_mask.shape[-1] != q.shape[-1] broke dynamo with "
+            "dynamic shapes; with --static-shapes-unified those dims are "
+            "bounded at trace time and the branch should fold."
+        ),
+    )
+    parser.add_argument(
         "--dummy-seconds",
         type=float,
         default=2.0,
@@ -206,7 +220,8 @@ def ensure_output_dir(path: Path, overwrite: bool) -> None:
 # ---------------------------------------------------------------------------
 
 def load_model_and_processor(
-    repo_id: str, revision: str | None, device: str, dtype: Any, torch: Any
+    repo_id: str, revision: str | None, device: str, dtype: Any, torch: Any,
+    attn_implementation: str = "eager",
 ) -> tuple[Any, Any]:
     from transformers import AutoProcessor, GraniteSpeechForConditionalGeneration
 
@@ -214,10 +229,20 @@ def load_model_and_processor(
     print(f"Loading processor from {repo_id}{rev_suffix} ...")
     processor = AutoProcessor.from_pretrained(repo_id, revision=revision)
 
-    # `attn_implementation="eager"` keeps the language-model attention out of
-    # transformers' sdpa_attention_forward path, which contains a data-dependent
-    # branch (`attention_mask.shape[-1] != q.shape[-1]`) that the dynamo
-    # exporter cannot guard. Eager is mathematically equivalent and traces cleanly.
+    # Default `attn_implementation="eager"` because transformers' sdpa path has
+    # a data-dependent branch (`attention_mask.shape[-1] != q.shape[-1]`) that
+    # the dynamo exporter cannot guard at runtime-symbolic shapes. Eager is
+    # mathematically equivalent and traces cleanly.
+    #
+    # The --sdpa-attention flag (issue #43) overrides to "sdpa" for the
+    # *language model only* on static-shape exports — Granite's audio
+    # Q-former (Blip2QFormerModel) doesn't have an SDPA implementation, so
+    # passing attn_implementation="sdpa" at the top-level
+    # GraniteSpeechForConditionalGeneration constructor errors. Loading with
+    # eager and overriding the language_model.config._attn_implementation
+    # post-load is the surgical version. The goal is to emit a pattern
+    # ORT's AttentionFusion / GroupQueryAttentionFusion passes recognize so
+    # we get fused attention without writing a custom graph rewriter.
     print(f"Loading model from {repo_id}{rev_suffix} on {device} as {dtype} (attn_implementation=eager) ...")
     model = GraniteSpeechForConditionalGeneration.from_pretrained(
         repo_id,
@@ -226,6 +251,13 @@ def load_model_and_processor(
         low_cpu_mem_usage=True,
         attn_implementation="eager",
     )
+    if attn_implementation == "sdpa":
+        print("  Overriding language_model._attn_implementation to sdpa "
+              "(issue #43 / spike). encoder + projector stay eager.")
+        model.language_model.config._attn_implementation = "sdpa"
+    elif attn_implementation != "eager":
+        raise ValueError(
+            f"Unknown attn_implementation {attn_implementation!r}; expected eager or sdpa.")
     model.to(device)
     model.eval()
 
@@ -1322,8 +1354,10 @@ def main() -> int:
         "bfloat16": torch.bfloat16,
     }[args.dtype]
 
+    attn_impl = "sdpa" if args.sdpa_attention else "eager"
     model, processor = load_model_and_processor(
-        args.model_repo, args.revision, args.device, dtype, torch
+        args.model_repo, args.revision, args.device, dtype, torch,
+        attn_implementation=attn_impl,
     )
 
     # Mixed-precision policy: when --dtype is BF16 (or fp16), only the

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -206,21 +206,25 @@ def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: in
                          outputs=[v_adapted], name=f"{pfx}_v_reshape"),
     ]
 
-    # MultiHeadAttention. We feed the original graph's per-call additive
-    # mask (`where_2`-style; bf16 with 0 for attend / -inf for ignore +
-    # causal triangulation) as relative_position_bias. ORT MHA adds this
-    # to the attention scores before softmax — same semantics as the
-    # original Add node we removed, so per-layer behaviour is preserved.
+    # MultiHeadAttention. We pass the graph's raw attention_mask (cast to
+    # int32 once at the top of the graph) as key_padding_mask, plus
+    # is_unidirectional=1 to have MHA apply causal masking internally.
+    # This wiring lets MHA's CUDA kernel skip masked positions in COMPUTE,
+    # not just zero them post-softmax — that's the difference between
+    # "correct output but slow" (relative_position_bias path) and
+    # "correct AND fast". Relevant ORT MHA implementation skip happens
+    # only via key_padding_mask + is_unidirectional, not via RPB.
     mha_out = f"{pfx}_out"
     scale = 1.0 / (HEAD_DIM ** 0.5)
     mha_node = helper.make_node(
         "MultiHeadAttention",
-        inputs=[q_adapted, k_adapted, v_adapted, "", "", mask],
+        inputs=[q_adapted, k_adapted, v_adapted, "", "mha_mask_int32"],
         outputs=[mha_out],
         name=f"{pfx}_node",
         domain="com.microsoft",
         num_heads=NUM_HEADS,
         scale=scale,
+        unidirectional=1,
     )
 
     # Rewire output_tensor consumers to use mha_out instead.
@@ -268,6 +272,10 @@ def main() -> int:
         else [int(x) for x in args.layers.split(",")]
     )
     print(f"  Rewriting layers: {target_layers}")
+
+    # Cast the graph's attention_mask (int64) to int32 once for all layers'
+    # MHA key_padding_mask consumers.
+    add_mask_int32(graph)
 
     all_new_nodes: list[onnx.NodeProto] = []
     all_new_inits: list[onnx.TensorProto] = []

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -47,9 +47,11 @@ import numpy as np
 import onnx
 from onnx import helper, numpy_helper, TensorProto
 
-NUM_HEADS = 16
-HEAD_DIM  = 128
-HIDDEN    = NUM_HEADS * HEAD_DIM  # 2048
+NUM_HEADS    = 16
+NUM_KV_HEADS = 4
+HEAD_DIM     = 128
+HIDDEN       = NUM_HEADS * HEAD_DIM        # 2048
+KV_HIDDEN    = NUM_KV_HEADS * HEAD_DIM     # 512
 
 
 def parse_args() -> argparse.Namespace:
@@ -60,6 +62,11 @@ def parse_args() -> argparse.Namespace:
                     help="Output decoder.onnx with attention rewritten to MHA.")
     ap.add_argument("--layers", type=str, default=None,
                     help="Comma-separated layer indices to rewrite (default: all).")
+    ap.add_argument("--mode", choices=["mha", "gqa"], default="mha",
+                    help="Fusion target: mha (MultiHeadAttention, default) or gqa "
+                         "(GroupQueryAttention). GQA enables compute-skip via "
+                         "seqlens_k and requires a coordinated cache-layout "
+                         "change in the C# driver.")
     return ap.parse_args()
 
 
@@ -171,10 +178,69 @@ def add_q_kv_adapter_nodes(prefix: str, src: str, dst: str) -> list[onnx.NodePro
     ]
 
 
-def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
-                  producer, consumers):
-    """Rewrite one layer's attention. Returns (added_nodes, added_initializers,
-    nodes_to_remove).
+def find_kv_chain_for_gqa(kv_tensor: str, producer, consumers):
+    """Walk back from the K/V tensor consumed by the attention MatMul (post
+    broadcast 4→16) to the underlying Concat that joins the past_kv graph
+    input with the fresh K/V (post-RoPE for K, post-Transpose for V).
+
+    Returns:
+      past_kv:      name of the past_key_<L>/past_value_<L> graph input.
+      fresh_kv:     name of the fresh K/V tensor (B, num_kv_heads, S, head_dim).
+      present_kv:   name of the present_key_<L>/present_value_<L> graph output
+                    (currently produced by a Slice on top of the Concat).
+      slice_node:   the Slice node that produces present_kv; must be removed
+                    so the GQA op can claim the graph-output name.
+    """
+    # Walk back through Transpose/Reshape/Expand/Unsqueeze chain until Concat.
+    cur = kv_tensor
+    for _ in range(10):
+        n = producer.get(cur)
+        if n is None:
+            raise ValueError(f"Hit graph input {cur} before finding Concat")
+        if n.op_type == "Concat":
+            concat_node = n
+            break
+        if n.op_type not in ("Transpose", "Reshape", "Expand", "Unsqueeze"):
+            raise ValueError(
+                f"Unexpected op {n.op_type} ({n.name}) walking back K/V chain")
+        cur = n.input[0]
+    else:
+        raise ValueError("K/V chain too deep; expected Concat within 10 hops")
+
+    # Identify which Concat input is the past_kv graph input by name pattern.
+    past_kv = None
+    fresh_kv = None
+    for inp in concat_node.input:
+        if inp.startswith("past_key_") or inp.startswith("past_value_"):
+            past_kv = inp
+        else:
+            fresh_kv = inp
+    if past_kv is None or fresh_kv is None:
+        raise ValueError(
+            f"Concat {concat_node.name} inputs {list(concat_node.input)} "
+            f"don't match expected past_kv/fresh_kv pattern")
+
+    # Find the Slice that consumes the concat output and produces the
+    # graph's present_key_<L>/present_value_<L> output.
+    slice_node = None
+    for c in consumers.get(concat_node.output[0], []):
+        if c.op_type == "Slice" and (
+            c.output[0].startswith("present_key_") or
+            c.output[0].startswith("present_value_")
+        ):
+            slice_node = c
+            break
+    if slice_node is None:
+        raise ValueError(
+            f"Concat {concat_node.name} output has no present_kv Slice consumer")
+
+    return past_kv, fresh_kv, slice_node.output[0], slice_node
+
+
+def rewrite_layer_mha(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
+                      producer, consumers):
+    """Rewrite one layer's attention to MultiHeadAttention. Returns
+    (added_nodes, added_initializers, nodes_to_remove).
 
     Iter 5 wiring:
       - Q: Transpose+Reshape adapter to (B, S, hidden_size).
@@ -233,6 +299,114 @@ def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: in
     return new_nodes, new_inits, to_remove
 
 
+def rewrite_layer_gqa(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
+                      producer, consumers):
+    """Rewrite one layer's attention to GroupQueryAttention. Returns
+    (added_nodes, added_initializers, nodes_to_remove).
+
+    Layout (Run 20):
+      - Q: Transpose+Reshape adapter to (B, S, hidden_size=2048) rank-3.
+      - K, V: walked back through Expand(4→16) + Concat(past, fresh) to
+        the fresh K/V (post-RoPE for K, post-Transpose for V) in
+        (B, kv_num_heads=4, S, head_dim=128); adapted via Transpose+Reshape
+        to (B, S, kv_hidden_size=512) rank-3 for GQA's key/value inputs.
+      - past_key, past_value: graph inputs past_key_<L>/past_value_<L>
+        feed directly into GQA (BNSH layout, max-sized buffer).
+      - seqlens_k, total_sequence_length: new graph inputs (added once
+        at the top level by main()), passed into every layer's GQA.
+      - No attention_bias is wired: GQA does causal masking internally
+        via seqlens_k. We rely on the C# driver to right-pad prompts
+        and pass per-call seqlens_k that reflects the true real length
+        per batch row, which excludes pad tokens from compute and
+        attention without an explicit mask.
+      - Output: GQA's `present_key`/`present_value` directly claim the
+        graph output names `present_key_<L>`/`present_value_<L>` (the
+        original Slice→graph_output path is removed and replaced).
+      - do_rotary=0: RoPE is already applied in the graph (HF wrapper);
+        GQA only does scoring + cache append.
+      - scale=1/HEAD_DIM: Granite's attention_multiplier (Run 19 finding).
+    """
+    q, k, v, _mask, output_tensor, to_remove = find_attention_block(softmax, producer, consumers)
+
+    past_k, fresh_k, present_k_name, k_slice = find_kv_chain_for_gqa(k, producer, consumers)
+    past_v, fresh_v, present_v_name, v_slice = find_kv_chain_for_gqa(v, producer, consumers)
+
+    pfx = f"gqa_l{layer_idx}"
+
+    # Q adapter: (B, 16, S, 128) -> (B, S, 2048)
+    init_q = make_const_int64(f"{pfx}_q_shape", [16, -1, HIDDEN])
+    q_adapted = f"{pfx}_q_in"
+    q_nodes = [
+        helper.make_node("Transpose", inputs=[q], outputs=[f"{pfx}_q_t"],
+                         name=f"{pfx}_q_transpose", perm=[0, 2, 1, 3]),
+        helper.make_node("Reshape", inputs=[f"{pfx}_q_t", f"{pfx}_q_shape"],
+                         outputs=[q_adapted], name=f"{pfx}_q_reshape"),
+    ]
+
+    # K/V adapters: (B, 4, S, 128) -> (B, S, 512)
+    init_kv = make_const_int64(f"{pfx}_kv_shape", [16, -1, KV_HIDDEN])
+    k_adapted = f"{pfx}_k_in"
+    k_nodes = [
+        helper.make_node("Transpose", inputs=[fresh_k], outputs=[f"{pfx}_k_t"],
+                         name=f"{pfx}_k_transpose", perm=[0, 2, 1, 3]),
+        helper.make_node("Reshape", inputs=[f"{pfx}_k_t", f"{pfx}_kv_shape"],
+                         outputs=[k_adapted], name=f"{pfx}_k_reshape"),
+    ]
+    v_adapted = f"{pfx}_v_in"
+    v_nodes = [
+        helper.make_node("Transpose", inputs=[fresh_v], outputs=[f"{pfx}_v_t"],
+                         name=f"{pfx}_v_transpose", perm=[0, 2, 1, 3]),
+        helper.make_node("Reshape", inputs=[f"{pfx}_v_t", f"{pfx}_kv_shape"],
+                         outputs=[v_adapted], name=f"{pfx}_v_reshape"),
+    ]
+
+    gqa_out = f"{pfx}_out"
+    scale = 1.0 / HEAD_DIM
+    gqa_node = helper.make_node(
+        "GroupQueryAttention",
+        inputs=[
+            q_adapted, k_adapted, v_adapted,
+            past_k, past_v,
+            "seqlens_k", "total_sequence_length",
+        ],
+        outputs=[gqa_out, present_k_name, present_v_name],
+        name=f"{pfx}_node",
+        domain="com.microsoft",
+        num_heads=NUM_HEADS,
+        kv_num_heads=NUM_KV_HEADS,
+        scale=scale,
+        do_rotary=0,
+    )
+
+    # Rewire output_tensor consumers (o_proj input) -> gqa_out.
+    for c in consumers.get(output_tensor, []):
+        for i, inp in enumerate(c.input):
+            if inp == output_tensor:
+                c.input[i] = gqa_out
+
+    # Old Slice nodes that produced present_key_<L>/present_value_<L> are
+    # removed; GQA's outputs claim those graph-output names. The upstream
+    # K/V chain (Concat → Unsqueeze → Expand → Reshape → Transpose) becomes
+    # dead once the original attention nodes are gone — ORT DCE handles it.
+    new_nodes = q_nodes + k_nodes + v_nodes + [gqa_node]
+    new_inits = [init_q, init_kv]
+    to_remove_combined = to_remove + [k_slice, v_slice]
+    return new_nodes, new_inits, to_remove_combined
+
+
+def add_gqa_graph_inputs(graph: onnx.GraphProto, batch_size: int) -> None:
+    """Append `seqlens_k` (int32, [B]) and `total_sequence_length`
+    (int32, scalar) as new graph inputs so per-layer GQA nodes can
+    reference them by name."""
+    existing = {i.name for i in graph.input}
+    if "seqlens_k" not in existing:
+        graph.input.append(helper.make_tensor_value_info(
+            "seqlens_k", TensorProto.INT32, [batch_size]))
+    if "total_sequence_length" not in existing:
+        graph.input.append(helper.make_tensor_value_info(
+            "total_sequence_length", TensorProto.INT32, []))
+
+
 def main() -> int:
     args = parse_args()
 
@@ -250,7 +424,22 @@ def main() -> int:
         list(range(len(softmaxes))) if args.layers is None
         else [int(x) for x in args.layers.split(",")]
     )
-    print(f"  Rewriting layers: {target_layers}")
+    print(f"  Mode: {args.mode}; rewriting layers: {target_layers}")
+
+    rewrite_fn = rewrite_layer_mha if args.mode == "mha" else rewrite_layer_gqa
+    fused_op = "MHA" if args.mode == "mha" else "GQA"
+
+    # GQA needs two extra graph inputs (seqlens_k, total_sequence_length)
+    # that every layer's GQA node references. Infer batch size from any
+    # past_key_<L> graph input (they're all the same B).
+    if args.mode == "gqa":
+        b = next(
+            i.type.tensor_type.shape.dim[0].dim_value
+            for i in graph.input if i.name.startswith("past_key_")
+        )
+        add_gqa_graph_inputs(graph, batch_size=b)
+        print(f"  Added GQA graph inputs: seqlens_k (int32, [{b}]) + "
+              f"total_sequence_length (int32, scalar)")
 
     all_new_nodes: list[onnx.NodeProto] = []
     all_new_inits: list[onnx.TensorProto] = []
@@ -261,11 +450,11 @@ def main() -> int:
             raise ValueError(f"Layer {li} out of range; graph has {len(softmaxes)} layers")
         sm = softmaxes[li]
         try:
-            new_n, new_i, rem = rewrite_layer(graph, sm, li, producer, consumers)
+            new_n, new_i, rem = rewrite_fn(graph, sm, li, producer, consumers)
         except ValueError as e:
             print(f"  layer {li}: SKIP — {e}")
             continue
-        print(f"  layer {li}: replaced {len(rem)} nodes with MHA + {len(new_n) - 1} adapter nodes")
+        print(f"  layer {li}: replaced {len(rem)} nodes with {fused_op} + {len(new_n) - 1} adapter nodes")
         all_new_nodes.extend(new_n)
         all_new_inits.extend(new_i)
         all_remove.extend(rem)

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -162,9 +162,13 @@ def add_q_kv_adapter_nodes(prefix: str, src: str, dst: str) -> list[onnx.NodePro
 
 
 def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
-                  producer, consumers, mask_int32_tensor: str):
+                  producer, consumers):
     """Rewrite one layer's attention. Returns (added_nodes, added_initializers,
-    nodes_to_remove)."""
+    nodes_to_remove). Reuses the per-call additive mask `where_2` (or whatever
+    the graph computes once and shares across all 40 layers' Add nodes) as
+    MHA's relative_position_bias — that mask already encodes both
+    key-padding AND causal restrictions, so we don't need to feed a separate
+    key_padding_mask."""
     q, k, v, mask, output_tensor, to_remove = find_attention_block(softmax, producer, consumers)
 
     pfx = f"mha_l{layer_idx}"
@@ -202,12 +206,16 @@ def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: in
                          outputs=[v_adapted], name=f"{pfx}_v_reshape"),
     ]
 
-    # MultiHeadAttention. All layers share the same int32 mask.
+    # MultiHeadAttention. We feed the original graph's per-call additive
+    # mask (`where_2`-style; bf16 with 0 for attend / -inf for ignore +
+    # causal triangulation) as relative_position_bias. ORT MHA adds this
+    # to the attention scores before softmax — same semantics as the
+    # original Add node we removed, so per-layer behaviour is preserved.
     mha_out = f"{pfx}_out"
     scale = 1.0 / (HEAD_DIM ** 0.5)
     mha_node = helper.make_node(
         "MultiHeadAttention",
-        inputs=[q_adapted, k_adapted, v_adapted, "", mask_int32_tensor],
+        inputs=[q_adapted, k_adapted, v_adapted, "", "", mask],
         outputs=[mha_out],
         name=f"{pfx}_node",
         domain="com.microsoft",
@@ -261,9 +269,6 @@ def main() -> int:
     )
     print(f"  Rewriting layers: {target_layers}")
 
-    # Add the int32 mask cast once (shared across all layers).
-    mask_int32 = add_mask_int32(graph)
-
     all_new_nodes: list[onnx.NodeProto] = []
     all_new_inits: list[onnx.TensorProto] = []
     all_remove: list[onnx.NodeProto] = []
@@ -273,7 +278,7 @@ def main() -> int:
             raise ValueError(f"Layer {li} out of range; graph has {len(softmaxes)} layers")
         sm = softmaxes[li]
         try:
-            new_n, new_i, rem = rewrite_layer(graph, sm, li, producer, consumers, mask_int32)
+            new_n, new_i, rem = rewrite_layer(graph, sm, li, producer, consumers)
         except ValueError as e:
             print(f"  layer {li}: SKIP — {e}")
             continue

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -1,0 +1,315 @@
+"""Granite Speech 4.1 attention-fusion rewriter (issue #43, phase B).
+
+Rewrites the per-layer attention pattern in a static-shape Granite
+decoder.onnx, replacing the unfused
+  MatMul(Q, K^T) -> Mul(scale) -> Add(mask) -> Softmax -> MatMul(V)
+sequence with a single com.microsoft.MultiHeadAttention node.
+
+Granite's attention pattern is uniform across all 40 decoder layers
+(verified via Run 18 inspection). The matcher anchors on each Softmax
+node and walks back/forward to identify the seven nodes per attention
+block that we replace. The remaining Q/K/V projection chain, the RoPE
+Mul/Add applied to Q and K, the past_kv Concat, and the GQA broadcast
+Expand all stay in place — MHA wants K/V already broadcast to 16 heads
+and already RoPE'd, which is exactly what those upstream nodes produce.
+
+The matcher emits transpose+reshape adapters around MHA because MHA's
+input layout is (B, S, num_heads × head_dim) flat-hidden whereas the
+existing chain produces (B, num_heads, S, head_dim) split-hidden. The
+adapters are constant-folded by ORT in many cases (transpose+reshape
+of static dims).
+
+USAGE (called as a post-export step):
+
+    python scripts/granite_export/rewrite_attention_to_mha.py \\
+        --input  /tmp/granite_static_eager/decoder.onnx \\
+        --output /tmp/granite_static_mha/decoder.onnx \\
+        [--layers 0,1,2]    # only rewrite specific layers (default: all)
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper, TensorProto
+
+NUM_HEADS = 16
+HEAD_DIM  = 128
+HIDDEN    = NUM_HEADS * HEAD_DIM  # 2048
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--input",  type=Path, required=True,
+                    help="Input decoder.onnx (static-shape, eager-attention export).")
+    ap.add_argument("--output", type=Path, required=True,
+                    help="Output decoder.onnx with attention rewritten to MHA.")
+    ap.add_argument("--layers", type=str, default=None,
+                    help="Comma-separated layer indices to rewrite (default: all).")
+    return ap.parse_args()
+
+
+def build_indices(graph: onnx.GraphProto):
+    """Build producer / consumer indices for the graph."""
+    producer: dict[str, onnx.NodeProto] = {}
+    consumers: dict[str, list[onnx.NodeProto]] = {}
+    for n in graph.node:
+        for o in n.output:
+            producer[o] = n
+        for i in n.input:
+            consumers.setdefault(i, []).append(n)
+    return producer, consumers
+
+
+def find_attention_block(softmax: onnx.NodeProto, producer, consumers):
+    """Given a Softmax node anchoring an attention block, return:
+       (q_tensor, k_tensor, v_tensor, mask_tensor, output_consumers,
+        nodes_to_remove)
+    or raise ValueError if the surrounding pattern doesn't match."""
+    # Walk back: softmax(in) <- Add(scaled, mask) <- Mul(matmul_QK, scale)
+    add_mask = producer.get(softmax.input[0])
+    if add_mask is None or add_mask.op_type != "Add":
+        raise ValueError(f"{softmax.name}: expected Softmax input from Add, got {add_mask.op_type if add_mask else 'GRAPH_INPUT'}")
+
+    # Identify which Add input is the scaled scores vs the mask
+    add_in0_node = producer.get(add_mask.input[0])
+    add_in1_node = producer.get(add_mask.input[1])
+    if add_in0_node and add_in0_node.op_type == "Mul":
+        scale_mul, mask_tensor = add_in0_node, add_mask.input[1]
+    elif add_in1_node and add_in1_node.op_type == "Mul":
+        scale_mul, mask_tensor = add_in1_node, add_mask.input[0]
+    else:
+        raise ValueError(f"{softmax.name}: Add doesn't have a Mul producer for scaled scores")
+
+    scores_matmul = producer.get(scale_mul.input[0])
+    if scores_matmul is None or scores_matmul.op_type != "MatMul":
+        raise ValueError(f"{softmax.name}: scale Mul doesn't follow a MatMul (got {scores_matmul})")
+
+    q_tensor = scores_matmul.input[0]
+    k_transposed = scores_matmul.input[1]
+
+    # K feeder: walk back through Transpose to get the un-transposed K
+    k_transpose = producer.get(k_transposed)
+    if k_transpose is None or k_transpose.op_type != "Transpose":
+        raise ValueError(f"{softmax.name}: K is not transposed by a Transpose node")
+    k_tensor = k_transpose.input[0]   # (B, num_heads, T, head_dim)
+
+    # Walk forward: softmax_out -> attn_matmul (× V) -> transpose_5 -> view_9 -> linear_3
+    sm_out_consumers = consumers.get(softmax.output[0], [])
+    if len(sm_out_consumers) != 1 or sm_out_consumers[0].op_type != "MatMul":
+        raise ValueError(f"{softmax.name}: softmax output not consumed by exactly one MatMul")
+    attn_matmul = sm_out_consumers[0]
+    v_tensor = attn_matmul.input[1]   # (B, num_heads, T, head_dim)
+
+    # Walk forward two hops to find the consumer of the reshape (which is
+    # the output_proj's input). After our rewrite, MHA's output replaces
+    # the reshape's output.
+    cur = attn_matmul.output[0]
+    chain_after_attn = []
+    for _ in range(3):
+        cs = consumers.get(cur, [])
+        if len(cs) != 1:
+            break
+        n = cs[0]
+        chain_after_attn.append(n)
+        cur = n.output[0]
+        if n.op_type == "Reshape":
+            break
+
+    # Expecting: Transpose -> Reshape (then linear_3 consumes Reshape output)
+    if len(chain_after_attn) < 2 or chain_after_attn[-1].op_type != "Reshape":
+        raise ValueError(
+            f"{softmax.name}: attn output chain doesn't terminate at Reshape "
+            f"(got {[n.op_type for n in chain_after_attn]})")
+
+    # output_proj input tensor name = the reshape's output. We rewire this.
+    output_tensor = chain_after_attn[-1].output[0]
+    output_consumers = consumers.get(output_tensor, [])
+
+    nodes_to_remove = [scores_matmul, scale_mul, add_mask, softmax, attn_matmul, *chain_after_attn]
+    return q_tensor, k_tensor, v_tensor, mask_tensor, output_tensor, nodes_to_remove
+
+
+def make_const_int64(name: str, values: list[int]) -> onnx.TensorProto:
+    return numpy_helper.from_array(np.array(values, dtype=np.int64), name=name)
+
+
+def add_q_kv_adapter_nodes(prefix: str, src: str, dst: str) -> list[onnx.NodeProto]:
+    """Build Transpose+Reshape that adapts (B, num_heads, S, head_dim) ->
+    (B, S, num_heads × head_dim). The adapter shape constant is shared
+    via the prefix-derived initializer name; caller is responsible for
+    adding the initializer."""
+    transposed = f"{prefix}_t"
+    return [
+        helper.make_node(
+            "Transpose",
+            inputs=[src],
+            outputs=[transposed],
+            name=f"{prefix}_transpose",
+            perm=[0, 2, 1, 3],
+        ),
+        helper.make_node(
+            "Reshape",
+            inputs=[transposed, f"{prefix}_shape"],
+            outputs=[dst],
+            name=f"{prefix}_reshape",
+        ),
+    ]
+
+
+def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
+                  producer, consumers, mask_int32_tensor: str):
+    """Rewrite one layer's attention. Returns (added_nodes, added_initializers,
+    nodes_to_remove)."""
+    q, k, v, mask, output_tensor, to_remove = find_attention_block(softmax, producer, consumers)
+
+    pfx = f"mha_l{layer_idx}"
+
+    # Adapter shape constants (shared across Q/K/V):
+    # We can't fold seq/total_len since they're symbolic. Use [-1, -1, HIDDEN]
+    # — but Reshape only allows one -1. So use [B=16, -1, HIDDEN]:
+    init_q = make_const_int64(f"{pfx}_q_shape", [16, -1, HIDDEN])
+    init_kv = make_const_int64(f"{pfx}_kv_shape", [16, -1, HIDDEN])
+
+    # Q adapter (B, 16, S, 128) -> (B, S, 2048)
+    q_adapted = f"{pfx}_q_in"
+    q_nodes = [
+        helper.make_node("Transpose", inputs=[q], outputs=[f"{pfx}_q_t"],
+                         name=f"{pfx}_q_transpose", perm=[0, 2, 1, 3]),
+        helper.make_node("Reshape", inputs=[f"{pfx}_q_t", f"{pfx}_q_shape"],
+                         outputs=[q_adapted], name=f"{pfx}_q_reshape"),
+    ]
+
+    # K adapter
+    k_adapted = f"{pfx}_k_in"
+    k_nodes = [
+        helper.make_node("Transpose", inputs=[k], outputs=[f"{pfx}_k_t"],
+                         name=f"{pfx}_k_transpose", perm=[0, 2, 1, 3]),
+        helper.make_node("Reshape", inputs=[f"{pfx}_k_t", f"{pfx}_kv_shape"],
+                         outputs=[k_adapted], name=f"{pfx}_k_reshape"),
+    ]
+
+    # V adapter
+    v_adapted = f"{pfx}_v_in"
+    v_nodes = [
+        helper.make_node("Transpose", inputs=[v], outputs=[f"{pfx}_v_t"],
+                         name=f"{pfx}_v_transpose", perm=[0, 2, 1, 3]),
+        helper.make_node("Reshape", inputs=[f"{pfx}_v_t", f"{pfx}_kv_shape"],
+                         outputs=[v_adapted], name=f"{pfx}_v_reshape"),
+    ]
+
+    # MultiHeadAttention. All layers share the same int32 mask.
+    mha_out = f"{pfx}_out"
+    scale = 1.0 / (HEAD_DIM ** 0.5)
+    mha_node = helper.make_node(
+        "MultiHeadAttention",
+        inputs=[q_adapted, k_adapted, v_adapted, "", mask_int32_tensor],
+        outputs=[mha_out],
+        name=f"{pfx}_node",
+        domain="com.microsoft",
+        num_heads=NUM_HEADS,
+        scale=scale,
+    )
+
+    # Rewire output_tensor consumers to use mha_out instead.
+    output_consumers = consumers.get(output_tensor, [])
+    for c in output_consumers:
+        for i, inp in enumerate(c.input):
+            if inp == output_tensor:
+                c.input[i] = mha_out
+
+    new_nodes = q_nodes + k_nodes + v_nodes + [mha_node]
+    new_inits = [init_q, init_kv]
+    return new_nodes, new_inits, to_remove
+
+
+def add_mask_int32(graph: onnx.GraphProto) -> str:
+    """Add a Cast node that converts the existing graph-input attention_mask
+    (int64) to int32 for MHA. Returns the int32 tensor name."""
+    out_name = "mha_mask_int32"
+    cast = helper.make_node(
+        "Cast",
+        inputs=["attention_mask"],
+        outputs=[out_name],
+        name="mha_mask_cast_int32",
+        to=TensorProto.INT32,
+    )
+    graph.node.insert(0, cast)
+    return out_name
+
+
+def main() -> int:
+    args = parse_args()
+
+    print(f"Loading {args.input} ...")
+    model = onnx.load(str(args.input), load_external_data=False)
+    graph = model.graph
+    print(f"  nodes={len(graph.node)} inputs={len(graph.input)} outputs={len(graph.output)}")
+
+    producer, consumers = build_indices(graph)
+
+    softmaxes = [n for n in graph.node if n.op_type == "Softmax"]
+    print(f"  Found {len(softmaxes)} softmax nodes (one per layer).")
+
+    target_layers = (
+        list(range(len(softmaxes))) if args.layers is None
+        else [int(x) for x in args.layers.split(",")]
+    )
+    print(f"  Rewriting layers: {target_layers}")
+
+    # Add the int32 mask cast once (shared across all layers).
+    mask_int32 = add_mask_int32(graph)
+
+    all_new_nodes: list[onnx.NodeProto] = []
+    all_new_inits: list[onnx.TensorProto] = []
+    all_remove: list[onnx.NodeProto] = []
+
+    for li in target_layers:
+        if li >= len(softmaxes):
+            raise ValueError(f"Layer {li} out of range; graph has {len(softmaxes)} layers")
+        sm = softmaxes[li]
+        try:
+            new_n, new_i, rem = rewrite_layer(graph, sm, li, producer, consumers, mask_int32)
+        except ValueError as e:
+            print(f"  layer {li}: SKIP — {e}")
+            continue
+        print(f"  layer {li}: replaced {len(rem)} nodes with MHA + 6 adapter nodes")
+        all_new_nodes.extend(new_n)
+        all_new_inits.extend(new_i)
+        all_remove.extend(rem)
+
+    # Apply: remove old nodes, append new nodes + initializers.
+    remove_names = {n.name for n in all_remove}
+    new_node_list = [n for n in graph.node if n.name not in remove_names]
+    new_node_list.extend(all_new_nodes)
+    del graph.node[:]
+    graph.node.extend(new_node_list)
+    graph.initializer.extend(all_new_inits)
+
+    # Need com.microsoft opset
+    has_msft = any(o.domain == "com.microsoft" for o in model.opset_import)
+    if not has_msft:
+        model.opset_import.append(helper.make_opsetid("com.microsoft", 1))
+
+    print(f"\nSaving {args.output} ...")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    # Save with external-data sidecar matching the input
+    onnx.save(model, str(args.output), save_as_external_data=False)
+
+    # Copy the .data sidecar over (we didn't touch weights).
+    in_data = args.input.with_suffix(".onnx.data")
+    out_data = args.output.with_suffix(".onnx.data")
+    if in_data.exists() and not out_data.exists():
+        print(f"  Copying weights sidecar {in_data} -> {out_data}")
+        shutil.copy(in_data, out_data)
+
+    print(f"  Wrote graph proto: {args.output.stat().st_size / 1024:.0f} KB")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -206,25 +206,27 @@ def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: in
                          outputs=[v_adapted], name=f"{pfx}_v_reshape"),
     ]
 
-    # MultiHeadAttention. We pass the graph's raw attention_mask (cast to
-    # int32 once at the top of the graph) as key_padding_mask, plus
-    # is_unidirectional=1 to have MHA apply causal masking internally.
-    # This wiring lets MHA's CUDA kernel skip masked positions in COMPUTE,
-    # not just zero them post-softmax — that's the difference between
-    # "correct output but slow" (relative_position_bias path) and
-    # "correct AND fast". Relevant ORT MHA implementation skip happens
-    # only via key_padding_mask + is_unidirectional, not via RPB.
+    # MultiHeadAttention. Iter 4 — re-test where_2 as relative_position_bias
+    # but cast to fp32 first (in case iter 2's garbled output was a dtype
+    # precision issue rather than a wiring issue). where_2 is bf16 in the
+    # original graph; ORT MHA may compute attention scores in fp32
+    # internally and add an fp32-promoted bias, but if the cast happens
+    # incorrectly we'd see drift.
     mha_out = f"{pfx}_out"
+    mask_fp32 = f"{pfx}_mask_fp32"
     scale = 1.0 / (HEAD_DIM ** 0.5)
+    mask_cast_node = helper.make_node(
+        "Cast", inputs=[mask], outputs=[mask_fp32],
+        name=f"{pfx}_mask_cast", to=TensorProto.FLOAT,
+    )
     mha_node = helper.make_node(
         "MultiHeadAttention",
-        inputs=[q_adapted, k_adapted, v_adapted, "", "mha_mask_int32"],
+        inputs=[q_adapted, k_adapted, v_adapted, "", "", mask_fp32],
         outputs=[mha_out],
         name=f"{pfx}_node",
         domain="com.microsoft",
         num_heads=NUM_HEADS,
         scale=scale,
-        unidirectional=1,
     )
 
     # Rewire output_tensor consumers to use mha_out instead.
@@ -234,7 +236,7 @@ def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: in
             if inp == output_tensor:
                 c.input[i] = mha_out
 
-    new_nodes = q_nodes + k_nodes + v_nodes + [mha_node]
+    new_nodes = q_nodes + k_nodes + v_nodes + [mask_cast_node, mha_node]
     new_inits = [init_q, init_kv]
     return new_nodes, new_inits, to_remove
 

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -313,7 +313,7 @@ def rewrite_layer_mha(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx
 
 
 def rewrite_layer_gqa(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
-                      producer, consumers):
+                      producer, consumers, pass_attention_bias: bool = False):
     """Rewrite one layer's attention to GroupQueryAttention. Returns
     (added_nodes, added_initializers, nodes_to_remove).
 
@@ -339,7 +339,7 @@ def rewrite_layer_gqa(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx
         GQA only does scoring + cache append.
       - scale=1/HEAD_DIM: Granite's attention_multiplier (Run 19 finding).
     """
-    q, k, v, _mask, output_tensor, to_remove = find_attention_block(softmax, producer, consumers)
+    q, k, v, mask, output_tensor, to_remove = find_attention_block(softmax, producer, consumers)
 
     past_k, fresh_k, present_k_name, k_slice = find_kv_chain_for_gqa(k, producer, consumers)
     past_v, fresh_v, present_v_name, v_slice = find_kv_chain_for_gqa(v, producer, consumers)
@@ -375,13 +375,25 @@ def rewrite_layer_gqa(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx
 
     gqa_out = f"{pfx}_out"
     scale = 1.0 / HEAD_DIM
-    gqa_node = helper.make_node(
-        "GroupQueryAttention",
-        inputs=[
+    if pass_attention_bias:
+        # attention_bias is GQA input slot 10. Fill slots 7..9 with empty.
+        gqa_inputs = [
             q_adapted, k_adapted, v_adapted,
             past_k, past_v,
             "seqlens_k", "total_sequence_length",
-        ],
+            "", "",      # cos_cache, sin_cache (do_rotary=0)
+            "",          # position_ids (not used; RoPE applied upstream)
+            mask,        # attention_bias = where_2
+        ]
+    else:
+        gqa_inputs = [
+            q_adapted, k_adapted, v_adapted,
+            past_k, past_v,
+            "seqlens_k", "total_sequence_length",
+        ]
+    gqa_node = helper.make_node(
+        "GroupQueryAttention",
+        inputs=gqa_inputs,
         outputs=[gqa_out, present_k_name, present_v_name],
         name=f"{pfx}_node",
         domain="com.microsoft",
@@ -440,22 +452,39 @@ def main() -> int:
     )
     print(f"  Mode: {args.mode}; rewriting layers: {target_layers}")
 
-    rewrite_fn = rewrite_layer_mha if args.mode == "mha" else rewrite_layer_gqa
+    if args.mode == "mha":
+        rewrite_fn = lambda graph, sm, li, producer, consumers: rewrite_layer_mha(
+            graph, sm, li, producer, consumers)
+    else:
+        rewrite_fn = lambda graph, sm, li, producer, consumers: rewrite_layer_gqa(
+            graph, sm, li, producer, consumers,
+            pass_attention_bias=pass_attention_bias)
     fused_op = "MHA" if args.mode == "mha" else "GQA"
 
     # GQA needs two extra graph inputs (seqlens_k, total_sequence_length)
     # that every layer's GQA node references. Infer batch size from any
     # past_key_<L> graph input (they're all the same B).
+    pass_attention_bias = False
     if args.mode == "gqa":
         # batch dim: int if static (dim_value > 0), str symbol name if dynamic.
-        pk_dim0 = next(
-            i.type.tensor_type.shape.dim[0]
-            for i in graph.input if i.name.startswith("past_key_")
+        pk_input = next(
+            i for i in graph.input if i.name.startswith("past_key_")
         )
+        pk_dim0 = pk_input.type.tensor_type.shape.dim[0]
         batch_dim = pk_dim0.dim_value if pk_dim0.dim_value > 0 else pk_dim0.dim_param
+        # CUDA's GQA kernel doesn't yet support the attention_bias input
+        # (only listed in the contrib spec; "attention_bias is not supported
+        # in GroupQueryAttention cuda kernel" at runtime). So we never wire
+        # it, even when shapes would match. Variable-length batching relies
+        # on BatchSizer grouping similar-length segments and tolerating the
+        # small pad contamination — the LLM is robust to PAD-token K at
+        # the few trailing slots when realLen variation within a batch is
+        # ~one or two tokens.
+        pass_attention_bias = False
         add_gqa_graph_inputs(graph, batch_dim=batch_dim)
+        bias_note = "with attention_bias=where_2" if pass_attention_bias else "(no attention_bias)"
         print(f"  Added GQA graph inputs: seqlens_k (int32, [{batch_dim!r}]) + "
-              f"total_sequence_length (int32, scalar)")
+              f"total_sequence_length (int32, scalar) {bias_note}")
 
     all_new_nodes: list[onnx.NodeProto] = []
     all_new_inits: list[onnx.TensorProto] = []

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -67,6 +67,11 @@ def parse_args() -> argparse.Namespace:
                          "(GroupQueryAttention). GQA enables compute-skip via "
                          "seqlens_k and requires a coordinated cache-layout "
                          "change in the C# driver.")
+    ap.add_argument("--add-argmax", action="store_true",
+                    help="Append Slice(last)+ArgMax(V) to the LM head and "
+                         "replace `logits` with `next_token` (int64 [B, 1]) "
+                         "as a graph output. Eliminates ~6 MB of "
+                         "GPU→CPU logits transfer per step (Run 20 phase 9).")
     return ap.parse_args()
 
 
@@ -433,6 +438,67 @@ def add_gqa_graph_inputs(graph: onnx.GraphProto, batch_dim: "int | str") -> None
             "total_sequence_length", TensorProto.INT32, []))
 
 
+def add_argmax_head(graph: onnx.GraphProto) -> None:
+    """Append `Slice(logits, last_position) → ArgMax(V) → next_token` to
+    the LM head, then replace `logits` in the graph outputs with
+    `next_token` (shape [B, 1], int64).
+
+    With left-padded prompts the real last token sits at S-1 for every
+    row at prefill, and at position 0 at step (S=1). Either way "last
+    position along axis 1" is what we want. Slicing first keeps the
+    ArgMax cheap (over [B, 1, V] instead of [B, S, V]).
+
+    Dropping `logits` from outputs lets ORT keep the logits tensor as
+    an on-device intermediate (no GPU→CPU transfer per step). Greedy
+    decoding only needs the argmax index, not the raw logits."""
+    # Find and remove the `logits` graph output (preserve its dtype info).
+    logits_vi = None
+    for i, o in enumerate(graph.output):
+        if o.name == "logits":
+            logits_vi = o
+            del graph.output[i]
+            break
+    if logits_vi is None:
+        raise ValueError("`logits` not found in graph outputs")
+
+    # Borrow batch dim spec from the (now-removed) logits output.
+    batch_dim_proto = logits_vi.type.tensor_type.shape.dim[0]
+    if batch_dim_proto.dim_value > 0:
+        batch_dim: "int | str" = batch_dim_proto.dim_value
+    else:
+        batch_dim = batch_dim_proto.dim_param
+
+    # Slice(logits, starts=[-1], ends=[INT_MAX], axes=[1]) → [B, 1, V].
+    starts_init = numpy_helper.from_array(
+        np.array([-1], dtype=np.int64), name="argmax_slice_starts")
+    ends_init = numpy_helper.from_array(
+        np.array([np.iinfo(np.int64).max], dtype=np.int64), name="argmax_slice_ends")
+    axes_init = numpy_helper.from_array(
+        np.array([1], dtype=np.int64), name="argmax_slice_axes")
+    graph.initializer.extend([starts_init, ends_init, axes_init])
+
+    slice_node = helper.make_node(
+        "Slice",
+        inputs=["logits", "argmax_slice_starts", "argmax_slice_ends", "argmax_slice_axes"],
+        outputs=["logits_last"],
+        name="argmax_slice",
+    )
+    argmax_node = helper.make_node(
+        "ArgMax",
+        inputs=["logits_last"],
+        outputs=["next_token"],
+        name="argmax_head",
+        axis=2,
+        keepdims=0,        # output shape [B, 1] (drop the V axis)
+    )
+    graph.node.extend([slice_node, argmax_node])
+
+    # Add `next_token` as graph output.
+    next_token_vi = helper.make_tensor_value_info(
+        "next_token", TensorProto.INT64, [batch_dim, 1])
+    graph.output.append(next_token_vi)
+
+
 def main() -> int:
     args = parse_args()
 
@@ -511,6 +577,11 @@ def main() -> int:
     del graph.node[:]
     graph.node.extend(new_node_list)
     graph.initializer.extend(all_new_inits)
+
+    if args.add_argmax:
+        add_argmax_head(graph)
+        print(f"  Replaced `logits` output with `next_token` (int64 [B, 1]) "
+              f"via Slice(last) + ArgMax(V).")
 
     # Need com.microsoft opset
     has_msft = any(o.domain == "com.microsoft" for o in model.opset_import)

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -13,11 +13,21 @@ Mul/Add applied to Q and K, the past_kv Concat, and the GQA broadcast
 Expand all stay in place — MHA wants K/V already broadcast to 16 heads
 and already RoPE'd, which is exactly what those upstream nodes produce.
 
-The matcher emits transpose+reshape adapters around MHA because MHA's
-input layout is (B, S, num_heads × head_dim) flat-hidden whereas the
-existing chain produces (B, num_heads, S, head_dim) split-hidden. The
-adapters are constant-folded by ORT in many cases (transpose+reshape
-of static dims).
+Layout (Run 19 — grounded in ORT contrib spec on `main`):
+
+  - Q is fed via Transpose+Reshape adapter into (B, S, num_heads*head_dim)
+    rank-3 form. MHA requires query rank 3 or 5.
+  - K and V are fed DIRECTLY in their native (B, num_heads, T, head_dim)
+    rank-4 layout. The contrib spec accepts this for the `key`/`value`
+    inputs (described as "past_key with shape (batch_size, num_heads,
+    kv_sequence_length, head_size)"). This eliminates the K/V adapter
+    Transpose+Reshape pair and any head-ordering bug in it — the most
+    likely cause of iter-2's partial-correctness output.
+  - The graph's per-call additive mask (`where_2`-style; bf16, encodes
+    both key-padding and causal triangulation) is fed as `attention_bias`
+    (input 5; renamed from `relative_position_bias` in current ORT). The
+    spec confirms it is a literal element-wise add on QxK' with shape
+    (batch_size or 1, num_heads or 1, S, total_S).
 
 USAGE (called as a post-export step):
 
@@ -164,20 +174,22 @@ def add_q_kv_adapter_nodes(prefix: str, src: str, dst: str) -> list[onnx.NodePro
 def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
                   producer, consumers):
     """Rewrite one layer's attention. Returns (added_nodes, added_initializers,
-    nodes_to_remove). Reuses the per-call additive mask `where_2` (or whatever
-    the graph computes once and shares across all 40 layers' Add nodes) as
-    MHA's relative_position_bias — that mask already encodes both
-    key-padding AND causal restrictions, so we don't need to feed a separate
-    key_padding_mask."""
+    nodes_to_remove).
+
+    Iter 5 wiring:
+      - Q: Transpose+Reshape adapter to (B, S, hidden_size).
+      - K, V: passed directly in (B, num_heads, T, head_dim) — ORT MHA
+        accepts this rank-4 layout for the `key`/`value` inputs.
+      - attention_bias: graph's `where_2` mask (bf16, additive, encodes
+        causal+padding) fed unchanged as MHA input 5.
+    """
     q, k, v, mask, output_tensor, to_remove = find_attention_block(softmax, producer, consumers)
 
     pfx = f"mha_l{layer_idx}"
 
-    # Adapter shape constants (shared across Q/K/V):
-    # We can't fold seq/total_len since they're symbolic. Use [-1, -1, HIDDEN]
-    # — but Reshape only allows one -1. So use [B=16, -1, HIDDEN]:
+    # Q must be rank 3 (B, S, hidden_size). Reshape needs the batch dim
+    # explicit since it can only carry one -1.
     init_q = make_const_int64(f"{pfx}_q_shape", [16, -1, HIDDEN])
-    init_kv = make_const_int64(f"{pfx}_kv_shape", [16, -1, HIDDEN])
 
     # Q adapter (B, 16, S, 128) -> (B, S, 2048)
     q_adapted = f"{pfx}_q_in"
@@ -188,40 +200,20 @@ def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: in
                          outputs=[q_adapted], name=f"{pfx}_q_reshape"),
     ]
 
-    # K adapter
-    k_adapted = f"{pfx}_k_in"
-    k_nodes = [
-        helper.make_node("Transpose", inputs=[k], outputs=[f"{pfx}_k_t"],
-                         name=f"{pfx}_k_transpose", perm=[0, 2, 1, 3]),
-        helper.make_node("Reshape", inputs=[f"{pfx}_k_t", f"{pfx}_kv_shape"],
-                         outputs=[k_adapted], name=f"{pfx}_k_reshape"),
-    ]
-
-    # V adapter
-    v_adapted = f"{pfx}_v_in"
-    v_nodes = [
-        helper.make_node("Transpose", inputs=[v], outputs=[f"{pfx}_v_t"],
-                         name=f"{pfx}_v_transpose", perm=[0, 2, 1, 3]),
-        helper.make_node("Reshape", inputs=[f"{pfx}_v_t", f"{pfx}_kv_shape"],
-                         outputs=[v_adapted], name=f"{pfx}_v_reshape"),
-    ]
-
-    # MultiHeadAttention. Iter 4 — re-test where_2 as relative_position_bias
-    # but cast to fp32 first (in case iter 2's garbled output was a dtype
-    # precision issue rather than a wiring issue). where_2 is bf16 in the
-    # original graph; ORT MHA may compute attention scores in fp32
-    # internally and add an fp32-promoted bias, but if the cast happens
-    # incorrectly we'd see drift.
+    # K and V are already in (B, num_heads, T, head_dim) at the source
+    # tensors `k` and `v`. Pass them straight through.
     mha_out = f"{pfx}_out"
-    mask_fp32 = f"{pfx}_mask_fp32"
-    scale = 1.0 / (HEAD_DIM ** 0.5)
-    mask_cast_node = helper.make_node(
-        "Cast", inputs=[mask], outputs=[mask_fp32],
-        name=f"{pfx}_mask_cast", to=TensorProto.FLOAT,
-    )
+    # Granite uses an unusual scale: 1/head_dim (= 0.0078125 for head_dim=128),
+    # not the conventional 1/sqrt(head_dim). This is the `attention_multiplier`
+    # in IBM Granite's HF config; it shows up in the unfused graph as the
+    # initializer `scalar_tensor_default_2 = 0.0078125`. Passing the wrong
+    # scale here (e.g., 1/sqrt(head_dim) ~= 0.0884) makes attention 11.3×
+    # too peaky per layer; one layer is recoverable but it compounds across
+    # 40 layers into garbled output (Run 19 bisect, 2026-05-10).
+    scale = 1.0 / HEAD_DIM
     mha_node = helper.make_node(
         "MultiHeadAttention",
-        inputs=[q_adapted, k_adapted, v_adapted, "", "", mask_fp32],
+        inputs=[q_adapted, k, v, "", "", mask],
         outputs=[mha_out],
         name=f"{pfx}_node",
         domain="com.microsoft",
@@ -236,24 +228,9 @@ def rewrite_layer(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: in
             if inp == output_tensor:
                 c.input[i] = mha_out
 
-    new_nodes = q_nodes + k_nodes + v_nodes + [mask_cast_node, mha_node]
-    new_inits = [init_q, init_kv]
+    new_nodes = q_nodes + [mha_node]
+    new_inits = [init_q]
     return new_nodes, new_inits, to_remove
-
-
-def add_mask_int32(graph: onnx.GraphProto) -> str:
-    """Add a Cast node that converts the existing graph-input attention_mask
-    (int64) to int32 for MHA. Returns the int32 tensor name."""
-    out_name = "mha_mask_int32"
-    cast = helper.make_node(
-        "Cast",
-        inputs=["attention_mask"],
-        outputs=[out_name],
-        name="mha_mask_cast_int32",
-        to=TensorProto.INT32,
-    )
-    graph.node.insert(0, cast)
-    return out_name
 
 
 def main() -> int:
@@ -275,10 +252,6 @@ def main() -> int:
     )
     print(f"  Rewriting layers: {target_layers}")
 
-    # Cast the graph's attention_mask (int64) to int32 once for all layers'
-    # MHA key_padding_mask consumers.
-    add_mask_int32(graph)
-
     all_new_nodes: list[onnx.NodeProto] = []
     all_new_inits: list[onnx.TensorProto] = []
     all_remove: list[onnx.NodeProto] = []
@@ -292,7 +265,7 @@ def main() -> int:
         except ValueError as e:
             print(f"  layer {li}: SKIP — {e}")
             continue
-        print(f"  layer {li}: replaced {len(rem)} nodes with MHA + 6 adapter nodes")
+        print(f"  layer {li}: replaced {len(rem)} nodes with MHA + {len(new_n) - 1} adapter nodes")
         all_new_nodes.extend(new_n)
         all_new_inits.extend(new_i)
         all_remove.extend(rem)

--- a/scripts/granite_export/rewrite_attention_to_mha.py
+++ b/scripts/granite_export/rewrite_attention_to_mha.py
@@ -220,21 +220,34 @@ def find_kv_chain_for_gqa(kv_tensor: str, producer, consumers):
             f"Concat {concat_node.name} inputs {list(concat_node.input)} "
             f"don't match expected past_kv/fresh_kv pattern")
 
-    # Find the Slice that consumes the concat output and produces the
-    # graph's present_key_<L>/present_value_<L> output.
-    slice_node = None
+    # Locate the present_key_<L>/present_value_<L> graph-output edge.
+    # Two shapes here:
+    #   - static-shapes-unified export: Concat → Slice → graph output (the
+    #     sliding-window slice that pins present_kv to past_len).
+    #   - dynamic-shape export: Concat output IS the graph output directly
+    #     (no Slice — present_kv grows by S each call).
+    present_name = None
+    drop_node = None        # node to remove so GQA's output can claim the name
     for c in consumers.get(concat_node.output[0], []):
         if c.op_type == "Slice" and (
             c.output[0].startswith("present_key_") or
             c.output[0].startswith("present_value_")
         ):
-            slice_node = c
+            present_name = c.output[0]
+            drop_node = c
             break
-    if slice_node is None:
-        raise ValueError(
-            f"Concat {concat_node.name} output has no present_kv Slice consumer")
+    if present_name is None:
+        # Direct: Concat output is itself the graph output.
+        concat_out = concat_node.output[0]
+        if concat_out.startswith("present_key_") or concat_out.startswith("present_value_"):
+            present_name = concat_out
+            drop_node = concat_node
+        else:
+            raise ValueError(
+                f"Concat {concat_node.name} output has no present_kv "
+                f"Slice consumer and isn't itself a graph output")
 
-    return past_kv, fresh_kv, slice_node.output[0], slice_node
+    return past_kv, fresh_kv, present_name, drop_node
 
 
 def rewrite_layer_mha(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx: int,
@@ -255,7 +268,7 @@ def rewrite_layer_mha(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx
 
     # Q must be rank 3 (B, S, hidden_size). Reshape needs the batch dim
     # explicit since it can only carry one -1.
-    init_q = make_const_int64(f"{pfx}_q_shape", [16, -1, HIDDEN])
+    init_q = make_const_int64(f"{pfx}_q_shape", [0, -1, HIDDEN])
 
     # Q adapter (B, 16, S, 128) -> (B, S, 2048)
     q_adapted = f"{pfx}_q_in"
@@ -334,7 +347,7 @@ def rewrite_layer_gqa(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx
     pfx = f"gqa_l{layer_idx}"
 
     # Q adapter: (B, 16, S, 128) -> (B, S, 2048)
-    init_q = make_const_int64(f"{pfx}_q_shape", [16, -1, HIDDEN])
+    init_q = make_const_int64(f"{pfx}_q_shape", [0, -1, HIDDEN])
     q_adapted = f"{pfx}_q_in"
     q_nodes = [
         helper.make_node("Transpose", inputs=[q], outputs=[f"{pfx}_q_t"],
@@ -344,7 +357,7 @@ def rewrite_layer_gqa(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx
     ]
 
     # K/V adapters: (B, 4, S, 128) -> (B, S, 512)
-    init_kv = make_const_int64(f"{pfx}_kv_shape", [16, -1, KV_HIDDEN])
+    init_kv = make_const_int64(f"{pfx}_kv_shape", [0, -1, KV_HIDDEN])
     k_adapted = f"{pfx}_k_in"
     k_nodes = [
         helper.make_node("Transpose", inputs=[fresh_k], outputs=[f"{pfx}_k_t"],
@@ -394,14 +407,15 @@ def rewrite_layer_gqa(graph: onnx.GraphProto, softmax: onnx.NodeProto, layer_idx
     return new_nodes, new_inits, to_remove_combined
 
 
-def add_gqa_graph_inputs(graph: onnx.GraphProto, batch_size: int) -> None:
+def add_gqa_graph_inputs(graph: onnx.GraphProto, batch_dim: "int | str") -> None:
     """Append `seqlens_k` (int32, [B]) and `total_sequence_length`
     (int32, scalar) as new graph inputs so per-layer GQA nodes can
-    reference them by name."""
+    reference them by name. batch_dim may be either an int (static
+    batch) or a string symbol name (dynamic batch)."""
     existing = {i.name for i in graph.input}
     if "seqlens_k" not in existing:
         graph.input.append(helper.make_tensor_value_info(
-            "seqlens_k", TensorProto.INT32, [batch_size]))
+            "seqlens_k", TensorProto.INT32, [batch_dim]))
     if "total_sequence_length" not in existing:
         graph.input.append(helper.make_tensor_value_info(
             "total_sequence_length", TensorProto.INT32, []))
@@ -433,12 +447,14 @@ def main() -> int:
     # that every layer's GQA node references. Infer batch size from any
     # past_key_<L> graph input (they're all the same B).
     if args.mode == "gqa":
-        b = next(
-            i.type.tensor_type.shape.dim[0].dim_value
+        # batch dim: int if static (dim_value > 0), str symbol name if dynamic.
+        pk_dim0 = next(
+            i.type.tensor_type.shape.dim[0]
             for i in graph.input if i.name.startswith("past_key_")
         )
-        add_gqa_graph_inputs(graph, batch_size=b)
-        print(f"  Added GQA graph inputs: seqlens_k (int32, [{b}]) + "
+        batch_dim = pk_dim0.dim_value if pk_dim0.dim_value > 0 else pk_dim0.dim_param
+        add_gqa_graph_inputs(graph, batch_dim=batch_dim)
+        print(f"  Added GQA graph inputs: seqlens_k (int32, [{batch_dim!r}]) + "
               f"total_sequence_length (int32, scalar)")
 
     all_new_nodes: list[onnx.NodeProto] = []

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -119,6 +119,13 @@ public sealed class GraniteSpeech : IDisposable
     // 2 × NumDecoderLayers prefill past_kv inputs — they're all-zero and
     // ORT only reads, so sharing avoids 80 × 12 MB of redundant allocation.
     private readonly bool _isStaticBundle;
+    private readonly bool _isGqaBundle;     // Set when the static bundle was
+                                            // produced by `rewrite_attention_to_mha.py
+                                            // --mode gqa`. Detected by the
+                                            // presence of `seqlens_k` as a
+                                            // decoder graph input. Selects a
+                                            // left-aligned cache + compute-skip
+                                            // code path (Run 20).
     private readonly int _staticBatchSize;
     private readonly int _staticPastLen;
     private readonly int _staticAudioLen;
@@ -154,6 +161,7 @@ public sealed class GraniteSpeech : IDisposable
         // batch / past_len / head_dim => static; symbolic (-1) anywhere
         // => dynamic, and we use the legacy TranscribeBatch path.
         _isStaticBundle = false;
+        _isGqaBundle = _decoder.InputMetadata.ContainsKey("seqlens_k");
         _staticBatchSize = 0;
         _staticPastLen = 0;
         _staticAudioLen = 0;
@@ -770,6 +778,18 @@ public sealed class GraniteSpeech : IDisposable
             throw new InvalidOperationException(
                 $"Static-shape decoder requires batch size <= {_staticBatchSize}; got {realB}.");
 
+        // GQA bundle (Run 20): cache_position and per-row real length must
+        // agree across the batch for RoPE positions to be consistent. We
+        // sidestep variable-length batching by serialising — one segment per
+        // call, with B-1 dummy rows for static-shape compliance.
+        if (_isGqaBundle)
+        {
+            var gqaRows = new (string text, long[] tokens)[realB];
+            for (int i = 0; i < realB; i++)
+                gqaRows[i] = TranscribeStaticGqaSingle(waveforms[i], maxNewTokens);
+            return gqaRows;
+        }
+
         int B = _staticBatchSize;
         int A = _staticAudioLen;
         int P = _staticPastLen;
@@ -1085,6 +1105,284 @@ public sealed class GraniteSpeech : IDisposable
               + $"overhead={overhead}ms) static");
         }
         return rows;
+    }
+
+    /// <summary>
+    /// Single-segment static-shape decode against a GQA-rewritten bundle
+    /// (Run 20). Padded to B = _staticBatchSize with dummy rows so the
+    /// pre-built zero past-KV buffer can be reused; the dummies share Q's
+    /// position embeddings with row 0 (correct because realLen is uniform
+    /// across the batch by construction) and contribute nothing to row 0's
+    /// output since GQA is per-row.
+    ///
+    /// Cache layout: left-aligned in a fixed (B, kv_num_heads, max_seq,
+    /// head_dim) buffer. Real K/V live at [0, realLen) after prefill and
+    /// grow rightward by 1 per step. GQA's seqlens_k input tells the kernel
+    /// where the real K ends, so attention compute scales with the actual
+    /// past length, not the buffer length — the static-padding compute-skip
+    /// win this whole migration is for.
+    /// </summary>
+    private (string text, long[] tokens) TranscribeStaticGqaSingle(
+        float[] waveform, int maxNewTokens)
+    {
+        int B = _staticBatchSize;
+        int A = _staticAudioLen;
+        int P = _staticPastLen;
+
+        int audioTokens = NumAudioTokens(waveform.Length);
+        int realLen = AsrPromptPrefix.Length + audioTokens + AsrPromptSuffix.Length;
+        if (realLen + maxNewTokens > P)
+            throw new InvalidOperationException(
+                $"Segment too long for static-shape GQA bundle: prompt+max_new_tokens "
+              + $"({realLen + maxNewTokens}) exceeds pinned past_len ({P}).");
+        if (audioTokens > A)
+            throw new InvalidOperationException(
+                $"Segment too long for static-shape GQA bundle: audio_tokens "
+              + $"({audioTokens}) exceeds pinned audio_len ({A}).");
+
+        var swBatch = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+        long melLocal = 0, encLocal = 0, projLocal = 0;
+
+        // ── Mel + encoder + projector ──────────────────────────────────
+        var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+        var audioT = new DenseTensor<float>(waveform, [1, waveform.Length]);
+        using var melResults = _mel.Run(
+            [NamedOnnxValue.CreateFromTensor("audio", audioT)]);
+        var inputFeatures = melResults[0].AsTensor<float>();
+        var ifShape = inputFeatures.Dimensions.ToArray();
+        var ifData = inputFeatures is DenseTensor<float> dT
+            ? dT.ToArray() : inputFeatures.ToArray();
+        if (swStage != null) { swStage.Stop(); melLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+        using var encResults = _encoder.Run(
+            [NamedOnnxValue.CreateFromTensor(
+                "input_features", new DenseTensor<float>(ifData, ifShape))]);
+        var encoderHidden = encResults[0].AsTensor<float>();
+        var encShape = encoderHidden.Dimensions.ToArray();
+        var encData = encoderHidden.ToArray();
+        if (swStage != null) { swStage.Stop(); encLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+        using var projResults = _projector.Run(
+            [NamedOnnxValue.CreateFromTensor(
+                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
+        var ae = projResults[0].AsTensor<float>();
+        long audioDim = ae.Dimensions[2];
+        var audioEmbedsRow = ae.ToArray();
+        if (swStage != null) { swStage.Stop(); projLocal = swStage.ElapsedMilliseconds; }
+
+        // ── Build prefill inputs ───────────────────────────────────────
+        // input_ids [B, realLen]: row 0 is the real prompt, dummies are PAD.
+        var inputIdsBatch = new long[B * realLen];
+        int p = 0;
+        for (int i = 0; i < AsrPromptPrefix.Length; i++)
+            inputIdsBatch[p++] = AsrPromptPrefix[i];
+        for (int i = 0; i < audioTokens; i++)
+            inputIdsBatch[p++] = AudioTokenId;
+        for (int i = 0; i < AsrPromptSuffix.Length; i++)
+            inputIdsBatch[p++] = AsrPromptSuffix[i];
+        for (int b = 1; b < B; b++)
+        {
+            int off = b * realLen;
+            for (int i = 0; i < realLen; i++) inputIdsBatch[off + i] = PadTokenId;
+        }
+
+        // audio_embeds [B, A, audioDim]: row 0 fills the first audioTokens
+        // entries; rest of A and all dummies remain zero.
+        var audioEmbedsBatch = new float[B * A * (int)audioDim];
+        Array.Copy(audioEmbedsRow, 0, audioEmbedsBatch, 0,
+                   audioTokens * (int)audioDim);
+
+        // attention_mask [B, realLen]: row 0 all 1s, dummies all 0s. (Where
+        // this propagates to where_2 inside the wrapper is dead code in the
+        // GQA-rewritten graph, but the input is still part of the graph
+        // signature so we must pass a valid tensor.)
+        var attnMaskBatch = new long[B * realLen];
+        for (int i = 0; i < realLen; i++) attnMaskBatch[i] = 1L;
+
+        // cache_position [realLen]: left-aligned positions [0..realLen-1].
+        // HF's RoPE uses these to look up cos/sin caches.
+        var cachePosBuf = new long[realLen];
+        for (int i = 0; i < realLen; i++) cachePosBuf[i] = i;
+
+        // seqlens_k [B]: total_seq - 1 = realLen - 1 (uniform across rows).
+        var seqlensKBuf = new int[B];
+        for (int b = 0; b < B; b++) seqlensKBuf[b] = realLen - 1;
+        var totalSeqBuf = new int[] { realLen };
+
+        // ── Decoder I/O names ──────────────────────────────────────────
+        var decInputNames = new List<string>(6 + 2 * NumDecoderLayers)
+        { "input_ids", "audio_embeds", "attention_mask", "cache_position" };
+        for (int L = 0; L < NumDecoderLayers; L++)
+        {
+            decInputNames.Add($"past_key_{L}");
+            decInputNames.Add($"past_value_{L}");
+        }
+        decInputNames.Add("seqlens_k");
+        decInputNames.Add("total_sequence_length");
+
+        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { "logits" };
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_key_{L}");
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_value_{L}");
+
+        var generated = new List<long>(maxNewTokens);
+        bool finished = false;
+        bool looped = false;
+
+        long prefillLocal = 0, stepLocal = 0;
+        long stepCountLocal = 0;
+
+        using (var runOpts = new RunOptions())
+        {
+            var swPrefill = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Prefill ────────────────────────────────────────────────
+            using var inputIdsVal = OrtValue.CreateTensorValueFromMemory(
+                inputIdsBatch, new long[] { B, realLen });
+            using var audioVal = OrtValue.CreateTensorValueFromMemory(
+                audioEmbedsBatch, new long[] { B, A, audioDim });
+            using var attnVal = OrtValue.CreateTensorValueFromMemory(
+                attnMaskBatch, new long[] { B, realLen });
+            using var cpVal = OrtValue.CreateTensorValueFromMemory(
+                cachePosBuf, new long[] { realLen });
+            using var seqlensVal = OrtValue.CreateTensorValueFromMemory(
+                seqlensKBuf, new long[] { B });
+            using var totalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                totalSeqBuf, Array.Empty<long>());
+
+            var prefillInputs = new List<OrtValue>(6 + 2 * NumDecoderLayers)
+            { inputIdsVal, audioVal, attnVal, cpVal };
+            prefillInputs.AddRange(_staticZeroPastKv!);
+            prefillInputs.Add(seqlensVal);
+            prefillInputs.Add(totalSeqVal);
+
+            var prefillOutputs = _decoder.Run(
+                runOpts, decInputNames, prefillInputs, decOutputNames);
+
+            var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+            long nextTok = ArgmaxRowLastPosition(prefillLogitsSpan, 0, realLen, VocabSize);
+            generated.Add(nextTok);
+            if (nextTok == EosTokenId) finished = true;
+            prefillOutputs[0].Dispose();
+
+            var pastKvs = new OrtValue[2 * NumDecoderLayers];
+            for (int L = 0; L < NumDecoderLayers; L++)
+            {
+                pastKvs[2 * L]     = prefillOutputs[1 + L];
+                pastKvs[2 * L + 1] = prefillOutputs[1 + NumDecoderLayers + L];
+            }
+
+            if (swPrefill != null) { swPrefill.Stop(); prefillLocal = swPrefill.ElapsedMilliseconds; }
+            var swStep = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Step loop ──────────────────────────────────────────────
+            long[] stepInputIds = new long[B];
+            float[] dummyAudio = new float[B * A * (int)audioDim];
+            for (int step = 0; step < maxNewTokens && !finished; step++)
+            {
+                int totalLenCurrent = realLen + step + 1;
+                int seqlensK = realLen + step;  // (total - 1)
+
+                stepInputIds[0] = nextTok;
+                for (int b = 1; b < B; b++) stepInputIds[b] = EosTokenId;
+
+                // attention_mask [B, totalLenCurrent]: row 0 attends to all
+                // positions [0..totalLenCurrent), dummies see nothing.
+                var stepMaskBatch = new long[B * totalLenCurrent];
+                for (int i = 0; i < totalLenCurrent; i++) stepMaskBatch[i] = 1L;
+
+                // cache_position [1]: RoPE position of the new token.
+                var cachePosStep = new long[] { seqlensK };
+
+                for (int b = 0; b < B; b++) seqlensKBuf[b] = seqlensK;
+                totalSeqBuf[0] = totalLenCurrent;
+
+                using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
+                    stepInputIds, new long[] { B, 1 });
+                using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
+                    dummyAudio, new long[] { B, A, audioDim });
+                using var stepAttnVal = OrtValue.CreateTensorValueFromMemory(
+                    stepMaskBatch, new long[] { B, totalLenCurrent });
+                using var cachePosVal = OrtValue.CreateTensorValueFromMemory(
+                    cachePosStep, new long[] { 1 });
+                using var stepSeqlensVal = OrtValue.CreateTensorValueFromMemory(
+                    seqlensKBuf, new long[] { B });
+                using var stepTotalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                    totalSeqBuf, Array.Empty<long>());
+
+                var stepInputs = new List<OrtValue>(6 + 2 * NumDecoderLayers)
+                { stepInputIdVal, stepAudioVal, stepAttnVal, cachePosVal };
+                stepInputs.AddRange(pastKvs);
+                stepInputs.Add(stepSeqlensVal);
+                stepInputs.Add(stepTotalSeqVal);
+
+                var outputs = _decoder.Run(
+                    runOpts, decInputNames, stepInputs, decOutputNames);
+
+                var oldPast = pastKvs;
+                pastKvs = new OrtValue[2 * NumDecoderLayers];
+                for (int L = 0; L < NumDecoderLayers; L++)
+                {
+                    pastKvs[2 * L]     = outputs[1 + L];
+                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
+                }
+
+                var stepLogits = outputs[0];
+                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
+                nextTok = ArgmaxRowLastPosition(stepLogitsSpan, 0, 1, VocabSize);
+                generated.Add(nextTok);
+
+                if (nextTok == EosTokenId) finished = true;
+                else if (IsRepetitionLoop(generated)) { finished = true; looped = true; }
+
+                stepLogits.Dispose();
+                foreach (var ov in oldPast) ov.Dispose();
+                stepCountLocal++;
+            }
+
+            foreach (var ov in pastKvs) ov.Dispose();
+            if (swStep != null) { swStep.Stop(); stepLocal = swStep.ElapsedMilliseconds; }
+        }
+
+        // Trim trailing EOS and loop tails.
+        int realCount = generated.Count;
+        while (realCount > 0 && generated[realCount - 1] == EosTokenId) realCount--;
+        int trimmed = looped
+            ? TrimRepetitionTail(generated, realCount)
+            : realCount;
+        long[] outputTokens;
+        string text;
+        if (trimmed == generated.Count)
+        {
+            outputTokens = generated.ToArray();
+            text = DecodeTokens(generated);
+        }
+        else
+        {
+            var trimmedToks = generated.GetRange(0, trimmed);
+            outputTokens = trimmedToks.ToArray();
+            text = DecodeTokens(trimmedToks);
+        }
+
+        if (swBatch != null)
+        {
+            swBatch.Stop();
+            long total = swBatch.ElapsedMilliseconds;
+            long accounted = melLocal + encLocal + projLocal + prefillLocal + stepLocal;
+            long overhead = Math.Max(0, total - accounted);
+            lock (_profileLock)
+            {
+                MelMs += melLocal; EncMs += encLocal; ProjMs += projLocal;
+                PrefillMs += prefillLocal; StepLoopMs += stepLocal; OverheadMs += overhead;
+                BatchCount++; RowCount++; StepCount += stepCountLocal;
+                if (B > MaxBatchSeen) MaxBatchSeen = B;
+            }
+            Console.Error.WriteLine(
+                $"[granite-prof] B=1/{B} total={total}ms (mel={melLocal} enc={encLocal} "
+              + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
+              + $"overhead={overhead}ms) static-gqa");
+        }
+
+        return (text, outputTokens);
     }
 
     /// <summary>Print accumulated profile stats and reset. Returns true if profiling was on.</summary>

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -138,6 +138,15 @@ public sealed class GraniteSpeech : IDisposable
                                             // step; no buffer-sharing
                                             // IOBinding possible. Run 20
                                             // phase 4.
+    private readonly bool _hasNextTokenOutput;   // Bundle was rewritten with
+                                            // --add-argmax: the LM head has
+                                            // an on-GPU Slice(last) + ArgMax
+                                            // appended and `logits` is no
+                                            // longer a graph output —
+                                            // `next_token` (int64 [B, 1])
+                                            // is. Eliminates ~6 MB of
+                                            // GPU→CPU logits transfer per
+                                            // step (Run 20 phase 9).
     private readonly int _staticBatchSize;
     private readonly int _staticPastLen;
     private readonly int _staticAudioLen;
@@ -175,6 +184,7 @@ public sealed class GraniteSpeech : IDisposable
         _isStaticBundle = false;
         _isGqaBundle = _decoder.InputMetadata.ContainsKey("seqlens_k");
         _hasPositionIdsInput = _decoder.InputMetadata.ContainsKey("position_ids");
+        _hasNextTokenOutput = _decoder.OutputMetadata.ContainsKey("next_token");
         // Dynamic GQA: GQA bundle with past_kv batch dim symbolic
         // (no static batch pinning).
         _isDynamicGqaBundle = false;
@@ -588,7 +598,12 @@ public sealed class GraniteSpeech : IDisposable
             decInputNames.Add($"past_key_{L}");
             decInputNames.Add($"past_value_{L}");
         }
-        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { "logits" };
+        // If the bundle was rewritten with --add-argmax, the LM head emits
+        // `next_token` (int64 [B, 1]) instead of `logits` (fp32 [B, S, V]).
+        // The argmax happens on the GPU and we only transfer 8 bytes per
+        // row per step instead of ~6 MB.
+        string headOutputName = _hasNextTokenOutput ? "next_token" : "logits";
+        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { headOutputName };
         for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_key_{L}");
         for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_value_{L}");
 
@@ -644,14 +659,31 @@ public sealed class GraniteSpeech : IDisposable
                 runOpts, decInputNames, prefillInputs, decOutputNames);
 
             // Argmax per row at the LAST position (S-1) — left-padding
-            // means real last token sits there for every row.
-            var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
-            for (int b = 0; b < B; b++)
+            // means real last token sits there for every row. With
+            // --add-argmax the head emits `next_token` (int64 [B, 1]),
+            // so we just read tokens directly; otherwise argmax the
+            // float logits on CPU.
+            if (_hasNextTokenOutput)
             {
-                long tok = ArgmaxRowLastPosition(prefillLogitsSpan, b, sMax, VocabSize);
-                nextTok[b] = tok;
-                generated[b].Add(tok);
-                if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+                var prefillTokSpan = prefillOutputs[0].GetTensorDataAsSpan<long>();
+                for (int b = 0; b < B; b++)
+                {
+                    long tok = prefillTokSpan[b];
+                    nextTok[b] = tok;
+                    generated[b].Add(tok);
+                    if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+                }
+            }
+            else
+            {
+                var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+                for (int b = 0; b < B; b++)
+                {
+                    long tok = ArgmaxRowLastPosition(prefillLogitsSpan, b, sMax, VocabSize);
+                    nextTok[b] = tok;
+                    generated[b].Add(tok);
+                    if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+                }
             }
             prefillOutputs[0].Dispose();
             posPrefillVal?.Dispose();
@@ -692,7 +724,11 @@ public sealed class GraniteSpeech : IDisposable
             // per-step GetTensorDataAsSpan readout that pulls logits across
             // the GPU→CPU bus implicitly.
             float[] dummyAudio = new float[B * 1 * (int)audioDim];
-            float[] stepLogitsBuf = new float[B * 1 * VocabSize];
+            // With --add-argmax bundles the head output is `next_token`
+            // int64 [B, 1] — pre-allocate a small CPU buffer for it; the
+            // float logits buffer is unused in that case.
+            float[]? stepLogitsBuf = _hasNextTokenOutput ? null : new float[B * 1 * VocabSize];
+            long[]? stepNextTokenBuf = _hasNextTokenOutput ? new long[B * 1] : null;
             long[] stepPositionIds = new long[B];
 
             using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
@@ -704,8 +740,14 @@ public sealed class GraniteSpeech : IDisposable
             using var stepPosVal = _hasPositionIdsInput
                 ? OrtValue.CreateTensorValueFromMemory(stepPositionIds, new long[] { B, 1 })
                 : null;
-            using var stepLogitsVal = OrtValue.CreateTensorValueFromMemory(
-                stepLogitsBuf, new long[] { B, 1, VocabSize });
+            using var stepLogitsVal = stepLogitsBuf is null
+                ? null
+                : OrtValue.CreateTensorValueFromMemory(
+                    stepLogitsBuf, new long[] { B, 1, VocabSize });
+            using var stepNextTokenVal = stepNextTokenBuf is null
+                ? null
+                : OrtValue.CreateTensorValueFromMemory(
+                    stepNextTokenBuf, new long[] { B, 1 });
 
             // Lifetime management across iterations follows WhisperTurbo's
             // pattern (see WhisperTurbo.cs step loop): pastKvs holds borrowed
@@ -752,11 +794,14 @@ public sealed class GraniteSpeech : IDisposable
                     stepBinding.BindInput($"past_key_{L}",   pastKvs[2 * L]);
                     stepBinding.BindInput($"past_value_{L}", pastKvs[2 * L + 1]);
                 }
-                // Bind output order matches `decOutputNames` so GetOutputValues()
-                // indices line up: [0]=logits, [1..40]=present_key_<L>,
-                // [41..80]=present_value_<L> — same convention as the non-
-                // IOBinding code path.
-                stepBinding.BindOutput("logits", stepLogitsVal);
+                // Bind output order matches `decOutputNames` so
+                // GetOutputValues() indices line up: [0]=head (logits or
+                // next_token), [1..40]=present_key_<L>, [41..80]=
+                // present_value_<L>.
+                if (_hasNextTokenOutput)
+                    stepBinding.BindOutput("next_token", stepNextTokenVal!);
+                else
+                    stepBinding.BindOutput("logits", stepLogitsVal!);
                 for (int L = 0; L < NumDecoderLayers; L++)
                     stepBinding.BindOutputToDevice($"present_key_{L}", cudaMemInfo);
                 for (int L = 0; L < NumDecoderLayers; L++)
@@ -781,25 +826,34 @@ public sealed class GraniteSpeech : IDisposable
                 prevStepOutputs?.Dispose();
                 prevStepOutputs = curOutputs;
 
-                // Logits are in stepLogitsBuf (CPU) via BindOutput — direct
-                // .NET array read, no GetTensorDataAsSpan round-trip.
-                var stepLogitsSpan = new ReadOnlySpan<float>(stepLogitsBuf);
-                for (int b = 0; b < B; b++)
+                // Read next token: either from the GPU-argmax output
+                // (`next_token`, int64) or by argmaxing the float logits
+                // on CPU.
+                if (_hasNextTokenOutput)
                 {
-                    if (finished[b]) { nextTok[b] = EosTokenId; continue; }
-                    long tok = ArgmaxRowLastPosition(stepLogitsSpan, b, 1, VocabSize);
-                    nextTok[b] = tok;
-                    generated[b].Add(tok);
-                    if (tok == EosTokenId)
+                    for (int b = 0; b < B; b++)
                     {
-                        finished[b] = true;
-                        finishedCount++;
+                        if (finished[b]) { nextTok[b] = EosTokenId; continue; }
+                        long tok = stepNextTokenBuf![b];
+                        nextTok[b] = tok;
+                        generated[b].Add(tok);
+                        if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+                        else if (IsRepetitionLoop(generated[b]))
+                        { finished[b] = true; loopDetected[b] = true; finishedCount++; }
                     }
-                    else if (IsRepetitionLoop(generated[b]))
+                }
+                else
+                {
+                    var stepLogitsSpan = new ReadOnlySpan<float>(stepLogitsBuf);
+                    for (int b = 0; b < B; b++)
                     {
-                        finished[b] = true;
-                        loopDetected[b] = true;
-                        finishedCount++;
+                        if (finished[b]) { nextTok[b] = EosTokenId; continue; }
+                        long tok = ArgmaxRowLastPosition(stepLogitsSpan, b, 1, VocabSize);
+                        nextTok[b] = tok;
+                        generated[b].Add(tok);
+                        if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+                        else if (IsRepetitionLoop(generated[b]))
+                        { finished[b] = true; loopDetected[b] = true; finishedCount++; }
                     }
                 }
                 pastLen = totalLen;

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -1623,11 +1623,24 @@ public sealed class GraniteSpeech : IDisposable
             if (swPrefill != null) { swPrefill.Stop(); prefillLocal = swPrefill.ElapsedMilliseconds; }
             var swStep = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
 
-            // ── Step loop ────────────────────────────────────────────────
+            // ── Step loop with IOBinding (Run 20 phase 3) ─────────────────
+            // Bind past_key_<L> input and present_key_<L> output to the SAME
+            // OrtValue per layer. GQA detects the shared buffer (same memory
+            // address for past and present) and writes new K in place at
+            // past_kv[seqlens_k+1] without copying the rest of the cache.
+            // Per-step memcpy elimination is 80 layers × 16 × 4 × 512 × 128
+            // × 2 (bf16) = ~6.4 GB of avoided KV traffic per step iteration.
+            //
+            // Logits is bound to a pre-allocated CPU buffer so we can argmax
+            // directly without an extra GetTensorDataAsSpan round-trip.
             float[] dummyAudio = new float[B * A * (int)audioDim];
             long[] stepInputIds = new long[B];
             long[] cachePosStep = new long[1];
-            long[] stepPositionIds = new long[B];   // shape [B, 1] flattened
+            long[] stepPositionIds = new long[B];
+            float[] stepLogitsBuf = new float[B * 1 * VocabSize];
+
+            using var cudaMemInfo = new OrtMemoryInfo(
+                "Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
 
             for (int step = 0; step < maxNewTokens && finishedCount < B; step++)
             {
@@ -1639,14 +1652,13 @@ public sealed class GraniteSpeech : IDisposable
                     seqlensKBuf[b] = sl;
                     int rowTotal = sl + 1;
                     if (rowTotal > maxTotalLen) maxTotalLen = rowTotal;
-                    stepPositionIds[b] = sl;          // RoPE at the write position
+                    stepPositionIds[b] = sl;
                     stepInputIds[b] = (b >= realB || finished[b]) ? EosTokenId : nextTok[b];
                 }
                 int totalLen = maxTotalLen;
                 totalSeqBuf[0] = totalLen;
-                cachePosStep[0] = totalLen - 1;       // shared; only used by dead code
+                cachePosStep[0] = totalLen - 1;
 
-                // attention_mask [B, totalLen]: real rows have 1s at [0, realLen[b]+step+1).
                 var stepMaskBatch = new long[B * totalLen];
                 for (int b = 0; b < realB; b++)
                 {
@@ -1670,26 +1682,33 @@ public sealed class GraniteSpeech : IDisposable
                     seqlensKBuf, new long[] { B });
                 using var stepTotalSeqVal = OrtValue.CreateTensorValueFromMemory(
                     totalSeqBuf, Array.Empty<long>());
+                using var stepLogitsVal = OrtValue.CreateTensorValueFromMemory(
+                    stepLogitsBuf, new long[] { B, 1, VocabSize });
 
-                var stepInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
-                { stepInputIdVal, stepAudioVal, stepAttnVal, stepCpVal, stepPosVal };
-                stepInputs.AddRange(pastKvs);
-                stepInputs.Add(stepSeqlensVal);
-                stepInputs.Add(stepTotalSeqVal);
-
-                var outputs = _decoder.Run(
-                    runOpts, decInputNames, stepInputs, decOutputNames);
-
-                var oldPast = pastKvs;
-                pastKvs = new OrtValue[2 * NumDecoderLayers];
+                using var stepBinding = _decoder.CreateIoBinding();
+                stepBinding.BindInput("input_ids",             stepInputIdVal);
+                stepBinding.BindInput("audio_embeds",          stepAudioVal);
+                stepBinding.BindInput("attention_mask",        stepAttnVal);
+                stepBinding.BindInput("cache_position",        stepCpVal);
+                stepBinding.BindInput("position_ids",          stepPosVal);
+                stepBinding.BindInput("seqlens_k",             stepSeqlensVal);
+                stepBinding.BindInput("total_sequence_length", stepTotalSeqVal);
                 for (int L = 0; L < NumDecoderLayers; L++)
                 {
-                    pastKvs[2 * L]     = outputs[1 + L];
-                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
+                    stepBinding.BindInput($"past_key_{L}",   pastKvs[2 * L]);
+                    stepBinding.BindInput($"past_value_{L}", pastKvs[2 * L + 1]);
+                    // Same OrtValue as output → GQA writes new K in place.
+                    stepBinding.BindOutput($"present_key_{L}",   pastKvs[2 * L]);
+                    stepBinding.BindOutput($"present_value_{L}", pastKvs[2 * L + 1]);
                 }
+                stepBinding.BindOutput("logits", stepLogitsVal);
 
-                var stepLogits = outputs[0];
-                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
+                _decoder.RunWithBinding(runOpts, stepBinding);
+
+                // Logits are now in stepLogitsBuf (CPU). pastKvs OrtValues
+                // are unchanged references; their underlying GPU buffers
+                // have been updated in place.
+                var stepLogitsSpan = new ReadOnlySpan<float>(stepLogitsBuf);
                 for (int b = 0; b < realB; b++)
                 {
                     if (finished[b]) { nextTok[b] = EosTokenId; continue; }
@@ -1702,8 +1721,6 @@ public sealed class GraniteSpeech : IDisposable
                         finished[b] = true; loopDetected[b] = true; finishedCount++;
                     }
                 }
-                stepLogits.Dispose();
-                foreach (var ov in oldPast) ov.Dispose();
                 stepCountLocal++;
             }
 

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -938,6 +938,12 @@ public sealed class GraniteSpeech : IDisposable
     ///
     /// All other logic (per-row mel/encoder/projector, repetition-loop
     /// detection, EOS handling, profile bookkeeping) mirrors TranscribeBatch.
+    ///
+    /// **Status (Run 20):** The static-shape contract is a 3.7× wall-time
+    /// regression vs the dynamic path. Kept for back-compat with any
+    /// static-shape bundle still on disk; prefer the dynamic export +
+    /// MHA rewriter + IOBinding path (the default TranscribeBatch route
+    /// when the bundle's past_kv batch dim is symbolic).
     /// </summary>
     private (string text, long[] tokens)[] TranscribeBatchStatic(float[][] waveforms, int maxNewTokens)
     {
@@ -1295,6 +1301,11 @@ public sealed class GraniteSpeech : IDisposable
     /// where the real K ends, so attention compute scales with the actual
     /// past length, not the buffer length — the static-padding compute-skip
     /// win this whole migration is for.
+    ///
+    /// **Status (Run 20 phase 4 onwards):** Superseded by the dynamic
+    /// MHA-fused + IOBinding path (~3.6 s vs this path's ~13 s on the
+    /// 60 s test clip). Kept for back-compat with phase 1 GQA-static
+    /// bundles. New exports should use dynamic shapes.
     /// </summary>
     private (string text, long[] tokens) TranscribeStaticGqaSingle(
         float[] waveform, int maxNewTokens)
@@ -1587,6 +1598,10 @@ public sealed class GraniteSpeech : IDisposable
     /// pad tokens get [realLen[b]..S) (continuing the sequence so RoPE
     /// is stable across the prefill→step boundary), and step k's new
     /// token uses position realLen[b] + k.
+    ///
+    /// **Status (Run 20 phase 4 onwards):** Superseded by the dynamic
+    /// MHA-fused + IOBinding path. Kept for back-compat with phase 2
+    /// GQA-static bundles that include the position_ids input.
     /// </summary>
     private (string text, long[] tokens)[] TranscribeStaticGqaBatched(
         float[][] waveforms, int maxNewTokens)
@@ -2188,353 +2203,6 @@ public sealed class GraniteSpeech : IDisposable
         return (text, outputTokens);
     }
 
-    /// <summary>
-    /// Batched dynamic-shape decode against a GQA-rewritten bundle.
-    /// Run 20 phase 5.
-    ///
-    /// BatchSizer.Plan upstream sorts segments by duration before this is
-    /// called, so realLen across rows in one batch is similar. We right-pad
-    /// to S = max(realLen) within the batch; the small pad region is masked
-    /// at attention time via attention_bias = where_2 (which the rewriter
-    /// wires in when past_seq is dynamic, since where_2's shape then
-    /// matches GQA's expectation).
-    ///
-    /// past_kv grows uniformly by 1 per step in dynamic mode (no buffer
-    /// sharing). At step k, generated K for ALL rows lands at slot S+k.
-    /// position_ids is per-row so each row's generated K is RoPE'd at its
-    /// own continuation position (realLen[b]+k), giving the usual relative-
-    /// position correctness across batch.
-    /// </summary>
-    private (string text, long[] tokens)[] TranscribeDynamicGqaBatch(
-        float[][] waveforms, int maxNewTokens)
-    {
-        int B = waveforms.Length;
-        if (B == 0) return Array.Empty<(string, long[])>();
-
-        var swBatch = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-        long melLocal = 0, encLocal = 0, projLocal = 0;
-
-        // ── Per-row mel + encoder + projector ───────────────────────────
-        var audioEmbeds = new float[B][];
-        var nAudio      = new int[B];
-        long audioDim   = 2048;
-        for (int b = 0; b < B; b++)
-        {
-            int audioTokens = NumAudioTokens(waveforms[b].Length);
-            int promptLen   = AsrPromptPrefix.Length + audioTokens + AsrPromptSuffix.Length;
-            if (promptLen + maxNewTokens > MaxContextLen)
-                throw new InvalidOperationException(
-                    $"Segment too long: prompt+max_new_tokens ({promptLen + maxNewTokens}) "
-                  + $"exceeds Granite Speech context ({MaxContextLen}).");
-
-            var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-            var audioT = new DenseTensor<float>(waveforms[b], [1, waveforms[b].Length]);
-            using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
-            var inputFeatures = melResults[0].AsTensor<float>();
-            var ifShape = inputFeatures.Dimensions.ToArray();
-            var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
-            if (swStage != null) { swStage.Stop(); melLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
-                "input_features", new DenseTensor<float>(ifData, ifShape))]);
-            var encoderHidden = encResults[0].AsTensor<float>();
-            var encShape = encoderHidden.Dimensions.ToArray();
-            var encData = encoderHidden.ToArray();
-            if (swStage != null) { swStage.Stop(); encLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
-                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
-            var ae = projResults[0].AsTensor<float>();
-            audioDim = ae.Dimensions[2];
-            if (ae.Dimensions[1] != audioTokens)
-                throw new InvalidOperationException(
-                    $"Audio token count mismatch (row {b}): formula predicts {audioTokens}, "
-                  + $"projector produced {ae.Dimensions[1]}.");
-            audioEmbeds[b] = ae.ToArray();
-            nAudio[b] = audioTokens;
-            if (swStage != null) { swStage.Stop(); projLocal += swStage.ElapsedMilliseconds; }
-        }
-
-        // ── Build right-padded prompt at batch's actual sizes ───────────
-        var realLen = new int[B];
-        int sMax = 0;
-        int aMax = 0;
-        for (int b = 0; b < B; b++)
-        {
-            realLen[b] = AsrPromptPrefix.Length + nAudio[b] + AsrPromptSuffix.Length;
-            if (realLen[b] > sMax) sMax = realLen[b];
-            if (nAudio[b]  > aMax) aMax = nAudio[b];
-        }
-        int S = sMax;
-        int A = Math.Max(aMax, 1);   // graph requires audio_embeds dim>=1 at step
-
-        // input_ids [B, S]: real prompt at [0, realLen[b]), PAD at [realLen[b], S).
-        var inputIdsBatch = new long[B * S];
-        for (int b = 0; b < B; b++)
-        {
-            int rowOff = b * S;
-            int q = rowOff;
-            for (int i = 0; i < AsrPromptPrefix.Length; i++) inputIdsBatch[q++] = AsrPromptPrefix[i];
-            for (int i = 0; i < nAudio[b]; i++) inputIdsBatch[q++] = AudioTokenId;
-            for (int i = 0; i < AsrPromptSuffix.Length; i++) inputIdsBatch[q++] = AsrPromptSuffix[i];
-            for (int i = realLen[b]; i < S; i++) inputIdsBatch[rowOff + i] = PadTokenId;
-        }
-
-        // audio_embeds [B, A, audioDim]: real audio at [0, nAudio[b]) of each
-        // row, zeros after. A = max(nAudio) within this batch — much smaller
-        // than the static-shape A=192 since the BatchSizer groups similar
-        // durations.
-        var audioEmbedsBatch = new float[B * A * (int)audioDim];
-        for (int b = 0; b < B; b++)
-        {
-            int rowOff = b * A * (int)audioDim;
-            int n = nAudio[b] * (int)audioDim;
-            if (n > 0) Array.Copy(audioEmbeds[b], 0, audioEmbedsBatch, rowOff, n);
-        }
-
-        // attention_mask [B, S]: 1s at real, 0 at pad. The graph derives
-        // where_2 from this, and where_2 reaches GQA as attention_bias —
-        // pad slots get -inf added to attention scores, so within-batch
-        // length variation doesn't contaminate row b's attention.
-        var attnMaskBatch = new long[B * S];
-        for (int b = 0; b < B; b++)
-        {
-            int rowOff = b * S;
-            for (int i = 0; i < realLen[b]; i++) attnMaskBatch[rowOff + i] = 1L;
-        }
-
-        // cache_position [S]: shared sequence index 0..S-1. With position_ids
-        // overriding per-row, this only feeds HF's where_2-construction
-        // (which we route to GQA as attention_bias).
-        var cachePosBuf = new long[S];
-        for (int i = 0; i < S; i++) cachePosBuf[i] = i;
-
-        // position_ids [B, S]: per-row. Real positions [0..realLen[b]-1] for
-        // real prompt tokens, [realLen[b]..S-1] for the padded tail (pads are
-        // masked via attention_bias so values here don't matter beyond keeping
-        // RoPE continuous through prefill→step).
-        var positionIdsBatch = new long[B * S];
-        for (int b = 0; b < B; b++)
-        {
-            int rowOff = b * S;
-            for (int i = 0; i < S; i++) positionIdsBatch[rowOff + i] = i;
-        }
-
-        // seqlens_k [B] int32: uniform = S - 1 at prefill (GQA's write region
-        // is uniform across batch in non-buffer-sharing mode).
-        var seqlensKBuf = new int[B];
-        for (int b = 0; b < B; b++) seqlensKBuf[b] = S - 1;
-        var totalSeqBuf = new int[] { S };
-
-        var decInputNames = new List<string>(7 + 2 * NumDecoderLayers)
-        { "input_ids", "audio_embeds", "attention_mask", "cache_position", "position_ids" };
-        for (int L = 0; L < NumDecoderLayers; L++)
-        {
-            decInputNames.Add($"past_key_{L}");
-            decInputNames.Add($"past_value_{L}");
-        }
-        decInputNames.Add("seqlens_k");
-        decInputNames.Add("total_sequence_length");
-
-        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { "logits" };
-        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_key_{L}");
-        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_value_{L}");
-
-        var generated = new List<long>[B];
-        for (int b = 0; b < B; b++) generated[b] = new List<long>(maxNewTokens);
-        var finished     = new bool[B];
-        var loopDetected = new bool[B];
-        int finishedCount = 0;
-        var nextTok      = new long[B];
-
-        long prefillLocal = 0, stepLocal = 0;
-        long stepCountLocal = 0;
-
-        using (var runOpts = new RunOptions())
-        {
-            var swPrefill = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-
-            using var inputIdsVal = OrtValue.CreateTensorValueFromMemory(
-                inputIdsBatch, new long[] { B, S });
-            using var audioVal = OrtValue.CreateTensorValueFromMemory(
-                audioEmbedsBatch, new long[] { B, A, audioDim });
-            using var attnVal = OrtValue.CreateTensorValueFromMemory(
-                attnMaskBatch, new long[] { B, S });
-            using var cpVal = OrtValue.CreateTensorValueFromMemory(
-                cachePosBuf, new long[] { S });
-            using var posVal = OrtValue.CreateTensorValueFromMemory(
-                positionIdsBatch, new long[] { B, S });
-            using var seqlensVal = OrtValue.CreateTensorValueFromMemory(
-                seqlensKBuf, new long[] { B });
-            using var totalSeqVal = OrtValue.CreateTensorValueFromMemory(
-                totalSeqBuf, Array.Empty<long>());
-
-            // Empty past_kv: [B, kv_heads, 0, head_dim]. ORT accepts these.
-            var emptyShape = new long[] { B, NumKvHeads, 0, HeadDim };
-            var emptyPasts = new List<OrtValue>(2 * NumDecoderLayers);
-            for (int L = 0; L < NumDecoderLayers; L++)
-            {
-                emptyPasts.Add(CreateEmptyPastKv(emptyShape));
-                emptyPasts.Add(CreateEmptyPastKv(emptyShape));
-            }
-
-            var prefillInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
-            { inputIdsVal, audioVal, attnVal, cpVal, posVal };
-            prefillInputs.AddRange(emptyPasts);
-            prefillInputs.Add(seqlensVal);
-            prefillInputs.Add(totalSeqVal);
-
-            var prefillOutputs = _decoder.Run(
-                runOpts, decInputNames, prefillInputs, decOutputNames);
-
-            // Per-row argmax at realLen[b]-1.
-            var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
-            for (int b = 0; b < B; b++)
-            {
-                long tok = ArgmaxRowAtPosition(prefillLogitsSpan, b, S, realLen[b] - 1, VocabSize);
-                nextTok[b] = tok;
-                generated[b].Add(tok);
-                if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
-            }
-            prefillOutputs[0].Dispose();
-            foreach (var ov in emptyPasts) ov.Dispose();
-
-            var pastKvs = new OrtValue[2 * NumDecoderLayers];
-            for (int L = 0; L < NumDecoderLayers; L++)
-            {
-                pastKvs[2 * L]     = prefillOutputs[1 + L];
-                pastKvs[2 * L + 1] = prefillOutputs[1 + NumDecoderLayers + L];
-            }
-
-            if (swPrefill != null) { swPrefill.Stop(); prefillLocal = swPrefill.ElapsedMilliseconds; }
-            var swStep = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-
-            // ── Step loop ────────────────────────────────────────────────
-            var dummyAudio = new float[B * 1 * (int)audioDim];
-            var stepInputIds = new long[B];
-            var stepPositionIds = new long[B];
-
-            for (int step = 0; step < maxNewTokens && finishedCount < B; step++)
-            {
-                int totalLen = S + step + 1;
-                int newKSlot = S + step;     // uniform write position
-
-                for (int b = 0; b < B; b++)
-                {
-                    stepInputIds[b] = finished[b] ? EosTokenId : nextTok[b];
-                    // RoPE position for row b's new token: continue from its
-                    // own prompt's last real position. (Step k token in row b
-                    // is semantic position realLen[b]+k.)
-                    stepPositionIds[b] = realLen[b] + step;
-                }
-                seqlensKBuf[0] = 0;  // unused — overwrite below
-                for (int b = 0; b < B; b++) seqlensKBuf[b] = newKSlot;
-                totalSeqBuf[0] = totalLen;
-
-                // attention_mask [B, totalLen]: real prompt [0, realLen[b]) +
-                // generated tail [S, totalLen). Pad slots [realLen[b], S)
-                // stay zero so attention_bias masks them.
-                var stepMaskBatch = new long[B * totalLen];
-                for (int b = 0; b < B; b++)
-                {
-                    int rowOff = b * totalLen;
-                    for (int i = 0; i < realLen[b]; i++) stepMaskBatch[rowOff + i] = 1L;
-                    for (int i = S; i < totalLen; i++)  stepMaskBatch[rowOff + i] = 1L;
-                }
-                var stepCachePos = new long[] { (long)newKSlot };
-
-                using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
-                    stepInputIds, new long[] { B, 1 });
-                using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
-                    dummyAudio, new long[] { B, 1, audioDim });
-                using var stepAttnVal = OrtValue.CreateTensorValueFromMemory(
-                    stepMaskBatch, new long[] { B, totalLen });
-                using var stepCpVal = OrtValue.CreateTensorValueFromMemory(
-                    stepCachePos, new long[] { 1 });
-                using var stepPosVal = OrtValue.CreateTensorValueFromMemory(
-                    stepPositionIds, new long[] { B, 1 });
-                using var stepSeqlensVal = OrtValue.CreateTensorValueFromMemory(
-                    seqlensKBuf, new long[] { B });
-                using var stepTotalSeqVal = OrtValue.CreateTensorValueFromMemory(
-                    totalSeqBuf, Array.Empty<long>());
-
-                var stepInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
-                { stepInputIdVal, stepAudioVal, stepAttnVal, stepCpVal, stepPosVal };
-                stepInputs.AddRange(pastKvs);
-                stepInputs.Add(stepSeqlensVal);
-                stepInputs.Add(stepTotalSeqVal);
-
-                var outputs = _decoder.Run(
-                    runOpts, decInputNames, stepInputs, decOutputNames);
-
-                var oldPast = pastKvs;
-                pastKvs = new OrtValue[2 * NumDecoderLayers];
-                for (int L = 0; L < NumDecoderLayers; L++)
-                {
-                    pastKvs[2 * L]     = outputs[1 + L];
-                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
-                }
-
-                var stepLogits = outputs[0];
-                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
-                for (int b = 0; b < B; b++)
-                {
-                    if (finished[b]) { nextTok[b] = EosTokenId; continue; }
-                    long tok = ArgmaxRowLastPosition(stepLogitsSpan, b, 1, VocabSize);
-                    nextTok[b] = tok;
-                    generated[b].Add(tok);
-                    if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
-                    else if (IsRepetitionLoop(generated[b]))
-                    {
-                        finished[b] = true; loopDetected[b] = true; finishedCount++;
-                    }
-                }
-                stepLogits.Dispose();
-                foreach (var ov in oldPast) ov.Dispose();
-                stepCountLocal++;
-            }
-
-            foreach (var ov in pastKvs) ov.Dispose();
-            if (swStep != null) { swStep.Stop(); stepLocal = swStep.ElapsedMilliseconds; }
-        }
-
-        var rows = new (string text, long[] tokens)[B];
-        for (int b = 0; b < B; b++)
-        {
-            var toks = generated[b];
-            int realCount = toks.Count;
-            while (realCount > 0 && toks[realCount - 1] == EosTokenId) realCount--;
-            int trimmed = loopDetected[b] ? TrimRepetitionTail(toks, realCount) : realCount;
-            if (trimmed == toks.Count)
-                rows[b] = (DecodeTokens(toks), toks.ToArray());
-            else
-            {
-                var trimmedToks = toks.GetRange(0, trimmed);
-                rows[b] = (DecodeTokens(trimmedToks), trimmedToks.ToArray());
-            }
-        }
-
-        if (swBatch != null)
-        {
-            swBatch.Stop();
-            long total = swBatch.ElapsedMilliseconds;
-            long accounted = melLocal + encLocal + projLocal + prefillLocal + stepLocal;
-            long overhead = Math.Max(0, total - accounted);
-            lock (_profileLock)
-            {
-                MelMs += melLocal; EncMs += encLocal; ProjMs += projLocal;
-                PrefillMs += prefillLocal; StepLoopMs += stepLocal; OverheadMs += overhead;
-                BatchCount++; RowCount += B; StepCount += stepCountLocal;
-                if (B > MaxBatchSeen) MaxBatchSeen = B;
-            }
-            Console.Error.WriteLine(
-                $"[granite-prof] B={B} S={S} A={A} total={total}ms (mel={melLocal} enc={encLocal} "
-              + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
-              + $"overhead={overhead}ms) dynamic-gqa-batched");
-        }
-
-        return rows;
-    }
 
     /// <summary>Print accumulated profile stats and reset. Returns true if profiling was on.</summary>
     public static bool DumpProfile(System.IO.TextWriter? w = null)

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -132,6 +132,12 @@ public sealed class GraniteSpeech : IDisposable
                                             // C# driver feed per-row RoPE
                                             // positions and restore batched
                                             // dispatch.
+    private readonly bool _isDynamicGqaBundle;   // GQA bundle with FULLY
+                                            // dynamic shapes (no past_len
+                                            // pinning). Past_kv grows each
+                                            // step; no buffer-sharing
+                                            // IOBinding possible. Run 20
+                                            // phase 4.
     private readonly int _staticBatchSize;
     private readonly int _staticPastLen;
     private readonly int _staticAudioLen;
@@ -169,6 +175,17 @@ public sealed class GraniteSpeech : IDisposable
         _isStaticBundle = false;
         _isGqaBundle = _decoder.InputMetadata.ContainsKey("seqlens_k");
         _hasPositionIdsInput = _decoder.InputMetadata.ContainsKey("position_ids");
+        // Dynamic GQA: GQA bundle with past_kv batch dim symbolic
+        // (no static batch pinning).
+        _isDynamicGqaBundle = false;
+        if (_isGqaBundle
+            && _hasPositionIdsInput
+            && _decoder.InputMetadata.TryGetValue("past_key_0", out var pkDynMeta)
+            && pkDynMeta.Dimensions.Length == 4
+            && pkDynMeta.Dimensions[0] <= 0)
+        {
+            _isDynamicGqaBundle = true;
+        }
         _staticBatchSize = 0;
         _staticPastLen = 0;
         _staticAudioLen = 0;
@@ -414,6 +431,18 @@ public sealed class GraniteSpeech : IDisposable
 
     private (string text, long[] tokens)[] TranscribeBatch(float[][] waveforms, int maxNewTokens)
     {
+        // Dynamic GQA bundle (Run 20 phase 4): drop all the static-shape
+        // padding (B=16, A=192, S=max(realLen)) and process each segment
+        // at its actual size. GQA fusion is preserved; buffer-sharing is
+        // not (past_kv grows per step in dynamic mode).
+        if (_isDynamicGqaBundle)
+        {
+            var dynRows = new (string text, long[] tokens)[waveforms.Length];
+            for (int i = 0; i < waveforms.Length; i++)
+                dynRows[i] = TranscribeDynamicGqaSingle(waveforms[i], maxNewTokens);
+            return dynRows;
+        }
+
         // Static-shape bundle (Run 15 phase 2c) takes the padded-to-fixed-B
         // path; the legacy dynamic-shape bundle keeps the original loop.
         if (_isStaticBundle)
@@ -1764,6 +1793,266 @@ public sealed class GraniteSpeech : IDisposable
               + $"overhead={overhead}ms) static-gqa-batched");
         }
         return rows;
+    }
+
+    /// <summary>
+    /// Single-segment dynamic-shape decode against a GQA-rewritten bundle
+    /// where the decoder is fully dynamic (no static B/A/past_len pinning).
+    /// Run 20 phase 4.
+    ///
+    /// One segment per call: B=1, no dummies, audio_embeds sized to the
+    /// segment's actual audio tokens, input_ids sized to the segment's
+    /// actual prompt length, past_kv starts empty and grows by one slot
+    /// per step. Eliminates the static-shape padding overhead (16× batch,
+    /// up-to-12× audio_len, up-to-6× past_len) that bounded the static
+    /// GQA path's perf.
+    /// </summary>
+    private (string text, long[] tokens) TranscribeDynamicGqaSingle(
+        float[] waveform, int maxNewTokens)
+    {
+        int audioTokens = NumAudioTokens(waveform.Length);
+        int realLen = AsrPromptPrefix.Length + audioTokens + AsrPromptSuffix.Length;
+        if (realLen + maxNewTokens > MaxContextLen)
+            throw new InvalidOperationException(
+                $"Segment too long: prompt+max_new_tokens ({realLen + maxNewTokens}) "
+              + $"exceeds Granite Speech context ({MaxContextLen}).");
+
+        var swBatch = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+        long melLocal = 0, encLocal = 0, projLocal = 0;
+
+        // ── Mel + encoder + projector (B=1) ──────────────────────────────
+        var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+        var audioT = new DenseTensor<float>(waveform, [1, waveform.Length]);
+        using var melResults = _mel.Run(
+            [NamedOnnxValue.CreateFromTensor("audio", audioT)]);
+        var inputFeatures = melResults[0].AsTensor<float>();
+        var ifShape = inputFeatures.Dimensions.ToArray();
+        var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
+        if (swStage != null) { swStage.Stop(); melLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+        using var encResults = _encoder.Run(
+            [NamedOnnxValue.CreateFromTensor(
+                "input_features", new DenseTensor<float>(ifData, ifShape))]);
+        var encoderHidden = encResults[0].AsTensor<float>();
+        var encShape = encoderHidden.Dimensions.ToArray();
+        var encData = encoderHidden.ToArray();
+        if (swStage != null) { swStage.Stop(); encLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+        using var projResults = _projector.Run(
+            [NamedOnnxValue.CreateFromTensor(
+                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
+        var ae = projResults[0].AsTensor<float>();
+        long audioDim = ae.Dimensions[2];
+        if (ae.Dimensions[1] != audioTokens)
+            throw new InvalidOperationException(
+                $"Audio token count mismatch: formula predicts {audioTokens}, "
+              + $"projector produced {ae.Dimensions[1]}.");
+        var audioEmbedsRow = ae.ToArray();
+        if (swStage != null) { swStage.Stop(); projLocal = swStage.ElapsedMilliseconds; }
+
+        // ── Build prefill inputs at actual sizes ────────────────────────
+        var inputIds = new long[realLen];
+        int p = 0;
+        for (int i = 0; i < AsrPromptPrefix.Length; i++) inputIds[p++] = AsrPromptPrefix[i];
+        for (int i = 0; i < audioTokens; i++) inputIds[p++] = AudioTokenId;
+        for (int i = 0; i < AsrPromptSuffix.Length; i++) inputIds[p++] = AsrPromptSuffix[i];
+
+        var attentionMask = new long[realLen];
+        for (int i = 0; i < realLen; i++) attentionMask[i] = 1L;
+
+        var cachePos = new long[realLen];
+        for (int i = 0; i < realLen; i++) cachePos[i] = i;
+
+        var positionIds = new long[realLen];
+        for (int i = 0; i < realLen; i++) positionIds[i] = i;
+
+        var seqlensKBuf = new int[] { realLen - 1 };
+        var totalSeqBuf = new int[] { realLen };
+
+        // Input/output name lists.
+        var decInputNames = new List<string>(7 + 2 * NumDecoderLayers)
+        { "input_ids", "audio_embeds", "attention_mask", "cache_position", "position_ids" };
+        for (int L = 0; L < NumDecoderLayers; L++)
+        {
+            decInputNames.Add($"past_key_{L}");
+            decInputNames.Add($"past_value_{L}");
+        }
+        decInputNames.Add("seqlens_k");
+        decInputNames.Add("total_sequence_length");
+
+        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { "logits" };
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_key_{L}");
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_value_{L}");
+
+        var generated = new List<long>(maxNewTokens);
+        bool finished = false;
+        bool looped = false;
+        long prefillLocal = 0, stepLocal = 0;
+        long stepCountLocal = 0;
+
+        using (var runOpts = new RunOptions())
+        {
+            var swPrefill = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Prefill ────────────────────────────────────────────────
+            using var inputIdsVal = OrtValue.CreateTensorValueFromMemory(
+                inputIds, new long[] { 1, realLen });
+            using var audioVal = OrtValue.CreateTensorValueFromMemory(
+                audioEmbedsRow, new long[] { 1, audioTokens, audioDim });
+            using var attnVal = OrtValue.CreateTensorValueFromMemory(
+                attentionMask, new long[] { 1, realLen });
+            using var cpVal = OrtValue.CreateTensorValueFromMemory(
+                cachePos, new long[] { realLen });
+            using var posVal = OrtValue.CreateTensorValueFromMemory(
+                positionIds, new long[] { 1, realLen });
+            using var seqlensVal = OrtValue.CreateTensorValueFromMemory(
+                seqlensKBuf, new long[] { 1 });
+            using var totalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                totalSeqBuf, Array.Empty<long>());
+
+            // Empty past_kv: shape [1, NumKvHeads, 0, HeadDim]. ORT accepts
+            // 0-element tensors via a dummy non-empty backing buffer.
+            var emptyShape = new long[] { 1, NumKvHeads, 0, HeadDim };
+            var emptyPasts = new List<OrtValue>(2 * NumDecoderLayers);
+            for (int L = 0; L < NumDecoderLayers; L++)
+            {
+                emptyPasts.Add(CreateEmptyPastKv(emptyShape));
+                emptyPasts.Add(CreateEmptyPastKv(emptyShape));
+            }
+
+            var prefillInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
+            { inputIdsVal, audioVal, attnVal, cpVal, posVal };
+            prefillInputs.AddRange(emptyPasts);
+            prefillInputs.Add(seqlensVal);
+            prefillInputs.Add(totalSeqVal);
+
+            var prefillOutputs = _decoder.Run(
+                runOpts, decInputNames, prefillInputs, decOutputNames);
+
+            var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+            long nextTok = ArgmaxRowLastPosition(prefillLogitsSpan, 0, realLen, VocabSize);
+            generated.Add(nextTok);
+            if (nextTok == EosTokenId) finished = true;
+            prefillOutputs[0].Dispose();
+            foreach (var ov in emptyPasts) ov.Dispose();
+
+            var pastKvs = new OrtValue[2 * NumDecoderLayers];
+            for (int L = 0; L < NumDecoderLayers; L++)
+            {
+                pastKvs[2 * L]     = prefillOutputs[1 + L];
+                pastKvs[2 * L + 1] = prefillOutputs[1 + NumDecoderLayers + L];
+            }
+
+            if (swPrefill != null) { swPrefill.Stop(); prefillLocal = swPrefill.ElapsedMilliseconds; }
+            var swStep = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Step loop ──────────────────────────────────────────────
+            // audio_embeds at step is a [1, 1, audioDim] zero placeholder —
+            // graph requires audio_embeds.shape[1] >= 1 even when nothing
+            // is being merged.
+            var dummyAudio = new float[1 * 1 * (int)audioDim];
+            var stepInputIds = new long[1];
+
+            for (int step = 0; step < maxNewTokens && !finished; step++)
+            {
+                int seqlensK = realLen + step;       // total_seq - 1 after this call
+                int totalLen = seqlensK + 1;
+
+                stepInputIds[0] = nextTok;
+
+                var stepMask = new long[totalLen];
+                for (int i = 0; i < totalLen; i++) stepMask[i] = 1L;
+
+                var stepCachePos = new long[] { (long)seqlensK };
+                var stepPositionIds = new long[] { (long)seqlensK };
+                seqlensKBuf[0] = seqlensK;
+                totalSeqBuf[0] = totalLen;
+
+                using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
+                    stepInputIds, new long[] { 1, 1 });
+                using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
+                    dummyAudio, new long[] { 1, 1, audioDim });
+                using var stepAttnVal = OrtValue.CreateTensorValueFromMemory(
+                    stepMask, new long[] { 1, totalLen });
+                using var stepCpVal = OrtValue.CreateTensorValueFromMemory(
+                    stepCachePos, new long[] { 1 });
+                using var stepPosVal = OrtValue.CreateTensorValueFromMemory(
+                    stepPositionIds, new long[] { 1, 1 });
+                using var stepSeqlensVal = OrtValue.CreateTensorValueFromMemory(
+                    seqlensKBuf, new long[] { 1 });
+                using var stepTotalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                    totalSeqBuf, Array.Empty<long>());
+
+                var stepInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
+                { stepInputIdVal, stepAudioVal, stepAttnVal, stepCpVal, stepPosVal };
+                stepInputs.AddRange(pastKvs);
+                stepInputs.Add(stepSeqlensVal);
+                stepInputs.Add(stepTotalSeqVal);
+
+                var outputs = _decoder.Run(
+                    runOpts, decInputNames, stepInputs, decOutputNames);
+
+                var oldPast = pastKvs;
+                pastKvs = new OrtValue[2 * NumDecoderLayers];
+                for (int L = 0; L < NumDecoderLayers; L++)
+                {
+                    pastKvs[2 * L]     = outputs[1 + L];
+                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
+                }
+
+                var stepLogits = outputs[0];
+                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
+                nextTok = ArgmaxRowLastPosition(stepLogitsSpan, 0, 1, VocabSize);
+                generated.Add(nextTok);
+                if (nextTok == EosTokenId) finished = true;
+                else if (IsRepetitionLoop(generated)) { finished = true; looped = true; }
+
+                stepLogits.Dispose();
+                foreach (var ov in oldPast) ov.Dispose();
+                stepCountLocal++;
+            }
+
+            foreach (var ov in pastKvs) ov.Dispose();
+            if (swStep != null) { swStep.Stop(); stepLocal = swStep.ElapsedMilliseconds; }
+        }
+
+        int realCount = generated.Count;
+        while (realCount > 0 && generated[realCount - 1] == EosTokenId) realCount--;
+        int trimmed = looped ? TrimRepetitionTail(generated, realCount) : realCount;
+        long[] outputTokens;
+        string text;
+        if (trimmed == generated.Count)
+        {
+            outputTokens = generated.ToArray();
+            text = DecodeTokens(generated);
+        }
+        else
+        {
+            var trimmedToks = generated.GetRange(0, trimmed);
+            outputTokens = trimmedToks.ToArray();
+            text = DecodeTokens(trimmedToks);
+        }
+
+        if (swBatch != null)
+        {
+            swBatch.Stop();
+            long total = swBatch.ElapsedMilliseconds;
+            long accounted = melLocal + encLocal + projLocal + prefillLocal + stepLocal;
+            long overhead = Math.Max(0, total - accounted);
+            lock (_profileLock)
+            {
+                MelMs += melLocal; EncMs += encLocal; ProjMs += projLocal;
+                PrefillMs += prefillLocal; StepLoopMs += stepLocal; OverheadMs += overhead;
+                BatchCount++; RowCount++; StepCount += stepCountLocal;
+                if (1 > MaxBatchSeen) MaxBatchSeen = 1;
+            }
+            Console.Error.WriteLine(
+                $"[granite-prof] B=1 total={total}ms (mel={melLocal} enc={encLocal} "
+              + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
+              + $"overhead={overhead}ms) dynamic-gqa");
+        }
+
+        return (text, outputTokens);
     }
 
     /// <summary>Print accumulated profile stats and reset. Returns true if profiling was on.</summary>

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -682,8 +682,40 @@ public sealed class GraniteSpeech : IDisposable
                 int rowOff = b * (sMax + maxNewTokens + 1);
                 for (int s = padLen; s < sMax; s++) stepAttnBuf[rowOff + s] = 1L;
             }
+            // ── Step-loop IOBinding (Run 20 phase 8) ───────────────────────
+            // Pre-allocate the constant-shape inputs (input_ids, audio_embeds,
+            // cache_position, position_ids) and the logits OUTPUT buffer
+            // once, then re-use them every iteration. attention_mask and
+            // past_kv still vary shape per step so they get fresh
+            // OrtValues, but everything else stops re-allocating ~60 times.
+            // Binding `logits` to a pre-allocated CPU buffer also skips the
+            // per-step GetTensorDataAsSpan readout that pulls logits across
+            // the GPU→CPU bus implicitly.
             float[] dummyAudio = new float[B * 1 * (int)audioDim];
+            float[] stepLogitsBuf = new float[B * 1 * VocabSize];
+            long[] stepPositionIds = new long[B];
 
+            using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
+                stepInputIds, new long[] { B, 1 });
+            using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
+                dummyAudio, new long[] { B, 1, audioDim });
+            using var cachePosVal = OrtValue.CreateTensorValueFromMemory(
+                cachePosStep, new long[] { 1 });
+            using var stepPosVal = _hasPositionIdsInput
+                ? OrtValue.CreateTensorValueFromMemory(stepPositionIds, new long[] { B, 1 })
+                : null;
+            using var stepLogitsVal = OrtValue.CreateTensorValueFromMemory(
+                stepLogitsBuf, new long[] { B, 1, VocabSize });
+
+            // Lifetime management across iterations follows WhisperTurbo's
+            // pattern (see WhisperTurbo.cs step loop): pastKvs holds borrowed
+            // references into either prefillOutputs or the previous step's
+            // bound output collection. `prevStepOutputs` keeps that
+            // collection alive until the NEXT iteration has consumed (re-bound)
+            // its OrtValues — at which point we can release it.
+            using var cudaMemInfo = new OrtMemoryInfo(
+                "Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+            IDisposableReadOnlyCollection<OrtValue>? prevStepOutputs = null;
             int pastLen = sMax;
             for (int step = 0; step < maxNewTokens && finishedCount < B; step++)
             {
@@ -693,13 +725,11 @@ public sealed class GraniteSpeech : IDisposable
                 {
                     stepInputIds[b] = finished[b] ? EosTokenId : nextTok[b];
                     int rowOff = b * (sMax + maxNewTokens + 1);
-                    stepAttnBuf[rowOff + pastLen] = 1L;  // new token position
+                    stepAttnBuf[rowOff + pastLen] = 1L;
+                    if (_hasPositionIdsInput) stepPositionIds[b] = realLen[b] + step;
                 }
                 cachePosStep[0] = pastLen;
 
-                // Build a contiguous [B, totalLen] attn mask for this step:
-                // ORT requires the OrtValue's backing memory to match the
-                // declared shape, so we copy out the live prefix per row.
                 var stepAttnFlat = new long[B * totalLen];
                 for (int b = 0; b < B; b++)
                 {
@@ -707,47 +737,53 @@ public sealed class GraniteSpeech : IDisposable
                     int dstOff = b * totalLen;
                     Array.Copy(stepAttnBuf, srcOff, stepAttnFlat, dstOff, totalLen);
                 }
-
-                using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
-                    stepInputIds, new long[] { B, 1 });
-                using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
-                    dummyAudio, new long[] { B, 1, audioDim });
                 using var stepAttnVal = OrtValue.CreateTensorValueFromMemory(
                     stepAttnFlat, new long[] { B, totalLen });
-                using var cachePosVal = OrtValue.CreateTensorValueFromMemory(
-                    cachePosStep, new long[] { 1 });
 
-                // Per-row position_ids for the new step token: realLen[b] + step.
-                long[]? stepPositionIds = null;
-                OrtValue? stepPosVal = null;
-                if (_hasPositionIdsInput)
+                using var stepBinding = _decoder.CreateIoBinding();
+                stepBinding.BindInput("input_ids",      stepInputIdVal);
+                stepBinding.BindInput("audio_embeds",   stepAudioVal);
+                stepBinding.BindInput("attention_mask", stepAttnVal);
+                stepBinding.BindInput("cache_position", cachePosVal);
+                if (stepPosVal is not null)
+                    stepBinding.BindInput("position_ids", stepPosVal);
+                for (int L = 0; L < NumDecoderLayers; L++)
                 {
-                    stepPositionIds = new long[B];
-                    for (int b = 0; b < B; b++)
-                        stepPositionIds[b] = realLen[b] + step;
-                    stepPosVal = OrtValue.CreateTensorValueFromMemory(
-                        stepPositionIds, new long[] { B, 1 });
+                    stepBinding.BindInput($"past_key_{L}",   pastKvs[2 * L]);
+                    stepBinding.BindInput($"past_value_{L}", pastKvs[2 * L + 1]);
                 }
+                // Bind output order matches `decOutputNames` so GetOutputValues()
+                // indices line up: [0]=logits, [1..40]=present_key_<L>,
+                // [41..80]=present_value_<L> — same convention as the non-
+                // IOBinding code path.
+                stepBinding.BindOutput("logits", stepLogitsVal);
+                for (int L = 0; L < NumDecoderLayers; L++)
+                    stepBinding.BindOutputToDevice($"present_key_{L}", cudaMemInfo);
+                for (int L = 0; L < NumDecoderLayers; L++)
+                    stepBinding.BindOutputToDevice($"present_value_{L}", cudaMemInfo);
 
-                var stepInputs = new List<OrtValue>(baseInputCount + 2 * NumDecoderLayers)
-                { stepInputIdVal, stepAudioVal, stepAttnVal, cachePosVal };
-                if (stepPosVal is not null) stepInputs.Add(stepPosVal);
-                stepInputs.AddRange(pastKvs);
+                _decoder.RunWithBinding(runOpts, stepBinding);
+                var curOutputs = stepBinding.GetOutputValues();
 
-                var outputs = _decoder.Run(
-                    runOpts, decInputNames, stepInputs, decOutputNames);
-
-                var oldPast = pastKvs;
                 pastKvs = new OrtValue[2 * NumDecoderLayers];
                 for (int L = 0; L < NumDecoderLayers; L++)
                 {
-                    pastKvs[2 * L]     = outputs[1 + L];
-                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
+                    pastKvs[2 * L]     = curOutputs[1 + L];
+                    pastKvs[2 * L + 1] = curOutputs[1 + NumDecoderLayers + L];
                 }
 
-                var stepLogits = outputs[0];
-                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
-                // Step logits shape: [B, 1, V]
+                // The previous iteration's collection no longer has any
+                // active borrowers (we just swapped pastKvs off it), so it
+                // can go. On the FIRST step, prevStepOutputs is null —
+                // pastKvs was pointing into prefillOutputs there, which we
+                // intentionally don't dispose because it owns the per-step
+                // logits OrtValue we already disposed earlier.
+                prevStepOutputs?.Dispose();
+                prevStepOutputs = curOutputs;
+
+                // Logits are in stepLogitsBuf (CPU) via BindOutput — direct
+                // .NET array read, no GetTensorDataAsSpan round-trip.
+                var stepLogitsSpan = new ReadOnlySpan<float>(stepLogitsBuf);
                 for (int b = 0; b < B; b++)
                 {
                     if (finished[b]) { nextTok[b] = EosTokenId; continue; }
@@ -766,14 +802,11 @@ public sealed class GraniteSpeech : IDisposable
                         finishedCount++;
                     }
                 }
-                stepLogits.Dispose();
-                stepPosVal?.Dispose();
-                foreach (var ov in oldPast) ov.Dispose();
                 pastLen = totalLen;
                 stepCountLocal++;
             }
 
-            foreach (var ov in pastKvs) ov.Dispose();
+            prevStepOutputs?.Dispose();
             if (swStep != null) { swStep.Stop(); stepLocal = swStep.ElapsedMilliseconds; }
         }
 

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -559,9 +559,30 @@ public sealed class GraniteSpeech : IDisposable
         var cachePosPrefill = new long[sMax];
         for (int i = 0; i < sMax; i++) cachePosPrefill[i] = i;
 
+        // Run 20 phase 6: dynamic-MHA-fused bundles also pass through this
+        // path, but their graph signature includes a `position_ids` input
+        // (the --unified-position-ids export adds it so the C# driver can
+        // feed per-row RoPE positions). Build per-row position_ids that
+        // map left-padded slot indices to the row's semantic positions
+        // [0, realLen[b]).
+        long[]? positionIdsPrefill = null;
+        if (_hasPositionIdsInput)
+        {
+            positionIdsPrefill = new long[B * sMax];
+            for (int b = 0; b < B; b++)
+            {
+                int padLen = sMax - realLen[b];
+                int rowOff = b * sMax;
+                for (int s = 0; s < sMax; s++)
+                    positionIdsPrefill[rowOff + s] = Math.Max(0, s - padLen);
+            }
+        }
+
         // ── Decoder: prefill + chained Run-with-OrtValue step loop ──────
-        var decInputNames = new List<string>(4 + 2 * NumDecoderLayers)
+        int baseInputCount = _hasPositionIdsInput ? 5 : 4;
+        var decInputNames = new List<string>(baseInputCount + 2 * NumDecoderLayers)
         { "input_ids", "audio_embeds", "attention_mask", "cache_position" };
+        if (_hasPositionIdsInput) decInputNames.Add("position_ids");
         for (int L = 0; L < NumDecoderLayers; L++)
         {
             decInputNames.Add($"past_key_{L}");
@@ -599,9 +620,15 @@ public sealed class GraniteSpeech : IDisposable
             if (aMax == 0)
                 audioEmbedsBatch = new float[B * 1 * (int)audioDim];
 
+            OrtValue? posPrefillVal = positionIdsPrefill is null
+                ? null
+                : OrtValue.CreateTensorValueFromMemory(
+                    positionIdsPrefill, new long[] { B, sMax });
+
             var emptyPasts = new List<OrtValue>(2 * NumDecoderLayers);
-            var prefillInputs = new List<OrtValue>(4 + 2 * NumDecoderLayers)
+            var prefillInputs = new List<OrtValue>(baseInputCount + 2 * NumDecoderLayers)
             { inputIdsVal, audioVal, attnVal, cpVal };
+            if (posPrefillVal is not null) prefillInputs.Add(posPrefillVal);
             long[] emptyPastShape = { B, NumKvHeads, 0, HeadDim };
             for (int L = 0; L < NumDecoderLayers; L++)
             {
@@ -627,6 +654,7 @@ public sealed class GraniteSpeech : IDisposable
                 if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
             }
             prefillOutputs[0].Dispose();
+            posPrefillVal?.Dispose();
             foreach (var p in emptyPasts) p.Dispose();
 
             // pastKvs = prefill output OrtValues, GPU-resident, chained forward.
@@ -689,8 +717,21 @@ public sealed class GraniteSpeech : IDisposable
                 using var cachePosVal = OrtValue.CreateTensorValueFromMemory(
                     cachePosStep, new long[] { 1 });
 
-                var stepInputs = new List<OrtValue>(4 + 2 * NumDecoderLayers)
+                // Per-row position_ids for the new step token: realLen[b] + step.
+                long[]? stepPositionIds = null;
+                OrtValue? stepPosVal = null;
+                if (_hasPositionIdsInput)
+                {
+                    stepPositionIds = new long[B];
+                    for (int b = 0; b < B; b++)
+                        stepPositionIds[b] = realLen[b] + step;
+                    stepPosVal = OrtValue.CreateTensorValueFromMemory(
+                        stepPositionIds, new long[] { B, 1 });
+                }
+
+                var stepInputs = new List<OrtValue>(baseInputCount + 2 * NumDecoderLayers)
                 { stepInputIdVal, stepAudioVal, stepAttnVal, cachePosVal };
+                if (stepPosVal is not null) stepInputs.Add(stepPosVal);
                 stepInputs.AddRange(pastKvs);
 
                 var outputs = _decoder.Run(
@@ -726,6 +767,7 @@ public sealed class GraniteSpeech : IDisposable
                     }
                 }
                 stepLogits.Dispose();
+                stepPosVal?.Dispose();
                 foreach (var ov in oldPast) ov.Dispose();
                 pastLen = totalLen;
                 stepCountLocal++;

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -110,6 +110,21 @@ public sealed class GraniteSpeech : IDisposable
     // GPU-resident and never touch managed memory.
     private readonly TensorElementType _pastKvDtype;
 
+    // Static-shape bundle plumbing (Run 15 phase 2c, issue #41).
+    // _isStaticBundle = true when the decoder graph pins past_kv / audio_embeds
+    // to fixed dims (the --static-shapes-unified export). The pinned values
+    // come from the graph's input metadata; we never hard-code 768 / 375 / 16
+    // here so that re-exports with different sizes work without a rebuild.
+    // The shared zero past_kv buffer is allocated once and referenced by all
+    // 2 × NumDecoderLayers prefill past_kv inputs — they're all-zero and
+    // ORT only reads, so sharing avoids 80 × 12 MB of redundant allocation.
+    private readonly bool _isStaticBundle;
+    private readonly int _staticBatchSize;
+    private readonly int _staticPastLen;
+    private readonly int _staticAudioLen;
+    private readonly Array? _staticZeroPastKvBuffer;
+    private readonly OrtValue[]? _staticZeroPastKv;
+
     private readonly string?[] _idToToken;
     private readonly Dictionary<int, string> _addedTokens;
     private readonly Dictionary<char, byte> _byteLevelDecode;
@@ -131,16 +146,86 @@ public sealed class GraniteSpeech : IDisposable
             ? pkMeta.ElementDataType
             : TensorElementType.Float;
 
+        // Static-shape bundle detection (Run 15 phase 2c, issue #41). The
+        // sliding-window static export pins past_kv to a fixed shape and
+        // slices KV outputs to match, eliminating Run 13's per-step
+        // CPU-resident shape island. Detect by reading past_key_0's
+        // dimensions from input metadata: positive integers across
+        // batch / past_len / head_dim => static; symbolic (-1) anywhere
+        // => dynamic, and we use the legacy TranscribeBatch path.
+        _isStaticBundle = false;
+        _staticBatchSize = 0;
+        _staticPastLen = 0;
+        _staticAudioLen = 0;
+        if (pkMeta is not null)
+        {
+            var dims = pkMeta.Dimensions;
+            // Expected static layout: [B, NumKvHeads, past_len, HeadDim].
+            if (dims.Length == 4 && dims[0] > 0 && dims[2] > 0)
+            {
+                _isStaticBundle = true;
+                _staticBatchSize = dims[0];
+                _staticPastLen   = dims[2];
+                if (_decoder.InputMetadata.TryGetValue("audio_embeds", out var aeMeta)
+                    && aeMeta.Dimensions.Length == 3 && aeMeta.Dimensions[1] > 0)
+                {
+                    _staticAudioLen = aeMeta.Dimensions[1];
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        "Static-shape decoder bundle declared past_kv with fixed past_len but "
+                      + "audio_embeds is not statically shaped. Re-export with --static-shapes-unified.");
+                }
+                // Pre-allocate the shared zero past_kv buffer once and bind it
+                // to 2 * NumDecoderLayers OrtValues (one buffer, many views).
+                // ORT only reads the past_kv at prefill; sharing is safe.
+                long total = (long)_staticBatchSize * NumKvHeads * _staticPastLen * HeadDim;
+                long[] shape = { _staticBatchSize, NumKvHeads, _staticPastLen, HeadDim };
+                _staticZeroPastKvBuffer = AllocateZeroPastKvBuffer(total);
+                _staticZeroPastKv = new OrtValue[2 * NumDecoderLayers];
+                for (int L = 0; L < NumDecoderLayers; L++)
+                {
+                    _staticZeroPastKv[2 * L]     = CreateZeroPastKvView(_staticZeroPastKvBuffer, shape);
+                    _staticZeroPastKv[2 * L + 1] = CreateZeroPastKvView(_staticZeroPastKvBuffer, shape);
+                }
+            }
+        }
+
         _vramBudgetForKvBytes = QueryVramBudget();
     }
 
     public void Dispose()
     {
+        if (_staticZeroPastKv is not null)
+        {
+            foreach (var ov in _staticZeroPastKv) ov.Dispose();
+        }
         _mel.Dispose();
         _encoder.Dispose();
         _projector.Dispose();
         _decoder.Dispose();
     }
+
+    // ── Static-shape helpers (Run 15 phase 2c) ───────────────────────────
+
+    private Array AllocateZeroPastKvBuffer(long totalElements) => _pastKvDtype switch
+    {
+        TensorElementType.Float    => new float[totalElements],
+        TensorElementType.BFloat16 => new BFloat16[totalElements],
+        TensorElementType.Float16  => new Float16[totalElements],
+        _ => throw new InvalidOperationException(
+            $"Unsupported past_kv dtype {_pastKvDtype}."),
+    };
+
+    private OrtValue CreateZeroPastKvView(Array sharedBuffer, long[] shape) => _pastKvDtype switch
+    {
+        TensorElementType.Float    => OrtValue.CreateTensorValueFromMemory((float[])sharedBuffer, shape),
+        TensorElementType.BFloat16 => OrtValue.CreateTensorValueFromMemory((BFloat16[])sharedBuffer, shape),
+        TensorElementType.Float16  => OrtValue.CreateTensorValueFromMemory((Float16[])sharedBuffer, shape),
+        _ => throw new InvalidOperationException(
+            $"Unsupported past_kv dtype {_pastKvDtype}."),
+    };
 
     // ── Audio-token-count derivation ────────────────────────────────────
 
@@ -314,6 +399,11 @@ public sealed class GraniteSpeech : IDisposable
 
     private (string text, long[] tokens)[] TranscribeBatch(float[][] waveforms, int maxNewTokens)
     {
+        // Static-shape bundle (Run 15 phase 2c) takes the padded-to-fixed-B
+        // path; the legacy dynamic-shape bundle keeps the original loop.
+        if (_isStaticBundle)
+            return TranscribeBatchStatic(waveforms, maxNewTokens);
+
         int B = waveforms.Length;
         if (B == 0) return Array.Empty<(string, long[])>();
 
@@ -640,6 +730,359 @@ public sealed class GraniteSpeech : IDisposable
                 $"[granite-prof] B={B} total={total}ms (mel={melLocal} enc={encLocal} "
               + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
               + $"overhead={overhead}ms)");
+        }
+        return rows;
+    }
+
+    // ── Static-shape decoder path (Run 15 phase 2c, issue #41) ─────────────
+    /// <summary>
+    /// Transcribes a batch through the static-shape decoder bundle. The
+    /// graph pins past_kv to (StaticBatchSize, NumKvHeads, StaticPastLen,
+    /// HeadDim) and audio_embeds to (StaticBatchSize, StaticAudioLen,
+    /// audioDim); the wrapper-level slice in the export keeps present_kv
+    /// the same shape as past_kv so the chained Run-with-OrtValue pattern
+    /// works verbatim, GPU-resident throughout. Compared to the dynamic
+    /// path (TranscribeBatch above) the differences are:
+    ///
+    ///   - Real batch size B_real may be less than StaticBatchSize; we
+    ///     pad to StaticBatchSize with PAD-token rows whose attention
+    ///     mask is fully zero. They get computed but discarded.
+    ///   - audio_embeds is right-zero-padded to StaticAudioLen.
+    ///   - past_kv comes in at past_len = StaticPastLen (not 0); the
+    ///     attention mask gates all StaticPastLen positions out at
+    ///     prefill. The shared all-zero past_kv buffer is allocated once
+    ///     in the ctor and reused.
+    ///   - cache_position values are StaticPastLen, StaticPastLen+1, ...
+    ///     because the empty-prefix cache positions [0, StaticPastLen)
+    ///     are conceptually before-the-start.
+    ///   - At each step the attention mask shifts left: the cache
+    ///     positions that were "real" creep one slot earlier as the
+    ///     sliding window absorbs the new token.
+    ///
+    /// All other logic (per-row mel/encoder/projector, repetition-loop
+    /// detection, EOS handling, profile bookkeeping) mirrors TranscribeBatch.
+    /// </summary>
+    private (string text, long[] tokens)[] TranscribeBatchStatic(float[][] waveforms, int maxNewTokens)
+    {
+        int realB = waveforms.Length;
+        if (realB == 0) return Array.Empty<(string, long[])>();
+        if (realB > _staticBatchSize)
+            throw new InvalidOperationException(
+                $"Static-shape decoder requires batch size <= {_staticBatchSize}; got {realB}.");
+
+        int B = _staticBatchSize;
+        int A = _staticAudioLen;
+        int P = _staticPastLen;
+
+        var swBatch = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+        long melLocal = 0, encLocal = 0, projLocal = 0;
+
+        // ── Per-row mel + encoder + projector (only for real rows) ──────
+        var audioEmbeds = new float[realB][];
+        var nAudio      = new int[realB];
+        long audioDim   = 2048;
+        for (int b = 0; b < realB; b++)
+        {
+            int audioTokens = NumAudioTokens(waveforms[b].Length);
+            int promptLen   = AsrPromptPrefix.Length + audioTokens + AsrPromptSuffix.Length;
+            if (promptLen + maxNewTokens > P)
+            {
+                throw new InvalidOperationException(
+                    $"Segment too long for static-shape bundle: prompt+max_new_tokens "
+                  + $"({promptLen + maxNewTokens}) exceeds pinned past_len ({P}). "
+                  + $"Re-export with a larger --static-past-len, or pre-segment audio.");
+            }
+            if (audioTokens > A)
+            {
+                throw new InvalidOperationException(
+                    $"Segment too long for static-shape bundle: audio_tokens ({audioTokens}) "
+                  + $"exceeds pinned audio_len ({A}). Re-export with a larger "
+                  + $"--static-audio-len, or pre-segment audio.");
+            }
+
+            var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+            var audioT = new DenseTensor<float>(waveforms[b], [1, waveforms[b].Length]);
+            using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
+            var inputFeatures = melResults[0].AsTensor<float>();
+            var ifShape = inputFeatures.Dimensions.ToArray();
+            var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
+            if (swStage != null) { swStage.Stop(); melLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+            using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
+                "input_features", new DenseTensor<float>(ifData, ifShape))]);
+            var encoderHidden = encResults[0].AsTensor<float>();
+            var encShape = encoderHidden.Dimensions.ToArray();
+            var encData = encoderHidden.ToArray();
+            if (swStage != null) { swStage.Stop(); encLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+            using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
+                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
+            var ae = projResults[0].AsTensor<float>();
+            var projShape = ae.Dimensions.ToArray();
+            if (projShape[1] != audioTokens)
+                throw new InvalidOperationException(
+                    $"Audio token count mismatch (row {b}): formula predicts {audioTokens}, "
+                  + $"projector produced {projShape[1]}.");
+            audioEmbeds[b] = ae.ToArray();
+            nAudio[b]      = audioTokens;
+            audioDim       = projShape[2];
+            if (swStage != null) { swStage.Stop(); projLocal += swStage.ElapsedMilliseconds; }
+        }
+
+        // ── Build padded prompt at fixed B ───────────────────────────────
+        var realLen = new int[B];   // 0 for padding rows (b >= realB)
+        int sMaxReal = 0;
+        for (int b = 0; b < realB; b++)
+        {
+            realLen[b] = AsrPromptPrefix.Length + nAudio[b] + AsrPromptSuffix.Length;
+            if (realLen[b] > sMaxReal) sMaxReal = realLen[b];
+        }
+        int S = sMaxReal;  // graph keeps seq dynamic; use real max across the batch
+
+        var inputIdsBatch = new long[B * S];
+        for (int b = 0; b < realB; b++)
+        {
+            int padLen = S - realLen[b];
+            int rowOff = b * S;
+            for (int s = 0; s < padLen; s++) inputIdsBatch[rowOff + s] = PadTokenId;
+            int p = rowOff + padLen;
+            for (int i = 0; i < AsrPromptPrefix.Length; i++) inputIdsBatch[p++] = AsrPromptPrefix[i];
+            for (int i = 0; i < nAudio[b]; i++)              inputIdsBatch[p++] = AudioTokenId;
+            for (int i = 0; i < AsrPromptSuffix.Length; i++) inputIdsBatch[p++] = AsrPromptSuffix[i];
+        }
+        // Padding rows (b >= realB): all PadTokenId. attention_mask stays 0.
+        for (int b = realB; b < B; b++)
+        {
+            int rowOff = b * S;
+            for (int s = 0; s < S; s++) inputIdsBatch[rowOff + s] = PadTokenId;
+        }
+
+        // attention_mask at prefill: shape [B, P + S]. First P positions are
+        // empty cache (mask=0). Remaining S per row: padLen zeros + realLen ones.
+        var attnMaskPrefill = new long[B * (P + S)];
+        for (int b = 0; b < realB; b++)
+        {
+            int padLen = S - realLen[b];
+            int rowOff = b * (P + S);
+            for (int s = padLen; s < S; s++) attnMaskPrefill[rowOff + P + s] = 1L;
+        }
+
+        // audio_embeds at prefill: [B, A, audioDim], real rows zero-padded
+        // up to A on the audio_len axis. Padding rows are all zero.
+        var audioEmbedsBatch = new float[B * A * audioDim];
+        for (int b = 0; b < realB; b++)
+        {
+            int rowOff = b * A * (int)audioDim;
+            int n = nAudio[b] * (int)audioDim;
+            if (n > 0) Array.Copy(audioEmbeds[b], 0, audioEmbedsBatch, rowOff, n);
+        }
+
+        // cache_position at prefill: positions P, P+1, ..., P+S-1.
+        // The first P cache slots are conceptually before-the-start (zero
+        // past + masked) so the new tokens land at "real" positions starting
+        // at index P. Granite's RoPE uses cache_position as the absolute
+        // position; with our right-aligned cache layout this matches the
+        // model's expected position numbering.
+        var cachePosPrefill = new long[S];
+        for (int i = 0; i < S; i++) cachePosPrefill[i] = P + i;
+
+        // ── Decoder I/O names ────────────────────────────────────────────
+        var decInputNames = new List<string>(4 + 2 * NumDecoderLayers)
+        { "input_ids", "audio_embeds", "attention_mask", "cache_position" };
+        for (int L = 0; L < NumDecoderLayers; L++)
+        {
+            decInputNames.Add($"past_key_{L}");
+            decInputNames.Add($"past_value_{L}");
+        }
+        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { "logits" };
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_key_{L}");
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_value_{L}");
+
+        var generated = new List<long>[B];
+        for (int b = 0; b < B; b++) generated[b] = new List<long>(maxNewTokens);
+        var finished      = new bool[B];
+        var loopDetected  = new bool[B];
+        int finishedCount = 0;
+        var nextTok       = new long[B];
+
+        // Mark padding rows as finished — their decoded output is discarded
+        // anyway, and we don't want them dragging the rest of the batch
+        // toward maxNewTokens.
+        for (int b = realB; b < B; b++) { finished[b] = true; finishedCount++; }
+
+        long prefillLocal = 0, stepLocal = 0;
+        long stepCountLocal = 0;
+        using (var runOpts = new RunOptions())
+        {
+            var swPrefill = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Prefill ──────────────────────────────────────────────────
+            using var inputIdsVal = OrtValue.CreateTensorValueFromMemory(
+                inputIdsBatch, new long[] { B, S });
+            using var audioVal = OrtValue.CreateTensorValueFromMemory(
+                audioEmbedsBatch, new long[] { B, A, audioDim });
+            using var attnVal = OrtValue.CreateTensorValueFromMemory(
+                attnMaskPrefill, new long[] { B, P + S });
+            using var cpVal = OrtValue.CreateTensorValueFromMemory(
+                cachePosPrefill, new long[] { S });
+
+            var prefillInputs = new List<OrtValue>(4 + 2 * NumDecoderLayers)
+            { inputIdsVal, audioVal, attnVal, cpVal };
+            // Reuse the shared zero past_kv from the ctor — read-only at prefill.
+            prefillInputs.AddRange(_staticZeroPastKv!);
+
+            var prefillOutputs = _decoder.Run(runOpts, decInputNames, prefillInputs, decOutputNames);
+
+            // Argmax per real row at the LAST position (S-1); padding rows
+            // don't contribute. Left-padding inside the row means the real
+            // last token always sits at S-1 after the prompt.
+            var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+            for (int b = 0; b < realB; b++)
+            {
+                long tok = ArgmaxRowLastPosition(prefillLogitsSpan, b, S, VocabSize);
+                nextTok[b] = tok;
+                generated[b].Add(tok);
+                if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+            }
+            prefillOutputs[0].Dispose();
+
+            // pastKvs = prefill's sliced output. Already shape (B, H, P, D).
+            var pastKvs = new OrtValue[2 * NumDecoderLayers];
+            for (int L = 0; L < NumDecoderLayers; L++)
+            {
+                pastKvs[2 * L]     = prefillOutputs[1 + L];
+                pastKvs[2 * L + 1] = prefillOutputs[1 + NumDecoderLayers + L];
+            }
+
+            if (swPrefill != null) { swPrefill.Stop(); prefillLocal = swPrefill.ElapsedMilliseconds; }
+            var swStep = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Step loop ────────────────────────────────────────────────
+            // cache_position monotonically increases: prefill used [P..P+S-1],
+            // so step 0 starts at P+S and grows by 1 per step. Granite uses
+            // RoPE only; relative-position dependence dominates so the
+            // absolute offset (starting at P instead of 0) is shift-
+            // invariant in attention math.
+            long[] cachePosStep = new long[1];
+            // Static graph pins audio_embeds shape to (B, A, audioDim). At
+            // step time the audio fuse collapses to a no-op (no AudioTokenId
+            // in the next-token input), so we pass an A-sized zero buffer.
+            // Allocated once and the OrtValue recreated each step pointing
+            // at the same buffer.
+            float[] dummyAudio = new float[B * A * (int)audioDim];
+
+            for (int step = 0; step < maxNewTokens && finishedCount < B; step++)
+            {
+                cachePosStep[0] = P + S + step;
+                long[] stepInputIds = new long[B];
+                for (int b = 0; b < B; b++)
+                {
+                    stepInputIds[b] = (b >= realB || finished[b]) ? EosTokenId : nextTok[b];
+                }
+
+                // Build attention mask for this step: shape (B, P + 1).
+                // For row b: (P - realLen[b] - step) zeros + (realLen[b] +
+                // step + 1) ones. As step advances, the "real" prefix
+                // length grows. The pinning P >= prompt + max_new_tokens
+                // (checked above) keeps realStart >= 0.
+                var stepMask = new long[B * (P + 1)];
+                for (int b = 0; b < realB; b++)
+                {
+                    int realStart = P - realLen[b] - step;
+                    int rowOff = b * (P + 1);
+                    for (int t = realStart; t < P + 1; t++) stepMask[rowOff + t] = 1L;
+                }
+                // Padding rows: leave mask all zeros so the decoder treats
+                // them as completely-padded; their output is discarded.
+
+                using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
+                    stepInputIds, new long[] { B, 1 });
+                using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
+                    dummyAudio, new long[] { B, A, audioDim });
+                using var stepAttnVal = OrtValue.CreateTensorValueFromMemory(
+                    stepMask, new long[] { B, P + 1 });
+                using var cachePosVal = OrtValue.CreateTensorValueFromMemory(
+                    cachePosStep, new long[] { 1 });
+
+                var stepInputs = new List<OrtValue>(4 + 2 * NumDecoderLayers)
+                { stepInputIdVal, stepAudioVal, stepAttnVal, cachePosVal };
+                stepInputs.AddRange(pastKvs);
+
+                var outputs = _decoder.Run(runOpts, decInputNames, stepInputs, decOutputNames);
+
+                var oldPast = pastKvs;
+                pastKvs = new OrtValue[2 * NumDecoderLayers];
+                for (int L = 0; L < NumDecoderLayers; L++)
+                {
+                    pastKvs[2 * L]     = outputs[1 + L];
+                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
+                }
+
+                var stepLogits = outputs[0];
+                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
+                for (int b = 0; b < realB; b++)
+                {
+                    if (finished[b]) { nextTok[b] = EosTokenId; continue; }
+                    long tok = ArgmaxRowLastPosition(stepLogitsSpan, b, 1, VocabSize);
+                    nextTok[b] = tok;
+                    generated[b].Add(tok);
+                    if (tok == EosTokenId)
+                    {
+                        finished[b] = true;
+                        finishedCount++;
+                    }
+                    else if (IsRepetitionLoop(generated[b]))
+                    {
+                        finished[b] = true;
+                        loopDetected[b] = true;
+                        finishedCount++;
+                    }
+                }
+                stepLogits.Dispose();
+                foreach (var ov in oldPast) ov.Dispose();
+                stepCountLocal++;
+            }
+
+            foreach (var ov in pastKvs) ov.Dispose();
+            if (swStep != null) { swStep.Stop(); stepLocal = swStep.ElapsedMilliseconds; }
+        }
+
+        // Trim trailing EOS / runaway-loop tail per row (real rows only).
+        var rows = new (string text, long[] tokens)[realB];
+        for (int b = 0; b < realB; b++)
+        {
+            var toks = generated[b];
+            int realCount = toks.Count;
+            while (realCount > 0 && toks[realCount - 1] == EosTokenId) realCount--;
+            int trimmed = loopDetected[b]
+                ? TrimRepetitionTail(toks, realCount)
+                : realCount;
+            if (trimmed == toks.Count)
+                rows[b] = (DecodeTokens(toks), toks.ToArray());
+            else
+            {
+                var trimmedToks = toks.GetRange(0, trimmed);
+                rows[b] = (DecodeTokens(trimmedToks), trimmedToks.ToArray());
+            }
+        }
+
+        if (swBatch != null)
+        {
+            swBatch.Stop();
+            long total = swBatch.ElapsedMilliseconds;
+            long accounted = melLocal + encLocal + projLocal + prefillLocal + stepLocal;
+            long overhead = Math.Max(0, total - accounted);
+            lock (_profileLock)
+            {
+                MelMs += melLocal; EncMs += encLocal; ProjMs += projLocal;
+                PrefillMs += prefillLocal; StepLoopMs += stepLocal; OverheadMs += overhead;
+                BatchCount++; RowCount += realB; StepCount += stepCountLocal;
+                if (realB > MaxBatchSeen) MaxBatchSeen = realB;
+            }
+            Console.Error.WriteLine(
+                $"[granite-prof] B={realB}/{B} total={total}ms (mel={melLocal} enc={encLocal} "
+              + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
+              + $"overhead={overhead}ms) static");
         }
         return rows;
     }

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -126,6 +126,12 @@ public sealed class GraniteSpeech : IDisposable
                                             // decoder graph input. Selects a
                                             // left-aligned cache + compute-skip
                                             // code path (Run 20).
+    private readonly bool _hasPositionIdsInput;  // Set when the decoder graph
+                                            // has a `position_ids` input (the
+                                            // Run 20 phase 2 export). Lets the
+                                            // C# driver feed per-row RoPE
+                                            // positions and restore batched
+                                            // dispatch.
     private readonly int _staticBatchSize;
     private readonly int _staticPastLen;
     private readonly int _staticAudioLen;
@@ -162,6 +168,7 @@ public sealed class GraniteSpeech : IDisposable
         // => dynamic, and we use the legacy TranscribeBatch path.
         _isStaticBundle = false;
         _isGqaBundle = _decoder.InputMetadata.ContainsKey("seqlens_k");
+        _hasPositionIdsInput = _decoder.InputMetadata.ContainsKey("position_ids");
         _staticBatchSize = 0;
         _staticPastLen = 0;
         _staticAudioLen = 0;
@@ -778,10 +785,15 @@ public sealed class GraniteSpeech : IDisposable
             throw new InvalidOperationException(
                 $"Static-shape decoder requires batch size <= {_staticBatchSize}; got {realB}.");
 
-        // GQA bundle (Run 20): cache_position and per-row real length must
-        // agree across the batch for RoPE positions to be consistent. We
-        // sidestep variable-length batching by serialising — one segment per
-        // call, with B-1 dummy rows for static-shape compliance.
+        // GQA bundles split by capability:
+        //   - phase-2 (has `position_ids` input): per-row RoPE positions
+        //     let the whole batch run together. Use TranscribeStaticGqaBatched.
+        //   - phase-1 (no position_ids): cache_position is shared across the
+        //     batch, so we can't mix variable-length prompts. Fall back to
+        //     serialising one segment per call.
+        if (_isGqaBundle && _hasPositionIdsInput)
+            return TranscribeStaticGqaBatched(waveforms, maxNewTokens);
+
         if (_isGqaBundle)
         {
             var gqaRows = new (string text, long[] tokens)[realB];
@@ -1385,6 +1397,358 @@ public sealed class GraniteSpeech : IDisposable
         return (text, outputTokens);
     }
 
+    /// <summary>
+    /// Batched static-shape decode against a GQA-rewritten bundle that
+    /// also exposes a `position_ids` graph input (Run 20 phase 2 export
+    /// with `--unified-position-ids`).
+    ///
+    /// Prompts are right-padded to S = max(realLen): each real row's
+    /// prompt sits at [0, realLen[b]) of the row, and PAD tokens fill
+    /// [realLen[b], S). Dummy rows (b ≥ realB) are all PAD.
+    ///
+    /// At prefill we use a UNIFORM seqlens_k = S - 1 — GQA's write
+    /// region is derived from seqlens_k - new_S + 1 and won't accept
+    /// per-row write positions inside one call. This writes pad K into
+    /// past_kv[b, realLen[b], S) for shorter rows; that contamination
+    /// is paid by the prefill's own attention compute and would also
+    /// poison step-time attention if we left it there.
+    ///
+    /// At STEP time we switch to per-row seqlens_k[b] = realLen[b] + k,
+    /// so GQA's write position is exactly past_kv[b, realLen[b]+k].
+    /// Step k=0 overwrites the first pad slot at past_kv[b, realLen[b]],
+    /// step k=1 overwrites the next, etc. — the per-row attention bound
+    /// [0, realLen[b]+k+1) never reaches the un-overwritten pad slots,
+    /// so step-time attention is clean regardless of what prefill wrote
+    /// to the pad region.
+    ///
+    /// position_ids are per-row throughout: real tokens get [0..realLen[b]),
+    /// pad tokens get [realLen[b]..S) (continuing the sequence so RoPE
+    /// is stable across the prefill→step boundary), and step k's new
+    /// token uses position realLen[b] + k.
+    /// </summary>
+    private (string text, long[] tokens)[] TranscribeStaticGqaBatched(
+        float[][] waveforms, int maxNewTokens)
+    {
+        int realB = waveforms.Length;
+        int B = _staticBatchSize;
+        int A = _staticAudioLen;
+        int P = _staticPastLen;
+
+        var swBatch = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+        long melLocal = 0, encLocal = 0, projLocal = 0;
+
+        // ── Per-row mel + encoder + projector ────────────────────────────
+        var audioEmbeds = new float[realB][];
+        var nAudio      = new int[realB];
+        long audioDim   = 2048;
+        for (int b = 0; b < realB; b++)
+        {
+            int audioTokens = NumAudioTokens(waveforms[b].Length);
+            int promptLen   = AsrPromptPrefix.Length + audioTokens + AsrPromptSuffix.Length;
+            if (promptLen + maxNewTokens > P)
+                throw new InvalidOperationException(
+                    $"Segment too long for static-shape GQA bundle: prompt+max_new_tokens "
+                  + $"({promptLen + maxNewTokens}) exceeds pinned past_len ({P}).");
+            if (audioTokens > A)
+                throw new InvalidOperationException(
+                    $"Segment too long: audio_tokens ({audioTokens}) > pinned A ({A}).");
+
+            var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+            var audioT = new DenseTensor<float>(waveforms[b], [1, waveforms[b].Length]);
+            using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
+            var inputFeatures = melResults[0].AsTensor<float>();
+            var ifShape = inputFeatures.Dimensions.ToArray();
+            var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
+            if (swStage != null) { swStage.Stop(); melLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+            using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
+                "input_features", new DenseTensor<float>(ifData, ifShape))]);
+            var encoderHidden = encResults[0].AsTensor<float>();
+            var encShape = encoderHidden.Dimensions.ToArray();
+            var encData = encoderHidden.ToArray();
+            if (swStage != null) { swStage.Stop(); encLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+            using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
+                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
+            var ae = projResults[0].AsTensor<float>();
+            audioDim = ae.Dimensions[2];
+            audioEmbeds[b] = ae.ToArray();
+            nAudio[b] = audioTokens;
+            if (swStage != null) { swStage.Stop(); projLocal += swStage.ElapsedMilliseconds; }
+        }
+
+        // ── Build padded prompt at fixed B ───────────────────────────────
+        var realLen = new int[B];   // 0 for dummies
+        int sMax = 0;
+        for (int b = 0; b < realB; b++)
+        {
+            realLen[b] = AsrPromptPrefix.Length + nAudio[b] + AsrPromptSuffix.Length;
+            if (realLen[b] > sMax) sMax = realLen[b];
+        }
+        if (sMax == 0) sMax = 1;
+        int S = sMax;
+
+        // input_ids [B, S]: right-padded. Real rows: prompt at [0, realLen[b]),
+        // PAD at [realLen[b], S). Dummies: all PAD.
+        var inputIdsBatch = new long[B * S];
+        for (int b = 0; b < realB; b++)
+        {
+            int rowOff = b * S;
+            int q = rowOff;
+            for (int i = 0; i < AsrPromptPrefix.Length; i++) inputIdsBatch[q++] = AsrPromptPrefix[i];
+            for (int i = 0; i < nAudio[b]; i++) inputIdsBatch[q++] = AudioTokenId;
+            for (int i = 0; i < AsrPromptSuffix.Length; i++) inputIdsBatch[q++] = AsrPromptSuffix[i];
+            for (int i = realLen[b]; i < S; i++) inputIdsBatch[rowOff + i] = PadTokenId;
+        }
+        for (int b = realB; b < B; b++)
+        {
+            int rowOff = b * S;
+            for (int i = 0; i < S; i++) inputIdsBatch[rowOff + i] = PadTokenId;
+        }
+
+        // audio_embeds [B, A, audioDim]: real audio at the start of each
+        // real row, zero elsewhere.
+        var audioEmbedsBatch = new float[B * A * (int)audioDim];
+        for (int b = 0; b < realB; b++)
+        {
+            int rowOff = b * A * (int)audioDim;
+            int n = nAudio[b] * (int)audioDim;
+            if (n > 0) Array.Copy(audioEmbeds[b], 0, audioEmbedsBatch, rowOff, n);
+        }
+
+        // attention_mask [B, S]: real rows have 1s at [0, realLen[b]).
+        // Dead-code in the GQA-rewritten graph but still part of the
+        // graph signature.
+        var attnMaskBatch = new long[B * S];
+        for (int b = 0; b < realB; b++)
+        {
+            int rowOff = b * S;
+            for (int i = 0; i < realLen[b]; i++) attnMaskBatch[rowOff + i] = 1L;
+        }
+
+        // cache_position [S]: shared sequence index 0..S-1. Used by the
+        // wrapper's now-dead RoPE/mask construction; harmless.
+        var cachePosBuf = new long[S];
+        for (int i = 0; i < S; i++) cachePosBuf[i] = i;
+
+        // position_ids [B, S]: per-row. Real positions at [0..realLen[b]),
+        // pad positions continue [realLen[b]..S-1] so RoPE is stable.
+        // Dummies use the same scheme (they don't matter).
+        var positionIdsBatch = new long[B * S];
+        for (int b = 0; b < B; b++)
+        {
+            int rowOff = b * S;
+            for (int i = 0; i < S; i++) positionIdsBatch[rowOff + i] = i;
+        }
+
+        // seqlens_k [B] int32: at prefill, UNIFORM = S - 1 (GQA can't accept
+        // per-row write positions inside one call). Per-row is restored at
+        // step time.
+        var seqlensKBuf = new int[B];
+        for (int b = 0; b < B; b++) seqlensKBuf[b] = S - 1;
+        var totalSeqBuf = new int[] { S };
+
+        // ── Decoder I/O names ────────────────────────────────────────────
+        var decInputNames = new List<string>(7 + 2 * NumDecoderLayers)
+        { "input_ids", "audio_embeds", "attention_mask", "cache_position", "position_ids" };
+        for (int L = 0; L < NumDecoderLayers; L++)
+        {
+            decInputNames.Add($"past_key_{L}");
+            decInputNames.Add($"past_value_{L}");
+        }
+        decInputNames.Add("seqlens_k");
+        decInputNames.Add("total_sequence_length");
+
+        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { "logits" };
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_key_{L}");
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_value_{L}");
+
+        var generated = new List<long>[B];
+        for (int b = 0; b < B; b++) generated[b] = new List<long>(maxNewTokens);
+        var finished     = new bool[B];
+        var loopDetected = new bool[B];
+        int finishedCount = 0;
+        var nextTok      = new long[B];
+        for (int b = realB; b < B; b++) { finished[b] = true; finishedCount++; }
+
+        long prefillLocal = 0, stepLocal = 0;
+        long stepCountLocal = 0;
+
+        using (var runOpts = new RunOptions())
+        {
+            var swPrefill = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            using var inputIdsVal = OrtValue.CreateTensorValueFromMemory(
+                inputIdsBatch, new long[] { B, S });
+            using var audioVal = OrtValue.CreateTensorValueFromMemory(
+                audioEmbedsBatch, new long[] { B, A, audioDim });
+            using var attnVal = OrtValue.CreateTensorValueFromMemory(
+                attnMaskBatch, new long[] { B, S });
+            using var cpVal = OrtValue.CreateTensorValueFromMemory(
+                cachePosBuf, new long[] { S });
+            using var posVal = OrtValue.CreateTensorValueFromMemory(
+                positionIdsBatch, new long[] { B, S });
+            using var seqlensVal = OrtValue.CreateTensorValueFromMemory(
+                seqlensKBuf, new long[] { B });
+            using var totalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                totalSeqBuf, Array.Empty<long>());
+
+            var prefillInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
+            { inputIdsVal, audioVal, attnVal, cpVal, posVal };
+            prefillInputs.AddRange(_staticZeroPastKv!);
+            prefillInputs.Add(seqlensVal);
+            prefillInputs.Add(totalSeqVal);
+
+            var prefillOutputs = _decoder.Run(
+                runOpts, decInputNames, prefillInputs, decOutputNames);
+
+            // Per-row argmax at realLen[b]-1 (last real token).
+            var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+            for (int b = 0; b < realB; b++)
+            {
+                long tok = ArgmaxRowAtPosition(prefillLogitsSpan, b, S, realLen[b] - 1, VocabSize);
+                nextTok[b] = tok;
+                generated[b].Add(tok);
+                if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+            }
+            prefillOutputs[0].Dispose();
+
+            var pastKvs = new OrtValue[2 * NumDecoderLayers];
+            for (int L = 0; L < NumDecoderLayers; L++)
+            {
+                pastKvs[2 * L]     = prefillOutputs[1 + L];
+                pastKvs[2 * L + 1] = prefillOutputs[1 + NumDecoderLayers + L];
+            }
+
+            if (swPrefill != null) { swPrefill.Stop(); prefillLocal = swPrefill.ElapsedMilliseconds; }
+            var swStep = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Step loop ────────────────────────────────────────────────
+            float[] dummyAudio = new float[B * A * (int)audioDim];
+            long[] stepInputIds = new long[B];
+            long[] cachePosStep = new long[1];
+            long[] stepPositionIds = new long[B];   // shape [B, 1] flattened
+
+            for (int step = 0; step < maxNewTokens && finishedCount < B; step++)
+            {
+                // Per-row seqlens_k: realLen[b] + step (= write position).
+                int maxTotalLen = 0;
+                for (int b = 0; b < B; b++)
+                {
+                    int sl = (b < realB ? realLen[b] : realLen[Math.Max(0, realB - 1)]) + step;
+                    seqlensKBuf[b] = sl;
+                    int rowTotal = sl + 1;
+                    if (rowTotal > maxTotalLen) maxTotalLen = rowTotal;
+                    stepPositionIds[b] = sl;          // RoPE at the write position
+                    stepInputIds[b] = (b >= realB || finished[b]) ? EosTokenId : nextTok[b];
+                }
+                int totalLen = maxTotalLen;
+                totalSeqBuf[0] = totalLen;
+                cachePosStep[0] = totalLen - 1;       // shared; only used by dead code
+
+                // attention_mask [B, totalLen]: real rows have 1s at [0, realLen[b]+step+1).
+                var stepMaskBatch = new long[B * totalLen];
+                for (int b = 0; b < realB; b++)
+                {
+                    int rowOff = b * totalLen;
+                    int end = realLen[b] + step + 1;
+                    if (end > totalLen) end = totalLen;
+                    for (int i = 0; i < end; i++) stepMaskBatch[rowOff + i] = 1L;
+                }
+
+                using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
+                    stepInputIds, new long[] { B, 1 });
+                using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
+                    dummyAudio, new long[] { B, A, audioDim });
+                using var stepAttnVal = OrtValue.CreateTensorValueFromMemory(
+                    stepMaskBatch, new long[] { B, totalLen });
+                using var stepCpVal = OrtValue.CreateTensorValueFromMemory(
+                    cachePosStep, new long[] { 1 });
+                using var stepPosVal = OrtValue.CreateTensorValueFromMemory(
+                    stepPositionIds, new long[] { B, 1 });
+                using var stepSeqlensVal = OrtValue.CreateTensorValueFromMemory(
+                    seqlensKBuf, new long[] { B });
+                using var stepTotalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                    totalSeqBuf, Array.Empty<long>());
+
+                var stepInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
+                { stepInputIdVal, stepAudioVal, stepAttnVal, stepCpVal, stepPosVal };
+                stepInputs.AddRange(pastKvs);
+                stepInputs.Add(stepSeqlensVal);
+                stepInputs.Add(stepTotalSeqVal);
+
+                var outputs = _decoder.Run(
+                    runOpts, decInputNames, stepInputs, decOutputNames);
+
+                var oldPast = pastKvs;
+                pastKvs = new OrtValue[2 * NumDecoderLayers];
+                for (int L = 0; L < NumDecoderLayers; L++)
+                {
+                    pastKvs[2 * L]     = outputs[1 + L];
+                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
+                }
+
+                var stepLogits = outputs[0];
+                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
+                for (int b = 0; b < realB; b++)
+                {
+                    if (finished[b]) { nextTok[b] = EosTokenId; continue; }
+                    long tok = ArgmaxRowLastPosition(stepLogitsSpan, b, 1, VocabSize);
+                    nextTok[b] = tok;
+                    generated[b].Add(tok);
+                    if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+                    else if (IsRepetitionLoop(generated[b]))
+                    {
+                        finished[b] = true; loopDetected[b] = true; finishedCount++;
+                    }
+                }
+                stepLogits.Dispose();
+                foreach (var ov in oldPast) ov.Dispose();
+                stepCountLocal++;
+            }
+
+            foreach (var ov in pastKvs) ov.Dispose();
+            if (swStep != null) { swStep.Stop(); stepLocal = swStep.ElapsedMilliseconds; }
+        }
+
+        // Trim + decode per real row.
+        var rows = new (string text, long[] tokens)[realB];
+        for (int b = 0; b < realB; b++)
+        {
+            var toks = generated[b];
+            int realCount = toks.Count;
+            while (realCount > 0 && toks[realCount - 1] == EosTokenId) realCount--;
+            int trimmed = loopDetected[b] ? TrimRepetitionTail(toks, realCount) : realCount;
+            if (trimmed == toks.Count)
+                rows[b] = (DecodeTokens(toks), toks.ToArray());
+            else
+            {
+                var trimmedToks = toks.GetRange(0, trimmed);
+                rows[b] = (DecodeTokens(trimmedToks), trimmedToks.ToArray());
+            }
+        }
+
+        if (swBatch != null)
+        {
+            swBatch.Stop();
+            long total = swBatch.ElapsedMilliseconds;
+            long accounted = melLocal + encLocal + projLocal + prefillLocal + stepLocal;
+            long overhead = Math.Max(0, total - accounted);
+            lock (_profileLock)
+            {
+                MelMs += melLocal; EncMs += encLocal; ProjMs += projLocal;
+                PrefillMs += prefillLocal; StepLoopMs += stepLocal; OverheadMs += overhead;
+                BatchCount++; RowCount += realB; StepCount += stepCountLocal;
+                if (realB > MaxBatchSeen) MaxBatchSeen = realB;
+            }
+            Console.Error.WriteLine(
+                $"[granite-prof] B={realB}/{B} total={total}ms (mel={melLocal} enc={encLocal} "
+              + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
+              + $"overhead={overhead}ms) static-gqa-batched");
+        }
+        return rows;
+    }
+
     /// <summary>Print accumulated profile stats and reset. Returns true if profiling was on.</summary>
     public static bool DumpProfile(System.IO.TextWriter? w = null)
     {
@@ -1506,7 +1870,13 @@ public sealed class GraniteSpeech : IDisposable
     private static long ArgmaxRowLastPosition(
         ReadOnlySpan<float> logits, int b, int seqLen, int vocab)
     {
-        int offset = (b * seqLen + (seqLen - 1)) * vocab;
+        return ArgmaxRowAtPosition(logits, b, seqLen, seqLen - 1, vocab);
+    }
+
+    private static long ArgmaxRowAtPosition(
+        ReadOnlySpan<float> logits, int b, int seqLen, int pos, int vocab)
+    {
+        int offset = (b * seqLen + pos) * vocab;
         long best = 0;
         float bestVal = float.NegativeInfinity;
         for (int v = 0; v < vocab; v++)

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -431,10 +431,14 @@ public sealed class GraniteSpeech : IDisposable
 
     private (string text, long[] tokens)[] TranscribeBatch(float[][] waveforms, int maxNewTokens)
     {
-        // Dynamic GQA bundle (Run 20 phase 4): drop all the static-shape
-        // padding (B=16, A=192, S=max(realLen)) and process each segment
-        // at its actual size. GQA fusion is preserved; buffer-sharing is
-        // not (past_kv grows per step in dynamic mode).
+        // Dynamic GQA bundle: B=1 per segment (Run 20 phase 4). Phase 5
+        // attempted true batched dispatch but the CUDA GroupQueryAttention
+        // kernel doesn't implement the `attention_bias` input (spec lists
+        // it; runtime errors with "attention_bias is not supported in
+        // GroupQueryAttention cuda kernel"). Without that, batched
+        // variable-length prompts can't mask their pad slots, and pad K
+        // contamination breaks transcripts even when BatchSizer groups
+        // similar-duration segments.
         if (_isDynamicGqaBundle)
         {
             var dynRows = new (string text, long[] tokens)[waveforms.Length];
@@ -2053,6 +2057,354 @@ public sealed class GraniteSpeech : IDisposable
         }
 
         return (text, outputTokens);
+    }
+
+    /// <summary>
+    /// Batched dynamic-shape decode against a GQA-rewritten bundle.
+    /// Run 20 phase 5.
+    ///
+    /// BatchSizer.Plan upstream sorts segments by duration before this is
+    /// called, so realLen across rows in one batch is similar. We right-pad
+    /// to S = max(realLen) within the batch; the small pad region is masked
+    /// at attention time via attention_bias = where_2 (which the rewriter
+    /// wires in when past_seq is dynamic, since where_2's shape then
+    /// matches GQA's expectation).
+    ///
+    /// past_kv grows uniformly by 1 per step in dynamic mode (no buffer
+    /// sharing). At step k, generated K for ALL rows lands at slot S+k.
+    /// position_ids is per-row so each row's generated K is RoPE'd at its
+    /// own continuation position (realLen[b]+k), giving the usual relative-
+    /// position correctness across batch.
+    /// </summary>
+    private (string text, long[] tokens)[] TranscribeDynamicGqaBatch(
+        float[][] waveforms, int maxNewTokens)
+    {
+        int B = waveforms.Length;
+        if (B == 0) return Array.Empty<(string, long[])>();
+
+        var swBatch = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+        long melLocal = 0, encLocal = 0, projLocal = 0;
+
+        // ── Per-row mel + encoder + projector ───────────────────────────
+        var audioEmbeds = new float[B][];
+        var nAudio      = new int[B];
+        long audioDim   = 2048;
+        for (int b = 0; b < B; b++)
+        {
+            int audioTokens = NumAudioTokens(waveforms[b].Length);
+            int promptLen   = AsrPromptPrefix.Length + audioTokens + AsrPromptSuffix.Length;
+            if (promptLen + maxNewTokens > MaxContextLen)
+                throw new InvalidOperationException(
+                    $"Segment too long: prompt+max_new_tokens ({promptLen + maxNewTokens}) "
+                  + $"exceeds Granite Speech context ({MaxContextLen}).");
+
+            var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+            var audioT = new DenseTensor<float>(waveforms[b], [1, waveforms[b].Length]);
+            using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
+            var inputFeatures = melResults[0].AsTensor<float>();
+            var ifShape = inputFeatures.Dimensions.ToArray();
+            var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
+            if (swStage != null) { swStage.Stop(); melLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+            using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
+                "input_features", new DenseTensor<float>(ifData, ifShape))]);
+            var encoderHidden = encResults[0].AsTensor<float>();
+            var encShape = encoderHidden.Dimensions.ToArray();
+            var encData = encoderHidden.ToArray();
+            if (swStage != null) { swStage.Stop(); encLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+            using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
+                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
+            var ae = projResults[0].AsTensor<float>();
+            audioDim = ae.Dimensions[2];
+            if (ae.Dimensions[1] != audioTokens)
+                throw new InvalidOperationException(
+                    $"Audio token count mismatch (row {b}): formula predicts {audioTokens}, "
+                  + $"projector produced {ae.Dimensions[1]}.");
+            audioEmbeds[b] = ae.ToArray();
+            nAudio[b] = audioTokens;
+            if (swStage != null) { swStage.Stop(); projLocal += swStage.ElapsedMilliseconds; }
+        }
+
+        // ── Build right-padded prompt at batch's actual sizes ───────────
+        var realLen = new int[B];
+        int sMax = 0;
+        int aMax = 0;
+        for (int b = 0; b < B; b++)
+        {
+            realLen[b] = AsrPromptPrefix.Length + nAudio[b] + AsrPromptSuffix.Length;
+            if (realLen[b] > sMax) sMax = realLen[b];
+            if (nAudio[b]  > aMax) aMax = nAudio[b];
+        }
+        int S = sMax;
+        int A = Math.Max(aMax, 1);   // graph requires audio_embeds dim>=1 at step
+
+        // input_ids [B, S]: real prompt at [0, realLen[b]), PAD at [realLen[b], S).
+        var inputIdsBatch = new long[B * S];
+        for (int b = 0; b < B; b++)
+        {
+            int rowOff = b * S;
+            int q = rowOff;
+            for (int i = 0; i < AsrPromptPrefix.Length; i++) inputIdsBatch[q++] = AsrPromptPrefix[i];
+            for (int i = 0; i < nAudio[b]; i++) inputIdsBatch[q++] = AudioTokenId;
+            for (int i = 0; i < AsrPromptSuffix.Length; i++) inputIdsBatch[q++] = AsrPromptSuffix[i];
+            for (int i = realLen[b]; i < S; i++) inputIdsBatch[rowOff + i] = PadTokenId;
+        }
+
+        // audio_embeds [B, A, audioDim]: real audio at [0, nAudio[b]) of each
+        // row, zeros after. A = max(nAudio) within this batch — much smaller
+        // than the static-shape A=192 since the BatchSizer groups similar
+        // durations.
+        var audioEmbedsBatch = new float[B * A * (int)audioDim];
+        for (int b = 0; b < B; b++)
+        {
+            int rowOff = b * A * (int)audioDim;
+            int n = nAudio[b] * (int)audioDim;
+            if (n > 0) Array.Copy(audioEmbeds[b], 0, audioEmbedsBatch, rowOff, n);
+        }
+
+        // attention_mask [B, S]: 1s at real, 0 at pad. The graph derives
+        // where_2 from this, and where_2 reaches GQA as attention_bias —
+        // pad slots get -inf added to attention scores, so within-batch
+        // length variation doesn't contaminate row b's attention.
+        var attnMaskBatch = new long[B * S];
+        for (int b = 0; b < B; b++)
+        {
+            int rowOff = b * S;
+            for (int i = 0; i < realLen[b]; i++) attnMaskBatch[rowOff + i] = 1L;
+        }
+
+        // cache_position [S]: shared sequence index 0..S-1. With position_ids
+        // overriding per-row, this only feeds HF's where_2-construction
+        // (which we route to GQA as attention_bias).
+        var cachePosBuf = new long[S];
+        for (int i = 0; i < S; i++) cachePosBuf[i] = i;
+
+        // position_ids [B, S]: per-row. Real positions [0..realLen[b]-1] for
+        // real prompt tokens, [realLen[b]..S-1] for the padded tail (pads are
+        // masked via attention_bias so values here don't matter beyond keeping
+        // RoPE continuous through prefill→step).
+        var positionIdsBatch = new long[B * S];
+        for (int b = 0; b < B; b++)
+        {
+            int rowOff = b * S;
+            for (int i = 0; i < S; i++) positionIdsBatch[rowOff + i] = i;
+        }
+
+        // seqlens_k [B] int32: uniform = S - 1 at prefill (GQA's write region
+        // is uniform across batch in non-buffer-sharing mode).
+        var seqlensKBuf = new int[B];
+        for (int b = 0; b < B; b++) seqlensKBuf[b] = S - 1;
+        var totalSeqBuf = new int[] { S };
+
+        var decInputNames = new List<string>(7 + 2 * NumDecoderLayers)
+        { "input_ids", "audio_embeds", "attention_mask", "cache_position", "position_ids" };
+        for (int L = 0; L < NumDecoderLayers; L++)
+        {
+            decInputNames.Add($"past_key_{L}");
+            decInputNames.Add($"past_value_{L}");
+        }
+        decInputNames.Add("seqlens_k");
+        decInputNames.Add("total_sequence_length");
+
+        var decOutputNames = new List<string>(1 + 2 * NumDecoderLayers) { "logits" };
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_key_{L}");
+        for (int L = 0; L < NumDecoderLayers; L++) decOutputNames.Add($"present_value_{L}");
+
+        var generated = new List<long>[B];
+        for (int b = 0; b < B; b++) generated[b] = new List<long>(maxNewTokens);
+        var finished     = new bool[B];
+        var loopDetected = new bool[B];
+        int finishedCount = 0;
+        var nextTok      = new long[B];
+
+        long prefillLocal = 0, stepLocal = 0;
+        long stepCountLocal = 0;
+
+        using (var runOpts = new RunOptions())
+        {
+            var swPrefill = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            using var inputIdsVal = OrtValue.CreateTensorValueFromMemory(
+                inputIdsBatch, new long[] { B, S });
+            using var audioVal = OrtValue.CreateTensorValueFromMemory(
+                audioEmbedsBatch, new long[] { B, A, audioDim });
+            using var attnVal = OrtValue.CreateTensorValueFromMemory(
+                attnMaskBatch, new long[] { B, S });
+            using var cpVal = OrtValue.CreateTensorValueFromMemory(
+                cachePosBuf, new long[] { S });
+            using var posVal = OrtValue.CreateTensorValueFromMemory(
+                positionIdsBatch, new long[] { B, S });
+            using var seqlensVal = OrtValue.CreateTensorValueFromMemory(
+                seqlensKBuf, new long[] { B });
+            using var totalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                totalSeqBuf, Array.Empty<long>());
+
+            // Empty past_kv: [B, kv_heads, 0, head_dim]. ORT accepts these.
+            var emptyShape = new long[] { B, NumKvHeads, 0, HeadDim };
+            var emptyPasts = new List<OrtValue>(2 * NumDecoderLayers);
+            for (int L = 0; L < NumDecoderLayers; L++)
+            {
+                emptyPasts.Add(CreateEmptyPastKv(emptyShape));
+                emptyPasts.Add(CreateEmptyPastKv(emptyShape));
+            }
+
+            var prefillInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
+            { inputIdsVal, audioVal, attnVal, cpVal, posVal };
+            prefillInputs.AddRange(emptyPasts);
+            prefillInputs.Add(seqlensVal);
+            prefillInputs.Add(totalSeqVal);
+
+            var prefillOutputs = _decoder.Run(
+                runOpts, decInputNames, prefillInputs, decOutputNames);
+
+            // Per-row argmax at realLen[b]-1.
+            var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+            for (int b = 0; b < B; b++)
+            {
+                long tok = ArgmaxRowAtPosition(prefillLogitsSpan, b, S, realLen[b] - 1, VocabSize);
+                nextTok[b] = tok;
+                generated[b].Add(tok);
+                if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+            }
+            prefillOutputs[0].Dispose();
+            foreach (var ov in emptyPasts) ov.Dispose();
+
+            var pastKvs = new OrtValue[2 * NumDecoderLayers];
+            for (int L = 0; L < NumDecoderLayers; L++)
+            {
+                pastKvs[2 * L]     = prefillOutputs[1 + L];
+                pastKvs[2 * L + 1] = prefillOutputs[1 + NumDecoderLayers + L];
+            }
+
+            if (swPrefill != null) { swPrefill.Stop(); prefillLocal = swPrefill.ElapsedMilliseconds; }
+            var swStep = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+            // ── Step loop ────────────────────────────────────────────────
+            var dummyAudio = new float[B * 1 * (int)audioDim];
+            var stepInputIds = new long[B];
+            var stepPositionIds = new long[B];
+
+            for (int step = 0; step < maxNewTokens && finishedCount < B; step++)
+            {
+                int totalLen = S + step + 1;
+                int newKSlot = S + step;     // uniform write position
+
+                for (int b = 0; b < B; b++)
+                {
+                    stepInputIds[b] = finished[b] ? EosTokenId : nextTok[b];
+                    // RoPE position for row b's new token: continue from its
+                    // own prompt's last real position. (Step k token in row b
+                    // is semantic position realLen[b]+k.)
+                    stepPositionIds[b] = realLen[b] + step;
+                }
+                seqlensKBuf[0] = 0;  // unused — overwrite below
+                for (int b = 0; b < B; b++) seqlensKBuf[b] = newKSlot;
+                totalSeqBuf[0] = totalLen;
+
+                // attention_mask [B, totalLen]: real prompt [0, realLen[b]) +
+                // generated tail [S, totalLen). Pad slots [realLen[b], S)
+                // stay zero so attention_bias masks them.
+                var stepMaskBatch = new long[B * totalLen];
+                for (int b = 0; b < B; b++)
+                {
+                    int rowOff = b * totalLen;
+                    for (int i = 0; i < realLen[b]; i++) stepMaskBatch[rowOff + i] = 1L;
+                    for (int i = S; i < totalLen; i++)  stepMaskBatch[rowOff + i] = 1L;
+                }
+                var stepCachePos = new long[] { (long)newKSlot };
+
+                using var stepInputIdVal = OrtValue.CreateTensorValueFromMemory(
+                    stepInputIds, new long[] { B, 1 });
+                using var stepAudioVal = OrtValue.CreateTensorValueFromMemory(
+                    dummyAudio, new long[] { B, 1, audioDim });
+                using var stepAttnVal = OrtValue.CreateTensorValueFromMemory(
+                    stepMaskBatch, new long[] { B, totalLen });
+                using var stepCpVal = OrtValue.CreateTensorValueFromMemory(
+                    stepCachePos, new long[] { 1 });
+                using var stepPosVal = OrtValue.CreateTensorValueFromMemory(
+                    stepPositionIds, new long[] { B, 1 });
+                using var stepSeqlensVal = OrtValue.CreateTensorValueFromMemory(
+                    seqlensKBuf, new long[] { B });
+                using var stepTotalSeqVal = OrtValue.CreateTensorValueFromMemory(
+                    totalSeqBuf, Array.Empty<long>());
+
+                var stepInputs = new List<OrtValue>(7 + 2 * NumDecoderLayers)
+                { stepInputIdVal, stepAudioVal, stepAttnVal, stepCpVal, stepPosVal };
+                stepInputs.AddRange(pastKvs);
+                stepInputs.Add(stepSeqlensVal);
+                stepInputs.Add(stepTotalSeqVal);
+
+                var outputs = _decoder.Run(
+                    runOpts, decInputNames, stepInputs, decOutputNames);
+
+                var oldPast = pastKvs;
+                pastKvs = new OrtValue[2 * NumDecoderLayers];
+                for (int L = 0; L < NumDecoderLayers; L++)
+                {
+                    pastKvs[2 * L]     = outputs[1 + L];
+                    pastKvs[2 * L + 1] = outputs[1 + NumDecoderLayers + L];
+                }
+
+                var stepLogits = outputs[0];
+                var stepLogitsSpan = stepLogits.GetTensorDataAsSpan<float>();
+                for (int b = 0; b < B; b++)
+                {
+                    if (finished[b]) { nextTok[b] = EosTokenId; continue; }
+                    long tok = ArgmaxRowLastPosition(stepLogitsSpan, b, 1, VocabSize);
+                    nextTok[b] = tok;
+                    generated[b].Add(tok);
+                    if (tok == EosTokenId) { finished[b] = true; finishedCount++; }
+                    else if (IsRepetitionLoop(generated[b]))
+                    {
+                        finished[b] = true; loopDetected[b] = true; finishedCount++;
+                    }
+                }
+                stepLogits.Dispose();
+                foreach (var ov in oldPast) ov.Dispose();
+                stepCountLocal++;
+            }
+
+            foreach (var ov in pastKvs) ov.Dispose();
+            if (swStep != null) { swStep.Stop(); stepLocal = swStep.ElapsedMilliseconds; }
+        }
+
+        var rows = new (string text, long[] tokens)[B];
+        for (int b = 0; b < B; b++)
+        {
+            var toks = generated[b];
+            int realCount = toks.Count;
+            while (realCount > 0 && toks[realCount - 1] == EosTokenId) realCount--;
+            int trimmed = loopDetected[b] ? TrimRepetitionTail(toks, realCount) : realCount;
+            if (trimmed == toks.Count)
+                rows[b] = (DecodeTokens(toks), toks.ToArray());
+            else
+            {
+                var trimmedToks = toks.GetRange(0, trimmed);
+                rows[b] = (DecodeTokens(trimmedToks), trimmedToks.ToArray());
+            }
+        }
+
+        if (swBatch != null)
+        {
+            swBatch.Stop();
+            long total = swBatch.ElapsedMilliseconds;
+            long accounted = melLocal + encLocal + projLocal + prefillLocal + stepLocal;
+            long overhead = Math.Max(0, total - accounted);
+            lock (_profileLock)
+            {
+                MelMs += melLocal; EncMs += encLocal; ProjMs += projLocal;
+                PrefillMs += prefillLocal; StepLoopMs += stepLocal; OverheadMs += overhead;
+                BatchCount++; RowCount += B; StepCount += stepCountLocal;
+                if (B > MaxBatchSeen) MaxBatchSeen = B;
+            }
+            Console.Error.WriteLine(
+                $"[granite-prof] B={B} S={S} A={A} total={total}ms (mel={melLocal} enc={encLocal} "
+              + $"proj={projLocal} prefill={prefillLocal} step={stepLocal}ms x{stepCountLocal} "
+              + $"overhead={overhead}ms) dynamic-gqa-batched");
+        }
+
+        return rows;
     }
 
     /// <summary>Print accumulated profile stats and reset. Returns true if profiling was on.</summary>


### PR DESCRIPTION
## Summary

Closes #43. The fused-attention investigation took a long route through static-shape MHA/GQA, hit ORT-CUDA kernel limitations, and ultimately landed on a **dynamic-shape MHA-fused decoder with IOBinding** that matches the legacy unfused dynamic baseline at ~3.6 s wall on the 60 s test clip (~2.2 s warm decode). The big lesson: **the static-shape padding contract was the perf ceiling, not attention fusion or compute-skip.** Once the static contract is dropped, GQA/MHA fusion in dynamic mode is roughly neutral against the un-rewritten decoder — the wins come from `BindOutput` for logits and from BatchSizer-grouped batched dispatch.

## What landed

- **Attention rewriter** (`scripts/granite_export/rewrite_attention_to_mha.py`)
  - `--mode {mha,gqa}` — replace per-layer unfused attention with `com.microsoft.MultiHeadAttention` or `com.microsoft.GroupQueryAttention`.
  - `--add-argmax` — optional `Slice(last) + ArgMax(V)` pass on the LM head; replaces `logits` output with `next_token` (int64 [B, 1]). Wins on prompt-heavy / loses on step-heavy workloads; auto-detected by the C# driver.
  - Handles static-shape (past_seq pinned) and dynamic-shape exports.
  - Discovered and fixed: Granite uses `attention_multiplier = 1/head_dim`, not `1/sqrt(head_dim)` (Run 19).
- **Export wrapper** (`scripts/granite_export/export_granite_speech_to_onnx.py`)
  - `--unified-position-ids` — adds `position_ids: [B, S]` as a decoder input so per-row RoPE positions can be threaded for batched variable-length inference.
- **C# driver** (`src/Vernacula.Base/GraniteSpeech.cs`)
  - Auto-detects bundle variant (static vs dynamic, GQA vs MHA, has-position-ids, has-next-token) from `decoder.InputMetadata` / `OutputMetadata` and routes through the appropriate code path.
  - Phase 8 IOBinding: pre-allocated reusable input OrtValues, `BindOutput(logits, cpu_buffer)` to skip per-step `GetTensorDataAsSpan`, prev/cur collection-disposal pattern for `past_kv` lifetime.
  - Phase 2 static-batched-GQA path with right-padded prompts + per-row position_ids (for the static GQA variant, retained for reference).
- **Investigation doc** (`docs/dev/granite_speech_perf_investigation.md`): Runs 17–20 (phases 1–9), ~1.5 k lines of chronological notes with negative findings preserved.

## Results on `/tmp/run15_short_60s.wav` (60 s clip, 18 diarization segments)

| Path | ASR wall (median 3 runs) |
|---|---|
| unfused-static (Run 18 baseline) | 13.29 s |
| MHA-fused static (Run 19) | 13.55 s |
| GQA static + IOBinding (phase 3) | 13.27 s |
| GQA dynamic B=1 serial (phase 4) | 5.23 s |
| MHA-fused dynamic batched (phase 6) | 4.76 s |
| **MHA-fused dynamic + IOBinding (phase 8, recommended)** | **3.61 s** |
| legacy unfused dynamic reference (~Run 16) | ~3.4 s |

Transcript parity verified through all 18 segments at each stage.

## Recommended production path

MHA-fused dynamic decoder + IOBinding (phase 8). Build with:

```
python scripts/granite_export/export_granite_speech_to_onnx.py \
    --unified-decoder --unified-position-ids --dtype bfloat16 ...
python scripts/granite_export/rewrite_attention_to_mha.py --mode mha \
    --input decoder.onnx --output decoder_mha.onnx
```

The C# driver detects the bundle and uses the right code path automatically. No bundle metadata flags needed.

## Negative findings worth keeping (in the investigation doc)

- **Static-shape padding is the perf trap.** ~3.7× regression vs dynamic; GQA's compute-skip only addresses one of three padding axes.
- **CUDA `GroupQueryAttention` doesn't implement `attention_bias`** (phase 5). Batched variable-length GQA is blocked there until ORT grows the kernel.
- **GPU-side argmax** (phase 9): real prefill win, real step loss for ASR. Plumbing preserved; default off.
- **FFN dominates per-layer cost** (~50 M ops vs attention's ~2 M). Attention fusion gives ~3 % per-layer headroom; not the lever.

## Test plan

- [x] `git diff main..HEAD --stat` — 4 files changed, +4290/-180.
- [x] Build: `dotnet build src/Vernacula.Base/Vernacula.Base.csproj -c Release -p:EP=Cuda` — clean.
- [x] Parity: transcript exact match through all 18 segments of `/tmp/run15_short_60s.wav` on the recommended path (phase 8).
- [x] Benchmark: 3-run median 3.61 s ASR on phase 8 vs 13.29 s on baseline static-bf16 bundle.
- [ ] (Optional follow-up) Audit `BindOutputToDevice("logits", cpuMemInfo)` sites in WhisperTurbo / Qwen3Asr / VibeVoiceAsr / CohereTranscribe — the phase-8 `BindOutput(name, preAllocatedOrtValue)` pattern likely gives a small step-loop win there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)