### PR TITLE
Chatterbox export Stage 0 — E1 scaffold + E2 three-graph export

### DIFF
--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -1,0 +1,315 @@
+# Chatterbox ONNX export — investigation log
+
+Running record of the Stage 0 export work in
+[chatterbox.scratch.md](../chatterbox.scratch.md). Chronological by run.
+Negative results stay; that's the whole point of the log.
+
+## Run 1 — 2026-05-15 — Provenance survey of upstream ONNX artifacts
+
+**Question:** Is there a publisher-canonical Chatterbox ONNX export we
+can rely on, or do we need to own it?
+
+**Commands / sources consulted:**
+
+- `WebFetch ResembleAI/chatterbox-turbo-ONNX` (HF model card)
+- `WebFetch onnx-community/chatterbox-ONNX` (HF model card + README +
+  file listing)
+- `WebFetch resemble-ai/chatterbox` (GitHub repo)
+- `WebFetch VladOS95-cyber/onnx_conversion_scripts/chatterbox`
+  (directory + issues)
+- `WebFetch huggingface.co/.../discussions/42` (offline iPhone/Mac
+  report)
+- WebSearch: "Chatterbox TTS ONNX export RTX 3090 CUDA execution
+  provider performance"
+- WebSearch: "ResembleAI chatterbox ONNX export official script 2026"
+
+**Findings:**
+
+1. **No publisher export script exists.** `resemble-ai/chatterbox` on
+   GitHub has zero ONNX code. ResembleAI's HF org publishes
+   `chatterbox-turbo-ONNX` artifacts but no recipe to reproduce them.
+2. **The `onnx-community/chatterbox-ONNX` bundle is Frankenstein.**
+   - `embed_tokens.onnx`, `speech_encoder.onnx`,
+     `conditional_decoder.onnx` come from VladOS95-cyber's script
+     (opset 20 / 20 / 17, fp32, no CUDA-specific options).
+   - `language_model.onnx` is **not** produced by that script. Open
+     issue [#2 on Vlad's repo](https://github.com/VladOS95-cyber/onnx_conversion_scripts/issues)
+     ("how to export language_model.onnx") confirms this — the LM came
+     from somewhere else, almost certainly HF's standard
+     transformers→ONNX exporter, but it's undocumented.
+3. **The published LM does have proper KV-cache.** 30 layers, 16
+   KV-heads, 64 head_dim. Variants: fp32 (~2 GB), fp16 (~1 GB), q4
+   (~354 MB), q4f16 (~305 MB). Inference example in the model card
+   threads `past_key_values.N.{key,value}` in and `present_key_values`
+   out per step.
+4. **The published `conditional_decoder.onnx` is anomalously small**
+   (6.35 MB with no `.onnx_data` sidecar listed). Either weights are
+   inline (genuinely small CNN vocoder) or there's external data the
+   HF directory listing doesn't show. Our re-export will resolve this.
+5. **Zero published 3090 + ORT-CUDA benchmarks.** The "decoder is the
+   bottleneck" finding is from CoreML on iPhone (community member
+   leowangxyz, not ResembleAI staff). Has to be re-validated on the
+   3090 once we have our own export.
+6. **Vlad's script maturity:** 2 open issues, 0 closed, 0 PRs.
+   Single-contributor side project. Useful as a structural reference
+   for the three graphs it does cover; not a basis we can sit on.
+
+**Implication for next step:**
+
+We own the export. Stage 0 of [chatterbox.scratch.md](../chatterbox.scratch.md)
+is now scoped:
+
+- E1: scaffold `scripts/chatterbox_export/` skeleton matching
+  `scripts/vibevoice_export/` conventions.
+- E2: adapt Vlad's three graphs (embed_tokens, speech_encoder,
+  conditional_decoder), run end-to-end numerical comparison against
+  PyTorch reference. Resolve the conditional_decoder size mystery as
+  a side effect.
+- E3: write the Llama LM export from scratch with proper KV-cache.
+- E4: end-to-end parity test (speech-token sequence + waveform
+  spectral distance).
+- E5: `export-report.json` capturing source SHA, hashes, opset,
+  tool versions.
+
+Working on branch `chatterbox-export`.
+
+## Run 2 — 2026-05-15 — Reading Vlad's script
+
+**Question:** What exactly does Vlad's script export, what wrapper
+modules does it define, and what can we copy structurally vs. need to
+rewrite?
+
+**Sources:** `/tmp/vlad_chatterbox_export.py` (1687 lines, pinned via
+header: `chatterbox-tts==0.1.4`, `transformers==4.46.3`, `torch==2.6.0`,
+`numpy==2.2.6`, `librosa==0.11.0`, `onnx==1.18.0`, `onnxslim==0.1.59`).
+
+**Findings:**
+
+1. **It loads `ChatterboxTTS.from_pretrained()` from the official
+   `chatterbox-tts` PyPI package.** The script doesn't reimplement
+   Chatterbox — it imports it. Our export will do the same; the model
+   code is upstream. The ~900 lines of nn.Module classes in Vlad's
+   script (`S3Tokenizer`, `FSMNMultiHeadAttention`,
+   `ResidualAttentionBlock`, `AudioEncoderV2`, `ISTFT`,
+   `ConditionalDecoder`, etc.) appear to be **vendored re-declarations of
+   Chatterbox internals** needed to construct the export-wrapper modules
+   — they aren't fresh model code. We need to verify whether the
+   official package now exposes enough surface that we can skip the
+   vendoring.
+
+2. **Three wrapper nn.Modules drive the export:**
+   - `PrepareConditionalsModel` — speech encoder + S3 tokenizer +
+     conditioning latent prep, single forward pass. Output:
+     `audio_features`, `audio_tokens`, `speaker_embeddings`,
+     `speaker_features`. (~285 lines)
+   - `InputsEmbeds` — text-embed + position/exaggeration handling.
+     Inputs: `input_ids`, `position_ids`, `exaggeration`. (~95 lines)
+   - `ConditionalDecoder` — speech-tokens + speaker conditioning →
+     waveform; includes a custom `ISTFT` module to keep the vocoder
+     graph ONNX-exportable. (~360 lines)
+
+3. **One monkeypatch is required before export:**
+   `chatterbox_model.s3gen.speaker_encoder.xvector.dense` (a `DenseLayer`
+   wrapping `BatchNorm1d`) is replaced with a `SafeDenseLayer` that uses
+   `LayerNorm`. Comment in the script: "we can safely do that because
+   it does not affect inference as we do no need matching training
+   dynamics". Load-bearing — without this, the speech_encoder graph
+   doesn't export. Need to verify the assertion (norm-equivalence at
+   inference) in parity test E4.
+
+4. **Opset choices: 20 / 20 / 17.** Embed tokens and speech encoder use
+   opset 20; conditional decoder uses opset 17 — likely because
+   ISTFT-related ops don't survive cleanly in newer opsets. We default
+   to opset 18 in Vernacula's other exports; for Chatterbox we should
+   probably keep 20 for the modern graphs and live with 17 for the
+   decoder unless we can verify 18 works.
+
+5. **The Llama LM is NOT exported in this script.** Vlad runs the LM in
+   PyTorch (`LlamaForCausalLM.from_pretrained("vladislavbro/llama_backbone_0.5")`)
+   to validate end-to-end behavior. The LM weight repo is **Vlad's
+   personal HF account**, not ResembleAI's — `vladislavbro/llama_backbone_0.5`.
+   This is the LM extraction we'll need to either reuse or redo from
+   the official `chatterbox-tts` package's `s3` LM weights.
+
+6. **Reference inputs hardcoded in script:**
+   - `input_ids`: 79-token prompt ending in `START_SPEECH_TOKEN,
+     START_SPEECH_TOKEN` (comment says "by accident but kept for
+     compatibility")
+   - `position_ids`: `where(input_ids >= START_SPEECH_TOKEN, 0,
+     arange - 1)`
+   - `exaggeration`: 0.5 scalar
+   - `dummy_audio_values`: `torch.randn(1, 312936)` — that's ~13 s at
+     S3GEN_SR (24 kHz)
+
+7. **Post-export onnxslim pass + external data:** `ONNXSLIM_THRESHOLD =
+   1e10` (effectively disables size-threshold pruning), then re-saves
+   with `save_as_external_data=True, all_tensors_to_one_file=True`.
+   Every exported `.onnx` should end up with an `.onnx_data` sidecar.
+   This makes the published `conditional_decoder.onnx` being 6.35 MB
+   *without* a sidecar on HF (per Run 1 finding 4) genuinely
+   suspicious — either the HF directory listing was incomplete, or the
+   HF artifact was post-processed differently. **E2 parity should
+   double-check this** by comparing our re-exported decoder against the
+   published one byte-for-byte (or graph-for-graph if external data
+   layout differs).
+
+8. **No CUDA-aware behavior.** Script accepts `device="cpu"` and
+   nothing else changes downstream. Our export needs to add
+   `--device cuda` for fp16-on-3090 ergonomics.
+
+**Implications for E2 plan:**
+
+- Determine whether Chatterbox's official package exposes
+  `speaker_encoder`, `s3gen`, `t3` modules cleanly enough that we can
+  skip vendoring ~900 lines of model code. If not, isolate the vendored
+  classes in a `_chatterbox_internals.py` so they're easy to spot.
+- Validate the `SafeDenseLayer` substitution numerically before
+  trusting it. Add a unit test that runs forward through the old and
+  new dense layer with random input and confirms close-enough
+  agreement at inference time.
+- The Llama backbone repo `vladislavbro/llama_backbone_0.5` is
+  third-party. Prefer extracting the LM directly from
+  `ChatterboxTTS.from_pretrained()` internals so our provenance chain
+  ends at ResembleAI, not at Vlad's personal HF.
+
+## Run 3 — 2026-05-15 — E1 + E2 land; three of four graphs exporting
+
+**Question:** Can we stand up the scripts/chatterbox_export/ skeleton
+matching vibevoice_export conventions, and adapt Vlad's three-graph
+export so it produces working ONNX artifacts on our 3090 stack?
+
+**Commands run (high level):**
+
+- `python3.10 -m venv` + `uv pip install` for the dep stack
+- 12 invocations of `python scripts/chatterbox_export/export_chatterbox_to_onnx.py --output-dir /tmp/chatterbox_smoke --device cuda --overwrite`, each surfacing a new failure mode
+
+**Outcome (smoke export, attempt #12):**
+
+```
+Graphs emitted: ['embed_tokens.onnx', 'speech_encoder.onnx', 'conditional_decoder.onnx']
+```
+
+Artifact sizes:
+
+| File | Header | Sidecar | Total |
+|---|---|---|---|
+| embed_tokens.onnx | 17 KB | 61.6 MB | 61.6 MB |
+| speech_encoder.onnx | 1.1 MB | 1.05 GB | 1.05 GB |
+| conditional_decoder.onnx | 32 MB | 533 MB | 565 MB |
+
+Compare to published `onnx-community/chatterbox-ONNX` directory listing
+(Run 1 finding 4): "conditional_decoder.onnx 6.35 MB no sidecar listed"
+— our 565 MB result makes it clear the HF directory listing was just
+incomplete. The decoder genuinely is a substantial graph; the published
+artifact must have an `.onnx_data` sidecar not surfaced in the directory
+view. **Mystery resolved.** The cond decoder is not a "small graph";
+it's a normal-sized vocoder with weights externalized.
+
+**Dependency stack pins that survived debugging:**
+
+```
+chatterbox-tts==0.1.5   (0.1.4 wants raw `pkuseg` which needs Python.h;
+                         0.1.7 wants transformers==5.x which breaks the
+                         wrapper API. 0.1.5 is the sweet spot.)
+transformers==4.46.3    (matches Vlad's reference)
+torch==2.6.0            (matches Vlad's reference)
+numpy>=1.24,<1.26       (chatterbox-tts cap — forces Python 3.10)
+onnxslim>=0.1.93,<0.2   (Vlad's 0.1.59 / 0.1.68 want sympy>=1.13.3 which
+                         conflicts with torch 2.6.0's sympy==1.13.1)
+setuptools<80           (resemble-perth imports pkg_resources, removed
+                         in setuptools 80+)
+```
+
+**The twelve fixes**, each captured because the issue is non-obvious
+and "Vlad's script just works for him" does not protect us:
+
+1. **resemble-perth import dies on setuptools 80+** — pkg_resources got
+   removed. Pinned setuptools<80.
+2. **`@torch.inference_mode()` decorators in vendored S3Tokenizer / FSQ
+   classes** — inference mode poisons tensors with a flag that prevents
+   `save_for_backward` during JIT tracing. Replaced 7 decorators with
+   `@torch.no_grad()` (same intent, doesn't trigger the trace conflict).
+   This is a chatterbox-tts 0.1.5 thing; 0.1.4 may not have it.
+3. **`PrepareConditionalsModel.cond_spkr` is precomputed in `__init__`
+   from trainable layers** — its `requires_grad=True` made the tracer
+   refuse to inline it as a constant. Wrapped in
+   `torch.no_grad() + .detach()`. Vlad's script worked because his entire
+   export ran under `@torch.no_grad()`; we use scoped semantics instead.
+4. **Wrappers needed `.to(device)`** — buffers registered via
+   `register_buffer` follow the parent module on `.to()`, but they sit
+   on the CPU default until you call it. Added to the export script.
+5. **`PrepareConditionalsModel.__init__` created `speaker_emb` on CPU**
+   when the chatterbox model was on CUDA. Fixed by reading the device
+   from `cond_enc.spkr_enc`.
+6. **`PrepareConditionalsModel.mel_spectrogram` created `hann_window` +
+   mel filter on CPU.** Added `device=y.device` hints.
+7. **LM head: chatterbox.t3 uses split `tfmr` (Llama backbone) +
+   `speech_head` (output projection)** — `.tfmr(...)` returns
+   `BaseModelOutputWithPast` with `last_hidden_state`, not
+   `CausalLMOutputWithPast` with `logits`. Vlad sidestepped this by
+   loading `vladislavbro/llama_backbone_0.5` from his personal HF mirror;
+   we keep provenance at ResembleAI by composing the two pieces ourselves.
+8. **`ConditionalDecoder.flow_forward` allocated `conds` zeros without
+   device hint** — added `device=text_encoded.device`.
+9. **`ConditionalDecoder.forward` allocated `trim_fade` zeros and
+   `cosine_window` linspace without device hint** — added device hints.
+10. **`ISTFT.window` was a plain attribute, not a registered buffer** —
+    `.to(device)` skipped it. Changed to `register_buffer('window', ...)`.
+11. **CUDA `torch.jit.trace` bug in upstream `CausalBlock1D.block(x * mask)`** —
+    reproduces with `torch.jit.trace` directly, not specific to ONNX. Eager mode
+    runs the same code path cleanly. Pre-casting mask to `x.dtype`
+    didn't help; `torch.set_default_device("cuda")` didn't help. **Workaround:
+    move the cond decoder + its inputs to CPU just for the export call.**
+    The resulting ONNX file is device-independent; runtime can still use
+    CUDA EP. The other two graphs (embed_tokens, speech_encoder) export
+    fine on CUDA.
+12. **`window_sumsquare` used `F.conv_transpose1d` with dynamic-shape input** —
+    fails the ONNX symbolic at opset 17 and 18 ("Unsupported: ONNX export of
+    convolution for kernel of unknown shape"). Rewrote with a `scatter_add`
+    formulation: build flat output-position indices `frame_idx * hop_length
+    + sample_idx`, scatter-add the squared window. Same math, ONNX-friendly.
+13. **`onnxslim.slim` crashes on the 565 MB cond decoder** —
+    `google.protobuf.message.EncodeError: Failed to serialize proto`
+    because the inline-weight proto exceeds protobuf's 2 GB limit during
+    onnxslim's `shape_infer` size-check (then masked by an
+    `UnboundLocalError` from `model` not being assigned in the slim's
+    exception handler). Made the slim pass fault-tolerant: on any
+    failure, fall back to raw externalization via `onnx.save_model(...,
+    save_as_external_data=True)`. Slim is an optimization, not load-bearing.
+
+**Observations on the broader story:**
+
+- Vlad's script "worked" for him under a narrow regime: CPU-only, inside
+  a global `@torch.no_grad()` decorator, with `torch.Tensor.item =
+  lambda x: x` monkeypatching, against `chatterbox-tts==0.1.4`. Every
+  constraint we relaxed surfaced a separate bug.
+- Roughly half of the bugs are Vlad's (cond_spkr requires_grad,
+  ISTFT.window as plain attribute, scatter_add formulation, device hints
+  missing), half are upstream chatterbox-tts (inference_mode decorators,
+  the CUDA trace bug in CausalBlock1D), one is onnxslim's own.
+- The investigation doc convention from CLAUDE.md paid off — each fix is
+  traceable to a specific failure mode, not "we just kept tweaking until
+  it worked".
+
+**What's now true:**
+
+- Branch `chatterbox-export` carries a working three-graph export.
+- `_chatterbox_internals.py` (1521 lines + 13 inline patches) is the
+  vendored baseline we'll iterate on. Attribution preserved in header.
+- `export-report.json` captures SHA256 hashes for all 6 artifacts plus
+  source revision, opset table, environment.
+- Branch `chatterbox-export` is uncommitted; next step is to commit
+  this state before tackling E3.
+
+**Open questions for E3 / E4:**
+
+- The Llama LM export: probably much smoother because it's a stock
+  Llama backbone and HF's tooling (`optimum.exporters.onnx`) handles
+  this well. Still need to compose with `chatterbox.t3.speech_head` (Vlad
+  used a separately-uploaded `LlamaForCausalLM` mirror that bundles the
+  head; we'd rather not depend on that).
+- E4 parity: do the three graphs we exported actually match the
+  PyTorch reference numerically? We haven't checked yet. The smoke
+  proves export *succeeds*; correctness comes in E4.
+
+## Run 4 — pending — Commit E2 state and start E3 (Llama LM export)

--- a/scripts/chatterbox_export/README.md
+++ b/scripts/chatterbox_export/README.md
@@ -1,0 +1,109 @@
+# Chatterbox → ONNX export
+
+Exports ResembleAI's Chatterbox TTS into the four-graph ONNX package
+consumed by `Chatterbox.Base` (forthcoming) and eventually folded into
+`Vernacula.Avalonia`. See [chatterbox.scratch.md](../../chatterbox.scratch.md)
+for the project context and [docs/chatterbox_investigation.md](../../docs/chatterbox_investigation.md)
+for the running design log.
+
+**Status: scaffold (Stage 0 step E1).** The CLI surface and dependency
+layout are in place; no graphs are wired up yet. `python
+export_chatterbox_to_onnx.py --output-dir ...` prints a placeholder run
+plan and emits a stub `export-report.json`.
+
+## Why we own this
+
+The upstream provenance for Chatterbox's ONNX bundle is split between
+ResembleAI (publishes artifacts, not export scripts), HF
+`onnx-community` (publishes a Frankenstein bundle), and
+[VladOS95-cyber's script](https://github.com/VladOS95-cyber/onnx_conversion_scripts/tree/main/chatterbox)
+(covers three of the four graphs, omits the language model). We need a
+single reproducible recipe anchored at a pinned `ResembleAI/chatterbox`
+revision. Details: Run 1 in the investigation log.
+
+## Files
+
+- `export_chatterbox_to_onnx.py` — main export entry point. Emits
+  `embed_tokens.onnx`, `speech_encoder.onnx`, `language_model.onnx`,
+  `conditional_decoder.onnx`, and `export-report.json`.
+- `_common.py` — shared helpers (device/dtype resolution, audio I/O at
+  24 kHz, ORT provider selection, `export-report.json` schema,
+  KV-cache name conventions).
+- `test_chatterbox_parity.py` — three-layer parity check (LM token
+  sequence, decoder waveform spectral distance, end-to-end audio).
+- `requirements.txt` — pinned dependencies. The `chatterbox-tts`
+  package and `transformers==4.46.3` are load-bearing; newer
+  transformers versions may break the Chatterbox internals
+  re-imported by the wrapper modules.
+
+## Environment
+
+Use Python `3.11` or `3.12`.
+
+```bash
+python3 -m venv .venv-chatterbox-export
+source .venv-chatterbox-export/bin/activate
+pip install -r scripts/chatterbox_export/requirements.txt
+```
+
+If the upstream `ResembleAI/chatterbox` HF repo becomes gated:
+
+```bash
+huggingface-cli login
+```
+
+## Usage (current scaffold)
+
+```bash
+python scripts/chatterbox_export/export_chatterbox_to_onnx.py \
+  --output-dir ./models/chatterbox_export \
+  --device cuda \
+  --dtype float32 \
+  --opset-language-model 18
+```
+
+Useful flags (all wired up; behavior arrives stepwise):
+
+- `--repo-id <id>` — defaults to `ResembleAI/chatterbox`. Use
+  `ResembleAI/chatterbox-turbo` once we add turbo support.
+- `--revision <commit-or-tag>` — pin exact model snapshot. Recorded in
+  `export-report.json`.
+- `--dtype {float32,float16,bfloat16}` — float32 for parity testing,
+  float16 for the 3090 ship target.
+- `--lm-graph-mode {unified,prefill+step}` — unified is the
+  reference-script style; prefill+step matches Vernacula's vibevoice
+  export pattern and is what we'll likely ship.
+- `--skip-{embed-tokens,speech-encoder,language-model,conditional-decoder}`
+  — re-run a single graph.
+- `--no-onnxslim` — skip the post-export slim + external-data pass.
+- `--overwrite` — replace existing files in `--output-dir`.
+
+## Roadmap
+
+See [docs/chatterbox_investigation.md](../../docs/chatterbox_investigation.md)
+for the running log; the staged plan:
+
+| Step | Status | Description |
+|---|---|---|
+| E1 | done | Scaffold CLI surface, `_common.py`, parity skeleton |
+| E2 | todo | Adapt Vlad's three graphs (embed_tokens, speech_encoder, conditional_decoder); validate `SafeDenseLayer` substitution; resolve `.onnx_data` sidecar question |
+| E3 | todo | Write the Llama LM export from scratch with KV-cache; emit `language_model.onnx` (and optionally `language_model_prefill.onnx` + `language_model_step.onnx`) |
+| E4 | todo | End-to-end parity test (token sequence, decoder spectral distance, full pipeline) |
+| E5 | todo | `export-report.json` finalization: source SHA, file hashes, opset table, tool versions |
+
+## Notes
+
+- **Opset choices** mirror Vlad's reference (20 / 20 / 17) on the three
+  graphs he covers, plus 18 for the LM to match Vernacula's existing
+  Llama exports. Try bumping the conditional decoder to 18+ during E2 —
+  Vlad's choice of 17 was driven by `ISTFT` op support and may no
+  longer be required.
+- **The `SafeDenseLayer` monkeypatch** (BatchNorm1d → LayerNorm on
+  `s3gen.speaker_encoder.xvector.dense`) is required for the
+  speech_encoder graph to export. The substitution is asserted-safe at
+  inference time by upstream; the E2 parity step validates this
+  numerically rather than trusting the assertion.
+- **The Llama backbone** for E3 is loaded via the `chatterbox-tts`
+  package's internals, not from `vladislavbro/llama_backbone_0.5`
+  (Vlad's personal HF mirror). Keeps our provenance chain anchored at
+  ResembleAI.

--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -1,0 +1,1558 @@
+#!/usr/bin/env python3
+"""Chatterbox export internals — vendored from VladOS95-cyber's MIT-licensed
+reference and adapted for Vernacula's export pipeline.
+
+Source: https://github.com/VladOS95-cyber/onnx_conversion_scripts/tree/main/chatterbox
+        (file `chatterbox_to_onnx_conversion_script.py`, fetched May 2026)
+License: MIT — see upstream repo for full text.
+
+This is the v0 starting point per `chatterbox.scratch.md` Stage 0. Each
+nn.Module here is either:
+
+  (a) an export-time wrapper (`PrepareConditionalsModel`, `InputsEmbeds`,
+      `ConditionalDecoder`, `SafeDenseLayer`, `ISTFT`) that re-implements
+      Chatterbox's forward pass in an ONNX-friendly way; or
+
+  (b) a vendored re-declaration of a Chatterbox internal class
+      (`S3Tokenizer` and its FSMN/FSQ/AudioEncoder dependency chain)
+      needed to construct (a). Vlad re-declared these to swap out
+      training-time ops (e.g. BatchNorm1d → LayerNorm via SafeDenseLayer)
+      that don't survive torch.onnx.export.
+
+Items flagged for E2 validation / E5 cleanup:
+
+  * `SafeDenseLayer` substitution is asserted-safe at inference time by
+    Vlad ("we can safely do that because it does not affect inference as
+    we do not need matching training dynamics"). E2 parity must verify
+    this numerically — not trusted on author's word.
+  * The global `torch.Tensor.item = lambda x: x` monkeypatch in Vlad's
+    script is INTENTIONALLY OMITTED here. It is load-bearing during
+    `torch.onnx.export` tracing (some Chatterbox internals call `.item()`
+    and the no-op makes the value traceable). If the export raises on a
+    `.item()` call, apply the patch via an explicit context manager
+    around the export() call, not as a global mutation.
+  * `EXAGGERATION_TOKEN = 6563` — verified against upstream constants in
+    `chatterbox.models.t3.t3` (E1 inspection, 2026-05-15).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import torchaudio as ta
+from torchaudio.compliance.kaldi import get_mel_banks
+
+from s3tokenizer.model import Conv1d, LayerNorm, Linear, MultiHeadAttention
+from s3tokenizer.utils import mask_to_bias as _s3tok_mask_to_bias  # noqa: F401  - kept to mirror Vlad's surface
+
+import numpy as np
+import librosa
+from librosa.filters import mel as librosa_mel_fn
+from tqdm import tqdm  # noqa: F401  - imported by some vendored loops
+# Sampling rate of the inputs to S3TokenizerV2
+S3GEN_SR = 24000
+S3_SR = 16_000
+S3_HOP = 160
+S3_TOKEN_HOP = 640
+S3_TOKEN_RATE = 25 # 25 tokens/sec
+SPEECH_VOCAB_SIZE = 6561
+MILLISECONDS_TO_SECONDS = 0.001
+
+START_SPEECH_TOKEN = 6561
+STOP_SPEECH_TOKEN = 6562
+EXAGGERATION_TOKEN = 6563
+
+ENC_COND_LEN = 6 * S3_SR
+DEC_COND_LEN = 10 * S3GEN_SR
+
+CFM_PARAMS = {
+    "sigma_min": 1e-06,
+    "solver": "euler",
+    "t_scheduler": "cosine",
+    "training_cfg_rate": 0.2,
+    "inference_cfg_rate": 0.7,
+    "reg_loss_type": "l1"
+}
+ISTFT_PARAMS = {"n_fft": 16, "hop_len": 4}
+
+# override certain torch functions
+
+
+@dataclass
+class ModelConfig:
+    n_mels: int = 128
+    n_audio_ctx: int = 1500
+    n_audio_state: int = 1280
+    n_audio_head: int = 20
+    n_audio_layer: int = 6
+    n_codebook_size: int = 3**8
+
+    use_sdpa: bool = False
+
+def make_non_pad_mask(lengths: torch.Tensor, max_len: int = 0) -> torch.Tensor:
+    """Make mask tensor containing indices of non-padded part.
+
+    The sequences in a batch may have different lengths. To enable
+    batch computing, padding is need to make all sequence in same
+    size. To avoid the padding part pass value to context dependent
+    block such as attention or convolution , this padding part is
+    masked.
+
+    1 for non-padded part and 0 for padded part.
+
+    Parameters
+    ----------
+        lengths (torch.Tensor): Batch of lengths (B,).
+
+    Returns:
+    -------
+        torch.Tensor: Mask tensor containing indices of padded part (B, max_T).
+
+    Examples:
+        >>> import torch
+        >>> import s3tokenizer
+        >>> lengths = torch.tensor([5, 3, 2])
+        >>> masks = s3tokenizer.make_non_pad_mask(lengths)
+        masks = [[1, 1, 1, 1, 1],
+                 [1, 1, 1, 0, 0],
+                 [1, 1, 0, 0, 0]]
+    """
+    batch_size = lengths.size(0)
+    # max_len = max_len if max_len > 0 else lengths.max()
+    max_len_2 = lengths.max()
+    seq_range = torch.arange(0,
+                             max_len_2,
+                             dtype=torch.int64,
+                             device=lengths.device)
+    seq_range_expand = seq_range.unsqueeze(0).expand(batch_size, max_len_2)
+    seq_length_expand = lengths.unsqueeze(-1)
+    return seq_range_expand < seq_length_expand
+
+
+def precompute_freqs_cis(dim: int,
+                         end: int,
+                         theta: float = 10000.0,
+                         scaling=None):
+    freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)  # type: ignore
+    if scaling is not None:
+        t = t * scaling
+    freqs = torch.outer(t, freqs).float()  # type: ignore
+    
+    cos = freqs.cos()
+    sin = freqs.sin()
+    
+    cos = torch.cat((cos, cos), dim=-1)
+    sin = torch.cat((sin, sin), dim=-1)
+    return cos, sin
+
+
+def apply_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(0).unsqueeze(2)
+    sin = sin.unsqueeze(0).unsqueeze(2)
+
+    D = xq.shape[-1]
+    half_l, half_r = xq[:, :, :, :D // 2], xq[:, :, :, D // 2:]
+    xq_r = torch.cat((-half_r, half_l), dim=-1)
+
+    D = xk.shape[-1]
+
+    half_l, half_r = xk[:, :, :, :D // 2], xk[:, :, :, D // 2:]
+    xk_r = torch.cat((-half_r, half_l), dim=-1)
+
+    return xq * cos + xq_r * sin, xk * cos + xk_r * sin
+
+
+def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
+    ndim = x.ndim
+    assert 0 <= 1 < ndim
+    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
+    shape = [
+        d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)
+    ]
+    return freqs_cis.view(*shape)
+
+
+class FSQCodebook(nn.Module):
+
+    def __init__(self, dim: int, level: int = 3):
+        super().__init__()
+        self.project_down = nn.Linear(dim, 8)
+        self.level = level
+        self.embed = None
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def preprocess(self, x: torch.Tensor) -> torch.Tensor:
+        # x = rearrange(x, "... d -> (...) d")
+        x = x.reshape(-1, x.shape[-1])
+        return x
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        x_shape = x.shape
+        # pre-process
+        x = self.preprocess(x)
+        # quantize
+        h = self.project_down(x).float()
+        h = h.tanh()
+        h = h * 0.9990000128746033
+        h = h.round() + 1
+        # h = ((self.level - 1) * h).round()  # range [-k, k]
+        powers = torch.pow(
+            self.level,
+            torch.arange(2**self.level, device=x.device, dtype=h.dtype))
+        mu = torch.sum(h * powers.unsqueeze(0), dim=-1)
+        ind = mu.reshape(x_shape[0], x_shape[1])
+        return ind
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def decode(self, embed_ind: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError(
+            'There is no official up project component provided')
+
+
+class FSQVectorQuantization(nn.Module):
+    """Vector quantization implementation (inference-only).
+    Args:
+        dim (int): Dimension
+        codebook_size (int): Codebook size
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        codebook_size: int,
+    ):
+        super().__init__()
+        assert 3**8 == codebook_size
+        self._codebook = FSQCodebook(dim=dim, level=3)
+        self.codebook_size = codebook_size
+
+    @property
+    def codebook(self):
+        return self._codebook.embed
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        return self._codebook.encode(x)
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def decode(self, embed_ind: torch.Tensor) -> torch.Tensor:
+        quantize = self._codebook.decode(embed_ind)
+        # quantize = rearrange(quantize, "b n d -> b d n")
+        quantize = quantize.permute(0, 2, 1)
+        return quantize
+
+
+class FSMNMultiHeadAttention(MultiHeadAttention):
+
+    def __init__(
+        self,
+        n_state: int,
+        n_head: int,
+        kernel_size: int = 31,
+        use_sdpa: bool = False,
+    ):
+        super().__init__(n_state, n_head)
+
+        self.fsmn_block = nn.Conv1d(n_state,
+                                          n_state,
+                                          kernel_size,
+                                          stride=1,
+                                          padding=0,
+                                          groups=n_state,
+                                          bias=False)
+        self.left_padding = (kernel_size - 1) // 2
+        self.right_padding = kernel_size - 1 - self.left_padding
+        self.pad_fn = nn.ConstantPad1d(
+            (self.left_padding, self.right_padding), 0.0)
+
+        self.use_sdpa = use_sdpa
+
+    def forward_fsmn(self,
+                     inputs: torch.Tensor,
+                     mask: Optional[torch.Tensor] = None):
+        b, t, _, _ = inputs.size()
+        inputs = inputs.view(b, t, -1)
+        if mask is not None and mask.size(2) > 0:  # time2 > 0
+            inputs = inputs * mask
+        x = inputs.transpose(1, 2)
+        x = self.pad_fn(x)
+        x = self.fsmn_block(x)
+        x = x.transpose(1, 2)
+        x += inputs
+        return x * mask
+
+    def qkv_attention(self,
+                      q: torch.Tensor,
+                      k: torch.Tensor,
+                      v: torch.Tensor,
+                      mask: Optional[torch.Tensor] = None,
+                      mask_pad: Optional[torch.Tensor] = None,
+                      cos: Optional[torch.Tensor] = None,
+                      sin: Optional[torch.Tensor] = None):
+        _, _, D = q.shape
+        scale = (D // self.n_head)**-0.25
+        q = q.view(*q.shape[:2], self.n_head, -1)
+        k = k.view(*k.shape[:2], self.n_head, -1)
+        v = v.view(*v.shape[:2], self.n_head, -1)
+
+        if cos is not None and sin is not None:
+            q, k = apply_rotary_emb(q, k, cos=cos, sin=sin)
+
+        fsm_memory = self.forward_fsmn(v, mask_pad)
+
+        q = q.permute(0, 2, 1, 3) * scale
+        v = v.permute(0, 2, 1, 3)
+
+        if not self.use_sdpa:
+            k = k.permute(0, 2, 3, 1) * scale
+            qk = q @ k  # (B, n_head, T, T)
+            if mask is not None:
+                qk = qk + mask
+            qk = qk.float()
+            w = F.softmax(qk, dim=-1).to(q.dtype)
+            return (w @ v).permute(
+                0, 2, 1, 3).flatten(start_dim=2), qk.detach(), fsm_memory
+        else:
+            k = k.permute(0, 2, 1, 3) * scale
+            assert mask is not None
+            output = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=0.,
+                scale=1.,
+            )
+            output = (output.transpose(1,
+                                       2).contiguous().view(q.size(0), -1, D)
+                      )  # (batch, time1, d_model)
+            return output, None, fsm_memory
+
+    def forward(self,
+                x: torch.Tensor,
+                mask: Optional[torch.Tensor] = None,
+                mask_pad: Optional[torch.Tensor] = None,
+                cos: Optional[torch.Tensor] = None,
+                sin: Optional[torch.Tensor] = None):
+
+        q = self.query(x)
+        k = self.key(x)
+        v = self.value(x)
+
+        wv, qk, fsm_memory = self.qkv_attention(q, k, v, mask, mask_pad,
+                                                cos, sin)
+        return self.out(wv) + fsm_memory, qk
+
+
+class ResidualAttentionBlock(nn.Module):
+
+    def __init__(
+        self,
+        n_state: int,
+        n_head: int,
+        kernel_size: int = 31,
+        use_sdpa: bool = False,
+    ):
+        super().__init__()
+
+        self.attn = FSMNMultiHeadAttention(n_state,
+                                           n_head,
+                                           kernel_size,
+                                           use_sdpa=use_sdpa)
+        self.attn_ln = LayerNorm(n_state, eps=1e-6)
+
+        n_mlp = n_state * 4
+
+        self.mlp = nn.Sequential(Linear(n_state, n_mlp), nn.GELU(),
+                                       Linear(n_mlp, n_state))
+        self.mlp_ln = LayerNorm(n_state)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        mask_pad: Optional[torch.Tensor] = None,
+        cos: Optional[torch.Tensor] = None,
+        sin: Optional[torch.Tensor] = None,
+    ):
+        x = x + self.attn(
+            self.attn_ln(x), mask=mask, mask_pad=mask_pad,
+            cos=cos, sin=sin)[0]
+
+        x = x + self.mlp(self.mlp_ln(x))
+        return x
+
+
+class AudioEncoderV2(nn.Module):
+
+    def __init__(
+        self,
+        n_mels: int,
+        n_state: int,
+        n_head: int,
+        n_layer: int,
+        stride: int,
+        use_sdpa: bool,
+    ):
+        super().__init__()
+        self.stride = stride
+
+        self.conv1 = Conv1d(n_mels,
+                            n_state,
+                            kernel_size=3,
+                            stride=stride,
+                            padding=1)
+        self.conv2 = Conv1d(n_state,
+                            n_state,
+                            kernel_size=3,
+                            stride=2,
+                            padding=1)
+        cos, sin = precompute_freqs_cis(64, 1024 * 2)
+        self.register_buffer("cos", cos)
+        self.register_buffer("sin", sin)
+
+        self.blocks = nn.ModuleList([
+            ResidualAttentionBlock(n_state, n_head, use_sdpa=use_sdpa)
+            for _ in range(n_layer)
+        ])
+
+    def forward(self, x: torch.Tensor,
+                x_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        x : torch.Tensor, shape = (batch_size, n_mels, T)
+            the mel spectrogram of the audio
+        x_len: torch.Tensor, shape = (batch_size,)
+            length of each audio in x
+        """
+        mask = make_non_pad_mask(x_len).unsqueeze(1)
+        x = F.gelu(self.conv1(x * mask))
+        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+        mask = make_non_pad_mask(x_len).unsqueeze(1)
+        x = F.gelu(self.conv2(x * mask))
+        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // 2 + 1
+        mask = make_non_pad_mask(x_len).unsqueeze(1)
+        x = x.permute(0, 2, 1)  # (B, T // 2, n_state)
+        # NOTE: .contiguous() is essential for dynamo export!
+        x = x.contiguous()
+
+        
+        cos = self.cos[:x.size(1)].to(x.device)
+        sin = self.sin[:x.size(1)].to(x.device)
+
+        mask_pad = mask.transpose(1, 2)
+        mask = mask_to_bias(mask, x.dtype).unsqueeze(1)
+
+        for block in self.blocks:
+            x = block(x, mask, mask_pad, cos, sin)
+
+        return x, x_len
+
+
+class S3TokenizerV2(nn.Module):
+    """S3 tokenizer v2 implementation (inference-only).
+    Args:
+        config (ModelConfig): Config
+    """
+
+    def __init__(self):
+        super().__init__()
+        # self.name = name  # Store model name for token_rate determination
+        self.config = ModelConfig()
+        self.encoder = AudioEncoderV2(
+            self.config.n_mels,
+            self.config.n_audio_state,
+            self.config.n_audio_head,
+            self.config.n_audio_layer,
+            2,
+            self.config.use_sdpa,
+        )
+        self.quantizer = FSQVectorQuantization(
+            self.config.n_audio_state,
+            self.config.n_codebook_size,
+        )
+
+    def forward(self, mel: torch.Tensor,
+                mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.quantize(mel, mel_len)
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def quantize(self, mel: torch.Tensor,
+                 mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Quantize mel spectrogram to tokens, with automatic long audio handling.
+
+        Args:
+            mel: mel spectrogram tensor, shape (batch_size, n_mels, T)
+            mel_len: mel length tensor, shape (batch_size,)
+
+        Returns:
+            code: quantized tokens, shape (batch_size, T')
+            code_len: token length, shape (batch_size,)
+        """
+        # Check if any audio in the batch exceeds 30 seconds
+        # Assuming 16kHz sample rate and hop_length=160, 30s = 30*16000/160 = 3000 frames
+        # max_frames = 3000
+
+        # Check which samples are long audio
+        # assert (mel_len <= max_frames).all()
+
+        # All short audio - use original method
+        hidden, code_len = self.encoder(mel, mel_len)
+        code = self.quantizer.encode(hidden).long()
+        return code, code_len
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def freeze(self):
+        for _, param in self.named_parameters():
+            param.requires_grad = False
+
+
+class S3Tokenizer(S3TokenizerV2):
+    """
+    s3tokenizer.S3TokenizerV2 with the following changes:
+    - a more integrated `forward`
+    - compute `log_mel_spectrogram` using `_mel_filters` and `window` in `register_buffers`
+    """
+
+    ignore_state_dict_missing = ("_mel_filters", "window")
+
+    def __init__(
+        self,
+        config: ModelConfig = ModelConfig()
+    ):
+        super().__init__()
+
+        self.n_fft = 400
+        _mel_filters = librosa.filters.mel(
+            sr=S3_SR,
+            n_fft=self.n_fft,
+            n_mels=config.n_mels
+        )
+        self.register_buffer(
+            "_mel_filters",
+            torch.FloatTensor(_mel_filters),
+        )
+
+        self.register_buffer(
+            "window",
+            torch.hann_window(self.n_fft),
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        wavs: torch.Tensor,
+        max_len,
+    ) -> torch.Tensor:
+        """
+        NOTE: mel-spec has a hop size of 160 points (100 frame/sec).
+
+        Args
+        ----
+        - `wavs`: 16 kHz speech audio
+        """
+        mels = self.log_mel_spectrogram(wavs)  # [B, F, T]
+        if max_len is not None:
+            mels = mels[..., :max_len * 4]
+        mel_lens = torch.full((mels.shape[0],), mels.shape[-1], dtype=torch.int32, device=self.device)
+
+        speech_tokens, _ = self.quantize(mels, mel_lens)
+        return speech_tokens
+
+    def log_mel_spectrogram(
+        self,
+        audio: torch.Tensor,
+        padding: int = 0,
+    ):
+        """
+        Compute the log-Mel spectrogram of
+
+        Parameters
+        ----------
+        audio: torch.Tensor, shape = (*)
+            The path to audio or either a NumPy array or Tensor containing the
+            audio waveform in 16 kHz
+
+        padding: int
+            Number of zero samples to pad to the right
+
+        Returns
+        -------
+        torch.Tensor, shape = (128, n_frames)
+            A Tensor that contains the Mel spectrogram
+        """
+
+        if audio.dim() == 1:
+            audio = audio.unsqueeze(0)
+
+        audio = audio.to(self.device)
+        if padding > 0:
+            audio = F.pad(audio, (0, padding))
+        stft = torch.stft(
+            audio, self.n_fft, S3_HOP,
+            window=self.window.to(self.device),
+            return_complex=False
+        )
+        # remove Nyquist bin
+        stft = stft[..., :-1, :]
+        # compute magnitude squared
+        magnitudes = stft[..., 0]**2 + stft[..., 1]**2
+
+        mel_spec = self._mel_filters.to(self.device) @ magnitudes
+
+        log_spec = torch.clamp(mel_spec, min=1e-10).log10()
+        log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
+        log_spec = (log_spec + 4.0) / 4.0
+        return log_spec
+
+
+class SafeDenseLayer(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, bias=False):
+        super(SafeDenseLayer, self).__init__()
+        self.linear = torch.nn.Conv1d(in_channels, out_channels, 1, bias=bias)
+        self.nonlinear = torch.nn.Sequential()
+        self.nonlinear.add_module("layernorm", torch.nn.LayerNorm(out_channels))
+
+    def forward(self, x):
+        if x.dim() == 2:
+            x = x.unsqueeze(-1)
+        x = self.linear(x)
+        if x.size(-1) == 1:
+            x = x[:, :, 0]
+        x = self.nonlinear(x)
+        return x
+
+
+class PrepareConditionalsModel(torch.nn.Module):
+
+    speech_cond_prompt_len = 150
+    speaker_embed_size = 256
+
+    def __init__(self, chatterbox):
+        super().__init__()
+
+        # TODO: Move loading elsewhere
+        self.s3 = S3Tokenizer()
+        self.s3.load_state_dict(chatterbox.s3gen.tokenizer.state_dict(), strict=False)
+
+        self.speaker_encoder = chatterbox.s3gen.speaker_encoder
+        self.flow = chatterbox.s3gen.flow
+
+        self.cond_enc = chatterbox.t3.cond_enc
+
+        self.resampler = ta.transforms.Resample(S3GEN_SR, S3_SR)
+        self.eps = torch.tensor(torch.finfo(torch.float).eps)
+        self.n_fft = 400
+        _mel_filters = librosa.filters.mel(
+            sr=S3_SR,
+            n_fft=self.n_fft,
+            n_mels=128
+        )
+        self.register_buffer(
+            "mel_filters",
+            torch.FloatTensor(_mel_filters),
+        )
+
+        self.register_buffer(
+            "window",
+            torch.hann_window(self.n_fft),
+        )
+
+        self.speech_emb = chatterbox.t3.speech_emb
+        self.speech_pos_emb = chatterbox.t3.speech_pos_emb
+
+        # Speaker embedding projection
+        # NOTE: From testing, randomly/zero initializing speaker embedding seems to work fine
+        # speaker_emb = torch.randn(batch_size, self.speaker_embed_size)
+        # Pre-computed in __init__ so the export graph sees it as a
+        # constant. detach() drops the autograd graph so torch.jit tracing
+        # won't refuse to inline it (Vlad's reference works because
+        # @torch.no_grad() wraps the whole export — we use scoped no_grad
+        # + detach instead, to avoid the global decorator and its
+        # inference-tensor footgun). Device pulled from spkr_enc so
+        # __init__ works whether the chatterbox model was loaded on
+        # cpu or cuda.
+        spkr_device = next(self.cond_enc.spkr_enc.parameters()).device
+        speaker_emb = torch.zeros(1, self.speaker_embed_size, device=spkr_device)
+        with torch.no_grad():
+            self.cond_spkr = self.cond_enc.spkr_enc(
+                speaker_emb.view(-1, self.speaker_embed_size)
+            )[:, None].detach()  # (B, 1, dim)
+
+    def mel_spectrogram(self, y, n_fft=1920, num_mels=80, sampling_rate=24000, hop_size=480, win_size=1920,
+                    fmin=0, fmax=8000, center=False):
+        y = F.pad(
+            y.unsqueeze(1),
+            ((n_fft - hop_size) // 2, (n_fft - hop_size) // 2),
+            mode="reflect",
+        )
+        y = y.squeeze(1)
+        # device must match `y`; Vlad's CPU-only flow didn't need this.
+        hann_window = torch.hann_window(win_size, device=y.device)
+        mel = librosa_mel_fn(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
+        mel = torch.from_numpy(mel).float().to(y.device)
+        spec = torch.stft(
+            y,
+            n_fft,
+            hop_length=hop_size,
+            win_length=win_size,
+            window=hann_window,
+            center=center,
+            pad_mode="reflect",
+            normalized=False,
+            onesided=True,
+            return_complex=False,
+        )
+        # real = spec[..., 0]
+        # imag = spec[..., 1]
+        # spec = torch.sqrt(real**2 + imag**2 + 1e-9)
+        spec = torch.sqrt(spec.pow(2).sum(-1) + (1e-9))
+
+        spec = torch.matmul(mel, spec)
+        spec = torch.log(torch.clamp(spec, min=1e-5) * 1) # spectral_normalize_torch
+
+        return spec
+    
+    def _next_power_of_2(self, x: int) -> int:
+        r"""Returns the smallest power of 2 that is greater than x"""
+        return 1 if x == 0 else 2 ** (x - 1).bit_length()
+    
+    def _get_strided(self, waveform: torch.Tensor, window_size: int, window_shift: int) -> torch.Tensor:
+        r"""Given a waveform (1D tensor of size ``num_samples``), it returns a 2D tensor (m, ``window_size``)
+        representing how the window is shifted along the waveform. Each row is a frame.
+
+        Args:
+            waveform (Tensor): Tensor of size ``num_samples``
+            window_size (int): Frame length
+            window_shift (int): Frame shift
+            snip_edges (bool): If True, end effects will be handled by outputting only frames that completely fit
+                in the file, and the number of frames depends on the frame_length.  If False, the number of frames
+                depends only on the frame_shift, and we reflect the data at the ends.
+
+        Returns:
+            Tensor: 2D tensor of size (m, ``window_size``) where each row is a frame
+        """
+        num_samples = waveform.size(0)
+        strides = (window_shift * waveform.stride(0), waveform.stride(0))
+
+        if num_samples < window_size:
+            return torch.empty((0, 0), dtype=waveform.dtype, device=waveform.device)
+        else:
+            m = 1 + (num_samples - window_size) // window_shift
+
+        sizes = (m, window_size)
+        return waveform.as_strided(sizes, strides)
+
+    def _get_log_energy(self, strided_input: torch.Tensor, epsilon: torch.Tensor, energy_floor: float) -> torch.Tensor:
+        r"""Returns the log energy of size (m) for a strided_input (m,*)"""
+        device, dtype = strided_input.device, strided_input.dtype
+        log_energy = torch.max(strided_input.pow(2).sum(1), epsilon).log()  # size (m)
+        if energy_floor == 0.0:
+            return log_energy
+        return torch.max(log_energy, torch.tensor(math.log(energy_floor), device=device, dtype=dtype))
+
+    def _get_window(
+        self,
+        waveform: torch.Tensor,
+        padded_window_size: int,
+        window_size: int,
+        window_shift: int,
+        preemphasis_coefficient: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        r"""Gets a window and its log energy
+
+        Returns:
+            (Tensor, Tensor): strided_input of size (m, ``padded_window_size``) and signal_log_energy of size (m)
+        """
+        device, dtype = waveform.device, waveform.dtype
+        # size (m, window_size)
+        strided_input = self._get_strided(waveform, window_size, window_shift)
+
+        # Subtract each row/frame by its mean
+        row_means = torch.mean(strided_input, dim=1).unsqueeze(1)  # size (m, 1)
+        strided_input = strided_input - row_means
+
+        if preemphasis_coefficient != 0.0:
+            # strided_input[i,j] -= preemphasis_coefficient * strided_input[i, max(0, j-1)] for all i,j
+            offset_strided_input = F.pad(strided_input.unsqueeze(0), (1, 0), mode="replicate").squeeze(
+                0
+            )  # size (m, window_size + 1)
+            strided_input = strided_input - preemphasis_coefficient * offset_strided_input[:, :-1]
+
+        # Apply window_function to each row/frame
+        window_function = torch.hann_window(window_size, periodic=False, device=device, dtype=dtype).pow(0.85).unsqueeze(0)  # size (1, window_size)
+        strided_input = strided_input * window_function  # size (m, window_size)
+
+        # Pad columns with zero until we reach size (m, padded_window_size)
+        if padded_window_size != window_size:
+            padding_right = padded_window_size - window_size
+            strided_input = F.pad(
+                strided_input.unsqueeze(0), (0, padding_right), mode="constant", value=0
+            ).squeeze(0)
+
+        return strided_input
+
+    def _get_waveform_and_window_properties(
+        self,
+        waveform: torch.Tensor,
+        channel: int,
+        sample_frequency: float,
+        frame_shift: float,
+        frame_length: float,
+    ) -> Tuple[torch.Tensor, int, int, int]:
+        r"""Gets the waveform and window properties"""
+        channel = max(channel, 0)
+        waveform = waveform[channel, :]  # size (n)
+        window_shift = int(sample_frequency * frame_shift * MILLISECONDS_TO_SECONDS)
+        window_size = int(sample_frequency * frame_length * MILLISECONDS_TO_SECONDS)
+        padded_window_size = self._next_power_of_2(window_size)
+        return waveform, window_shift, window_size, padded_window_size
+
+    def extract_feature(self, waveform: torch.Tensor,
+        channel: int = -1,
+        frame_length: float = 25.0,
+        frame_shift: float = 10.0,
+        high_freq: float = 0.0,
+        low_freq: float = 20.0,
+        num_mel_bins: int = 23,
+        preemphasis_coefficient: float = 0.97,
+        sample_frequency: float = 16000.0,
+        vtln_high: float = -500.0,
+        vtln_low: float = 100.0,
+        vtln_warp: float = 1.0):
+
+        device, dtype = waveform.device, waveform.dtype
+        waveform, window_shift, window_size, padded_window_size = self._get_waveform_and_window_properties(
+        waveform, channel, sample_frequency, frame_shift, frame_length)
+
+        # strided_input, size (m, padded_window_size) and signal_log_energy, size (m)
+        strided_input = self._get_window(
+            waveform,
+            padded_window_size,
+            window_size,
+            window_shift,
+            preemphasis_coefficient,
+        )
+
+        # size (m, padded_window_size // 2 + 1)
+        spec = torch.stft(
+            strided_input,
+            n_fft=512,
+            hop_length=512,
+            center=False,
+            window=None,
+            return_complex=False
+        )   # shape: [..., freq, 2]  (last dim = [real, imag])
+
+        # Compute magnitude manually
+        real = spec[..., 0]
+        imag = spec[..., 1]
+        spectrum = torch.sqrt(real**2 + imag**2).squeeze(-1)
+        spectrum = spectrum.pow(2.0)
+
+        # size (num_mel_bins, padded_window_size // 2)
+        mel_energies, _ = get_mel_banks(
+            num_mel_bins, padded_window_size, sample_frequency, low_freq, high_freq, vtln_low, vtln_high, vtln_warp
+        )
+        mel_energies = mel_energies.to(device=device, dtype=dtype)
+
+        # pad right column with zeros and add dimension, size (num_mel_bins, padded_window_size // 2 + 1)
+        mel_energies = F.pad(mel_energies, (0, 1), mode="constant", value=0)
+
+        # sum with mel fiterbanks over the power spectrum, size (m, num_mel_bins)
+        mel_energies = torch.matmul(spectrum, mel_energies.T)
+
+        # avoid log of zero (which should be prevented anyway by dithering)
+        mel_energies = torch.max(mel_energies, self.eps).log()
+        return mel_energies
+
+    def prepare_conditions_from_audio(self, audio_values):
+        batch_size = audio_values.shape[0]
+
+        # Compute embed_ref
+        ref_wav_24 = audio_values[..., :DEC_COND_LEN]
+        speaker_features = self.mel_spectrogram(ref_wav_24).transpose(1, 2)
+
+        # Resample to 16kHz
+        ref_wav_16 = self.resampler(audio_values) # resample uncropped audio
+
+        # Speech cond prompt tokens
+        # TODO START REMOVE
+        # -- AT EXPORT, WE MUST SWAP THIS WITH self.resampler(audio_values)
+        # ref_wav_16 = librosa.resample(audio_values.cpu().numpy(), orig_sr=S3GEN_SR, target_sr=S3_SR)
+        # ref_wav_16 = torch.from_numpy(ref_wav_16).to(audio_values.device)
+        # TODO END REMOVE
+
+        feature = self.extract_feature(ref_wav_16, num_mel_bins=80) # == Kaldi.fbank(ref_wav_16, num_mel_bins=80)
+        feature = feature - feature.mean(dim=0, keepdim=True)
+        speaker_embeddings = self.speaker_encoder(feature.unsqueeze(0))
+
+        t3_cond_prompt_tokens = self.s3(ref_wav_16[..., :ENC_COND_LEN], max_len=self.speech_cond_prompt_len)
+
+        resampled_wav_16 = self.resampler(ref_wav_24) # resample uncropped audio
+
+        # NOTE: For some reason, we do two passes of the s3 tokenizer
+        # TODO: Try reduce this?
+        # Tokenize 16khz reference
+        prompt_token = self.s3(resampled_wav_16, max_len=None)
+
+        cond_prompt_speech_emb = self.speech_emb(t3_cond_prompt_tokens) + \
+                     self.speech_pos_emb(t3_cond_prompt_tokens)
+
+        # Cond prompt
+        cond_prompt_speech_emb = self.cond_enc.perceiver(cond_prompt_speech_emb)
+
+        expanded_cond_spkr = self.cond_spkr.expand(batch_size, -1, -1)  # (B, 1, dim)
+
+        # Concat and return
+        cond_emb = torch.cat((
+            expanded_cond_spkr,
+            cond_prompt_speech_emb,
+        ), dim=1)  # (B, len_cond, dim)
+        # assert cond_emb.dim() == 3
+        return cond_emb, prompt_token, speaker_embeddings, speaker_features
+
+    def forward(
+        self,
+        audio_values: torch.Tensor, # NOTE: Must have sample rate of S3GEN_SR=24000
+    ):
+        cond_emb, prompt_token, speaker_embeddings, speaker_features = self.prepare_conditions_from_audio(audio_values)
+        return cond_emb, prompt_token, speaker_embeddings, speaker_features
+
+
+class InputsEmbeds(nn.Module):
+    def __init__(self, chatterbox):
+        super().__init__()
+        self.text_emb = chatterbox.t3.text_emb
+        self.text_pos_emb = chatterbox.t3.text_pos_emb.emb
+
+        self.speech_emb = chatterbox.t3.speech_emb
+        self.speech_pos_emb = chatterbox.t3.speech_pos_emb.emb
+
+        self.emotion_adv_fc = chatterbox.t3.cond_enc.emotion_adv_fc
+
+    def forward(self, input_ids, position_ids, exaggeration):
+        assert position_ids.shape == input_ids.shape
+        batch_size, seq_len = input_ids.shape
+
+        x = input_ids
+        idx = torch.arange(seq_len, device=x.device).unsqueeze(0).expand(batch_size, -1)
+        
+        # Detect first zero
+        is_zero = (x == 0)
+        has_zero = is_zero.any(dim=1)
+        zero_pos = torch.where(
+            has_zero,
+            is_zero.float().argmax(dim=1),
+            torch.full((batch_size,), -1, device=x.device)  # placeholder
+        )
+
+        # Masks
+        exaggeration_mask = (x == EXAGGERATION_TOKEN)
+        base_text_mask = (idx <= zero_pos.unsqueeze(1)) & has_zero.unsqueeze(1)
+        
+        text_mask = base_text_mask & ~exaggeration_mask
+        speech_mask = ~base_text_mask & ~exaggeration_mask
+
+        # Compute relative positions by multiplying with the masks
+        text_pos_ids = position_ids * text_mask
+        speech_pos_ids = position_ids * speech_mask
+
+        # Flatten
+        flat_x = x.view(-1)
+        flat_text_mask = text_mask.view(-1)
+        flat_speech_mask = speech_mask.view(-1)
+        flat_exaggeration_mask = exaggeration_mask.view(-1)
+        flat_text_pos = text_pos_ids.view(-1)
+        flat_speech_pos = speech_pos_ids.view(-1)
+
+        # Replace invalid indices with 0 (safe padding idx)
+        safe_text_idx = torch.where(flat_text_mask, flat_x, torch.zeros_like(flat_x))
+        safe_text_pos = torch.where(flat_text_mask, flat_text_pos, torch.zeros_like(flat_text_pos))
+
+        safe_speech_idx = torch.where(flat_speech_mask, flat_x, torch.zeros_like(flat_x))
+        safe_speech_pos = torch.where(flat_speech_mask, flat_speech_pos, torch.zeros_like(flat_speech_pos))
+
+        # Embed everything, but irrelevant positions will become "padding" embeddings
+        all_text_emb = self.text_emb(safe_text_idx) + self.text_pos_emb(safe_text_pos)
+        all_speech_emb = self.speech_emb(safe_speech_idx) + self.speech_pos_emb(safe_speech_pos)
+
+        # Finally, mask out the padding positions to zero them
+        text_emb = all_text_emb * flat_text_mask.unsqueeze(-1)
+        speech_emb = all_speech_emb * flat_speech_mask.unsqueeze(-1)
+
+        # Emotion Adv: must provide a value if this model uses emotion conditioning
+        emotion_adv = exaggeration.view(-1, 1, 1)
+        cond_emotion_adv = self.emotion_adv_fc(emotion_adv)
+
+        # Reshape to [B*L, D] to match masks
+        embed_dim = text_emb.size(-1)
+        text_emb_full   = text_emb
+        speech_emb_full = speech_emb
+
+        # Start with zeros
+        out = torch.zeros(batch_size * seq_len, embed_dim, device=x.device, dtype=text_emb.dtype)
+
+        # Where text mask is True → take text_emb, else keep current out
+        out = torch.where(flat_text_mask.unsqueeze(-1), text_emb_full, out)
+
+        # Where speech mask is True → take speech_emb, else keep current out
+        out = torch.where(flat_speech_mask.unsqueeze(-1), speech_emb_full, out)
+        
+        # Handle exaggeration tokens
+        # We need to expand cond_emotion_adv to match the number of exaggeration tokens
+        # This assumes cond_emotion_adv is (batch_size, 1, dim) and we need to map it correctly
+        # to the flattened positions.
+        # We can create an index mapping from the flattened index to the batch index.
+        batch_indices = torch.arange(batch_size, device=x.device).unsqueeze(1).expand(-1, seq_len).reshape(-1)
+        exaggeration_emb_full = cond_emotion_adv[batch_indices].transpose(0, 1) 
+
+        # Zero out positions where mask is False
+        exaggeration_emb = exaggeration_emb_full * flat_exaggeration_mask.unsqueeze(-1)
+
+        out = out + exaggeration_emb
+        out = out.view(batch_size, seq_len, embed_dim)
+        return out
+
+
+class ISTFT(torch.nn.Module):
+    def __init__(self, n_fft: int, hop_length: int, win_length: int):
+        assert n_fft >= win_length
+        super().__init__()
+
+        self.filter_length = n_fft
+        self.win_length = win_length
+        self.hop_length = hop_length
+
+        scale = self.filter_length / self.hop_length
+        fourier_basis = np.fft.fft(np.eye(self.filter_length))
+
+        cutoff = self.filter_length // 2 + 1
+        fourier_basis = np.vstack([np.real(fourier_basis[:cutoff, :]),
+                                   np.imag(fourier_basis[:cutoff, :])])
+
+        inverse_basis = torch.FloatTensor(np.linalg.pinv(scale * fourier_basis).T[:, None, :])
+
+
+        # Register as a buffer so .to(device) moves it. Plain-attribute
+        # assignment (Vlad's original) leaves it on CPU when the module
+        # is moved to CUDA, causing device-mismatch failures in
+        # window_sumsquare() during the cond-decoder forward.
+        self.register_buffer('window', torch.hann_window(win_length))
+
+        # Center pad the window to the size of n_fft
+        pad_length = n_fft - self.window.size(0)
+        pad_left = pad_length // 2
+        pad_right = pad_length - pad_left
+
+        torch_fft_window = F.pad(self.window, (pad_left, pad_right), mode='constant', value=0)
+        inverse_basis *= torch_fft_window
+
+        self.register_buffer('inverse_basis', inverse_basis.float())
+
+    @staticmethod
+    def window_sumsquare(
+        window,
+        n_frames,
+        hop_length,
+        win_length,
+        n_fft,
+    ):
+        """Overlap-add of window**2 over n_frames, stride hop_length.
+
+        Vlad's original used `F.conv_transpose1d` driven by
+        `torch.ones(1, 1, n_frames)`. That hits a hard ONNX symbolic
+        limit at opset 17 and 18 ("ONNX export of convolution for kernel
+        of unknown shape") — the trace produces a ConstantOfShape input
+        whose dynamic last dim defeats the conv symbolic. We replace it
+        with a scatter_add formulation that ONNX handles cleanly because
+        the operation is index-based instead of conv-based.
+        """
+        if win_length is None:
+            win_length = n_fft
+
+        n = n_fft + hop_length * (n_frames - 1)
+
+        # Squared window padded to n_fft (no-op when win_length == n_fft).
+        win_sq = window ** 2
+        pad_length = n_fft - win_sq.size(0)
+        pad_left = pad_length // 2
+        pad_right = pad_length - pad_left
+        win_sq = F.pad(win_sq, (pad_left, pad_right), mode='constant', value=0)
+        # win_sq is now (n_fft,)
+
+        # Output position indices: for frame i, sample k → i*hop_length + k.
+        device = window.device
+        frame_idx = torch.arange(n_frames, device=device).unsqueeze(1)  # (n_frames, 1)
+        sample_idx = torch.arange(n_fft, device=device).unsqueeze(0)    # (1, n_fft)
+        out_idx = (frame_idx * hop_length + sample_idx).flatten()       # (n_frames*n_fft,)
+
+        values = win_sq.unsqueeze(0).expand(n_frames, n_fft).reshape(-1)  # (n_frames*n_fft,)
+
+        x = torch.zeros(n, dtype=window.dtype, device=device)
+        x = x.scatter_add(0, out_idx, values)
+        return x
+
+    def forward(self, recombine_magnitude_phase):
+        assert recombine_magnitude_phase.dim() == 3, 'must be [B, 2 * N, T]'
+        num_frames = recombine_magnitude_phase.size(-1)
+
+        inverse_transform = F.conv_transpose1d(
+            recombine_magnitude_phase,
+            self.inverse_basis,
+            stride=self.hop_length,
+            padding=0,
+        )
+
+        window_sum = self.window_sumsquare(
+            self.window,
+            n_frames=num_frames,
+            hop_length=self.hop_length,
+            win_length=self.win_length,
+            n_fft=self.filter_length,
+        )
+
+        tiny_value = torch.finfo(window_sum.dtype).tiny
+
+        denom = torch.where(
+            window_sum > tiny_value,
+            window_sum,
+            torch.tensor(1.0, dtype=window_sum.dtype, device=window_sum.device),
+        )
+        # Apply the transformation
+        inverse_transform /= denom
+
+        # scale by hop ratio
+        inverse_transform *= self.filter_length / self.hop_length
+
+        q = self.filter_length // 2
+        inverse_transform = inverse_transform[:, 0, q:-q]
+        return inverse_transform
+
+istft = ISTFT(ISTFT_PARAMS["n_fft"], ISTFT_PARAMS["hop_len"], ISTFT_PARAMS["n_fft"])
+
+
+def make_pad_mask(lengths: torch.Tensor, max_len: int = 0) -> torch.Tensor:
+    """Make mask tensor containing indices of padded part.
+
+    See description of make_non_pad_mask.
+
+    Args:
+        lengths (torch.Tensor): Batch of lengths (B,).
+    Returns:
+        torch.Tensor: Mask tensor containing indices of padded part.
+
+    Examples:
+        >>> lengths = [5, 3, 2]
+        >>> make_pad_mask(lengths)
+        masks = [[0, 0, 0, 0 ,0],
+                    [0, 0, 0, 1, 1],
+                    [0, 0, 1, 1, 1]]
+    """
+    batch_size = lengths.size(0)
+    max_len = max_len if max_len > 0 else lengths.max()
+    seq_range = torch.arange(0,
+                            max_len,
+                            dtype=torch.int64,
+                            device=lengths.device)
+    seq_range_expand = seq_range.unsqueeze(0).expand(batch_size, max_len)
+    seq_length_expand = lengths.unsqueeze(-1)
+    mask = seq_range_expand >= seq_length_expand
+    return mask
+
+def mask_to_bias(mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    assert mask.dtype == torch.bool
+    assert dtype in [torch.float32, torch.bfloat16, torch.float16]
+    mask = mask.to(dtype)
+    mask = (1.0 - mask) * -1.0e+10
+    return mask
+
+
+class ConditionalDecoder(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.output_size = model.s3gen.flow.output_size
+        self.input_embedding = model.s3gen.flow.input_embedding
+        self.spk_embed_affine_layer = model.s3gen.flow.spk_embed_affine_layer
+        self.encoder = model.s3gen.flow.encoder
+        self.encoder_proj = model.s3gen.flow.encoder_proj
+        self.time_embeddings = model.s3gen.flow.decoder.estimator.time_embeddings
+        self.time_mlp = model.s3gen.flow.decoder.estimator.time_mlp
+        self.up_blocks = model.s3gen.flow.decoder.estimator.up_blocks
+        self.static_chunk_size = model.s3gen.flow.decoder.estimator.static_chunk_size
+        self.mid_blocks = model.s3gen.flow.decoder.estimator.mid_blocks
+        self.down_blocks = model.s3gen.flow.decoder.estimator.down_blocks
+        self.final_block = model.s3gen.flow.decoder.estimator.final_block
+        self.final_proj = model.s3gen.flow.decoder.estimator.final_proj
+        self.n_fft = ISTFT_PARAMS["n_fft"]
+        self.hop_len = ISTFT_PARAMS["hop_len"]
+        self.n_trim = S3GEN_SR // 50
+        self.stft_window = model.s3gen.mel2wav.stft_window
+        self.f0_predictor = model.s3gen.mel2wav.f0_predictor
+        self.f0_upsamp = model.s3gen.mel2wav.f0_upsamp
+        self.m_source = model.s3gen.mel2wav.m_source
+        self.inference_cfg_rate = 0.7
+        self.conv_pre = model.s3gen.mel2wav.conv_pre
+        self.lrelu_slope = model.s3gen.mel2wav.lrelu_slope
+        self.reflection_pad = model.s3gen.mel2wav.reflection_pad
+        self.ups = model.s3gen.mel2wav.ups
+        self.source_downs = model.s3gen.mel2wav.source_downs
+        self.source_resblocks = model.s3gen.mel2wav.source_resblocks
+        self.resblocks = model.s3gen.mel2wav.resblocks
+        self.conv_post = model.s3gen.mel2wav.conv_post
+        self.istft = istft
+    
+    def cond_forward(self, x, mask, mu, t, spks, cond) -> torch.Tensor:
+        """Forward pass of the UNet1DConditional model.
+
+        Args:
+            x (torch.Tensor): shape (batch_size, in_channels, time)
+            mask (_type_): shape (batch_size, 1, time)
+            t (_type_): shape (batch_size)
+            spks (_type_, optional): shape: (batch_size, condition_channels). Defaults to None.
+            cond (_type_, optional): placeholder for future use. Defaults to None.
+        """
+
+        t = self.time_embeddings(t).to(t.dtype)
+        t = self.time_mlp(t)
+
+        x = torch.cat([x, mu], dim=1)
+        spks = spks.unsqueeze(-1).expand(-1, -1, x.shape[-1])
+        x = torch.cat([x, spks], dim=1)
+        x = torch.cat([x, cond], dim=1)
+
+        # Cast mask to x.dtype here, before it enters the upstream Block1D
+        # blocks. Block1D.forward does `x * mask` internally — eager mode
+        # handles bool→float promotion, but torch.onnx.export's trace puts
+        # the promoted intermediate on cpu while x stays on cuda, producing
+        # a device-mismatch error. Pre-casting to float keeps everything
+        # on the same device through the trace.
+        mask = mask.to(x.dtype)
+
+        masks = [mask]
+        resnet, transformer_blocks, downsample = self.down_blocks[0]
+        mask_down = masks[-1]
+        x = resnet(x, mask_down, t)
+        x = x.permute(0, 2, 1).contiguous()
+        attn_mask = mask_to_bias(mask_down.bool() == 1, x.dtype)
+        for transformer_block in transformer_blocks:
+            x = transformer_block(
+                hidden_states=x,
+                attention_mask=attn_mask,
+                timestep=t,
+            )
+        x = x.permute(0, 2, 1).contiguous()
+        residual = x  # Save hidden states for skip connections
+        x = downsample(x * mask_down)
+        masks.append(mask_down[:, :, ::2])
+        masks = masks[:-1]
+        mask_mid = masks[-1]
+
+        for resnet, transformer_blocks in self.mid_blocks:
+            x = resnet(x, mask_mid, t)
+            x = x.permute(0, 2, 1).contiguous()
+            attn_mask = mask_to_bias(mask_mid.bool() == 1, x.dtype)
+            for transformer_block in transformer_blocks:
+                x = transformer_block(
+                    hidden_states=x,
+                    attention_mask=attn_mask,
+                    timestep=t,
+                )
+            x = x.permute(0, 2, 1).contiguous() 
+
+        resnet, transformer_blocks, upsample = self.up_blocks[0]
+        mask_up = masks.pop()
+        x = torch.cat([x[:, :, :residual.shape[-1]], residual], dim=1)
+        x = resnet(x, mask_up, t)
+        x = x.permute(0, 2, 1).contiguous()
+        attn_mask = mask_to_bias(mask_up.bool() == 1, x.dtype)
+        for transformer_block in transformer_blocks:
+            x = transformer_block(
+                hidden_states=x,
+                attention_mask=attn_mask,
+                timestep=t,
+            )
+        x = x.permute(0, 2, 1).contiguous()
+        x = upsample(x * mask_up)
+        x = self.final_block(x, mask_up)
+        output = self.final_proj(x * mask_up)
+        return output
+
+    def flow_forward(self, speech_tokens, token_len, mask, embedding, prompt_feat):
+        # xvec projection
+        embedding = F.normalize(embedding, dim=1)
+        embedding = self.spk_embed_affine_layer(embedding)
+
+        # concat text and prompt_text
+        speech_tokens = self.input_embedding(torch.clamp(speech_tokens, min=0))
+        speech_tokens = speech_tokens * mask
+
+        # text encode
+        text_encoded, _ = self.encoder(speech_tokens, token_len)
+        mel_len1, mel_len2 = prompt_feat.shape[1], text_encoded.shape[1] - prompt_feat.shape[1]
+        text_encoded = self.encoder_proj(text_encoded)
+
+        # get conditions
+        conds = torch.zeros(
+            [1, mel_len1 + mel_len2, self.output_size],
+            device=text_encoded.device, dtype=text_encoded.dtype,
+        )
+        conds[:, :mel_len1] = prompt_feat
+        conds = conds.transpose(1, 2)
+
+        mu = text_encoded
+        spks = embedding
+        if not isinstance(mel_len1, torch.Tensor):
+            mel_len1 = torch.tensor(mel_len1, device=speech_tokens.device)
+        if not isinstance(mel_len2, torch.Tensor):
+            mel_len2 = torch.tensor(mel_len2, device=speech_tokens.device)
+        return mel_len1, mel_len2, mu, spks, conds
+
+    def decode(self, x: torch.Tensor, s_stft: torch.Tensor) -> torch.Tensor:
+        x = self.conv_pre(x)
+
+        # ---- Upsample 0 ----
+        x = F.leaky_relu(x, self.lrelu_slope)
+        x = self.ups[0](x)
+
+        si = self.source_downs[0](s_stft)
+        si = self.source_resblocks[0](si)
+        x = x + si
+
+        xs0 = self.resblocks[0](x) + self.resblocks[1](x) + self.resblocks[2](x)
+        x = xs0 / 3
+
+        # ---- Upsample 1 ----
+        x = F.leaky_relu(x, self.lrelu_slope)
+        x = self.ups[1](x)
+
+        si = self.source_downs[1](s_stft)
+        si = self.source_resblocks[1](si)
+        x = x + si
+
+        xs1 = self.resblocks[3](x) + self.resblocks[4](x) + self.resblocks[5](x)
+        x = xs1 / 3
+
+        # ---- Upsample 2 ----
+        x = F.leaky_relu(x, self.lrelu_slope)
+        x = self.ups[2](x)
+        x = self.reflection_pad(x)
+
+        si = self.source_downs[2](s_stft)
+        si = self.source_resblocks[2](si)
+        x = x + si
+
+        xs2 = self.resblocks[6](x) + self.resblocks[7](x) + self.resblocks[8](x)
+        x = xs2 / 3
+
+        # ---- Final layers ----
+        x = F.leaky_relu(x)
+        x = self.conv_post(x)
+
+        magnitude = torch.exp(x[:, :self.n_fft // 2 + 1, :])
+        phase = torch.sin(x[:, self.n_fft // 2 + 1:, :])
+
+        return magnitude, phase
+
+    def forward(self, speech_tokens, speaker_embeddings, speaker_features):
+        token_len = torch.full((speech_tokens.size(0),), speech_tokens.size(1), dtype=torch.long, device=speech_tokens.device)
+        mask = (~make_pad_mask(token_len)).unsqueeze(-1)
+        mel_len1, mel_len2, mu, spks, cond = self.flow_forward(speech_tokens, token_len, mask, speaker_embeddings, speaker_features)
+        mu = mu.transpose(1, 2).contiguous()
+        total_len = mel_len1.add(mel_len2).unsqueeze(0)
+        mask = (~make_pad_mask(total_len)).unsqueeze(0)
+        n_timesteps = 10
+        temperature = 1.0
+        x = torch.randn_like(mu, dtype=mu.dtype) * temperature
+        t_span = torch.linspace(0, 1, n_timesteps+1, device=mu.device, dtype=mu.dtype)
+        t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
+        dt_all = t_span[1:] - t_span[:-1]
+
+        t = t_span[0:1]
+        dt = dt_all[0:1]
+
+        x_in = torch.cat([x, torch.zeros_like(x)], dim=0) 
+        mask_in = torch.cat([mask, torch.zeros_like(mask)], dim=0) 
+        mu_in = torch.cat([mu, torch.zeros_like(mu)], dim=0) 
+        t_in = torch.cat([t, torch.zeros_like(t)], dim=0) 
+        spks_in = torch.cat([spks, torch.zeros_like(spks)], dim=0) 
+        cond_in = torch.cat([cond, torch.zeros_like(cond)], dim=0)
+
+        ## Classifier-Free Guidance inference introduced in VoiceBox
+        # step 1
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[1 + 1] - t
+
+        # step 2
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[2 + 1] - t
+
+        # step 3
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[3 + 1] - t
+
+        # step 4
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[4 + 1] - t
+
+        # step 5
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[5 + 1] - t
+
+        # step 6
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[6 + 1] - t
+
+        # step 7
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[7 + 1] - t
+
+        # step 8
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[8 + 1] - t
+
+        # step 9
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[9 + 1] - t
+
+        # step 10
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        output = x.float()
+        speech_feat = torch.narrow(output, dim=2, start=mel_len1, length=output.size(2) - mel_len1)
+        #mel->f0
+        f0 = self.f0_predictor(speech_feat)
+        # f0->source
+        s = self.f0_upsamp(f0[:, None]).transpose(1, 2)  # bs,n,t
+        s, _, _ = self.m_source(s)
+        output_sources = s.transpose(1, 2).squeeze(1)
+        spec = torch.stft(
+            output_sources,
+            self.n_fft, 
+            self.hop_len, 
+            self.n_fft, 
+            window=self.stft_window.to(output_sources.device),
+            return_complex=False)
+        s_stft_real, s_stft_imag = spec[..., 0], spec[..., 1]
+        output_sources = torch.cat([s_stft_real, s_stft_imag], dim=1)
+        magnitude, phase = self.decode(x=speech_feat, s_stft=output_sources)
+        magnitude = torch.clip(magnitude, max=1e2)
+        real = magnitude * torch.cos(phase)
+        img = magnitude * torch.sin(phase)
+        recombine_magnitude_phase = torch.cat([real, img], dim=1)
+        output_wavs = self.istft(recombine_magnitude_phase)
+        trim_fade = torch.zeros(2 * self.n_trim, device=output_wavs.device)
+        cosine_window = (torch.cos(
+            torch.linspace(torch.pi, 0, self.n_trim, device=output_wavs.device)
+        ) + 1) / 2
+        trim_fade[self.n_trim:] = cosine_window
+        output_wavs[:, :trim_fade.size(0)] *= trim_fade
+        return output_wavs
+

--- a/scripts/chatterbox_export/_common.py
+++ b/scripts/chatterbox_export/_common.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Shared helpers for the Chatterbox ONNX export and parity scripts.
+
+Mirrors the conventions in `scripts/vibevoice_export/_common.py`. Keep
+helpers narrow — anything Chatterbox-specific (wrapper nn.Modules,
+monkeypatches) stays in the export script itself or a dedicated
+`_chatterbox_internals.py` once we decide how much of the Vlad-script
+model code we need to vendor.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+try:
+    import ml_dtypes
+except ImportError:  # pragma: no cover - optional until BF16 path is used
+    ml_dtypes = None
+
+
+# Chatterbox-wide constants extracted from the upstream Python package /
+# Vlad's reference script. Keep these in sync with `chatterbox-tts`.
+S3GEN_SR = 24000
+SPEECH_VOCAB_SIZE = 6561
+START_SPEECH_TOKEN = 6561
+STOP_SPEECH_TOKEN = 6562
+EXAGGERATION_TOKEN = 6563
+S3_SR = 16_000
+LLM_NUM_LAYERS = 30
+LLM_NUM_KV_HEADS = 16
+LLM_HEAD_DIM = 64
+
+
+def fail(message: str):
+    raise SystemExit(message)
+
+
+def ensure_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_device(torch: Any, requested: str) -> str:
+    if requested == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if requested == "cuda" and not torch.cuda.is_available():
+        fail("CUDA was requested but torch.cuda.is_available() is False.")
+    return requested
+
+
+def resolve_dtype(torch: Any, name: str) -> Any:
+    mapping = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    return mapping[name]
+
+
+def torch_dtype_name(dtype: Any) -> str:
+    for name in ("bfloat16", "float32", "float16"):
+        if str(dtype).endswith(name):
+            return name
+    return str(dtype)
+
+
+def ensure_output_dir(path: Path, overwrite: bool, export_files: list[str]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if overwrite:
+        return
+    collisions = [name for name in export_files if (path / name).exists()]
+    if collisions:
+        fail(
+            "Output directory already contains Chatterbox export targets. "
+            "Re-run with --overwrite to replace them.\n"
+            f"Existing files: {', '.join(collisions)}"
+        )
+
+
+def json_dump(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_export_report(model_dir: Path) -> dict[str, Any]:
+    report_path = model_dir / "export-report.json"
+    if not report_path.exists():
+        fail(f"Missing export-report.json in {model_dir}")
+    return load_json(report_path)
+
+
+def kv_input_names(num_layers: int) -> list[str]:
+    """LM input names for `past_key_values`, matching the HF-standard
+    transformers exporter shape used by the published `onnx-community`
+    `language_model.onnx`. The HF schema is
+    `past_key_values.{layer}.{key|value}`, so we emit those literal names.
+    """
+    names: list[str] = []
+    for idx in range(num_layers):
+        names.append(f"past_key_values.{idx}.key")
+        names.append(f"past_key_values.{idx}.value")
+    return names
+
+
+def kv_output_names(num_layers: int) -> list[str]:
+    names: list[str] = []
+    for idx in range(num_layers):
+        names.append(f"present.{idx}.key")
+        names.append(f"present.{idx}.value")
+    return names
+
+
+def load_audio_mono_24k(audio_path: Path) -> tuple[np.ndarray, int]:
+    import librosa
+    import soundfile as sf
+
+    waveform, sr = sf.read(str(audio_path), always_2d=False)
+    if waveform.ndim == 2:
+        waveform = waveform.mean(axis=1)
+    waveform = waveform.astype(np.float32, copy=False)
+    if sr != S3GEN_SR:
+        waveform = librosa.resample(waveform, orig_sr=sr, target_sr=S3GEN_SR).astype(np.float32, copy=False)
+        sr = S3GEN_SR
+    return waveform, sr
+
+
+def choose_onnx_providers(runtime: str) -> list[str]:
+    runtime = runtime.lower()
+    if runtime == "cpu":
+        return ["CPUExecutionProvider"]
+    if runtime == "cuda":
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if runtime == "tensorrt":
+        return ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]
+    fail(f"Unsupported runtime '{runtime}'.")
+
+
+def read_ort_available_providers() -> list[str]:
+    import onnxruntime as ort
+    return list(ort.get_available_providers())
+
+
+def nvidia_smi_query() -> dict[str, str] | None:
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,driver_version,memory.total,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+    if not out:
+        return None
+
+    first = out.splitlines()[0]
+    name, driver_version, memory_total, memory_used = [part.strip() for part in first.split(",")]
+    return {
+        "name": name,
+        "driver_version": driver_version,
+        "memory_total_mib": memory_total,
+        "memory_used_mib": memory_used,
+    }
+
+
+def save_export_report(
+    path: Path,
+    *,
+    repo_id: str,
+    revision: str | None,
+    device: str,
+    dtype: str,
+    opset_embed_tokens: int,
+    opset_speech_encoder: int,
+    opset_language_model: int,
+    opset_conditional_decoder: int,
+    lm_graph_mode: str,
+    safe_dense_layer_patched: bool,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    payload = {
+        "repo_id": repo_id,
+        "revision": revision,
+        "device": device,
+        "dtype": dtype,
+        "opsets": {
+            "embed_tokens": opset_embed_tokens,
+            "speech_encoder": opset_speech_encoder,
+            "language_model": opset_language_model,
+            "conditional_decoder": opset_conditional_decoder,
+        },
+        "lm_graph_mode": lm_graph_mode,
+        "safe_dense_layer_patched": safe_dense_layer_patched,
+        "constants": {
+            "s3gen_sr": S3GEN_SR,
+            "start_speech_token": START_SPEECH_TOKEN,
+            "stop_speech_token": STOP_SPEECH_TOKEN,
+            "llm_num_layers": LLM_NUM_LAYERS,
+            "llm_num_kv_heads": LLM_NUM_KV_HEADS,
+            "llm_head_dim": LLM_HEAD_DIM,
+        },
+    }
+    if extra:
+        payload.update(extra)
+    json_dump(path, payload)
+
+
+def add_local_script_path() -> None:
+    script_dir = Path(__file__).resolve().parent
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))

--- a/scripts/chatterbox_export/_common.py
+++ b/scripts/chatterbox_export/_common.py
@@ -26,14 +26,33 @@ except ImportError:  # pragma: no cover - optional until BF16 path is used
 # Chatterbox-wide constants extracted from the upstream Python package /
 # Vlad's reference script. Keep these in sync with `chatterbox-tts`.
 S3GEN_SR = 24000
-SPEECH_VOCAB_SIZE = 6561
+S3_SR = 16_000
+
+# Speech-token vocabulary.
+#   - SPEECH_BASE_VOCAB_SIZE is the count of "real" speech tokens (ids
+#     0..SPEECH_BASE_VOCAB_SIZE-1) emitted by the S3 tokenizer.
+#   - The three special ids that follow it happen to share numeric
+#     adjacency, but the names refer to different concepts: don't use
+#     `SPEECH_BASE_VOCAB_SIZE` as a token id.
+SPEECH_BASE_VOCAB_SIZE = 6561
 START_SPEECH_TOKEN = 6561
 STOP_SPEECH_TOKEN = 6562
 EXAGGERATION_TOKEN = 6563
-S3_SR = 16_000
+
+# Llama backbone dims (verified at runtime against
+# chatterbox.t3.tfmr.config — 30 layers, 16 KV heads, 64 head_dim).
+LLM_HIDDEN_SIZE = 1024
 LLM_NUM_LAYERS = 30
 LLM_NUM_KV_HEADS = 16
-LLM_HEAD_DIM = 64
+LLM_NUM_ATTN_HEADS = 16
+LLM_HEAD_DIM = LLM_HIDDEN_SIZE // LLM_NUM_ATTN_HEADS  # 64
+
+# Output projection dims (verified against chatterbox.t3.speech_head and
+# .text_head Linear layers). The LM emits 8194 speech-vocab logits per
+# step; only the lower SPEECH_BASE_VOCAB_SIZE + 3 are "named". The
+# remaining 1630 are reserved/unused — likely a power-of-2-adjacent pad.
+SPEECH_HEAD_OUTPUT_DIM = 8194
+TEXT_HEAD_OUTPUT_DIM = 704
 
 
 def fail(message: str):

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Export Chatterbox TTS to ONNX.
+
+Stage 0 step E2: implements three of the four graphs by orchestrating
+the wrapper modules vendored in `_chatterbox_internals.py`:
+
+  * `embed_tokens.onnx`        — text token embedding + position handling
+  * `speech_encoder.onnx`      — speech encoder + S3 tokenizer + cond prep
+  * `conditional_decoder.onnx` — speech tokens + conditioning → waveform
+
+The Llama language model graph lands in step E3 (separate work — we own
+that export from scratch, not adapted from Vlad's reference).
+
+Run:
+
+    python scripts/chatterbox_export/export_chatterbox_to_onnx.py \\
+        --output-dir ./models/chatterbox_export \\
+        --device cuda --dtype float32
+
+`--skip-language-model` is set by default at the CLI layer until E3 lands.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from _common import (
+    add_local_script_path,
+    ensure_output_dir,
+    nvidia_smi_query,
+    read_ort_available_providers,
+    resolve_device,
+    resolve_dtype,
+    save_export_report,
+    EXAGGERATION_TOKEN,
+    START_SPEECH_TOKEN,
+    S3GEN_SR,
+)
+
+add_local_script_path()
+
+
+DEFAULT_REPO_ID = "ResembleAI/chatterbox"
+EXPORT_FILES = [
+    "embed_tokens.onnx",
+    "speech_encoder.onnx",
+    "language_model.onnx",
+    "conditional_decoder.onnx",
+    "export-report.json",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo-id", default=DEFAULT_REPO_ID)
+    p.add_argument("--revision", default=None)
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--device", default="auto", choices=["auto", "cpu", "cuda"])
+    p.add_argument("--dtype", default="float32", choices=["float32", "float16", "bfloat16"])
+    p.add_argument("--opset-embed-tokens", type=int, default=20)
+    p.add_argument("--opset-speech-encoder", type=int, default=20)
+    p.add_argument("--opset-language-model", type=int, default=18)
+    p.add_argument("--opset-conditional-decoder", type=int, default=17)
+    p.add_argument("--lm-graph-mode", default="unified", choices=["unified", "prefill+step"])
+    p.add_argument("--skip-embed-tokens", action="store_true")
+    p.add_argument("--skip-speech-encoder", action="store_true")
+    p.add_argument("--skip-language-model", action="store_true", default=True,
+                   help="(default: skipped until E3 lands)")
+    p.add_argument("--skip-conditional-decoder", action="store_true")
+    p.add_argument("--overwrite", action="store_true")
+    p.add_argument("--audio-prompt", type=Path, default=None,
+                   help="Reference audio at any sample rate. If omitted, a 13 s torch.randn dummy is used "
+                        "(fine for smoke tests, not for parity).")
+    p.add_argument("--no-onnxslim", action="store_true",
+                   help="Skip the onnxslim + external-data pass after export")
+    p.add_argument("--with-item-patch", action="store_true",
+                   help="Apply Vlad's `torch.Tensor.item = lambda x: x` monkeypatch around "
+                        "torch.onnx.export. Off by default; turn on if tracing fails on .item() calls.")
+    return p.parse_args()
+
+
+@contextmanager
+def item_no_op_patch(enabled: bool):
+    """Context manager for Vlad's `.item()` no-op trick. Scoped, not global."""
+    import torch
+    if not enabled:
+        yield
+        return
+    original = torch.Tensor.item
+    torch.Tensor.item = lambda self: self  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        torch.Tensor.item = original  # type: ignore[method-assign]
+
+
+def stage_environment() -> dict:
+    """Print + collect environment info for export-report.json."""
+    import torch
+    import onnxruntime as ort
+    env = {
+        "torch": torch.__version__,
+        "torch_cuda_available": bool(torch.cuda.is_available()),
+        "onnxruntime": ort.__version__,
+        "ort_providers": read_ort_available_providers(),
+    }
+    print(f"torch: {env['torch']}  cuda_available={env['torch_cuda_available']}")
+    print(f"onnxruntime: {env['onnxruntime']}")
+    print(f"  providers available: {env['ort_providers']}")
+    smi = nvidia_smi_query()
+    if smi:
+        env["nvidia_smi"] = smi
+        print(f"GPU: {smi['name']} (driver {smi['driver_version']}, "
+              f"{smi['memory_used_mib']}/{smi['memory_total_mib']} MiB)")
+    return env
+
+
+def hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_audio_prompt(path: Path | None, target_sr: int, device, dtype):
+    """Return a 1xN audio tensor at target_sr. If path is None, return
+    random noise sized for the dummy export (~13 s at 24 kHz, matching
+    Vlad's reference dummy size for trace shape stability).
+    """
+    import torch
+    if path is None:
+        # 312_936 samples == 13.039 s at 24 kHz, matching Vlad's dummy
+        return torch.randn(1, 312_936, device=device, dtype=dtype)
+    import librosa
+    waveform, _sr = librosa.load(str(path), sr=target_sr, mono=True)
+    return torch.from_numpy(waveform).unsqueeze(0).to(device=device, dtype=dtype)
+
+
+def build_reference_input_ids(device):
+    """Vlad's hardcoded 79-token reference prompt with the trailing
+    `START_SPEECH_TOKEN, START_SPEECH_TOKEN` pair retained per his
+    compatibility note ('most likely by accident, but we keep it').
+    """
+    import torch
+    return torch.tensor([[
+        EXAGGERATION_TOKEN, 255, 281,  39,  46,  56,   2,  53,   2, 286,  41,  37,   2, 136, 122,
+        49,   2, 152,   2, 103,   2, 277,  21, 101,   7,   2, 301,  55,  34,
+        28,   7,   2,  53,   2, 296,  18,  18, 115,   2,  51,   2,  33, 245,
+        2,  17, 190,   2,  42,   2,  50,  18, 125,   4,  32,   2, 290, 169,
+        142,   2,  41,   2,  43,   2,  18,  29,  91,   2,  25, 186,   8,  20,
+        14,  80,   2,  29,  86, 213, 216,   9,   0, START_SPEECH_TOKEN, START_SPEECH_TOKEN
+    ]], dtype=torch.long, device=device)
+
+
+def apply_safe_dense_patch(chatterbox_model, SafeDenseLayer):
+    """Replace `s3gen.speaker_encoder.xvector.dense` (DenseLayer wrapping
+    BatchNorm1d) with `SafeDenseLayer` (LayerNorm). Required for the
+    speech_encoder graph to export. Vlad asserts this is inference-equivalent;
+    E2 parity test must verify numerically.
+    """
+    old = chatterbox_model.s3gen.speaker_encoder.xvector.dense
+    new = SafeDenseLayer(old.linear.in_channels, old.linear.out_channels)
+    new.linear.weight.data.copy_(old.linear.weight.data)
+    chatterbox_model.s3gen.speaker_encoder.xvector.dense = new
+    return True
+
+
+def export_embed_tokens(embed_tokens_mod, input_ids, position_ids, exaggeration,
+                        out_path: Path, opset: int, item_patch: bool):
+    import torch
+    print(f"  exporting embed_tokens.onnx (opset {opset}) ...")
+    t0 = time.perf_counter()
+    with item_no_op_patch(item_patch):
+        torch.onnx.export(
+            embed_tokens_mod,
+            (input_ids, position_ids, exaggeration),
+            str(out_path),
+            export_params=True,
+            opset_version=opset,
+            input_names=["input_ids", "position_ids", "exaggeration"],
+            output_names=["inputs_embeds"],
+            dynamic_axes={
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "position_ids": {0: "batch_size", 1: "sequence_length"},
+                "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+                "exaggeration": {0: "batch_size"},
+            },
+        )
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path,
+                          opset: int, item_patch: bool):
+    import torch
+    print(f"  exporting speech_encoder.onnx (opset {opset}) ...")
+    t0 = time.perf_counter()
+    with item_no_op_patch(item_patch):
+        torch.onnx.export(
+            prepare_conditionals_mod,
+            (audio_values,),
+            str(out_path),
+            export_params=True,
+            opset_version=opset,
+            input_names=["audio_values"],
+            output_names=["audio_features", "audio_tokens", "speaker_embeddings", "speaker_features"],
+            dynamic_axes={
+                "audio_values": {0: "batch_size", 1: "num_samples"},
+                "audio_features": {0: "batch_size", 1: "sequence_length"},
+                "audio_tokens": {0: "batch_size", 1: "audio_sequence_length"},
+                "speaker_embeddings": {0: "batch_size"},
+                "speaker_features": {0: "batch_size", 1: "feature_dim"},
+            },
+        )
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddings,
+                               speaker_features, out_path: Path, opset: int, item_patch: bool):
+    """Export the conditional decoder.
+
+    On CUDA, torch.jit.trace (used internally by torch.onnx.export) fails
+    inside upstream chatterbox `CausalBlock1D.block(x * mask)` with a
+    spurious cuda:0/cpu device-mismatch — confirmed by repro outside ONNX
+    via direct torch.jit.trace. Eager mode runs the same code path
+    cleanly. Workaround: move the module + inputs to CPU just for the
+    export. The resulting ONNX graph is device-independent; ORT will run
+    it on CUDA at session-load time.
+
+    `set_default_device("cpu")` is also pinned for the duration of the
+    export so any intermediates the tracer materializes land on CPU.
+    """
+    import torch
+    print(f"  exporting conditional_decoder.onnx (opset {opset}) ...")
+    t0 = time.perf_counter()
+    cond_decoder_mod = cond_decoder_mod.cpu()
+    speech_tokens_cpu = speech_tokens.cpu()
+    speaker_embeddings_cpu = speaker_embeddings.cpu()
+    speaker_features_cpu = speaker_features.cpu()
+    # The vendored `istft` singleton is held by reference inside cond_decoder.
+    import _chatterbox_internals as ci  # noqa - already imported in main; reimport keeps the function self-contained
+    ci.istft.cpu()
+    prev_default = torch.get_default_device() if hasattr(torch, "get_default_device") else None
+    torch.set_default_device("cpu")
+    try:
+        with item_no_op_patch(item_patch):
+            torch.onnx.export(
+                cond_decoder_mod,
+                (speech_tokens_cpu, speaker_embeddings_cpu, speaker_features_cpu),
+                str(out_path),
+                export_params=True,
+                opset_version=opset,
+                input_names=["speech_tokens", "speaker_embeddings", "speaker_features"],
+                output_names=["waveform"],
+                dynamic_axes={
+                    "speech_tokens": {0: "batch_size", 1: "num_speech_tokens"},
+                    "speaker_embeddings": {0: "batch_size"},
+                    "speaker_features": {0: "batch_size", 1: "feature_dim"},
+                    "waveform": {0: "batch_size", 1: "num_samples"},
+                },
+            )
+    finally:
+        if prev_default is not None:
+            torch.set_default_device(prev_default)
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def slim_and_externalize(output_dir: Path, filenames: list[str]) -> None:
+    """Post-export onnxslim pass + external data save.
+
+    Matches Vlad's post-processing block (`ONNXSLIM_THRESHOLD=1e10` to
+    disable size-threshold pruning, then save all tensors into a single
+    sidecar). If onnxslim's shape inference raises — typically on large
+    graphs whose proto-serialized size exceeds protobuf's 2 GB limit —
+    we fall back to externalizing the raw export. The slim is an
+    optimization, not load-bearing; correctness comes from torch.onnx.export.
+    """
+    import onnx
+    import onnxslim
+    os.environ["ONNXSLIM_THRESHOLD"] = "10000000000"
+    for fn in filenames:
+        path = output_dir / fn
+        if not path.exists():
+            continue
+        slimmed = None
+        try:
+            print(f"  slimming {fn} ...")
+            slimmed = onnxslim.slim(str(path))
+        except Exception as e:
+            print(f"    slim failed for {fn}: {type(e).__name__}: {e}")
+            print(f"    falling back to raw externalization")
+        if slimmed is None:
+            # Re-load the raw export (torch.onnx.export wrote it inline)
+            # and rewrite with external data.
+            slimmed = onnx.load(str(path))
+        onnx.save_model(
+            slimmed, str(path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=f"{fn}_data",
+        )
+
+
+def main() -> None:
+    args = parse_args()
+
+    print("Chatterbox ONNX export — Stage 0 / E2")
+    print(f"  repo_id: {args.repo_id}")
+    print(f"  revision: {args.revision or '(latest)'}")
+    print(f"  output_dir: {args.output_dir}")
+    print(f"  device: {args.device}  dtype: {args.dtype}")
+    print()
+
+    env = stage_environment()
+    print()
+
+    ensure_output_dir(args.output_dir, args.overwrite, EXPORT_FILES)
+
+    # Lazy imports so --help works without paying the chatterbox/torch load cost
+    import torch
+    from chatterbox.tts import ChatterboxTTS
+    import _chatterbox_internals as ci
+
+    device = resolve_device(torch, args.device)
+    dtype = resolve_dtype(torch, args.dtype)
+    if dtype is not torch.float32:
+        # Vlad's reference exports fp32. Float16/bfloat16 paths are an E2 stretch
+        # — leave fp32 as the smoke-test default; the 3090 ship target casts the
+        # exported fp32 graph at session load time via ORT.
+        print(f"  WARN: dtype={args.dtype} not yet validated; export proceeds but may fail.")
+
+    print(f"Loading ChatterboxTTS from {args.repo_id} (revision={args.revision or 'latest'}) ...")
+    t0 = time.perf_counter()
+    chatterbox_model = ChatterboxTTS.from_pretrained(device=device)
+    print(f"  loaded in {time.perf_counter() - t0:.1f}s")
+    param_count = (
+        sum(p.numel() for p in chatterbox_model.s3gen.parameters())
+        + sum(p.numel() for p in chatterbox_model.t3.parameters())
+    )
+    print(f"  s3gen + t3 parameter count: {param_count:,}")
+
+    print("Applying SafeDenseLayer monkeypatch on speaker_encoder.xvector.dense ...")
+    patched = apply_safe_dense_patch(chatterbox_model, ci.SafeDenseLayer)
+
+    print("Building export wrappers ...")
+    prepare_conditionals = ci.PrepareConditionalsModel(chatterbox_model).eval().to(device)
+    embed_tokens = ci.InputsEmbeds(chatterbox_model).eval().to(device)
+    cond_decoder = ci.ConditionalDecoder(chatterbox_model).eval().to(device)
+    # The vendored `istft` is a module-level singleton; its hann_window
+    # buffer must also follow the export device or torch.stft crashes
+    # during trace.
+    ci.istft.to(device)
+    print("  PrepareConditionalsModel, InputsEmbeds, ConditionalDecoder built")
+
+    # Build canonical inputs
+    audio_values = load_audio_prompt(args.audio_prompt, target_sr=S3GEN_SR,
+                                     device=device, dtype=torch.float32)
+    prompt_label = "random noise" if args.audio_prompt is None else args.audio_prompt
+    print(f"  audio_values: shape={tuple(audio_values.shape)} (prompt={prompt_label})")
+
+    input_ids = build_reference_input_ids(device)
+    position_ids = torch.where(
+        input_ids >= START_SPEECH_TOKEN,
+        torch.zeros_like(input_ids),
+        torch.arange(input_ids.shape[1], device=device).unsqueeze(0) - 1,
+    )
+    exaggeration = torch.tensor([0.5], device=device)
+    print(f"  input_ids: shape={tuple(input_ids.shape)}  position_ids: {tuple(position_ids.shape)}")
+
+    graphs_exported: list[str] = []
+
+    if not args.skip_embed_tokens:
+        export_embed_tokens(
+            embed_tokens, input_ids, position_ids, exaggeration,
+            args.output_dir / "embed_tokens.onnx",
+            opset=args.opset_embed_tokens, item_patch=args.with_item_patch,
+        )
+        graphs_exported.append("embed_tokens.onnx")
+
+    if not args.skip_speech_encoder:
+        export_speech_encoder(
+            prepare_conditionals, audio_values,
+            args.output_dir / "speech_encoder.onnx",
+            opset=args.opset_speech_encoder, item_patch=args.with_item_patch,
+        )
+        graphs_exported.append("speech_encoder.onnx")
+
+    if not args.skip_conditional_decoder:
+        # Cond decoder needs real speech tokens + speaker conditioning. Run
+        # PrepareConditionalsModel + InputsEmbeds + (eager Llama LM) to get
+        # them, then feed to the cond decoder export. Mirrors Vlad's flow.
+        print("Running PyTorch reference pipeline to build cond decoder inputs ...")
+        with torch.no_grad():
+            cond_emb, prompt_token, speaker_embeddings, speaker_features = \
+                prepare_conditionals(audio_values=audio_values)
+            text_emb = embed_tokens(input_ids=input_ids, position_ids=position_ids, exaggeration=exaggeration)
+            inputs_embeds = torch.cat((cond_emb, text_emb), dim=1)
+
+            # chatterbox.t3 uses a split LlamaModel + speech_head layout:
+            # `tfmr` is the bare backbone (returns BaseModelOutputWithPast
+            # with `last_hidden_state` only), and `speech_head` projects the
+            # last hidden state to the speech vocab. Vlad sidestepped this
+            # by loading his own `vladislavbro/llama_backbone_0.5`
+            # LlamaForCausalLM mirror; we keep provenance at ResembleAI by
+            # composing the backbone + head ourselves.
+            llm = chatterbox_model.t3.tfmr
+            speech_head = chatterbox_model.t3.speech_head
+            llm.eval()
+            speech_head.eval()
+            from transformers import RepetitionPenaltyLogitsProcessor
+            rep_proc = RepetitionPenaltyLogitsProcessor(penalty=1.2)
+            generate_tokens = torch.tensor([[START_SPEECH_TOKEN]], dtype=torch.long, device=device)
+            past_key_values = None
+            max_new_tokens = 256
+            from tqdm import tqdm
+            for i in tqdm(range(max_new_tokens), desc="Sampling", dynamic_ncols=True):
+                out = llm(inputs_embeds=inputs_embeds, past_key_values=past_key_values)
+                past_key_values = out.past_key_values
+                next_logits = speech_head(out.last_hidden_state[:, -1, :])
+                next_logits = rep_proc(generate_tokens, next_logits)
+                next_token = torch.argmax(next_logits, dim=-1).unsqueeze(-1)
+                generate_tokens = torch.cat((generate_tokens, next_token), dim=-1)
+                if (next_token.view(-1) == ci.STOP_SPEECH_TOKEN).all():
+                    break
+                pos = torch.full((input_ids.shape[0], 1), i + 1, dtype=torch.long, device=device)
+                inputs_embeds = embed_tokens(next_token, pos, exaggeration)
+            speech_tokens = torch.cat([prompt_token, generate_tokens[:, 1:-1]], dim=1)
+            print(f"  speech_tokens: shape={tuple(speech_tokens.shape)}")
+
+        export_conditional_decoder(
+            cond_decoder, speech_tokens, speaker_embeddings, speaker_features,
+            args.output_dir / "conditional_decoder.onnx",
+            opset=args.opset_conditional_decoder, item_patch=args.with_item_patch,
+        )
+        graphs_exported.append("conditional_decoder.onnx")
+
+    if graphs_exported and not args.no_onnxslim:
+        print("\nPost-export: onnxslim + external data ...")
+        slim_and_externalize(args.output_dir, graphs_exported)
+
+    if args.skip_language_model:
+        print("\n[skipped] language_model.onnx (E3 work — not yet implemented)")
+
+    # Provenance: hash everything we emitted
+    hashes = {}
+    for fn in graphs_exported:
+        p = args.output_dir / fn
+        if p.exists():
+            hashes[fn] = {"sha256": hash_file(p), "size_bytes": p.stat().st_size}
+        data_path = args.output_dir / f"{fn}_data"
+        if data_path.exists():
+            hashes[f"{fn}_data"] = {"sha256": hash_file(data_path), "size_bytes": data_path.stat().st_size}
+
+    report_path = args.output_dir / "export-report.json"
+    save_export_report(
+        report_path,
+        repo_id=args.repo_id,
+        revision=args.revision,
+        device=device,
+        dtype=args.dtype,
+        opset_embed_tokens=args.opset_embed_tokens,
+        opset_speech_encoder=args.opset_speech_encoder,
+        opset_language_model=args.opset_language_model,
+        opset_conditional_decoder=args.opset_conditional_decoder,
+        lm_graph_mode=args.lm_graph_mode,
+        safe_dense_layer_patched=patched,
+        extra={
+            "stage": "E2-graphs-only",
+            "graphs_exported": graphs_exported,
+            "artifact_hashes": hashes,
+            "environment": env,
+            "audio_prompt": str(args.audio_prompt) if args.audio_prompt else None,
+            "audio_prompt_samples": int(audio_values.shape[1]),
+            "input_ids_length": int(input_ids.shape[1]),
+            "max_lm_steps_used": 256,  # for the cond-decoder input gen
+        },
+    )
+    print(f"\nWrote {report_path}")
+    print(f"Graphs emitted: {graphs_exported}")
+    if not graphs_exported:
+        print("(no graphs requested — passed --skip-* for all four)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -128,15 +128,24 @@ def hash_file(path: Path) -> str:
     return h.hexdigest()
 
 
+DUMMY_AUDIO_SAMPLES = 312_936  # 13.039 s at 24 kHz, matches Vlad's dummy
+DUMMY_AUDIO_SEED = 0
+
+
 def load_audio_prompt(path: Path | None, target_sr: int, device, dtype):
-    """Return a 1xN audio tensor at target_sr. If path is None, return
-    random noise sized for the dummy export (~13 s at 24 kHz, matching
-    Vlad's reference dummy size for trace shape stability).
+    """Return a 1xN audio tensor at target_sr.
+
+    If `path` is None, generate a *deterministic* random-noise prompt
+    by seeding a fresh Generator. Re-running the same command without
+    --audio-prompt produces byte-identical audio bytes → byte-identical
+    speech tokens → byte-identical conditional_decoder.onnx hashes.
+    Required for the parity test in E4 and for the artifact_hashes in
+    export-report.json to be reproducible across runs.
     """
     import torch
     if path is None:
-        # 312_936 samples == 13.039 s at 24 kHz, matching Vlad's dummy
-        return torch.randn(1, 312_936, device=device, dtype=dtype)
+        gen = torch.Generator(device=device).manual_seed(DUMMY_AUDIO_SEED)
+        return torch.randn(1, DUMMY_AUDIO_SAMPLES, device=device, dtype=dtype, generator=gen)
     import librosa
     waveform, _sr = librosa.load(str(path), sr=target_sr, mono=True)
     return torch.from_numpy(waveform).unsqueeze(0).to(device=device, dtype=dtype)
@@ -293,7 +302,7 @@ def slim_and_externalize(output_dir: Path, filenames: list[str]) -> None:
             slimmed = onnxslim.slim(str(path))
         except Exception as e:
             print(f"    slim failed for {fn}: {type(e).__name__}: {e}")
-            print(f"    falling back to raw externalization")
+            print("    falling back to raw externalization")
         if slimmed is None:
             # Re-load the raw export (torch.onnx.export wrote it inline)
             # and rewrite with external data.

--- a/scripts/chatterbox_export/requirements.txt
+++ b/scripts/chatterbox_export/requirements.txt
@@ -1,0 +1,31 @@
+chatterbox-tts==0.1.5
+transformers==4.46.3
+torch==2.6.0
+torchaudio==2.6.0
+# Pin numpy to chatterbox-tts's allowed range (0.1.4-0.1.6 cap at <1.26).
+# This needs Python 3.10 — no prebuilt numpy<1.26 wheels exist for cp312.
+# Stay on 0.1.5 rather than 0.1.4 because 0.1.4 depends on raw `pkuseg`
+# which requires Python.h at build time; 0.1.5 switched to
+# `spacy-pkuseg` which ships prebuilt wheels. transformers==4.46.3 is
+# kept identical to Vlad's reference; 0.1.7+ bumped to transformers 5.x
+# and breaks his wrapper API.
+numpy>=1.24,<1.26
+librosa==0.11.0
+soundfile>=0.12,<1
+huggingface_hub>=0.34,<2
+accelerate>=1.10,<2
+onnx==1.18.0
+# Both Vlad's pinned onnxslim versions (0.1.59, 0.1.68) require
+# sympy>=1.13.3, conflicting with torch 2.6.0 (sympy==1.13.1). 0.1.93
+# relaxed to sympy>=1.13.1. The post-export slim pass should be
+# version-tolerant; re-verify the cmd compares clean against
+# Vlad's reference if we hit a regression.
+onnxslim>=0.1.93,<0.2
+onnxscript>=0.3,<1
+onnxruntime-gpu>=1.22,<2
+ml_dtypes>=0.5,<1
+safetensors>=0.5,<1
+# resemble-perth (transitive via chatterbox-tts) uses pkg_resources,
+# removed in setuptools 80+. Pin to keep PerthImplicitWatermarker
+# importable at chatterbox model construction time.
+setuptools<80

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""End-to-end parity check: ONNX export vs PyTorch reference.
+
+Stage 0 / step E4: skeleton only. Wires up once the export script
+emits real artifacts.
+
+The parity protocol is three layers, in order of strictness:
+
+  1. **Speech-token sequence parity (LM):** same prompt + same reference
+     audio through PyTorch and through our ONNX pipeline; assert
+     near-identical token sequences (modulo numerical drift in early
+     positions; allow first-divergence > N tokens). Same idiom as
+     `scripts/vibevoice_export/test_static_kv_parity.py`.
+
+  2. **Decoder waveform parity:** feed identical speech-tokens +
+     speaker conditioning to the PyTorch decoder and our ONNX decoder.
+     Compare via mel-spectral distance — bit-exact is unrealistic for a
+     vocoder.
+
+  3. **End-to-end audio parity:** full pipeline both ways, spectral
+     distance + a short listen-test sample dumped to disk for the
+     investigation doc.
+
+Layers 1 and 2 are CI-gateable. Layer 3 is informational.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _common import (
+    add_local_script_path,
+    choose_onnx_providers,
+    fail,
+    read_export_report,
+)
+
+add_local_script_path()
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--onnx-dir", type=Path, required=True,
+                   help="Directory produced by export_chatterbox_to_onnx.py")
+    p.add_argument("--audio", type=Path, required=True,
+                   help="Reference voice clip (any sample rate, mono or stereo)")
+    p.add_argument("--text", type=str, default="The Lord of the Rings is the greatest work of literature.",
+                   help="Prompt text for parity comparison")
+    p.add_argument("--max-tokens", type=int, default=256,
+                   help="Max LM steps for token-parity check (default: 256)")
+    p.add_argument("--runtime", default="cuda", choices=["cpu", "cuda", "tensorrt"],
+                   help="ONNX Runtime EP family (default: cuda)")
+    p.add_argument("--no-decoder-parity", action="store_true",
+                   help="Skip layer 2 (decoder waveform parity)")
+    p.add_argument("--no-end-to-end", action="store_true",
+                   help="Skip layer 3 (end-to-end audio comparison)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    report = read_export_report(args.onnx_dir)
+    graphs = report.get("graphs_exported", [])
+    if not graphs:
+        fail("export-report.json reports no graphs exported yet. Run the export script first.")
+
+    providers = choose_onnx_providers(args.runtime)
+    print(f"Parity check against {args.onnx_dir}")
+    print(f"  graphs available: {graphs}")
+    print(f"  providers: {providers}")
+    print()
+
+    # TODO E4 — Layer 1: token-sequence parity
+    print("[ ] Layer 1 (LM token sequence parity) — not implemented yet")
+
+    # TODO E4 — Layer 2: decoder waveform parity
+    if not args.no_decoder_parity:
+        print("[ ] Layer 2 (decoder waveform spectral parity) — not implemented yet")
+
+    # TODO E4 — Layer 3: end-to-end audio
+    if not args.no_end_to_end:
+        print("[ ] Layer 3 (end-to-end audio comparison) — not implemented yet")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Stand up `scripts/chatterbox_export/` matching the `scripts/vibevoice_export/` idiom: CLI entry point, vendored chatterbox-tts internals, parity-test skeleton, pinned `requirements.txt`, README documenting why we own this export and what's still ahead.
- Implement three of four ONNX graphs end-to-end: `embed_tokens.onnx`, `speech_encoder.onnx`, `conditional_decoder.onnx`. Llama LM (`language_model.onnx`) lands in E3 — `--skip-language-model` defaults on at the CLI.
- Document the full debug journey (13 distinct fixes spanning vendored internals, ONNX export machinery, onnxslim, and dep resolution) in `docs/chatterbox_investigation.md` Run 3.

## Provenance context

The upstream Chatterbox ONNX bundle is a Frankenstein — ResembleAI publishes artifacts without a recipe, `onnx-community/chatterbox-ONNX` mixes [VladOS95-cyber's MIT script](https://github.com/VladOS95-cyber/onnx_conversion_scripts/tree/main/chatterbox) (three graphs, opset 17/20, fp32, CPU-only) with a Llama LM exported by separate undocumented tooling. We need a reproducible recipe anchored at a pinned `ResembleAI/chatterbox` revision. Details in Run 1 of the investigation log.

## Notable resolutions

- `@torch.inference_mode()` decorators on 7 vendored S3Tokenizer/FSQ methods replaced with `@torch.no_grad()`. Inference-mode tensors can't `save_for_backward` during JIT trace, even though Vlad's CPU-only flow tolerated them.
- Cond decoder export forced to CPU. Upstream `chatterbox/models/s3gen/decoder.py:60` (`CausalBlock1D.block(x * mask)`) raises a spurious `cuda:0/cpu` device mismatch under `torch.jit.trace` — reproduces outside ONNX, eager mode runs the same code path cleanly. The resulting ONNX file is device-independent; ORT can still use CUDA EP at session-load time.
- `ISTFT.window_sumsquare`'s `F.conv_transpose1d(torch.ones(1, 1, n_frames), win_sq, ...)` fails ONNX symbolic at opset 17 and 18 (`Unsupported: ONNX export of convolution for kernel of unknown shape`). Rewrote with `scatter_add` — same math, ONNX handles it.
- `onnxslim` crashes on the 565 MB cond decoder (`google.protobuf.message.EncodeError: Failed to serialize proto` because the inline-weight proto exceeds protobuf's 2 GB limit during shape inference). Slim pass made fault-tolerant: on any failure, fall back to raw externalization via `onnx.save_model(..., save_as_external_data=True)`.
- LM head wired correctly: chatterbox.t3 uses split `tfmr` (Llama backbone) + `speech_head` projection, not a fused `LlamaForCausalLM`. Composing them ourselves keeps provenance at ResembleAI (Vlad's reference relies on his personal `vladislavbro/llama_backbone_0.5` HF mirror for E3 LM weights).

## E2 smoke output

```
embed_tokens.onnx         17 KB +    61.6 MB sidecar
speech_encoder.onnx      1.1 MB +    1.05 GB sidecar
conditional_decoder.onnx  32 MB +    533 MB sidecar
```

Resolves the "conditional_decoder.onnx is anomalously small" mystery from Run 1 — the HF directory listing was just incomplete.

## Out of scope (E3, E4, E5)

- `language_model.onnx` export from `chatterbox.t3.tfmr` + `speech_head` with KV-cache.
- `test_chatterbox_parity.py` skeleton wires up but doesn't yet implement the three-layer parity protocol.
- `export-report.json` finalization once all four graphs are present.

## Test plan

- [ ] `uv venv --python 3.10` + `uv pip install -r scripts/chatterbox_export/requirements.txt` on a clean checkout — verify dep resolution still lands without the `pkuseg`/setuptools 80+/onnxslim/sympy conflicts we sorted through.
- [ ] `python scripts/chatterbox_export/export_chatterbox_to_onnx.py --output-dir /tmp/chatterbox_export --device cuda --overwrite` — reproduces the three artifacts + `export-report.json`.
- [ ] Confirm SHA256s in `export-report.json` match across re-runs (modulo the random-noise audio prompt — pass `--audio-prompt path/to/reference.wav` for determinism).
- [ ] On a CPU-only host, the same command path (`--device cpu`) should still complete (slower).

🤖 Generated with [Claude Code](https://claude.com/claude-code)