### PR TITLE
chore: disable C# Dev Kit in-project-folder cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ tmp/
 .claude/
 *.scratch.md
 *.scratch/
+
+# C# Dev Kit language-service cache. Should be redirected out of the
+# project tree via .vscode/settings.json, but keep an ignore here in
+# case a contributor overrides that setting.
+*.lscache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  // Keep C# Dev Kit's language-service cache out of the project tree.
+  // With this set to false, the .csproj.lscache files land in
+  // VSCode's global cache dir instead of next to each .csproj.
+  // See https://aka.ms/lscache.
+  "dotnet.projectsystem.cacheInProjectFolder": false
+}


### PR DESCRIPTION
## Summary

- Set `dotnet.projectsystem.cacheInProjectFolder: false` in workspace settings so the C# Dev Kit language service stops dropping `*.csproj.lscache` files next to each `.csproj`. The cache moves to VSCode's global cache dir instead.
- Add `*.lscache` to `.gitignore` as belt-and-suspenders if a contributor overrides the workspace setting.

Background: every `git status` was showing five untracked `.lscache` files in `src/Vernacula.{Avalonia,Base,CLI}` and `tests/{AsrBackendCoverage,IndicConformerTest}`. Header comment in those files documents the setting (see https://aka.ms/lscache).

## Test plan

- [ ] Re-open the repo in VSCode, let C# Dev Kit reload, then run `find . -maxdepth 4 -name '*.lscache'` — should return nothing.
- [ ] `git status` shows clean tree after extension reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)