### PR TITLE
Chatterbox ONNX export — Stage 0 (all four graphs, dynamic shape, parity)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ tmp/
 .claude/
 *.scratch.md
 *.scratch/
+
+# C# Dev Kit
+samples/
+*.lscache

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -746,4 +746,75 @@ ways to ship around this:
   (378 tokens for the VCTK reference voice) and produces audio of the
   expected shape with the expected dynamic range.
 
-## Run 9 — pending — Pick MVP path: pad-to-trace-length on C# side, or revisit later
+## Run 9 — 2026-05-15 — Dynamo experiment: not a shortcut around the diffusers wall
+
+**Question:** Run 8 ended with the cond decoder stuck at a baked
+`/decoder/Reshape_9 = [80, 756]` inside `diffusers.models.attention_processor.Attention`.
+Before sinking weeks into patching diffusers' Attention surface, is
+`torch.onnx.dynamo_export` (TorchDynamo + torch.export) a meaningfully
+shorter path? It's PyTorch 2.x's newer ONNX exporter, designed for
+dynamic shapes via symbolic tracing rather than concrete-tensor tracing.
+
+**What we tried:**
+
+- Dynamo path on the cond decoder, full CFM=10 solve, CUDA. Hung 25+
+  minutes, killed.
+- Dynamo + CFM=1 (one-step CFM, diagnostic) + CUDA. Device-placement
+  errors during export — dynamo trips on mixed-device tensors that
+  legacy trace silently coerces.
+- Dynamo + CFM=1 + CPU. Completed in **104.7s** — proving dynamo can
+  in principle export this graph.
+
+**Patches still required for dynamo to even start:**
+
+| Failure | Patch |
+|---|---|
+| `aten._fft_r2c` not supported by ONNX exporter | Wrote a Conv1d-based STFT (real-only DFT projection matrix), verified bit-equivalent to `torch.stft` (max-abs 1.4e-6) |
+| `_add_optional_chunk_mask` has `.item()` (data-dependent guard, dynamo forbids) | `_add_optional_chunk_mask_no_guard`: drop the chunk-size branch, use the static path unconditionally |
+
+So just getting dynamo to *complete* required two non-trivial patches.
+
+**The runtime result was the same kind of failure:**
+
+The CFM=1 CPU export produced an ONNX graph that, at inference time,
+failed with a shape mismatch `197760 vs 198240` — exactly one mel hop
+off (480 samples). Tracing back: dynamo had emitted many "Ignored
+guard" warnings during export. Each "ignored guard" is a place where
+dynamo silently specialized on a concrete value rather than keeping a
+SymInt. At runtime those baked values mismatch the real input — same
+root cause as the legacy path, different reporting.
+
+**Conclusion:**
+
+Dynamo is **not a shortcut around the diffusers wall**. It exports a
+different ONNX graph from legacy trace, but it bakes shapes in many of
+the same places, just behind a less-obvious warning channel ("Ignored
+guard" rather than a hard error). Fixing dynamo means hunting down
+each ignored guard and adjusting the upstream code so dynamo keeps the
+SymInt — comparable depth-of-fix to the legacy patch path. And dynamo
+also brought *additional* failures (FFT, data-dependent guards) that
+legacy handles without help.
+
+**Decision:** Revert dynamo experiment, stay on legacy trace path,
+ship MVP with C# orchestrator padding `speech_tokens` to trace-time
+length. Revisit estimator rewrite (Option 2 in Run 8) if/when the pad
+pattern bites.
+
+**Code state:**
+
+- All dynamo-experiment code reverted to `c4be929` via
+  `git checkout c4be929 -- _export_patches.py export_chatterbox_to_onnx.py`.
+- `_export_patches.py` and `export_chatterbox_to_onnx.py` back to the
+  legacy CFM=10 trace path with the three dynamic-shape patches from
+  Run 8.
+- `/tmp/cb_dyno/` (dynamo ONNX dir) and the Conv1d-STFT / no-guard
+  patches are gone, not committed.
+- `scripts/chatterbox_export/_chatterbox_internals.py` unchanged.
+
+**What's next (Run 10):** Resume legacy iteration. Two threads open:
+1. The dec parity envelope drift (mel_log_l1 ~0.80 vs noise floor 0.012)
+   — needs layer-by-layer intermediate-output comparison inside upstream
+   HiFi-GAN mel2wav. E5+ polish, not MVP-blocking.
+2. End-to-end listen test against the trace-shape cond decoder ONNX
+   with the pad-to-trace-length convention, to confirm the MVP shipping
+   path actually produces intelligible speech.

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -484,4 +484,90 @@ real test.
   WIP `_export_patches.py` work has the seeds. Decision can wait
   until cond decoder parity is in.
 
-## Run 6 — pending — Conditional decoder parity
+## Run 6 — 2026-05-15 — De-vendor the S3Tokenizer chain (~600 LOC dropped)
+
+**Question:** Can we replace the vendored S3Tokenizer / FSMN / FSQ /
+AudioEncoderV2 model code in `_chatterbox_internals.py` with direct
+use of upstream `chatterbox.s3gen.tokenizer` plus targeted ONNX-export
+patches, without sacrificing parity?
+
+**Approach:** Four scoped monkey-patches in `_export_patches.py` that
+cover the four upstream ops which don't symbolic-convert to ONNX:
+
+| # | Patched | Reason | Replacement |
+|---|---|---|---|
+| 1 | `S3Tokenizer.log_mel_spectrogram` | `torch.stft(return_complex=True)` — ONNX has no complex scalar type | Use `return_complex=False`, manual `real² + imag²` magnitude |
+| 2 | `S3Tokenizer.forward` | `pad_sequence` over Python list — ONNX has no aten::pad_sequence | Operate on `(B, N)` tensor directly, batch through |
+| 3 | `s3tokenizer.model_v2.apply_rotary_emb` + `freqs_cis` buffers | `torch.polar` / `view_as_real` — complex tensors not supported | Convert buffers to real `(T, D, 2)` at patch time; replacement function reads real layout |
+| 4 | `AudioEncoderV2.forward` | Inline duplicate `view_as_real(freqs_cis)` (cos/sin computed but never used downstream — dead code) | Skip the dead block; pass real-format buffer through |
+
+**Verification protocol:**
+
+1. Standalone three-way parity (`/tmp/parity_s3tok.py`):
+   - A: upstream UNPATCHED eager
+   - B: upstream PATCHED eager (all 4 patches active)
+   - C: patched upstream ONNX-exported, run via ORT
+
+   All three produced **bit-identical** speech tokens
+   `[5533, 4036, 3927, 4254, 4011, 4008, 4251, 4000, ...]` for the
+   same fixed-seed audio input. A == B == C exactly. The patches are
+   mathematically equivalent transformations, not approximations.
+
+2. End-to-end parity (`test_chatterbox_parity.py --tests lm,embed,enc`):
+   - `lm` PASS — argmax tokens agree, 2.5e-3 SDPA noise (unchanged)
+   - `embed` PASS — bit-perfect (unchanged)
+   - `enc[onnx-vs-upstream]` PASS — speaker_embeddings cosine sim
+     0.999999 vs upstream eager (3.4e-3 max-abs, mean 1.0e-3).
+     **Identical to pre-deletion** — the swap is transparent.
+
+**Code dropped:** ~493 lines from `_chatterbox_internals.py`
+(1521 → 1028 lines):
+
+- `ModelConfig` (dataclass)
+- helpers: `make_non_pad_mask`, `precompute_freqs_cis`, `apply_rotary_emb`,
+  `reshape_for_broadcast`
+- `FSQCodebook`, `FSQVectorQuantization`
+- `FSMNMultiHeadAttention` (~100 lines)
+- `ResidualAttentionBlock`
+- `AudioEncoderV2` (~65 lines)
+- `S3TokenizerV2`, `S3Tokenizer` (~157 lines combined)
+- Imports that only the dropped classes used
+  (`MultiHeadAttention`, `Conv1d`, etc. from `s3tokenizer.model`)
+
+**Code added:** ~80 lines of patches in `_export_patches.py` (was
+inert WIP; now active).
+
+**Net:** -413 lines of vendored model code, replaced by parity-validated
+patches. The remaining `_chatterbox_internals.py` is *only* orchestration:
+`PrepareConditionalsModel`, `InputsEmbeds`, `ISTFT`, `ConditionalDecoder`,
+`SafeDenseLayer` (stub), `make_pad_mask`, `mask_to_bias`. None of these
+re-implement upstream model code; they assemble upstream pieces in an
+ONNX-friendly way.
+
+**Three-attempt journey to make the patches work:**
+
+The `_DenseLayerExportShim` story (Run 5) was actually a preview of
+what this run validated at scale — Vlad's vendoring was overkill in
+multiple dimensions. For the S3Tokenizer chain specifically, the four
+upstream issues are exactly the ops we'd expect to fail (complex
+tensors and Python-list operations), and each is a one-liner workaround
+relative to the 100-line module that wraps it. Vendoring the entire
+class hierarchy was a sledgehammer approach.
+
+**What's still vendored:**
+
+- `ISTFT` (~106 lines) — used by `ConditionalDecoder`. Has the
+  scatter_add `window_sumsquare` (Run 3 fix #12) which was OUR fix,
+  not Vlad's. Could potentially be replaced with `torch.istft` + a
+  patch, but lower-priority.
+- `PrepareConditionalsModel`, `InputsEmbeds`, `ConditionalDecoder` —
+  these are export-friendly orchestration of upstream submodules,
+  not vendored model code. They stay.
+
+**Still ahead:** cond decoder parity test (spectral distance) — the
+last graph to validate. Then the project moves into E5: artifact
+finalization (export-report.json schema lock, README updates, optional
+fp16 path) and cleanup (drop the SafeDenseLayer stub entirely, remove
+the `--with-item-patch` flag if no E5 work needs it, etc.).
+
+## Run 7 — pending — Conditional decoder parity

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -668,4 +668,82 @@ audio quality polish is an E5 follow-up.
 - `make_pad_mask`, `mask_to_bias` — small upstream-equivalent helpers,
   could be imported from `s3tokenizer.utils`
 
-## Run 8 — pending — E5 polish (audit, fp16, dec parity drift hunt)
+## Run 8 — 2026-05-15 — Dynamic-shape hunt; cond decoder is trace-shape-only
+
+**Question:** Can we make `conditional_decoder.onnx` accept arbitrary
+`speech_tokens` length, not just the trace-time value?
+
+**Why this matters:** The MVP scope is "continuous reading of long
+texts" — chunked synthesis with variable per-chunk audio. Without
+dynamic length, the cond decoder ONNX is unusable for real input.
+Discovered when the listen-test failed with a shape-mismatch
+(`LeftShape: {1,456,512}, RightShape: {1,378,1}`) on the very first
+real-voice export.
+
+**The chain of baked dimensions, each fix unlocking the next:**
+
+| # | Where | What was baked | Fix |
+|---|---|---|---|
+| 1 | `CausalConditionalCFM.solve_euler` | `torch.zeros([2, 80, x.size(2)])` — `x.size(2)` collapses to int | `_solve_euler_dynamic`: replace with `torch.cat([zeros_like(x), zeros_like(x)])` (preserves SymInt time dim) |
+| 2 | `MaskedDiffWithXvec.inference` mask via `make_pad_mask(token_len)` | `lengths.max()` collapses to int → arange end → mask shape | `_flow_inference_dynamic`: all-True mask via `torch.ones_like(token[:, :, :1])` |
+| 3 | flow.inference's conds tensor and feat slice | `prompt_feat.shape[1]` and `h.shape[1] - prompt_feat.shape[1]` Python ints in `torch.zeros(...)` and slicing | Use `narrow` with shape-derived lengths and `zeros_like(h.narrow(...))` |
+| 4 | `/decoder/Reshape_9` baked to `[80, 756]` | Inside upstream cond decoder estimator's diffusers `Attention` | **NOT FIXED** — see below |
+
+**Where the patching stopped:**
+
+- The cond decoder estimator uses
+  `diffusers.models.attention_processor.Attention` (HuggingFace
+  diffusers library), not chatterbox's own attention. Discovered after
+  patching `chatterbox.s3gen.matcha.text_encoder.MultiHeadAttention`
+  and finding the patch never fired.
+- Diffusers' `Attention` has a large surface (multiple processors:
+  SDPA, xformers, default; many code paths each, all with their own
+  shape arithmetic). Patching it cleanly is not a one-function fix.
+- Each round of patching has been "find baked dim → narrow it down to
+  one method → patch → re-export → discover next baked dim". The chain
+  goes deep into a third-party library now. Patching may take many
+  more iterations and might never be fully solved without rewriting
+  the diffusers integration.
+
+**Eager parity verified for the patches we did land:** patched
+`flow.inference` and `solve_euler` produce bit-identical outputs to
+upstream eager (max_abs = 0).
+
+**Pragmatic resolution for the MVP:**
+
+The cond decoder ONNX is **trace-shape-only** for now. Two acceptable
+ways to ship around this:
+
+1. **C# orchestrator pads `speech_tokens` to the trace-time length**
+   before calling the cond decoder, then trims output to the actual
+   audio duration. Wastes ~10–20% compute on average but is a one-
+   liner on the consumer side. Recommended for MVP.
+
+2. **Re-export with the longest expected per-chunk length** (e.g., the
+   max possible 256 LM steps × token_mel_ratio + reference clip).
+   Always pad to that length at runtime. Slightly nicer but commits
+   us to one specific max.
+
+**For the longer-term fix** (E5+):
+
+- Try `torch.onnx.dynamo_export` (PyTorch 2.x's newer ONNX path,
+  which is designed for dynamic shapes). Could trade this set of
+  problems for a different set.
+- Or re-implement the cond decoder estimator as our own thin module
+  that doesn't use diffusers — costly but gives us full control.
+- Or ship as-is with the pad-to-trace-length pattern and revisit
+  if/when it bites in production use.
+
+**Code state:**
+
+- `_export_patches.py`: 3 dynamic-shape patches landed
+  (`_solve_euler_dynamic`, `_flow_inference_dynamic`,
+  `patched_sinegen_deterministic` — the last is a probe, not active by
+  default). Plus all the prior cond decoder patches
+  (`_stft`/`_istft`/strip-inference-mode).
+- `_chatterbox_internals.py`: unchanged from Run 7.
+- Cond decoder ONNX exports cleanly, runs at the trace-time length
+  (378 tokens for the VCTK reference voice) and produces audio of the
+  expected shape with the expected dynamic range.
+
+## Run 9 — pending — Pick MVP path: pad-to-trace-length on C# side, or revisit later

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -1,0 +1,315 @@
+# Chatterbox ONNX export — investigation log
+
+Running record of the Stage 0 export work in
+[chatterbox.scratch.md](../chatterbox.scratch.md). Chronological by run.
+Negative results stay; that's the whole point of the log.
+
+## Run 1 — 2026-05-15 — Provenance survey of upstream ONNX artifacts
+
+**Question:** Is there a publisher-canonical Chatterbox ONNX export we
+can rely on, or do we need to own it?
+
+**Commands / sources consulted:**
+
+- `WebFetch ResembleAI/chatterbox-turbo-ONNX` (HF model card)
+- `WebFetch onnx-community/chatterbox-ONNX` (HF model card + README +
+  file listing)
+- `WebFetch resemble-ai/chatterbox` (GitHub repo)
+- `WebFetch VladOS95-cyber/onnx_conversion_scripts/chatterbox`
+  (directory + issues)
+- `WebFetch huggingface.co/.../discussions/42` (offline iPhone/Mac
+  report)
+- WebSearch: "Chatterbox TTS ONNX export RTX 3090 CUDA execution
+  provider performance"
+- WebSearch: "ResembleAI chatterbox ONNX export official script 2026"
+
+**Findings:**
+
+1. **No publisher export script exists.** `resemble-ai/chatterbox` on
+   GitHub has zero ONNX code. ResembleAI's HF org publishes
+   `chatterbox-turbo-ONNX` artifacts but no recipe to reproduce them.
+2. **The `onnx-community/chatterbox-ONNX` bundle is Frankenstein.**
+   - `embed_tokens.onnx`, `speech_encoder.onnx`,
+     `conditional_decoder.onnx` come from VladOS95-cyber's script
+     (opset 20 / 20 / 17, fp32, no CUDA-specific options).
+   - `language_model.onnx` is **not** produced by that script. Open
+     issue [#2 on Vlad's repo](https://github.com/VladOS95-cyber/onnx_conversion_scripts/issues)
+     ("how to export language_model.onnx") confirms this — the LM came
+     from somewhere else, almost certainly HF's standard
+     transformers→ONNX exporter, but it's undocumented.
+3. **The published LM does have proper KV-cache.** 30 layers, 16
+   KV-heads, 64 head_dim. Variants: fp32 (~2 GB), fp16 (~1 GB), q4
+   (~354 MB), q4f16 (~305 MB). Inference example in the model card
+   threads `past_key_values.N.{key,value}` in and `present_key_values`
+   out per step.
+4. **The published `conditional_decoder.onnx` is anomalously small**
+   (6.35 MB with no `.onnx_data` sidecar listed). Either weights are
+   inline (genuinely small CNN vocoder) or there's external data the
+   HF directory listing doesn't show. Our re-export will resolve this.
+5. **Zero published 3090 + ORT-CUDA benchmarks.** The "decoder is the
+   bottleneck" finding is from CoreML on iPhone (community member
+   leowangxyz, not ResembleAI staff). Has to be re-validated on the
+   3090 once we have our own export.
+6. **Vlad's script maturity:** 2 open issues, 0 closed, 0 PRs.
+   Single-contributor side project. Useful as a structural reference
+   for the three graphs it does cover; not a basis we can sit on.
+
+**Implication for next step:**
+
+We own the export. Stage 0 of [chatterbox.scratch.md](../chatterbox.scratch.md)
+is now scoped:
+
+- E1: scaffold `scripts/chatterbox_export/` skeleton matching
+  `scripts/vibevoice_export/` conventions.
+- E2: adapt Vlad's three graphs (embed_tokens, speech_encoder,
+  conditional_decoder), run end-to-end numerical comparison against
+  PyTorch reference. Resolve the conditional_decoder size mystery as
+  a side effect.
+- E3: write the Llama LM export from scratch with proper KV-cache.
+- E4: end-to-end parity test (speech-token sequence + waveform
+  spectral distance).
+- E5: `export-report.json` capturing source SHA, hashes, opset,
+  tool versions.
+
+Working on branch `chatterbox-export`.
+
+## Run 2 — 2026-05-15 — Reading Vlad's script
+
+**Question:** What exactly does Vlad's script export, what wrapper
+modules does it define, and what can we copy structurally vs. need to
+rewrite?
+
+**Sources:** `/tmp/vlad_chatterbox_export.py` (1687 lines, pinned via
+header: `chatterbox-tts==0.1.4`, `transformers==4.46.3`, `torch==2.6.0`,
+`numpy==2.2.6`, `librosa==0.11.0`, `onnx==1.18.0`, `onnxslim==0.1.59`).
+
+**Findings:**
+
+1. **It loads `ChatterboxTTS.from_pretrained()` from the official
+   `chatterbox-tts` PyPI package.** The script doesn't reimplement
+   Chatterbox — it imports it. Our export will do the same; the model
+   code is upstream. The ~900 lines of nn.Module classes in Vlad's
+   script (`S3Tokenizer`, `FSMNMultiHeadAttention`,
+   `ResidualAttentionBlock`, `AudioEncoderV2`, `ISTFT`,
+   `ConditionalDecoder`, etc.) appear to be **vendored re-declarations of
+   Chatterbox internals** needed to construct the export-wrapper modules
+   — they aren't fresh model code. We need to verify whether the
+   official package now exposes enough surface that we can skip the
+   vendoring.
+
+2. **Three wrapper nn.Modules drive the export:**
+   - `PrepareConditionalsModel` — speech encoder + S3 tokenizer +
+     conditioning latent prep, single forward pass. Output:
+     `audio_features`, `audio_tokens`, `speaker_embeddings`,
+     `speaker_features`. (~285 lines)
+   - `InputsEmbeds` — text-embed + position/exaggeration handling.
+     Inputs: `input_ids`, `position_ids`, `exaggeration`. (~95 lines)
+   - `ConditionalDecoder` — speech-tokens + speaker conditioning →
+     waveform; includes a custom `ISTFT` module to keep the vocoder
+     graph ONNX-exportable. (~360 lines)
+
+3. **One monkeypatch is required before export:**
+   `chatterbox_model.s3gen.speaker_encoder.xvector.dense` (a `DenseLayer`
+   wrapping `BatchNorm1d`) is replaced with a `SafeDenseLayer` that uses
+   `LayerNorm`. Comment in the script: "we can safely do that because
+   it does not affect inference as we do no need matching training
+   dynamics". Load-bearing — without this, the speech_encoder graph
+   doesn't export. Need to verify the assertion (norm-equivalence at
+   inference) in parity test E4.
+
+4. **Opset choices: 20 / 20 / 17.** Embed tokens and speech encoder use
+   opset 20; conditional decoder uses opset 17 — likely because
+   ISTFT-related ops don't survive cleanly in newer opsets. We default
+   to opset 18 in Vernacula's other exports; for Chatterbox we should
+   probably keep 20 for the modern graphs and live with 17 for the
+   decoder unless we can verify 18 works.
+
+5. **The Llama LM is NOT exported in this script.** Vlad runs the LM in
+   PyTorch (`LlamaForCausalLM.from_pretrained("vladislavbro/llama_backbone_0.5")`)
+   to validate end-to-end behavior. The LM weight repo is **Vlad's
+   personal HF account**, not ResembleAI's — `vladislavbro/llama_backbone_0.5`.
+   This is the LM extraction we'll need to either reuse or redo from
+   the official `chatterbox-tts` package's `s3` LM weights.
+
+6. **Reference inputs hardcoded in script:**
+   - `input_ids`: 79-token prompt ending in `START_SPEECH_TOKEN,
+     START_SPEECH_TOKEN` (comment says "by accident but kept for
+     compatibility")
+   - `position_ids`: `where(input_ids >= START_SPEECH_TOKEN, 0,
+     arange - 1)`
+   - `exaggeration`: 0.5 scalar
+   - `dummy_audio_values`: `torch.randn(1, 312936)` — that's ~13 s at
+     S3GEN_SR (24 kHz)
+
+7. **Post-export onnxslim pass + external data:** `ONNXSLIM_THRESHOLD =
+   1e10` (effectively disables size-threshold pruning), then re-saves
+   with `save_as_external_data=True, all_tensors_to_one_file=True`.
+   Every exported `.onnx` should end up with an `.onnx_data` sidecar.
+   This makes the published `conditional_decoder.onnx` being 6.35 MB
+   *without* a sidecar on HF (per Run 1 finding 4) genuinely
+   suspicious — either the HF directory listing was incomplete, or the
+   HF artifact was post-processed differently. **E2 parity should
+   double-check this** by comparing our re-exported decoder against the
+   published one byte-for-byte (or graph-for-graph if external data
+   layout differs).
+
+8. **No CUDA-aware behavior.** Script accepts `device="cpu"` and
+   nothing else changes downstream. Our export needs to add
+   `--device cuda` for fp16-on-3090 ergonomics.
+
+**Implications for E2 plan:**
+
+- Determine whether Chatterbox's official package exposes
+  `speaker_encoder`, `s3gen`, `t3` modules cleanly enough that we can
+  skip vendoring ~900 lines of model code. If not, isolate the vendored
+  classes in a `_chatterbox_internals.py` so they're easy to spot.
+- Validate the `SafeDenseLayer` substitution numerically before
+  trusting it. Add a unit test that runs forward through the old and
+  new dense layer with random input and confirms close-enough
+  agreement at inference time.
+- The Llama backbone repo `vladislavbro/llama_backbone_0.5` is
+  third-party. Prefer extracting the LM directly from
+  `ChatterboxTTS.from_pretrained()` internals so our provenance chain
+  ends at ResembleAI, not at Vlad's personal HF.
+
+## Run 3 — 2026-05-15 — E1 + E2 land; three of four graphs exporting
+
+**Question:** Can we stand up the scripts/chatterbox_export/ skeleton
+matching vibevoice_export conventions, and adapt Vlad's three-graph
+export so it produces working ONNX artifacts on our 3090 stack?
+
+**Commands run (high level):**
+
+- `python3.10 -m venv` + `uv pip install` for the dep stack
+- 12 invocations of `python scripts/chatterbox_export/export_chatterbox_to_onnx.py --output-dir /tmp/chatterbox_smoke --device cuda --overwrite`, each surfacing a new failure mode
+
+**Outcome (smoke export, attempt #12):**
+
+```
+Graphs emitted: ['embed_tokens.onnx', 'speech_encoder.onnx', 'conditional_decoder.onnx']
+```
+
+Artifact sizes:
+
+| File | Header | Sidecar | Total |
+|---|---|---|---|
+| embed_tokens.onnx | 17 KB | 61.6 MB | 61.6 MB |
+| speech_encoder.onnx | 1.1 MB | 1.05 GB | 1.05 GB |
+| conditional_decoder.onnx | 32 MB | 533 MB | 565 MB |
+
+Compare to published `onnx-community/chatterbox-ONNX` directory listing
+(Run 1 finding 4): "conditional_decoder.onnx 6.35 MB no sidecar listed"
+— our 565 MB result makes it clear the HF directory listing was just
+incomplete. The decoder genuinely is a substantial graph; the published
+artifact must have an `.onnx_data` sidecar not surfaced in the directory
+view. **Mystery resolved.** The cond decoder is not a "small graph";
+it's a normal-sized vocoder with weights externalized.
+
+**Dependency stack pins that survived debugging:**
+
+```
+chatterbox-tts==0.1.5   (0.1.4 wants raw `pkuseg` which needs Python.h;
+                         0.1.7 wants transformers==5.x which breaks the
+                         wrapper API. 0.1.5 is the sweet spot.)
+transformers==4.46.3    (matches Vlad's reference)
+torch==2.6.0            (matches Vlad's reference)
+numpy>=1.24,<1.26       (chatterbox-tts cap — forces Python 3.10)
+onnxslim>=0.1.93,<0.2   (Vlad's 0.1.59 / 0.1.68 want sympy>=1.13.3 which
+                         conflicts with torch 2.6.0's sympy==1.13.1)
+setuptools<80           (resemble-perth imports pkg_resources, removed
+                         in setuptools 80+)
+```
+
+**The twelve fixes**, each captured because the issue is non-obvious
+and "Vlad's script just works for him" does not protect us:
+
+1. **resemble-perth import dies on setuptools 80+** — pkg_resources got
+   removed. Pinned setuptools<80.
+2. **`@torch.inference_mode()` decorators in vendored S3Tokenizer / FSQ
+   classes** — inference mode poisons tensors with a flag that prevents
+   `save_for_backward` during JIT tracing. Replaced 7 decorators with
+   `@torch.no_grad()` (same intent, doesn't trigger the trace conflict).
+   This is a chatterbox-tts 0.1.5 thing; 0.1.4 may not have it.
+3. **`PrepareConditionalsModel.cond_spkr` is precomputed in `__init__`
+   from trainable layers** — its `requires_grad=True` made the tracer
+   refuse to inline it as a constant. Wrapped in
+   `torch.no_grad() + .detach()`. Vlad's script worked because his entire
+   export ran under `@torch.no_grad()`; we use scoped semantics instead.
+4. **Wrappers needed `.to(device)`** — buffers registered via
+   `register_buffer` follow the parent module on `.to()`, but they sit
+   on the CPU default until you call it. Added to the export script.
+5. **`PrepareConditionalsModel.__init__` created `speaker_emb` on CPU**
+   when the chatterbox model was on CUDA. Fixed by reading the device
+   from `cond_enc.spkr_enc`.
+6. **`PrepareConditionalsModel.mel_spectrogram` created `hann_window` +
+   mel filter on CPU.** Added `device=y.device` hints.
+7. **LM head: chatterbox.t3 uses split `tfmr` (Llama backbone) +
+   `speech_head` (output projection)** — `.tfmr(...)` returns
+   `BaseModelOutputWithPast` with `last_hidden_state`, not
+   `CausalLMOutputWithPast` with `logits`. Vlad sidestepped this by
+   loading `vladislavbro/llama_backbone_0.5` from his personal HF mirror;
+   we keep provenance at ResembleAI by composing the two pieces ourselves.
+8. **`ConditionalDecoder.flow_forward` allocated `conds` zeros without
+   device hint** — added `device=text_encoded.device`.
+9. **`ConditionalDecoder.forward` allocated `trim_fade` zeros and
+   `cosine_window` linspace without device hint** — added device hints.
+10. **`ISTFT.window` was a plain attribute, not a registered buffer** —
+    `.to(device)` skipped it. Changed to `register_buffer('window', ...)`.
+11. **CUDA `torch.jit.trace` bug in upstream `CausalBlock1D.block(x * mask)`** —
+    reproduces with `torch.jit.trace` directly, not specific to ONNX. Eager mode
+    runs the same code path cleanly. Pre-casting mask to `x.dtype`
+    didn't help; `torch.set_default_device("cuda")` didn't help. **Workaround:
+    move the cond decoder + its inputs to CPU just for the export call.**
+    The resulting ONNX file is device-independent; runtime can still use
+    CUDA EP. The other two graphs (embed_tokens, speech_encoder) export
+    fine on CUDA.
+12. **`window_sumsquare` used `F.conv_transpose1d` with dynamic-shape input** —
+    fails the ONNX symbolic at opset 17 and 18 ("Unsupported: ONNX export of
+    convolution for kernel of unknown shape"). Rewrote with a `scatter_add`
+    formulation: build flat output-position indices `frame_idx * hop_length
+    + sample_idx`, scatter-add the squared window. Same math, ONNX-friendly.
+13. **`onnxslim.slim` crashes on the 565 MB cond decoder** —
+    `google.protobuf.message.EncodeError: Failed to serialize proto`
+    because the inline-weight proto exceeds protobuf's 2 GB limit during
+    onnxslim's `shape_infer` size-check (then masked by an
+    `UnboundLocalError` from `model` not being assigned in the slim's
+    exception handler). Made the slim pass fault-tolerant: on any
+    failure, fall back to raw externalization via `onnx.save_model(...,
+    save_as_external_data=True)`. Slim is an optimization, not load-bearing.
+
+**Observations on the broader story:**
+
+- Vlad's script "worked" for him under a narrow regime: CPU-only, inside
+  a global `@torch.no_grad()` decorator, with `torch.Tensor.item =
+  lambda x: x` monkeypatching, against `chatterbox-tts==0.1.4`. Every
+  constraint we relaxed surfaced a separate bug.
+- Roughly half of the bugs are Vlad's (cond_spkr requires_grad,
+  ISTFT.window as plain attribute, scatter_add formulation, device hints
+  missing), half are upstream chatterbox-tts (inference_mode decorators,
+  the CUDA trace bug in CausalBlock1D), one is onnxslim's own.
+- The investigation doc convention from CLAUDE.md paid off — each fix is
+  traceable to a specific failure mode, not "we just kept tweaking until
+  it worked".
+
+**What's now true:**
+
+- Branch `chatterbox-export` carries a working three-graph export.
+- `_chatterbox_internals.py` (1521 lines + 13 inline patches) is the
+  vendored baseline we'll iterate on. Attribution preserved in header.
+- `export-report.json` captures SHA256 hashes for all 6 artifacts plus
+  source revision, opset table, environment.
+- Branch `chatterbox-export` is uncommitted; next step is to commit
+  this state before tackling E3.
+
+**Open questions for E3 / E4:**
+
+- The Llama LM export: probably much smoother because it's a stock
+  Llama backbone and HF's tooling (`optimum.exporters.onnx`) handles
+  this well. Still need to compose with `chatterbox.t3.speech_head` (Vlad
+  used a separately-uploaded `LlamaForCausalLM` mirror that bundles the
+  head; we'd rather not depend on that).
+- E4 parity: do the three graphs we exported actually match the
+  PyTorch reference numerically? We haven't checked yet. The smoke
+  proves export *succeeds*; correctness comes in E4.
+
+## Run 4 — pending — Commit E2 state and start E3 (Llama LM export)

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -382,4 +382,106 @@ maintenance debt. E3's LM is ours and clean.
 and E5 (export-report finalization, audit cleanup, optional fp16 path).
 Parity is the next gate before any C# consumer takes a dependency.
 
-## Run 5 — pending — E4 parity tests
+## Run 5 — 2026-05-15 — E4 parity catches a real bug; SafeDenseLayer removed
+
+**Question:** Do the four exported ONNX graphs produce numerically
+correct outputs vs upstream PyTorch chatterbox? (E4.)
+
+**Approach:** Per-graph parity framework in
+[test_chatterbox_parity.py](../scripts/chatterbox_export/test_chatterbox_parity.py).
+For each graph, run our ONNX through ORT and run the equivalent
+upstream PyTorch forward on the same inputs; compare via
+max-abs-diff + max-rel-diff + mean-abs-diff + (where appropriate)
+argmax agreement and cosine similarity.
+
+**Three tests landed; all three now pass:**
+
+| Test | Result | Notes |
+|---|---|---|
+| `lm` | PASS | logit max-abs 2.5e-3 on a [-7.7, 4.3] range, argmax tokens agree exactly. Normal SDPA-vs-PyTorch numerical noise. |
+| `embed` | PASS | bit-perfect (max_abs = 0). InputsEmbeds wrapper is uncontested. |
+| `enc[onnx-vs-upstream]` | PASS | speaker_embeddings cosine sim 0.999999 vs upstream eager, max_abs 3.4e-3. **Only after** SafeDenseLayer removal. |
+
+**The SafeDenseLayer bug:**
+
+The first version of `enc[safe-dense]` (a with-vs-without-patch
+diagnostic on the stock chatterbox model) revealed that Vlad's
+`SafeDenseLayer` substitution **drifted speaker_embeddings by 93% of
+dynamic range** (cosine sim 0.81 instead of 1.0). The substitution
+copies only the Conv1d weight from upstream and replaces the
+BatchNorm1d with a randomly-initialized LayerNorm. Vlad's stated
+reason ("safe at inference") was wrong: BatchNorm1d's running
+mean/var encode learned activation statistics that the random
+LayerNorm cannot match.
+
+A separate probe ([probe_dense.py](../scripts/chatterbox_export/_export_patches.py))
+showed that upstream `DenseLayer` with `BatchNorm1d` ONNX-exports
+fine on CPU — Vlad's earlier failure was the same generic CUDA
+trace bug we hit on the cond decoder, not a symbolic-conversion
+issue. **The substitution was unnecessary AND wrong.**
+
+**The fix turned into a four-step debug:**
+
+1. Removed the `apply_safe_dense_patch` call from `main()`.
+2. Added `register_buffer` for `cond_spkr` (it was a plain attribute,
+   so `.cpu()` skipped it during the new CPU-export path).
+3. First patch attempt: monkey-patch `DenseLayer.forward` to skip
+   the `if len(x.shape) == 2` branch. **Didn't work** — `squeeze(-1)`
+   is shape-conditional and produced its own ONNX `If` node.
+4. Second attempt: skip the `Conv1d`-with-`unsqueeze`/`squeeze` trick;
+   use a true `nn.Linear`. **Didn't work** — ONNX shape inference
+   couldn't propagate channel dim through `Linear` either.
+5. Third attempt: explicit `reshape(-1, 192)` after Linear. **Didn't
+   work** — even an explicit Reshape with static target shape didn't
+   give the BatchNorm symbolic the channel info it wanted.
+6. Final fix: `_DenseLayerExportShim` (in `_export_patches.py`)
+   replaces the entire DenseLayer with a Linear + inlined-BatchNorm
+   math. BatchNorm1d at inference (with `affine=False`, which the
+   xvector dense uses) is just `(x - running_mean) * rsqrt(running_var
+   + eps)`. Pure arithmetic, no BatchNorm op in the graph. **Works.**
+
+The shim copies BN running mean/var as buffers; behavior is
+mathematically identical to upstream BN at inference.
+
+**Side effects of dropping SafeDenseLayer:**
+
+- One inert function (`apply_safe_dense_patch`) preserved as a stub
+  that raises if anyone tries to re-introduce it.
+- Speech encoder export now runs on CPU (same trace-bug workaround
+  as cond decoder). Export time went from 9 s on CUDA to ~8 s on
+  CPU — no meaningful change. The exported ONNX runs on any EP at
+  session-load time.
+- One scoped patch (`patched_dense_layer_for_export` +
+  `_DenseLayerExportShim`) is now active during the speech_encoder
+  export. The earlier WIP patches in `_export_patches.py` (S3Tokenizer
+  STFT/forward/rotary) remain inert — kept as seeds for the
+  S3Tokenizer de-vendoring follow-up.
+
+**Final smoke export numbers, post-fix:**
+
+| Graph | Header | Sidecar | Total |
+|---|---|---|---|
+| embed_tokens.onnx | 17 KB | 61.6 MB | 61.6 MB |
+| speech_encoder.onnx | 1.1 MB | 1.05 GB | 1.05 GB |
+| language_model.onnx | 810 KB | 2.05 GB | 2.05 GB |
+| conditional_decoder.onnx | 32 MB | 533 MB | 565 MB |
+
+Total ~3.6 GB (unchanged from Run 4).
+
+**What this means:**
+
+Voice-clone quality from `speech_encoder.onnx` is now upstream-faithful.
+Anyone who was previously using a Vlad-pattern export was getting
+silently degraded speaker embeddings — and there was no way to know
+without parity tests. The E4 framework paid for itself on its first
+real test.
+
+**Still ahead:**
+- Cond decoder parity (spectral distance on waveform output).
+- Optional: `_chatterbox_internals.py` cleanup. Several big chunks
+  (S3Tokenizer family ~600 LOC, ISTFT ~106 LOC) are still vendored.
+  Replacing them with patches would shrink the surface further; the
+  WIP `_export_patches.py` work has the seeds. Decision can wait
+  until cond decoder parity is in.
+
+## Run 6 — pending — Conditional decoder parity

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -570,4 +570,102 @@ finalization (export-report.json schema lock, README updates, optional
 fp16 path) and cleanup (drop the SafeDenseLayer stub entirely, remove
 the `--with-item-patch` flag if no E5 work needs it, etc.).
 
-## Run 7 — pending — Conditional decoder parity
+## Run 7 — 2026-05-15 — De-vendor ConditionalDecoder; dec parity has known drift
+
+**Question:** Can we replace the ~360 LOC vendored `ConditionalDecoder`
+with a thin delegator to upstream `chatterbox.s3gen.flow.inference()`
++ `mel2wav.inference()`? And does the resulting export pass parity?
+
+**Approach:**
+
+- Probed upstream — `s3gen.flow.inference(token, token_len,
+  prompt_token, prompt_token_len, prompt_feat, prompt_feat_len,
+  embedding, finalize)` does the full speech_tokens → mel features
+  pipeline (including the CFM 10-step solve via `flow.decoder.forward`).
+  `mel2wav.inference(speech_feat, cache_source)` does mel → waveform.
+  Two upstream calls replace 360 LOC of Vlad's reimplementation.
+- Wrote `_DenseLayerExportShim`-style patches in `_export_patches.py`:
+  - `patched_cond_decoder_for_export(s3gen, istft_module)`:
+    - Strips `@torch.inference_mode()` from `flow.inference`,
+      `flow.decoder.forward` (CausalConditionalCFM), `mel2wav.inference`
+    - Patches `mel2wav._stft` to `return_complex=False` + manual
+      real/imag layout (same fix as S3Tokenizer.log_mel_spectrogram)
+    - Patches `mel2wav._istft` to use our `ISTFT` class instead of
+      `torch.istft(torch.complex(real, img), ...)`
+- Replaced `ConditionalDecoder` in `_chatterbox_internals.py` with
+  ~50 LOC thin wrapper that just calls `flow.inference` +
+  `mel2wav.inference` and applies a trim_fade.
+
+**Result:** All four graphs export. `lm`, `embed`, `enc[onnx-vs-upstream]`
+parity tests still PASS. New `dec` parity test FAILS with mel_log_l1
+~0.80 against an eager-vs-eager noise floor of ~0.012 — about 70× the
+inherent NSF stochasticity.
+
+**The `dec` parity drift — partial diagnosis:**
+
+| State | mel_log_l1 |
+|---|---|
+| eager-vs-eager (noise floor, NSF random sampling per call) | 0.012 |
+| Initial scatter_add ISTFT | 1.43 |
+| Scalar-saturation ISTFT (wrong: COLA doesn't hold at hop=N/4) | 1.43 |
+| Precomputed window_sumsquare buffer + cat-instead-of-mutate trim_fade | 0.80 |
+
+**Things attempted that didn't help (or weren't the cause):**
+
+- `index_add` instead of `scatter_add` — same warning, same drift
+- `F.fold` (Col2Im op) — fails ONNX symbolic with dynamic output_size
+- Scalar `window_sumsquare_saturation` — wrong because Hann window with
+  `hop = N/4` doesn't satisfy COLA; values vary per position
+- Precomputed-buffer window_sumsquare — values are now correct
+  position-by-position but didn't fix parity
+- Removing in-place mutation in `trim_fade` (replaced with `cat`) —
+  improved 0.97 → 0.80 but didn't close the gap
+- ScatterND warning red-herring: persists from upstream `mel2wav.decode`'s
+  `s_stft` handling, not from our ISTFT
+
+**Hypothesis for the remaining drift:** something in the upstream HiFi-GAN
+`mel2wav.decode` chain (resblocks, source-fusion, `_stft` of the
+NSF-derived source signal) that ONNX implements with different
+numerical kernels from PyTorch. Diagnosing further requires layer-by-layer
+intermediate output comparison — out of scope for this run.
+
+**Decision:** Commit the de-vendoring as-is. The architectural goal
+("drop vendored code that isn't ours") is fully achieved — `~360 LOC of
+Vlad's vendored ConditionalDecoder reimplementation is gone, replaced
+by ~50 LOC thin delegator + ~80 LOC of scoped patches`. The cond
+decoder ONNX **produces audio of correct shape and dynamic range**;
+the envelope drift is a measurable but not catastrophic issue (mean
+mel-log diff ~0.3 = ~30% loudness drift). The C# consumer will work;
+audio quality polish is an E5 follow-up.
+
+**Net code change for the cond decoder de-vendor:**
+
+- `_chatterbox_internals.py`: 1028 → 705 lines (−323 lines this run, on top of −493 from Run 6)
+- `_export_patches.py`: ~80 lines added (cond decoder patches)
+- `test_chatterbox_parity.py`: dec test added with mel-spectral metric
+
+**Cumulative since vendoring removal started:**
+
+- `_chatterbox_internals.py`: 1521 → 705 lines (−816 lines, ~54% reduction)
+- All vendored model code (S3Tokenizer chain, CFM cond_forward,
+  flow_forward, decode reimplementations) replaced with scoped patches
+  on upstream
+- 3 of 4 graphs parity-clean against upstream PyTorch
+- 1 graph (cond decoder) parity-measurably-drifting; functional but
+  needs E5 polish
+
+**What remains "vendored" in `_chatterbox_internals.py`:**
+
+- `SafeDenseLayer` stub (16 LOC) — kept as a poison-pill guard against
+  re-introduction; could be deleted entirely
+- `PrepareConditionalsModel`, `InputsEmbeds` — these are our
+  orchestration, not vendored model code
+- `ISTFT` (~140 LOC after our precomputed-buffer rewrite) — partly ours
+  (precomputed buffer, scatter_add → buffer-slice), partly Vlad's
+  (the conv_transpose1d-based inverse_basis approach). Could be
+  replaced by a torch.istft-based shim if we patch around the complex
+  tensor issue.
+- `make_pad_mask`, `mask_to_bias` — small upstream-equivalent helpers,
+  could be imported from `s3tokenizer.utils`
+
+## Run 8 — pending — E5 polish (audit, fp16, dec parity drift hunt)

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -939,3 +939,105 @@ mel-spectral envelope drift (mel_log_l1 ~0.78). That's a quality
 issue inside HiFi-GAN mel2wav export, not a shape issue. Defer to
 E5+ unless it turns out to bite intelligibility — current listen
 tests are intelligible.
+
+## Run 11 — 2026-05-16 — The "envelope drift" was rand_noise apples-vs-oranges
+
+**Question:** dec parity has been reporting `mel_log_l1 = 0.78` for
+several runs, presumed to be HiFi-GAN mel2wav export drift. Is it
+really vocoder export drift, or something else?
+
+**Method:** capture both wavs, then bisect.
+
+1. Capture `wav_eager` and `wav_onnx` from identical
+   `(speech_tokens, spk_emb, spk_feat)` inputs.
+2. Cross-correlate to detect time-shift. Result: per-chunk lags
+   varied wildly (+346, -1203, -480, -680, ...), and full-length
+   "best lag" was nonsense (560ms — shifting by it made mel L1
+   *worse*). The waveforms have **similar amplitude envelope but
+   different content per chunk** — classic phase-incoherence pattern.
+3. Per-window RMS ratio in non-silent regions: **0.99 ± 0.19**.
+   Amplitude is fine; the issue is fine-structure phase / time.
+4. Verify ONNX itself is deterministic between runs: two consecutive
+   `sess.run()` calls differ by `max_abs = 1.5e-5` (floating-point
+   noise floor). So drift is reproducible, not stochastic.
+5. Built a diagnostic export with two outputs `(mel, waveform)` so we
+   can compare the flow.inference output (mel after CFM solve)
+   independently from the mel2wav stage.
+6. Result: **mel itself drifts**. `max_abs = 3.33`, `mean_abs = 0.42`
+   between `mel_eager` and `mel_onnx`. So the bug is in `flow.inference`,
+   not (or not only) mel2wav.
+
+**The "aha" moment:**
+
+`solve_euler` parity is bit-identical eager-vs-eager (per
+`parity_solve_euler`), but mel still drifts. What can drift inside
+`flow.inference` without solve_euler drifting? **The input to
+solve_euler.** Specifically:
+
+```python
+# CausalConditionalCFM.__init__:
+self.rand_noise = torch.randn([1, 80, 50 * 300])  # plain attribute, not register_buffer
+```
+
+`rand_noise` is the initial `z` for the CFM ODE. It's set with
+`torch.randn(...)` at every `__init__` call and is **not registered as
+a buffer**, so it doesn't appear in the state_dict. Every
+`ChatterboxTTS.from_pretrained()` gets a different random init.
+
+The ONNX export bakes whatever `rand_noise` was present at trace time.
+The parity test loads a fresh model with a *different* `rand_noise`.
+The CFM solves start from different `z` → produce different mels → the
+"envelope drift" was an apples-vs-oranges comparison the whole time.
+
+**Verification:** force `rand_noise = zeros` in both export and eager,
+then compare mels. Result: `max_abs = 1.05e-5`. The export is
+mathematically faithful at float32 precision. The 0.78 drift was 100%
+artifactual.
+
+**The fix** (`_export_patches.py`):
+
+Add seeded-deterministic `rand_noise` to
+`patched_cond_decoder_for_export`. Every export now bakes the same
+canonical noise (seeded with `CFM_RAND_NOISE_SEED = 0xC4F`), and every
+parity test applies the same context manager so the comparison is
+honest. `parity_solve_euler` also pre-seeds `rand_noise` before
+running the upstream side, since the context manager applies only to
+the patched side.
+
+```python
+def _seeded_rand_noise_like(t):
+    g = torch.Generator(device="cpu").manual_seed(CFM_RAND_NOISE_SEED)
+    return torch.randn(t.shape, dtype=t.dtype, generator=g).to(t.device)
+
+# In patched_cond_decoder_for_export:
+saved["flow.decoder.rand_noise"] = flow.decoder.rand_noise
+flow.decoder.rand_noise = _seeded_rand_noise_like(flow.decoder.rand_noise)
+# (restored on exit alongside the other patches)
+```
+
+**Tradeoff considered and accepted:** every shipped ONNX has the same
+canonical CFM noise pattern. CFM is trained to map any noise sample to
+a valid mel, so this has negligible perceptual cost. The win is
+reproducible artifacts (same model + same code → same `.onnx` hash)
+and honest parity tests.
+
+**Results:**
+
+| Test | Before | After |
+|---|---|---|
+| `dec` `mel_log_l1` | 0.78 | **0.0102** (76× improvement) |
+| `dec` `cosine_sim` | 0.19 | **0.9994** |
+| `dec` waveform `max_abs` | 1.59e-1 | **1.71e-2** |
+| `solve_euler` `max_abs` | 0 | **0** (still bit-identical after pre-seeding both sides) |
+| Full suite | 4/5 pass (dec FAIL) | **5/5 pass** |
+
+**General lesson:** When the parity test reports a "drift," ask
+whether you're comparing the same thing. A plain attribute set via
+`torch.randn(...)` at `__init__` is a silent source of confounding
+randomness — it's not in the state_dict, not in the `.onnx`'s public
+contract, but it changes the model's output on every load. The fix
+isn't to find a real bug in the export; it's to pin the confounding
+state to a deterministic value.
+
+The previous "deferred to E5+" item on this drift is closed. The export
+is faithful.

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -312,4 +312,74 @@ and "Vlad's script just works for him" does not protect us:
   PyTorch reference numerically? We haven't checked yet. The smoke
   proves export *succeeds*; correctness comes in E4.
 
-## Run 4 — pending — Commit E2 state and start E3 (Llama LM export)
+## Run 4 — 2026-05-15 — E3 lands: Llama LM export, no debug fixes needed
+
+**Question:** Can we export `chatterbox.t3.tfmr` (Llama backbone, 30
+layers × 16 KV-heads × 64 head_dim) + `chatterbox.t3.speech_head`
+(Linear 1024→8194) as a single ONNX graph with HF-schema KV-cache I/O?
+
+**Approach:**
+
+- `LMWithSpeechHead` wrapper inside [export_chatterbox_to_onnx.py](../scripts/chatterbox_export/export_chatterbox_to_onnx.py):
+  ~30 lines of nn.Module that takes positional args
+  `(inputs_embeds, attention_mask, *past_kv_flat)`, reshapes the flat
+  KV tuple into HF's legacy tuple-of-tuples format, runs
+  `tfmr(...)` with `use_cache=True`, projects through `speech_head`, and
+  flattens `present_key_values` back to a positional output tuple.
+- Input names match the published `onnx-community/chatterbox-ONNX`
+  bundle's `language_model.onnx`:
+  `past_key_values.{N}.{key,value}` for N in 0..29 (62 ONNX inputs
+  including inputs_embeds + attention_mask). Output names follow
+  `present.{N}.{key,value}` (61 outputs).
+- Dynamic axes: batch dim + sequence-length dim + past-sequence-length
+  dim across all the KV tensors.
+- Dummy inputs for trace: `B=1, S=4, past_kv_len=0` ("prefill"
+  config). dynamic_axes lets ORT consume any shape at runtime.
+
+**Result:** **LM exported cleanly on first try.** Zero debug fixes.
+Contrast with E2's 13-fix journey.
+
+**Smoke export (full four-graph CUDA run):**
+
+| Graph | Export time | Header | Sidecar | Total |
+|---|---|---|---|---|
+| embed_tokens.onnx | 0.3 s | 17 KB | 61.6 MB | 61.6 MB |
+| speech_encoder.onnx | 9.5 s | 1.1 MB | 1.05 GB | 1.05 GB |
+| language_model.onnx | 8.6 s | 810 KB | 2.05 GB | 2.05 GB |
+| conditional_decoder.onnx | 62.4 s | 32 MB | 533 MB | 565 MB |
+| **Total** | **~80 s** | | | **3.6 GB** |
+
+Cond decoder is the slow one because it still runs on CPU (the upstream
+`CausalBlock1D` trace bug from Run 3 fix #11). The other three export
+on CUDA.
+
+**Cross-check against `onnx-community/chatterbox-ONNX` fp32:**
+
+| File | Theirs | Ours |
+|---|---|---|
+| `language_model.onnx` | 171 KB header + 2.08 GB sidecar | 810 KB header + 2.05 GB sidecar |
+
+Total LM bytes match within 1% — 30 MB delta plausibly from opset
+differences (we use 18; theirs is unspecified) or different external-data
+packing. Our header is ~5× bigger, probably more graph metadata; not a
+concern for runtime.
+
+**Why E3 was easy (in contrast to E2):**
+
+1. `tfmr` is a stock `transformers.LlamaModel` — HF's transformers code
+   is already ONNX-aware and well-trodden.
+2. `speech_head` is a single `nn.Linear`. Nothing for the tracer to
+   choke on.
+3. We didn't vendor anything. The wrapper is 30 lines of our own code.
+   No upstream surface area to hit.
+4. The KV-cache schema is a well-documented HF pattern; matching it
+   meant copying the naming convention from vibevoice_export.
+
+The take-away for E5 cleanup: E2's vendored graphs carry most of the
+maintenance debt. E3's LM is ours and clean.
+
+**Still ahead:** E4 (three-layer parity test against PyTorch reference)
+and E5 (export-report finalization, audit cleanup, optional fp16 path).
+Parity is the next gate before any C# consumer takes a dependency.
+
+## Run 5 — pending — E4 parity tests

--- a/docs/chatterbox_investigation.md
+++ b/docs/chatterbox_investigation.md
@@ -818,3 +818,124 @@ pattern bites.
 2. End-to-end listen test against the trace-shape cond decoder ONNX
    with the pad-to-trace-length convention, to confirm the MVP shipping
    path actually produces intelligible speech.
+
+## Run 10 — 2026-05-16 — Cond decoder is fully dynamic-shape now
+
+**Question:** Run 8 stalled at a "trace-shape-only" cond decoder ONNX
+because we hit baked dims inside diffusers Attention. Run 9 (dynamo
+experiment) confirmed dynamo wasn't a shortcut around that wall. With
+the legacy trace path: can we actually finish the dynamic-shape work
+with a systematic approach instead of "patch one bake → re-export →
+discover next"?
+
+**Method:** Up-front inventory rather than peel-the-onion.
+
+1. Built a scanner (`/tmp/scan_bakes.py`) that walks every `Constant`
+   node in the ONNX, decodes small int tensors, then reports every
+   downstream consumer whose constant input contains a "suspect"
+   trace-derived integer (the trace-time mel-frame count, its 2x, its
+   /2, etc.).
+2. Ran it against the trace-shape export and got **45 hits across 2
+   clusters in a single pass** — far more useful than chasing one
+   runtime error at a time.
+
+**Findings from the scan:**
+
+| Cluster | Where | Op pattern | Verdict |
+|---|---|---|---|
+| 1 | `/encoder/encoders.{0..5}/self_attn/Concat_7` + `up_encoders.{0..3}` (10 hits) | Concat builds `[batch_dim, -1, 512]` shape | **FALSE POSITIVE** — 512 = `h × d_k = 8 × 64` = inner_dim, a model architecture constant, not a trace-length bake. Coincidence that trace length 512 == inner_dim. |
+| 2 | `/decoder/Reshape*` + `Equal*` + `Where*` + `Expand*` (35 hits) | Shape constants `[80, T]` and `[2, 80, T]` | **REAL** — these all collapse to T-baked Reshape/Expand pairs. |
+
+**Bisecting Cluster 2:**
+
+False trails I followed before finding the real culprit:
+
+1. **`einops.repeat(spks, "b c -> b c t", t=x.shape[-1])` in
+   `ConditionalDecoder.forward`** — sounded right, but my patched
+   `_estimator_forward_dynamic` replacement (using multiplicative
+   broadcast via `ones_like(x[:, :1, :])`) had **zero effect** on the
+   bake count (still 35). False trail.
+2. **`rand_noise[:, :, :mu.size(2)]` in `CausalConditionalCFM.forward`**
+   — `mu.size(2)` collapses to a Python int. Replaced with `narrow(2,
+   0, mu.shape[2])`, which keeps a SymInt-derived length. Still 35
+   bakes. Necessary but not sufficient.
+3. **Diagnostic**: replaced `rand_noise.narrow(...)` with
+   `torch.zeros_like(mu)` entirely. Still 35 bakes — confirming
+   `rand_noise` is **not** the source.
+
+**The actual bake source:** solve_euler's in-place broadcast assigns.
+
+```python
+# Upstream (and our Run 8 patch) had:
+x_in = torch.zeros([2, 80, x.size(2)], ...)  # bakes T directly
+# or our patched version:
+x_in = torch.cat([torch.zeros_like(x), torch.zeros_like(x)], dim=0)
+# Then INSIDE the loop:
+x_in[:] = x       # broadcast assign  ← THE BAKE
+mask_in[:] = mask
+```
+
+`x_in[:] = x` with `x_in: [2, 80, T]` and `x: [1, 80, T]` requires
+broadcasting x. torch.jit.trace records this as
+`Reshape(x, [80, T]) → Expand(_, [2, 80, T])` — and `[80, T]` /
+`[2, 80, T]` get baked as constants. Each of the 10 CFM solve
+iterations produced 3-4 baked nodes, giving the 35 total.
+
+**The fix:** pure cat construction, no broadcast assigns.
+
+```python
+# CFG-pair tensors that don't change across iterations:
+mu_in    = torch.cat([mu, torch.zeros_like(mu)],   dim=0)   # row 0 = mu, row 1 = zeros (unconditional)
+spks_in  = torch.cat([spks, torch.zeros_like(spks)], dim=0)
+cond_in  = torch.cat([cond, torch.zeros_like(cond)], dim=0)
+mask_in  = torch.cat([mask, mask],                  dim=0)   # both rows = mask
+
+for step in range(1, len(t_span)):
+    # x and t change each iter; rebuild via cat (no broadcast)
+    x_in  = torch.cat([x, x], dim=0)
+    t_cur = t.unsqueeze(0)
+    t_in  = torch.cat([t_cur, t_cur], dim=0).view(2)
+    dphi_dt = self.forward_estimator(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+    ...
+```
+
+cat-of-same-shape produces `[2, 80, T_sym]` without any broadcast
+target shape needed. The trace stays fully symbolic.
+
+**Verification:**
+
+- Bake scanner: **0 baked trace-derived constants** in the new export.
+- Listen test at natural LM length (456 speech tokens, ≠ trace-time
+  505): produced 8.2s WAV cleanly with no shape errors. Trailing
+  static is gone (no zero-pad needed).
+- Dec parity at natural 505 length: runs end-to-end without shape
+  errors. mel_log_l1 = 0.78 envelope drift remains — that's the
+  separate quality issue deferred to E5+, unrelated to dynamic shape.
+
+**Code cleanup:**
+
+- Dropped `--cond-decoder-trace-len` CLI flag and the trace-length
+  padding logic from `export_chatterbox_to_onnx.py` (no longer needed).
+- Dropped `cond_decoder_trace_len` from export-report.json schema.
+- Dropped pad-and-rerun-eager logic from `test_chatterbox_parity.py::parity_dec`.
+- Listen test: dropped TRACED_LEN constant, pad logic, and output trim.
+  Just feeds the natural speech_tokens length now.
+- Kept `_cfm_forward_dynamic` (narrow-based rand_noise slice) — even
+  though insufficient on its own, it's the principled way to express
+  the dynamic slice and removes one bake source.
+
+**The general lesson** worth remembering across this whole investigation:
+when torch.jit.trace bakes a dim, the bake is at the place that
+*forces* a Reshape or Expand target shape, not necessarily the
+place the dim was first referenced. In-place broadcast assigns
+(`x_in[:] = x`) are a particularly silent offender — they look like
+no-ops semantically but compile to Reshape+Expand with baked target.
+Pure cat-based construction avoids the broadcast entirely.
+
+**What's next:**
+
+The dynamic-shape work is done. Remaining open thread is the
+mel-spectral envelope drift (mel_log_l1 ~0.78). That's a quality
+issue inside HiFi-GAN mel2wav export, not a shape issue. Defer to
+E5+ unless it turns out to bite intelligibility — current listen
+tests are intelligible.

--- a/scripts/_export_utils/scan_bakes.py
+++ b/scripts/_export_utils/scan_bakes.py
@@ -1,0 +1,144 @@
+"""Find baked-in trace-time shape constants in an ONNX graph.
+
+When `torch.jit.trace` records a sequence-length-dependent op (Reshape,
+Expand, Where, Concat-of-shape), it sometimes collapses a SymInt to a
+Python literal — e.g., a `view(80, T)` where T came from `x.size(-1)`
+becomes a `Reshape` with shape `[80, 1024]` baked as a constant. The
+exported ONNX only works at the exact trace-time length unless every
+such collapse is eliminated.
+
+This module walks every `Constant` node, decodes small int tensors, and
+reports the consumer ops whose constant inputs contain "suspect" values
+(integers derived from the trace-time sequence length: T, 2*T, T/2, etc.).
+Hits are grouped by ONNX op scope (e.g. `/decoder/Reshape_9`), which maps
+back to the PyTorch module path that produced the trace.
+
+Why this matters:
+- The "patch one bake, re-export, discover the next" loop is slow and
+  misses interactions. An up-front inventory of every bake site in a
+  single export pass scopes the fix work in one shot.
+- A passing run (zero hits for legitimate suspect values) is a strong
+  signal that the export is genuinely dynamic-shape.
+
+Caveats:
+- Suspect values must include legitimate model constants (e.g., `inner_dim`,
+  `num_heads`, `head_dim`) only when they coincidentally equal a trace
+  dimension — those are false positives. Compare against a second export
+  at a different trace length to disambiguate.
+- Only flags constants used directly by a consumer; doesn't currently
+  follow Concat/Gather chains. Those can hide trace-derived ints inside
+  composed shape tensors. Good enough in practice.
+
+CLI:
+    python scripts/_export_utils/scan_bakes.py <onnx_path> --suspect 512 1024 [...]
+"""
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Iterable
+
+import onnx
+from onnx import numpy_helper
+
+
+def _decode_constants(graph: onnx.GraphProto) -> dict[str, list[int]]:
+    """Return {tensor_name: int_list} for every small-int Constant node."""
+    out: dict[str, list[int]] = {}
+    for node in graph.node:
+        if node.op_type != "Constant":
+            continue
+        for attr in node.attribute:
+            if attr.name == "value":
+                try:
+                    arr = numpy_helper.to_array(attr.t)
+                except Exception:
+                    continue
+                if arr.dtype.kind in "iu" and arr.size <= 32:
+                    out[node.output[0]] = arr.flatten().tolist()
+            elif attr.name == "value_ints":
+                out[node.output[0]] = list(attr.ints)
+            elif attr.name == "value_int":
+                out[node.output[0]] = [attr.i]
+    return out
+
+
+def _top_scope(name: str) -> str:
+    parts = name.lstrip("/").split("/")
+    return "/" + "/".join(parts[:2]) if len(parts) >= 2 else "/" + name.lstrip("/")
+
+
+def scan(
+    onnx_path: Path,
+    suspect_vals: Iterable[int],
+) -> list[tuple[str, str, list[int], str, list[int]]]:
+    """Scan an ONNX file for nodes whose constant inputs contain suspect ints.
+
+    Returns a list of `(node_name, op_type, hits, input_name, full_const)`
+    tuples. The caller can format/group as needed; `print_report` does
+    a reasonable default.
+    """
+    suspect = set(suspect_vals)
+    model = onnx.load(str(onnx_path), load_external_data=False)
+    consts = _decode_constants(model.graph)
+    hits = []
+    for node in model.graph.node:
+        for inp in node.input:
+            if inp not in consts:
+                continue
+            vals = consts[inp]
+            seen = [v for v in vals if v in suspect]
+            if seen:
+                hits.append((node.name, node.op_type, seen, inp, vals))
+    return hits
+
+
+def print_report(
+    onnx_path: Path,
+    hits: list[tuple[str, str, list[int], str, list[int]]],
+    samples_per_scope: int = 5,
+) -> None:
+    by_scope: dict[str, list] = defaultdict(list)
+    for h in hits:
+        by_scope[_top_scope(h[0])].append(h)
+    print(f"Scanned: {onnx_path}")
+    print(f"  {len(hits)} consumer nodes use baked suspect constants")
+    print(f"  across {len(by_scope)} top-level scope(s)")
+    op_counter: Counter = Counter()
+    for scope, scope_hits in sorted(by_scope.items(), key=lambda kv: -len(kv[1])):
+        print(f"\n--- {scope}  ({len(scope_hits)} hits) ---")
+        for name, op, seen, _inp, vals in scope_hits[:samples_per_scope]:
+            op_counter[op] += 1
+            print(f"  {name}  [{op}]  seen={seen}  shape={vals}")
+        for name, op, _seen, _inp, _vals in scope_hits[samples_per_scope:]:
+            op_counter[op] += 1
+        if len(scope_hits) > samples_per_scope:
+            print(f"  ... +{len(scope_hits) - samples_per_scope} more")
+    if op_counter:
+        print("\nOp-type tally across all hits:")
+        for op, n in op_counter.most_common():
+            print(f"  {op}: {n}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("onnx_path", type=Path, help="Path to the .onnx file to scan")
+    p.add_argument(
+        "--suspect", type=int, nargs="+", required=True,
+        help="Trace-derived integers that signal a baked dim (e.g. 512 1024 "
+             "for a 512-token trace with 2x mel upsample). Compare against a "
+             "second export at a different trace length to rule out coincidental "
+             "matches with legitimate model constants.",
+    )
+    p.add_argument(
+        "--samples-per-scope", type=int, default=5,
+        help="How many hits to print per scope before summarizing 'and more'.",
+    )
+    args = p.parse_args()
+    hits = scan(args.onnx_path, args.suspect)
+    print_report(args.onnx_path, hits, samples_per_scope=args.samples_per_scope)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/chatterbox_export/README.md
+++ b/scripts/chatterbox_export/README.md
@@ -1,0 +1,109 @@
+# Chatterbox → ONNX export
+
+Exports ResembleAI's Chatterbox TTS into the four-graph ONNX package
+consumed by `Chatterbox.Base` (forthcoming) and eventually folded into
+`Vernacula.Avalonia`. See [chatterbox.scratch.md](../../chatterbox.scratch.md)
+for the project context and [docs/chatterbox_investigation.md](../../docs/chatterbox_investigation.md)
+for the running design log.
+
+**Status: scaffold (Stage 0 step E1).** The CLI surface and dependency
+layout are in place; no graphs are wired up yet. `python
+export_chatterbox_to_onnx.py --output-dir ...` prints a placeholder run
+plan and emits a stub `export-report.json`.
+
+## Why we own this
+
+The upstream provenance for Chatterbox's ONNX bundle is split between
+ResembleAI (publishes artifacts, not export scripts), HF
+`onnx-community` (publishes a Frankenstein bundle), and
+[VladOS95-cyber's script](https://github.com/VladOS95-cyber/onnx_conversion_scripts/tree/main/chatterbox)
+(covers three of the four graphs, omits the language model). We need a
+single reproducible recipe anchored at a pinned `ResembleAI/chatterbox`
+revision. Details: Run 1 in the investigation log.
+
+## Files
+
+- `export_chatterbox_to_onnx.py` — main export entry point. Emits
+  `embed_tokens.onnx`, `speech_encoder.onnx`, `language_model.onnx`,
+  `conditional_decoder.onnx`, and `export-report.json`.
+- `_common.py` — shared helpers (device/dtype resolution, audio I/O at
+  24 kHz, ORT provider selection, `export-report.json` schema,
+  KV-cache name conventions).
+- `test_chatterbox_parity.py` — three-layer parity check (LM token
+  sequence, decoder waveform spectral distance, end-to-end audio).
+- `requirements.txt` — pinned dependencies. The `chatterbox-tts`
+  package and `transformers==4.46.3` are load-bearing; newer
+  transformers versions may break the Chatterbox internals
+  re-imported by the wrapper modules.
+
+## Environment
+
+Use Python `3.11` or `3.12`.
+
+```bash
+python3 -m venv .venv-chatterbox-export
+source .venv-chatterbox-export/bin/activate
+pip install -r scripts/chatterbox_export/requirements.txt
+```
+
+If the upstream `ResembleAI/chatterbox` HF repo becomes gated:
+
+```bash
+huggingface-cli login
+```
+
+## Usage (current scaffold)
+
+```bash
+python scripts/chatterbox_export/export_chatterbox_to_onnx.py \
+  --output-dir ./models/chatterbox_export \
+  --device cuda \
+  --dtype float32 \
+  --opset-language-model 18
+```
+
+Useful flags (all wired up; behavior arrives stepwise):
+
+- `--repo-id <id>` — defaults to `ResembleAI/chatterbox`. Use
+  `ResembleAI/chatterbox-turbo` once we add turbo support.
+- `--revision <commit-or-tag>` — pin exact model snapshot. Recorded in
+  `export-report.json`.
+- `--dtype {float32,float16,bfloat16}` — float32 for parity testing,
+  float16 for the 3090 ship target.
+- `--lm-graph-mode {unified,prefill+step}` — unified is the
+  reference-script style; prefill+step matches Vernacula's vibevoice
+  export pattern and is what we'll likely ship.
+- `--skip-{embed-tokens,speech-encoder,language-model,conditional-decoder}`
+  — re-run a single graph.
+- `--no-onnxslim` — skip the post-export slim + external-data pass.
+- `--overwrite` — replace existing files in `--output-dir`.
+
+## Roadmap
+
+See [docs/chatterbox_investigation.md](../../docs/chatterbox_investigation.md)
+for the running log; the staged plan:
+
+| Step | Status | Description |
+|---|---|---|
+| E1 | done | Scaffold CLI surface, `_common.py`, parity skeleton |
+| E2 | todo | Adapt Vlad's three graphs (embed_tokens, speech_encoder, conditional_decoder); validate `SafeDenseLayer` substitution; resolve `.onnx_data` sidecar question |
+| E3 | todo | Write the Llama LM export from scratch with KV-cache; emit `language_model.onnx` (and optionally `language_model_prefill.onnx` + `language_model_step.onnx`) |
+| E4 | todo | End-to-end parity test (token sequence, decoder spectral distance, full pipeline) |
+| E5 | todo | `export-report.json` finalization: source SHA, file hashes, opset table, tool versions |
+
+## Notes
+
+- **Opset choices** mirror Vlad's reference (20 / 20 / 17) on the three
+  graphs he covers, plus 18 for the LM to match Vernacula's existing
+  Llama exports. Try bumping the conditional decoder to 18+ during E2 —
+  Vlad's choice of 17 was driven by `ISTFT` op support and may no
+  longer be required.
+- **The `SafeDenseLayer` monkeypatch** (BatchNorm1d → LayerNorm on
+  `s3gen.speaker_encoder.xvector.dense`) is required for the
+  speech_encoder graph to export. The substitution is asserted-safe at
+  inference time by upstream; the E2 parity step validates this
+  numerically rather than trusting the assertion.
+- **The Llama backbone** for E3 is loaded via the `chatterbox-tts`
+  package's internals, not from `vladislavbro/llama_backbone_0.5`
+  (Vlad's personal HF mirror). Keeps our provenance chain anchored at
+  ResembleAI.

--- a/scripts/chatterbox_export/README.md
+++ b/scripts/chatterbox_export/README.md
@@ -6,10 +6,11 @@ consumed by `Chatterbox.Base` (forthcoming) and eventually folded into
 for the project context and [docs/chatterbox_investigation.md](../../docs/chatterbox_investigation.md)
 for the running design log.
 
-**Status: scaffold (Stage 0 step E1).** The CLI surface and dependency
-layout are in place; no graphs are wired up yet. `python
-export_chatterbox_to_onnx.py --output-dir ...` prints a placeholder run
-plan and emits a stub `export-report.json`.
+**Status: Stage 0 complete.** All four graphs export, the cond decoder
+is fully dynamic-shape (accepts arbitrary `speech_tokens` length), and
+the per-graph parity suite passes 5/5 (lm, embed, enc, dec, solve_euler).
+End-to-end audio is intelligible at native LM-emitted lengths with no
+padding. Runs 1–11 of the investigation doc cover the methodology.
 
 ## Why we own this
 
@@ -26,11 +27,20 @@ revision. Details: Run 1 in the investigation log.
 - `export_chatterbox_to_onnx.py` — main export entry point. Emits
   `embed_tokens.onnx`, `speech_encoder.onnx`, `language_model.onnx`,
   `conditional_decoder.onnx`, and `export-report.json`.
-- `_common.py` — shared helpers (device/dtype resolution, audio I/O at
-  24 kHz, ORT provider selection, `export-report.json` schema,
+- `_chatterbox_internals.py` — thin export wrappers around upstream
+  `s3gen` / `t3` modules (`PrepareConditionalsModel`, `InputsEmbeds`,
+  `ConditionalDecoder`, `ISTFT`). Most of what used to be vendored
+  here has been de-vendored to scoped patches; see Runs 6–7.
+- `_export_patches.py` — context-managed monkey-patches for the
+  trace path. Covers complex-tensor STFT/iSTFT replacements, the
+  dynamic-shape `solve_euler` rewrite, deterministic `rand_noise` for
+  reproducibility, and the inference-mode strip. Every patch
+  restores its original on context exit.
+- `_common.py` — shared helpers (device/dtype resolution, audio I/O
+  at 24 kHz, ORT provider selection, `export-report.json` schema,
   KV-cache name conventions).
-- `test_chatterbox_parity.py` — three-layer parity check (LM token
-  sequence, decoder waveform spectral distance, end-to-end audio).
+- `test_chatterbox_parity.py` — 5-test parity suite (lm, embed, enc,
+  dec, solve_euler) against upstream eager. All pass.
 - `requirements.txt` — pinned dependencies. The `chatterbox-tts`
   package and `transformers==4.46.3` are load-bearing; newer
   transformers versions may break the Chatterbox internals
@@ -52,17 +62,16 @@ If the upstream `ResembleAI/chatterbox` HF repo becomes gated:
 huggingface-cli login
 ```
 
-## Usage (current scaffold)
+## Usage
 
 ```bash
 python scripts/chatterbox_export/export_chatterbox_to_onnx.py \
   --output-dir ./models/chatterbox_export \
   --device cuda \
-  --dtype float32 \
-  --opset-language-model 18
+  --dtype float32
 ```
 
-Useful flags (all wired up; behavior arrives stepwise):
+Useful flags:
 
 - `--repo-id <id>` — defaults to `ResembleAI/chatterbox`. Use
   `ResembleAI/chatterbox-turbo` once we add turbo support.
@@ -75,8 +84,25 @@ Useful flags (all wired up; behavior arrives stepwise):
   export pattern and is what we'll likely ship.
 - `--skip-{embed-tokens,speech-encoder,language-model,conditional-decoder}`
   — re-run a single graph.
+- `--audio-prompt <wav>` — use a real reference clip instead of the
+  default 13s `torch.randn` dummy. Required for any parity work that
+  depends on speaker identity matching upstream.
 - `--no-onnxslim` — skip the post-export slim + external-data pass.
 - `--overwrite` — replace existing files in `--output-dir`.
+
+After export, verify:
+
+```bash
+python scripts/chatterbox_export/test_chatterbox_parity.py \
+  --onnx-dir ./models/chatterbox_export --tests all
+```
+
+To audit an export for trace-time shape bakes:
+
+```bash
+python scripts/_export_utils/scan_bakes.py \
+  ./models/chatterbox_export/conditional_decoder.onnx --suspect 505 1010
+```
 
 ## Roadmap
 
@@ -86,24 +112,26 @@ for the running log; the staged plan:
 | Step | Status | Description |
 |---|---|---|
 | E1 | done | Scaffold CLI surface, `_common.py`, parity skeleton |
-| E2 | todo | Adapt Vlad's three graphs (embed_tokens, speech_encoder, conditional_decoder); validate `SafeDenseLayer` substitution; resolve `.onnx_data` sidecar question |
-| E3 | todo | Write the Llama LM export from scratch with KV-cache; emit `language_model.onnx` (and optionally `language_model_prefill.onnx` + `language_model_step.onnx`) |
-| E4 | todo | End-to-end parity test (token sequence, decoder spectral distance, full pipeline) |
-| E5 | todo | `export-report.json` finalization: source SHA, file hashes, opset table, tool versions |
+| E2 | done | Three graphs (embed_tokens, speech_encoder, conditional_decoder); `SafeDenseLayer` replaced with verified `_DenseLayerExportShim` (Run 5) |
+| E3 | done | Llama LM export from scratch with KV-cache; emits `language_model.onnx` |
+| E4 | done | Per-graph parity (5 tests, all PASS); dynamic-shape cond decoder (Run 10); rand_noise reproducibility (Run 11) |
+| E5 | todo | `export-report.json` artifact hashing + opset/version manifest; CLI sweep tests; voice-cloning variance tests |
 
 ## Notes
 
-- **Opset choices** mirror Vlad's reference (20 / 20 / 17) on the three
-  graphs he covers, plus 18 for the LM to match Vernacula's existing
-  Llama exports. Try bumping the conditional decoder to 18+ during E2 —
-  Vlad's choice of 17 was driven by `ISTFT` op support and may no
-  longer be required.
-- **The `SafeDenseLayer` monkeypatch** (BatchNorm1d → LayerNorm on
-  `s3gen.speaker_encoder.xvector.dense`) is required for the
-  speech_encoder graph to export. The substitution is asserted-safe at
-  inference time by upstream; the E2 parity step validates this
-  numerically rather than trusting the assertion.
-- **The Llama backbone** for E3 is loaded via the `chatterbox-tts`
-  package's internals, not from `vladislavbro/llama_backbone_0.5`
-  (Vlad's personal HF mirror). Keeps our provenance chain anchored at
-  ResembleAI.
+- **Opset choices**: 20 (embed_tokens, speech_encoder), 18 (LM, cond
+  decoder). Cond decoder needs ≥18 for Col2Im (used in the F.fold
+  window_sumsquare iSTFT replacement).
+- **`SafeDenseLayer` was dropped** in favor of `_DenseLayerExportShim`
+  in `_export_patches.py` (verified by `parity_enc[onnx-vs-upstream]`).
+  See Run 5 — the upstream "asserted-safe" substitution turned out to
+  drift by 93% cosine when the model wasn't fully zero-input.
+- **The Llama backbone** is composed from `chatterbox.t3.tfmr` +
+  `chatterbox.t3.speech_head` at export time, not loaded from
+  `vladislavbro/llama_backbone_0.5` (Vlad's personal HF mirror).
+  Keeps our provenance chain anchored at ResembleAI.
+- **Reproducibility:** every export bakes a canonical seeded
+  `rand_noise` (the CFM ODE's initial latent). Upstream sets it as a
+  plain attribute via `torch.randn(...)` at `__init__`, so without
+  pinning, two consecutive exports produce different `.onnx` files
+  (and parity tests are apples-to-oranges). See Run 11.

--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -1,0 +1,1558 @@
+#!/usr/bin/env python3
+"""Chatterbox export internals — vendored from VladOS95-cyber's MIT-licensed
+reference and adapted for Vernacula's export pipeline.
+
+Source: https://github.com/VladOS95-cyber/onnx_conversion_scripts/tree/main/chatterbox
+        (file `chatterbox_to_onnx_conversion_script.py`, fetched May 2026)
+License: MIT — see upstream repo for full text.
+
+This is the v0 starting point per `chatterbox.scratch.md` Stage 0. Each
+nn.Module here is either:
+
+  (a) an export-time wrapper (`PrepareConditionalsModel`, `InputsEmbeds`,
+      `ConditionalDecoder`, `SafeDenseLayer`, `ISTFT`) that re-implements
+      Chatterbox's forward pass in an ONNX-friendly way; or
+
+  (b) a vendored re-declaration of a Chatterbox internal class
+      (`S3Tokenizer` and its FSMN/FSQ/AudioEncoder dependency chain)
+      needed to construct (a). Vlad re-declared these to swap out
+      training-time ops (e.g. BatchNorm1d → LayerNorm via SafeDenseLayer)
+      that don't survive torch.onnx.export.
+
+Items flagged for E2 validation / E5 cleanup:
+
+  * `SafeDenseLayer` substitution is asserted-safe at inference time by
+    Vlad ("we can safely do that because it does not affect inference as
+    we do not need matching training dynamics"). E2 parity must verify
+    this numerically — not trusted on author's word.
+  * The global `torch.Tensor.item = lambda x: x` monkeypatch in Vlad's
+    script is INTENTIONALLY OMITTED here. It is load-bearing during
+    `torch.onnx.export` tracing (some Chatterbox internals call `.item()`
+    and the no-op makes the value traceable). If the export raises on a
+    `.item()` call, apply the patch via an explicit context manager
+    around the export() call, not as a global mutation.
+  * `EXAGGERATION_TOKEN = 6563` — verified against upstream constants in
+    `chatterbox.models.t3.t3` (E1 inspection, 2026-05-15).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import torchaudio as ta
+from torchaudio.compliance.kaldi import get_mel_banks
+
+from s3tokenizer.model import Conv1d, LayerNorm, Linear, MultiHeadAttention
+from s3tokenizer.utils import mask_to_bias as _s3tok_mask_to_bias  # noqa: F401  - kept to mirror Vlad's surface
+
+import numpy as np
+import librosa
+from librosa.filters import mel as librosa_mel_fn
+from tqdm import tqdm  # noqa: F401  - imported by some vendored loops
+# Sampling rate of the inputs to S3TokenizerV2
+S3GEN_SR = 24000
+S3_SR = 16_000
+S3_HOP = 160
+S3_TOKEN_HOP = 640
+S3_TOKEN_RATE = 25 # 25 tokens/sec
+SPEECH_VOCAB_SIZE = 6561
+MILLISECONDS_TO_SECONDS = 0.001
+
+START_SPEECH_TOKEN = 6561
+STOP_SPEECH_TOKEN = 6562
+EXAGGERATION_TOKEN = 6563
+
+ENC_COND_LEN = 6 * S3_SR
+DEC_COND_LEN = 10 * S3GEN_SR
+
+CFM_PARAMS = {
+    "sigma_min": 1e-06,
+    "solver": "euler",
+    "t_scheduler": "cosine",
+    "training_cfg_rate": 0.2,
+    "inference_cfg_rate": 0.7,
+    "reg_loss_type": "l1"
+}
+ISTFT_PARAMS = {"n_fft": 16, "hop_len": 4}
+
+# override certain torch functions
+
+
+@dataclass
+class ModelConfig:
+    n_mels: int = 128
+    n_audio_ctx: int = 1500
+    n_audio_state: int = 1280
+    n_audio_head: int = 20
+    n_audio_layer: int = 6
+    n_codebook_size: int = 3**8
+
+    use_sdpa: bool = False
+
+def make_non_pad_mask(lengths: torch.Tensor, max_len: int = 0) -> torch.Tensor:
+    """Make mask tensor containing indices of non-padded part.
+
+    The sequences in a batch may have different lengths. To enable
+    batch computing, padding is need to make all sequence in same
+    size. To avoid the padding part pass value to context dependent
+    block such as attention or convolution , this padding part is
+    masked.
+
+    1 for non-padded part and 0 for padded part.
+
+    Parameters
+    ----------
+        lengths (torch.Tensor): Batch of lengths (B,).
+
+    Returns:
+    -------
+        torch.Tensor: Mask tensor containing indices of padded part (B, max_T).
+
+    Examples:
+        >>> import torch
+        >>> import s3tokenizer
+        >>> lengths = torch.tensor([5, 3, 2])
+        >>> masks = s3tokenizer.make_non_pad_mask(lengths)
+        masks = [[1, 1, 1, 1, 1],
+                 [1, 1, 1, 0, 0],
+                 [1, 1, 0, 0, 0]]
+    """
+    batch_size = lengths.size(0)
+    # max_len = max_len if max_len > 0 else lengths.max()
+    max_len_2 = lengths.max()
+    seq_range = torch.arange(0,
+                             max_len_2,
+                             dtype=torch.int64,
+                             device=lengths.device)
+    seq_range_expand = seq_range.unsqueeze(0).expand(batch_size, max_len_2)
+    seq_length_expand = lengths.unsqueeze(-1)
+    return seq_range_expand < seq_length_expand
+
+
+def precompute_freqs_cis(dim: int,
+                         end: int,
+                         theta: float = 10000.0,
+                         scaling=None):
+    freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)  # type: ignore
+    if scaling is not None:
+        t = t * scaling
+    freqs = torch.outer(t, freqs).float()  # type: ignore
+    
+    cos = freqs.cos()
+    sin = freqs.sin()
+    
+    cos = torch.cat((cos, cos), dim=-1)
+    sin = torch.cat((sin, sin), dim=-1)
+    return cos, sin
+
+
+def apply_rotary_emb(
+    xq: torch.Tensor,
+    xk: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(0).unsqueeze(2)
+    sin = sin.unsqueeze(0).unsqueeze(2)
+
+    D = xq.shape[-1]
+    half_l, half_r = xq[:, :, :, :D // 2], xq[:, :, :, D // 2:]
+    xq_r = torch.cat((-half_r, half_l), dim=-1)
+
+    D = xk.shape[-1]
+
+    half_l, half_r = xk[:, :, :, :D // 2], xk[:, :, :, D // 2:]
+    xk_r = torch.cat((-half_r, half_l), dim=-1)
+
+    return xq * cos + xq_r * sin, xk * cos + xk_r * sin
+
+
+def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
+    ndim = x.ndim
+    assert 0 <= 1 < ndim
+    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
+    shape = [
+        d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)
+    ]
+    return freqs_cis.view(*shape)
+
+
+class FSQCodebook(nn.Module):
+
+    def __init__(self, dim: int, level: int = 3):
+        super().__init__()
+        self.project_down = nn.Linear(dim, 8)
+        self.level = level
+        self.embed = None
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def preprocess(self, x: torch.Tensor) -> torch.Tensor:
+        # x = rearrange(x, "... d -> (...) d")
+        x = x.reshape(-1, x.shape[-1])
+        return x
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        x_shape = x.shape
+        # pre-process
+        x = self.preprocess(x)
+        # quantize
+        h = self.project_down(x).float()
+        h = h.tanh()
+        h = h * 0.9990000128746033
+        h = h.round() + 1
+        # h = ((self.level - 1) * h).round()  # range [-k, k]
+        powers = torch.pow(
+            self.level,
+            torch.arange(2**self.level, device=x.device, dtype=h.dtype))
+        mu = torch.sum(h * powers.unsqueeze(0), dim=-1)
+        ind = mu.reshape(x_shape[0], x_shape[1])
+        return ind
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def decode(self, embed_ind: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError(
+            'There is no official up project component provided')
+
+
+class FSQVectorQuantization(nn.Module):
+    """Vector quantization implementation (inference-only).
+    Args:
+        dim (int): Dimension
+        codebook_size (int): Codebook size
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        codebook_size: int,
+    ):
+        super().__init__()
+        assert 3**8 == codebook_size
+        self._codebook = FSQCodebook(dim=dim, level=3)
+        self.codebook_size = codebook_size
+
+    @property
+    def codebook(self):
+        return self._codebook.embed
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        return self._codebook.encode(x)
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def decode(self, embed_ind: torch.Tensor) -> torch.Tensor:
+        quantize = self._codebook.decode(embed_ind)
+        # quantize = rearrange(quantize, "b n d -> b d n")
+        quantize = quantize.permute(0, 2, 1)
+        return quantize
+
+
+class FSMNMultiHeadAttention(MultiHeadAttention):
+
+    def __init__(
+        self,
+        n_state: int,
+        n_head: int,
+        kernel_size: int = 31,
+        use_sdpa: bool = False,
+    ):
+        super().__init__(n_state, n_head)
+
+        self.fsmn_block = nn.Conv1d(n_state,
+                                          n_state,
+                                          kernel_size,
+                                          stride=1,
+                                          padding=0,
+                                          groups=n_state,
+                                          bias=False)
+        self.left_padding = (kernel_size - 1) // 2
+        self.right_padding = kernel_size - 1 - self.left_padding
+        self.pad_fn = nn.ConstantPad1d(
+            (self.left_padding, self.right_padding), 0.0)
+
+        self.use_sdpa = use_sdpa
+
+    def forward_fsmn(self,
+                     inputs: torch.Tensor,
+                     mask: Optional[torch.Tensor] = None):
+        b, t, _, _ = inputs.size()
+        inputs = inputs.view(b, t, -1)
+        if mask is not None and mask.size(2) > 0:  # time2 > 0
+            inputs = inputs * mask
+        x = inputs.transpose(1, 2)
+        x = self.pad_fn(x)
+        x = self.fsmn_block(x)
+        x = x.transpose(1, 2)
+        x += inputs
+        return x * mask
+
+    def qkv_attention(self,
+                      q: torch.Tensor,
+                      k: torch.Tensor,
+                      v: torch.Tensor,
+                      mask: Optional[torch.Tensor] = None,
+                      mask_pad: Optional[torch.Tensor] = None,
+                      cos: Optional[torch.Tensor] = None,
+                      sin: Optional[torch.Tensor] = None):
+        _, _, D = q.shape
+        scale = (D // self.n_head)**-0.25
+        q = q.view(*q.shape[:2], self.n_head, -1)
+        k = k.view(*k.shape[:2], self.n_head, -1)
+        v = v.view(*v.shape[:2], self.n_head, -1)
+
+        if cos is not None and sin is not None:
+            q, k = apply_rotary_emb(q, k, cos=cos, sin=sin)
+
+        fsm_memory = self.forward_fsmn(v, mask_pad)
+
+        q = q.permute(0, 2, 1, 3) * scale
+        v = v.permute(0, 2, 1, 3)
+
+        if not self.use_sdpa:
+            k = k.permute(0, 2, 3, 1) * scale
+            qk = q @ k  # (B, n_head, T, T)
+            if mask is not None:
+                qk = qk + mask
+            qk = qk.float()
+            w = F.softmax(qk, dim=-1).to(q.dtype)
+            return (w @ v).permute(
+                0, 2, 1, 3).flatten(start_dim=2), qk.detach(), fsm_memory
+        else:
+            k = k.permute(0, 2, 1, 3) * scale
+            assert mask is not None
+            output = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=0.,
+                scale=1.,
+            )
+            output = (output.transpose(1,
+                                       2).contiguous().view(q.size(0), -1, D)
+                      )  # (batch, time1, d_model)
+            return output, None, fsm_memory
+
+    def forward(self,
+                x: torch.Tensor,
+                mask: Optional[torch.Tensor] = None,
+                mask_pad: Optional[torch.Tensor] = None,
+                cos: Optional[torch.Tensor] = None,
+                sin: Optional[torch.Tensor] = None):
+
+        q = self.query(x)
+        k = self.key(x)
+        v = self.value(x)
+
+        wv, qk, fsm_memory = self.qkv_attention(q, k, v, mask, mask_pad,
+                                                cos, sin)
+        return self.out(wv) + fsm_memory, qk
+
+
+class ResidualAttentionBlock(nn.Module):
+
+    def __init__(
+        self,
+        n_state: int,
+        n_head: int,
+        kernel_size: int = 31,
+        use_sdpa: bool = False,
+    ):
+        super().__init__()
+
+        self.attn = FSMNMultiHeadAttention(n_state,
+                                           n_head,
+                                           kernel_size,
+                                           use_sdpa=use_sdpa)
+        self.attn_ln = LayerNorm(n_state, eps=1e-6)
+
+        n_mlp = n_state * 4
+
+        self.mlp = nn.Sequential(Linear(n_state, n_mlp), nn.GELU(),
+                                       Linear(n_mlp, n_state))
+        self.mlp_ln = LayerNorm(n_state)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        mask_pad: Optional[torch.Tensor] = None,
+        cos: Optional[torch.Tensor] = None,
+        sin: Optional[torch.Tensor] = None,
+    ):
+        x = x + self.attn(
+            self.attn_ln(x), mask=mask, mask_pad=mask_pad,
+            cos=cos, sin=sin)[0]
+
+        x = x + self.mlp(self.mlp_ln(x))
+        return x
+
+
+class AudioEncoderV2(nn.Module):
+
+    def __init__(
+        self,
+        n_mels: int,
+        n_state: int,
+        n_head: int,
+        n_layer: int,
+        stride: int,
+        use_sdpa: bool,
+    ):
+        super().__init__()
+        self.stride = stride
+
+        self.conv1 = Conv1d(n_mels,
+                            n_state,
+                            kernel_size=3,
+                            stride=stride,
+                            padding=1)
+        self.conv2 = Conv1d(n_state,
+                            n_state,
+                            kernel_size=3,
+                            stride=2,
+                            padding=1)
+        cos, sin = precompute_freqs_cis(64, 1024 * 2)
+        self.register_buffer("cos", cos)
+        self.register_buffer("sin", sin)
+
+        self.blocks = nn.ModuleList([
+            ResidualAttentionBlock(n_state, n_head, use_sdpa=use_sdpa)
+            for _ in range(n_layer)
+        ])
+
+    def forward(self, x: torch.Tensor,
+                x_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        x : torch.Tensor, shape = (batch_size, n_mels, T)
+            the mel spectrogram of the audio
+        x_len: torch.Tensor, shape = (batch_size,)
+            length of each audio in x
+        """
+        mask = make_non_pad_mask(x_len).unsqueeze(1)
+        x = F.gelu(self.conv1(x * mask))
+        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+        mask = make_non_pad_mask(x_len).unsqueeze(1)
+        x = F.gelu(self.conv2(x * mask))
+        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // 2 + 1
+        mask = make_non_pad_mask(x_len).unsqueeze(1)
+        x = x.permute(0, 2, 1)  # (B, T // 2, n_state)
+        # NOTE: .contiguous() is essential for dynamo export!
+        x = x.contiguous()
+
+        
+        cos = self.cos[:x.size(1)].to(x.device)
+        sin = self.sin[:x.size(1)].to(x.device)
+
+        mask_pad = mask.transpose(1, 2)
+        mask = mask_to_bias(mask, x.dtype).unsqueeze(1)
+
+        for block in self.blocks:
+            x = block(x, mask, mask_pad, cos, sin)
+
+        return x, x_len
+
+
+class S3TokenizerV2(nn.Module):
+    """S3 tokenizer v2 implementation (inference-only).
+    Args:
+        config (ModelConfig): Config
+    """
+
+    def __init__(self):
+        super().__init__()
+        # self.name = name  # Store model name for token_rate determination
+        self.config = ModelConfig()
+        self.encoder = AudioEncoderV2(
+            self.config.n_mels,
+            self.config.n_audio_state,
+            self.config.n_audio_head,
+            self.config.n_audio_layer,
+            2,
+            self.config.use_sdpa,
+        )
+        self.quantizer = FSQVectorQuantization(
+            self.config.n_audio_state,
+            self.config.n_codebook_size,
+        )
+
+    def forward(self, mel: torch.Tensor,
+                mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.quantize(mel, mel_len)
+
+    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
+    def quantize(self, mel: torch.Tensor,
+                 mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Quantize mel spectrogram to tokens, with automatic long audio handling.
+
+        Args:
+            mel: mel spectrogram tensor, shape (batch_size, n_mels, T)
+            mel_len: mel length tensor, shape (batch_size,)
+
+        Returns:
+            code: quantized tokens, shape (batch_size, T')
+            code_len: token length, shape (batch_size,)
+        """
+        # Check if any audio in the batch exceeds 30 seconds
+        # Assuming 16kHz sample rate and hop_length=160, 30s = 30*16000/160 = 3000 frames
+        # max_frames = 3000
+
+        # Check which samples are long audio
+        # assert (mel_len <= max_frames).all()
+
+        # All short audio - use original method
+        hidden, code_len = self.encoder(mel, mel_len)
+        code = self.quantizer.encode(hidden).long()
+        return code, code_len
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    def freeze(self):
+        for _, param in self.named_parameters():
+            param.requires_grad = False
+
+
+class S3Tokenizer(S3TokenizerV2):
+    """
+    s3tokenizer.S3TokenizerV2 with the following changes:
+    - a more integrated `forward`
+    - compute `log_mel_spectrogram` using `_mel_filters` and `window` in `register_buffers`
+    """
+
+    ignore_state_dict_missing = ("_mel_filters", "window")
+
+    def __init__(
+        self,
+        config: ModelConfig = ModelConfig()
+    ):
+        super().__init__()
+
+        self.n_fft = 400
+        _mel_filters = librosa.filters.mel(
+            sr=S3_SR,
+            n_fft=self.n_fft,
+            n_mels=config.n_mels
+        )
+        self.register_buffer(
+            "_mel_filters",
+            torch.FloatTensor(_mel_filters),
+        )
+
+        self.register_buffer(
+            "window",
+            torch.hann_window(self.n_fft),
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        wavs: torch.Tensor,
+        max_len,
+    ) -> torch.Tensor:
+        """
+        NOTE: mel-spec has a hop size of 160 points (100 frame/sec).
+
+        Args
+        ----
+        - `wavs`: 16 kHz speech audio
+        """
+        mels = self.log_mel_spectrogram(wavs)  # [B, F, T]
+        if max_len is not None:
+            mels = mels[..., :max_len * 4]
+        mel_lens = torch.full((mels.shape[0],), mels.shape[-1], dtype=torch.int32, device=self.device)
+
+        speech_tokens, _ = self.quantize(mels, mel_lens)
+        return speech_tokens
+
+    def log_mel_spectrogram(
+        self,
+        audio: torch.Tensor,
+        padding: int = 0,
+    ):
+        """
+        Compute the log-Mel spectrogram of
+
+        Parameters
+        ----------
+        audio: torch.Tensor, shape = (*)
+            The path to audio or either a NumPy array or Tensor containing the
+            audio waveform in 16 kHz
+
+        padding: int
+            Number of zero samples to pad to the right
+
+        Returns
+        -------
+        torch.Tensor, shape = (128, n_frames)
+            A Tensor that contains the Mel spectrogram
+        """
+
+        if audio.dim() == 1:
+            audio = audio.unsqueeze(0)
+
+        audio = audio.to(self.device)
+        if padding > 0:
+            audio = F.pad(audio, (0, padding))
+        stft = torch.stft(
+            audio, self.n_fft, S3_HOP,
+            window=self.window.to(self.device),
+            return_complex=False
+        )
+        # remove Nyquist bin
+        stft = stft[..., :-1, :]
+        # compute magnitude squared
+        magnitudes = stft[..., 0]**2 + stft[..., 1]**2
+
+        mel_spec = self._mel_filters.to(self.device) @ magnitudes
+
+        log_spec = torch.clamp(mel_spec, min=1e-10).log10()
+        log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
+        log_spec = (log_spec + 4.0) / 4.0
+        return log_spec
+
+
+class SafeDenseLayer(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, bias=False):
+        super(SafeDenseLayer, self).__init__()
+        self.linear = torch.nn.Conv1d(in_channels, out_channels, 1, bias=bias)
+        self.nonlinear = torch.nn.Sequential()
+        self.nonlinear.add_module("layernorm", torch.nn.LayerNorm(out_channels))
+
+    def forward(self, x):
+        if x.dim() == 2:
+            x = x.unsqueeze(-1)
+        x = self.linear(x)
+        if x.size(-1) == 1:
+            x = x[:, :, 0]
+        x = self.nonlinear(x)
+        return x
+
+
+class PrepareConditionalsModel(torch.nn.Module):
+
+    speech_cond_prompt_len = 150
+    speaker_embed_size = 256
+
+    def __init__(self, chatterbox):
+        super().__init__()
+
+        # TODO: Move loading elsewhere
+        self.s3 = S3Tokenizer()
+        self.s3.load_state_dict(chatterbox.s3gen.tokenizer.state_dict(), strict=False)
+
+        self.speaker_encoder = chatterbox.s3gen.speaker_encoder
+        self.flow = chatterbox.s3gen.flow
+
+        self.cond_enc = chatterbox.t3.cond_enc
+
+        self.resampler = ta.transforms.Resample(S3GEN_SR, S3_SR)
+        self.eps = torch.tensor(torch.finfo(torch.float).eps)
+        self.n_fft = 400
+        _mel_filters = librosa.filters.mel(
+            sr=S3_SR,
+            n_fft=self.n_fft,
+            n_mels=128
+        )
+        self.register_buffer(
+            "mel_filters",
+            torch.FloatTensor(_mel_filters),
+        )
+
+        self.register_buffer(
+            "window",
+            torch.hann_window(self.n_fft),
+        )
+
+        self.speech_emb = chatterbox.t3.speech_emb
+        self.speech_pos_emb = chatterbox.t3.speech_pos_emb
+
+        # Speaker embedding projection
+        # NOTE: From testing, randomly/zero initializing speaker embedding seems to work fine
+        # speaker_emb = torch.randn(batch_size, self.speaker_embed_size)
+        # Pre-computed in __init__ so the export graph sees it as a
+        # constant. detach() drops the autograd graph so torch.jit tracing
+        # won't refuse to inline it (Vlad's reference works because
+        # @torch.no_grad() wraps the whole export — we use scoped no_grad
+        # + detach instead, to avoid the global decorator and its
+        # inference-tensor footgun). Device pulled from spkr_enc so
+        # __init__ works whether the chatterbox model was loaded on
+        # cpu or cuda.
+        spkr_device = next(self.cond_enc.spkr_enc.parameters()).device
+        speaker_emb = torch.zeros(1, self.speaker_embed_size, device=spkr_device)
+        with torch.no_grad():
+            self.cond_spkr = self.cond_enc.spkr_enc(
+                speaker_emb.view(-1, self.speaker_embed_size)
+            )[:, None].detach()  # (B, 1, dim)
+
+    def mel_spectrogram(self, y, n_fft=1920, num_mels=80, sampling_rate=24000, hop_size=480, win_size=1920,
+                    fmin=0, fmax=8000, center=False):
+        y = F.pad(
+            y.unsqueeze(1),
+            ((n_fft - hop_size) // 2, (n_fft - hop_size) // 2),
+            mode="reflect",
+        )
+        y = y.squeeze(1)
+        # device must match `y`; Vlad's CPU-only flow didn't need this.
+        hann_window = torch.hann_window(win_size, device=y.device)
+        mel = librosa_mel_fn(sr=sampling_rate, n_fft=n_fft, n_mels=num_mels, fmin=fmin, fmax=fmax)
+        mel = torch.from_numpy(mel).float().to(y.device)
+        spec = torch.stft(
+            y,
+            n_fft,
+            hop_length=hop_size,
+            win_length=win_size,
+            window=hann_window,
+            center=center,
+            pad_mode="reflect",
+            normalized=False,
+            onesided=True,
+            return_complex=False,
+        )
+        # real = spec[..., 0]
+        # imag = spec[..., 1]
+        # spec = torch.sqrt(real**2 + imag**2 + 1e-9)
+        spec = torch.sqrt(spec.pow(2).sum(-1) + (1e-9))
+
+        spec = torch.matmul(mel, spec)
+        spec = torch.log(torch.clamp(spec, min=1e-5) * 1) # spectral_normalize_torch
+
+        return spec
+    
+    def _next_power_of_2(self, x: int) -> int:
+        r"""Returns the smallest power of 2 that is greater than x"""
+        return 1 if x == 0 else 2 ** (x - 1).bit_length()
+    
+    def _get_strided(self, waveform: torch.Tensor, window_size: int, window_shift: int) -> torch.Tensor:
+        r"""Given a waveform (1D tensor of size ``num_samples``), it returns a 2D tensor (m, ``window_size``)
+        representing how the window is shifted along the waveform. Each row is a frame.
+
+        Args:
+            waveform (Tensor): Tensor of size ``num_samples``
+            window_size (int): Frame length
+            window_shift (int): Frame shift
+            snip_edges (bool): If True, end effects will be handled by outputting only frames that completely fit
+                in the file, and the number of frames depends on the frame_length.  If False, the number of frames
+                depends only on the frame_shift, and we reflect the data at the ends.
+
+        Returns:
+            Tensor: 2D tensor of size (m, ``window_size``) where each row is a frame
+        """
+        num_samples = waveform.size(0)
+        strides = (window_shift * waveform.stride(0), waveform.stride(0))
+
+        if num_samples < window_size:
+            return torch.empty((0, 0), dtype=waveform.dtype, device=waveform.device)
+        else:
+            m = 1 + (num_samples - window_size) // window_shift
+
+        sizes = (m, window_size)
+        return waveform.as_strided(sizes, strides)
+
+    def _get_log_energy(self, strided_input: torch.Tensor, epsilon: torch.Tensor, energy_floor: float) -> torch.Tensor:
+        r"""Returns the log energy of size (m) for a strided_input (m,*)"""
+        device, dtype = strided_input.device, strided_input.dtype
+        log_energy = torch.max(strided_input.pow(2).sum(1), epsilon).log()  # size (m)
+        if energy_floor == 0.0:
+            return log_energy
+        return torch.max(log_energy, torch.tensor(math.log(energy_floor), device=device, dtype=dtype))
+
+    def _get_window(
+        self,
+        waveform: torch.Tensor,
+        padded_window_size: int,
+        window_size: int,
+        window_shift: int,
+        preemphasis_coefficient: float,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        r"""Gets a window and its log energy
+
+        Returns:
+            (Tensor, Tensor): strided_input of size (m, ``padded_window_size``) and signal_log_energy of size (m)
+        """
+        device, dtype = waveform.device, waveform.dtype
+        # size (m, window_size)
+        strided_input = self._get_strided(waveform, window_size, window_shift)
+
+        # Subtract each row/frame by its mean
+        row_means = torch.mean(strided_input, dim=1).unsqueeze(1)  # size (m, 1)
+        strided_input = strided_input - row_means
+
+        if preemphasis_coefficient != 0.0:
+            # strided_input[i,j] -= preemphasis_coefficient * strided_input[i, max(0, j-1)] for all i,j
+            offset_strided_input = F.pad(strided_input.unsqueeze(0), (1, 0), mode="replicate").squeeze(
+                0
+            )  # size (m, window_size + 1)
+            strided_input = strided_input - preemphasis_coefficient * offset_strided_input[:, :-1]
+
+        # Apply window_function to each row/frame
+        window_function = torch.hann_window(window_size, periodic=False, device=device, dtype=dtype).pow(0.85).unsqueeze(0)  # size (1, window_size)
+        strided_input = strided_input * window_function  # size (m, window_size)
+
+        # Pad columns with zero until we reach size (m, padded_window_size)
+        if padded_window_size != window_size:
+            padding_right = padded_window_size - window_size
+            strided_input = F.pad(
+                strided_input.unsqueeze(0), (0, padding_right), mode="constant", value=0
+            ).squeeze(0)
+
+        return strided_input
+
+    def _get_waveform_and_window_properties(
+        self,
+        waveform: torch.Tensor,
+        channel: int,
+        sample_frequency: float,
+        frame_shift: float,
+        frame_length: float,
+    ) -> Tuple[torch.Tensor, int, int, int]:
+        r"""Gets the waveform and window properties"""
+        channel = max(channel, 0)
+        waveform = waveform[channel, :]  # size (n)
+        window_shift = int(sample_frequency * frame_shift * MILLISECONDS_TO_SECONDS)
+        window_size = int(sample_frequency * frame_length * MILLISECONDS_TO_SECONDS)
+        padded_window_size = self._next_power_of_2(window_size)
+        return waveform, window_shift, window_size, padded_window_size
+
+    def extract_feature(self, waveform: torch.Tensor,
+        channel: int = -1,
+        frame_length: float = 25.0,
+        frame_shift: float = 10.0,
+        high_freq: float = 0.0,
+        low_freq: float = 20.0,
+        num_mel_bins: int = 23,
+        preemphasis_coefficient: float = 0.97,
+        sample_frequency: float = 16000.0,
+        vtln_high: float = -500.0,
+        vtln_low: float = 100.0,
+        vtln_warp: float = 1.0):
+
+        device, dtype = waveform.device, waveform.dtype
+        waveform, window_shift, window_size, padded_window_size = self._get_waveform_and_window_properties(
+        waveform, channel, sample_frequency, frame_shift, frame_length)
+
+        # strided_input, size (m, padded_window_size) and signal_log_energy, size (m)
+        strided_input = self._get_window(
+            waveform,
+            padded_window_size,
+            window_size,
+            window_shift,
+            preemphasis_coefficient,
+        )
+
+        # size (m, padded_window_size // 2 + 1)
+        spec = torch.stft(
+            strided_input,
+            n_fft=512,
+            hop_length=512,
+            center=False,
+            window=None,
+            return_complex=False
+        )   # shape: [..., freq, 2]  (last dim = [real, imag])
+
+        # Compute magnitude manually
+        real = spec[..., 0]
+        imag = spec[..., 1]
+        spectrum = torch.sqrt(real**2 + imag**2).squeeze(-1)
+        spectrum = spectrum.pow(2.0)
+
+        # size (num_mel_bins, padded_window_size // 2)
+        mel_energies, _ = get_mel_banks(
+            num_mel_bins, padded_window_size, sample_frequency, low_freq, high_freq, vtln_low, vtln_high, vtln_warp
+        )
+        mel_energies = mel_energies.to(device=device, dtype=dtype)
+
+        # pad right column with zeros and add dimension, size (num_mel_bins, padded_window_size // 2 + 1)
+        mel_energies = F.pad(mel_energies, (0, 1), mode="constant", value=0)
+
+        # sum with mel fiterbanks over the power spectrum, size (m, num_mel_bins)
+        mel_energies = torch.matmul(spectrum, mel_energies.T)
+
+        # avoid log of zero (which should be prevented anyway by dithering)
+        mel_energies = torch.max(mel_energies, self.eps).log()
+        return mel_energies
+
+    def prepare_conditions_from_audio(self, audio_values):
+        batch_size = audio_values.shape[0]
+
+        # Compute embed_ref
+        ref_wav_24 = audio_values[..., :DEC_COND_LEN]
+        speaker_features = self.mel_spectrogram(ref_wav_24).transpose(1, 2)
+
+        # Resample to 16kHz
+        ref_wav_16 = self.resampler(audio_values) # resample uncropped audio
+
+        # Speech cond prompt tokens
+        # TODO START REMOVE
+        # -- AT EXPORT, WE MUST SWAP THIS WITH self.resampler(audio_values)
+        # ref_wav_16 = librosa.resample(audio_values.cpu().numpy(), orig_sr=S3GEN_SR, target_sr=S3_SR)
+        # ref_wav_16 = torch.from_numpy(ref_wav_16).to(audio_values.device)
+        # TODO END REMOVE
+
+        feature = self.extract_feature(ref_wav_16, num_mel_bins=80) # == Kaldi.fbank(ref_wav_16, num_mel_bins=80)
+        feature = feature - feature.mean(dim=0, keepdim=True)
+        speaker_embeddings = self.speaker_encoder(feature.unsqueeze(0))
+
+        t3_cond_prompt_tokens = self.s3(ref_wav_16[..., :ENC_COND_LEN], max_len=self.speech_cond_prompt_len)
+
+        resampled_wav_16 = self.resampler(ref_wav_24) # resample uncropped audio
+
+        # NOTE: For some reason, we do two passes of the s3 tokenizer
+        # TODO: Try reduce this?
+        # Tokenize 16khz reference
+        prompt_token = self.s3(resampled_wav_16, max_len=None)
+
+        cond_prompt_speech_emb = self.speech_emb(t3_cond_prompt_tokens) + \
+                     self.speech_pos_emb(t3_cond_prompt_tokens)
+
+        # Cond prompt
+        cond_prompt_speech_emb = self.cond_enc.perceiver(cond_prompt_speech_emb)
+
+        expanded_cond_spkr = self.cond_spkr.expand(batch_size, -1, -1)  # (B, 1, dim)
+
+        # Concat and return
+        cond_emb = torch.cat((
+            expanded_cond_spkr,
+            cond_prompt_speech_emb,
+        ), dim=1)  # (B, len_cond, dim)
+        # assert cond_emb.dim() == 3
+        return cond_emb, prompt_token, speaker_embeddings, speaker_features
+
+    def forward(
+        self,
+        audio_values: torch.Tensor, # NOTE: Must have sample rate of S3GEN_SR=24000
+    ):
+        cond_emb, prompt_token, speaker_embeddings, speaker_features = self.prepare_conditions_from_audio(audio_values)
+        return cond_emb, prompt_token, speaker_embeddings, speaker_features
+
+
+class InputsEmbeds(nn.Module):
+    def __init__(self, chatterbox):
+        super().__init__()
+        self.text_emb = chatterbox.t3.text_emb
+        self.text_pos_emb = chatterbox.t3.text_pos_emb.emb
+
+        self.speech_emb = chatterbox.t3.speech_emb
+        self.speech_pos_emb = chatterbox.t3.speech_pos_emb.emb
+
+        self.emotion_adv_fc = chatterbox.t3.cond_enc.emotion_adv_fc
+
+    def forward(self, input_ids, position_ids, exaggeration):
+        assert position_ids.shape == input_ids.shape
+        batch_size, seq_len = input_ids.shape
+
+        x = input_ids
+        idx = torch.arange(seq_len, device=x.device).unsqueeze(0).expand(batch_size, -1)
+        
+        # Detect first zero
+        is_zero = (x == 0)
+        has_zero = is_zero.any(dim=1)
+        zero_pos = torch.where(
+            has_zero,
+            is_zero.float().argmax(dim=1),
+            torch.full((batch_size,), -1, device=x.device)  # placeholder
+        )
+
+        # Masks
+        exaggeration_mask = (x == EXAGGERATION_TOKEN)
+        base_text_mask = (idx <= zero_pos.unsqueeze(1)) & has_zero.unsqueeze(1)
+        
+        text_mask = base_text_mask & ~exaggeration_mask
+        speech_mask = ~base_text_mask & ~exaggeration_mask
+
+        # Compute relative positions by multiplying with the masks
+        text_pos_ids = position_ids * text_mask
+        speech_pos_ids = position_ids * speech_mask
+
+        # Flatten
+        flat_x = x.view(-1)
+        flat_text_mask = text_mask.view(-1)
+        flat_speech_mask = speech_mask.view(-1)
+        flat_exaggeration_mask = exaggeration_mask.view(-1)
+        flat_text_pos = text_pos_ids.view(-1)
+        flat_speech_pos = speech_pos_ids.view(-1)
+
+        # Replace invalid indices with 0 (safe padding idx)
+        safe_text_idx = torch.where(flat_text_mask, flat_x, torch.zeros_like(flat_x))
+        safe_text_pos = torch.where(flat_text_mask, flat_text_pos, torch.zeros_like(flat_text_pos))
+
+        safe_speech_idx = torch.where(flat_speech_mask, flat_x, torch.zeros_like(flat_x))
+        safe_speech_pos = torch.where(flat_speech_mask, flat_speech_pos, torch.zeros_like(flat_speech_pos))
+
+        # Embed everything, but irrelevant positions will become "padding" embeddings
+        all_text_emb = self.text_emb(safe_text_idx) + self.text_pos_emb(safe_text_pos)
+        all_speech_emb = self.speech_emb(safe_speech_idx) + self.speech_pos_emb(safe_speech_pos)
+
+        # Finally, mask out the padding positions to zero them
+        text_emb = all_text_emb * flat_text_mask.unsqueeze(-1)
+        speech_emb = all_speech_emb * flat_speech_mask.unsqueeze(-1)
+
+        # Emotion Adv: must provide a value if this model uses emotion conditioning
+        emotion_adv = exaggeration.view(-1, 1, 1)
+        cond_emotion_adv = self.emotion_adv_fc(emotion_adv)
+
+        # Reshape to [B*L, D] to match masks
+        embed_dim = text_emb.size(-1)
+        text_emb_full   = text_emb
+        speech_emb_full = speech_emb
+
+        # Start with zeros
+        out = torch.zeros(batch_size * seq_len, embed_dim, device=x.device, dtype=text_emb.dtype)
+
+        # Where text mask is True → take text_emb, else keep current out
+        out = torch.where(flat_text_mask.unsqueeze(-1), text_emb_full, out)
+
+        # Where speech mask is True → take speech_emb, else keep current out
+        out = torch.where(flat_speech_mask.unsqueeze(-1), speech_emb_full, out)
+        
+        # Handle exaggeration tokens
+        # We need to expand cond_emotion_adv to match the number of exaggeration tokens
+        # This assumes cond_emotion_adv is (batch_size, 1, dim) and we need to map it correctly
+        # to the flattened positions.
+        # We can create an index mapping from the flattened index to the batch index.
+        batch_indices = torch.arange(batch_size, device=x.device).unsqueeze(1).expand(-1, seq_len).reshape(-1)
+        exaggeration_emb_full = cond_emotion_adv[batch_indices].transpose(0, 1) 
+
+        # Zero out positions where mask is False
+        exaggeration_emb = exaggeration_emb_full * flat_exaggeration_mask.unsqueeze(-1)
+
+        out = out + exaggeration_emb
+        out = out.view(batch_size, seq_len, embed_dim)
+        return out
+
+
+class ISTFT(torch.nn.Module):
+    def __init__(self, n_fft: int, hop_length: int, win_length: int):
+        assert n_fft >= win_length
+        super().__init__()
+
+        self.filter_length = n_fft
+        self.win_length = win_length
+        self.hop_length = hop_length
+
+        scale = self.filter_length / self.hop_length
+        fourier_basis = np.fft.fft(np.eye(self.filter_length))
+
+        cutoff = self.filter_length // 2 + 1
+        fourier_basis = np.vstack([np.real(fourier_basis[:cutoff, :]),
+                                   np.imag(fourier_basis[:cutoff, :])])
+
+        inverse_basis = torch.FloatTensor(np.linalg.pinv(scale * fourier_basis).T[:, None, :])
+
+
+        # Register as a buffer so .to(device) moves it. Plain-attribute
+        # assignment (Vlad's original) leaves it on CPU when the module
+        # is moved to CUDA, causing device-mismatch failures in
+        # window_sumsquare() during the cond-decoder forward.
+        self.register_buffer('window', torch.hann_window(win_length))
+
+        # Center pad the window to the size of n_fft
+        pad_length = n_fft - self.window.size(0)
+        pad_left = pad_length // 2
+        pad_right = pad_length - pad_left
+
+        torch_fft_window = F.pad(self.window, (pad_left, pad_right), mode='constant', value=0)
+        inverse_basis *= torch_fft_window
+
+        self.register_buffer('inverse_basis', inverse_basis.float())
+
+    @staticmethod
+    def window_sumsquare(
+        window,
+        n_frames,
+        hop_length,
+        win_length,
+        n_fft,
+    ):
+        """Overlap-add of window**2 over n_frames, stride hop_length.
+
+        Vlad's original used `F.conv_transpose1d` driven by
+        `torch.ones(1, 1, n_frames)`. That hits a hard ONNX symbolic
+        limit at opset 17 and 18 ("ONNX export of convolution for kernel
+        of unknown shape") — the trace produces a ConstantOfShape input
+        whose dynamic last dim defeats the conv symbolic. We replace it
+        with a scatter_add formulation that ONNX handles cleanly because
+        the operation is index-based instead of conv-based.
+        """
+        if win_length is None:
+            win_length = n_fft
+
+        n = n_fft + hop_length * (n_frames - 1)
+
+        # Squared window padded to n_fft (no-op when win_length == n_fft).
+        win_sq = window ** 2
+        pad_length = n_fft - win_sq.size(0)
+        pad_left = pad_length // 2
+        pad_right = pad_length - pad_left
+        win_sq = F.pad(win_sq, (pad_left, pad_right), mode='constant', value=0)
+        # win_sq is now (n_fft,)
+
+        # Output position indices: for frame i, sample k → i*hop_length + k.
+        device = window.device
+        frame_idx = torch.arange(n_frames, device=device).unsqueeze(1)  # (n_frames, 1)
+        sample_idx = torch.arange(n_fft, device=device).unsqueeze(0)    # (1, n_fft)
+        out_idx = (frame_idx * hop_length + sample_idx).flatten()       # (n_frames*n_fft,)
+
+        values = win_sq.unsqueeze(0).expand(n_frames, n_fft).reshape(-1)  # (n_frames*n_fft,)
+
+        x = torch.zeros(n, dtype=window.dtype, device=device)
+        x = x.scatter_add(0, out_idx, values)
+        return x
+
+    def forward(self, recombine_magnitude_phase):
+        assert recombine_magnitude_phase.dim() == 3, 'must be [B, 2 * N, T]'
+        num_frames = recombine_magnitude_phase.size(-1)
+
+        inverse_transform = F.conv_transpose1d(
+            recombine_magnitude_phase,
+            self.inverse_basis,
+            stride=self.hop_length,
+            padding=0,
+        )
+
+        window_sum = self.window_sumsquare(
+            self.window,
+            n_frames=num_frames,
+            hop_length=self.hop_length,
+            win_length=self.win_length,
+            n_fft=self.filter_length,
+        )
+
+        tiny_value = torch.finfo(window_sum.dtype).tiny
+
+        denom = torch.where(
+            window_sum > tiny_value,
+            window_sum,
+            torch.tensor(1.0, dtype=window_sum.dtype, device=window_sum.device),
+        )
+        # Apply the transformation
+        inverse_transform /= denom
+
+        # scale by hop ratio
+        inverse_transform *= self.filter_length / self.hop_length
+
+        q = self.filter_length // 2
+        inverse_transform = inverse_transform[:, 0, q:-q]
+        return inverse_transform
+
+istft = ISTFT(ISTFT_PARAMS["n_fft"], ISTFT_PARAMS["hop_len"], ISTFT_PARAMS["n_fft"])
+
+
+def make_pad_mask(lengths: torch.Tensor, max_len: int = 0) -> torch.Tensor:
+    """Make mask tensor containing indices of padded part.
+
+    See description of make_non_pad_mask.
+
+    Args:
+        lengths (torch.Tensor): Batch of lengths (B,).
+    Returns:
+        torch.Tensor: Mask tensor containing indices of padded part.
+
+    Examples:
+        >>> lengths = [5, 3, 2]
+        >>> make_pad_mask(lengths)
+        masks = [[0, 0, 0, 0 ,0],
+                    [0, 0, 0, 1, 1],
+                    [0, 0, 1, 1, 1]]
+    """
+    batch_size = lengths.size(0)
+    max_len = max_len if max_len > 0 else lengths.max()
+    seq_range = torch.arange(0,
+                            max_len,
+                            dtype=torch.int64,
+                            device=lengths.device)
+    seq_range_expand = seq_range.unsqueeze(0).expand(batch_size, max_len)
+    seq_length_expand = lengths.unsqueeze(-1)
+    mask = seq_range_expand >= seq_length_expand
+    return mask
+
+def mask_to_bias(mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    assert mask.dtype == torch.bool
+    assert dtype in [torch.float32, torch.bfloat16, torch.float16]
+    mask = mask.to(dtype)
+    mask = (1.0 - mask) * -1.0e+10
+    return mask
+
+
+class ConditionalDecoder(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.output_size = model.s3gen.flow.output_size
+        self.input_embedding = model.s3gen.flow.input_embedding
+        self.spk_embed_affine_layer = model.s3gen.flow.spk_embed_affine_layer
+        self.encoder = model.s3gen.flow.encoder
+        self.encoder_proj = model.s3gen.flow.encoder_proj
+        self.time_embeddings = model.s3gen.flow.decoder.estimator.time_embeddings
+        self.time_mlp = model.s3gen.flow.decoder.estimator.time_mlp
+        self.up_blocks = model.s3gen.flow.decoder.estimator.up_blocks
+        self.static_chunk_size = model.s3gen.flow.decoder.estimator.static_chunk_size
+        self.mid_blocks = model.s3gen.flow.decoder.estimator.mid_blocks
+        self.down_blocks = model.s3gen.flow.decoder.estimator.down_blocks
+        self.final_block = model.s3gen.flow.decoder.estimator.final_block
+        self.final_proj = model.s3gen.flow.decoder.estimator.final_proj
+        self.n_fft = ISTFT_PARAMS["n_fft"]
+        self.hop_len = ISTFT_PARAMS["hop_len"]
+        self.n_trim = S3GEN_SR // 50
+        self.stft_window = model.s3gen.mel2wav.stft_window
+        self.f0_predictor = model.s3gen.mel2wav.f0_predictor
+        self.f0_upsamp = model.s3gen.mel2wav.f0_upsamp
+        self.m_source = model.s3gen.mel2wav.m_source
+        self.inference_cfg_rate = 0.7
+        self.conv_pre = model.s3gen.mel2wav.conv_pre
+        self.lrelu_slope = model.s3gen.mel2wav.lrelu_slope
+        self.reflection_pad = model.s3gen.mel2wav.reflection_pad
+        self.ups = model.s3gen.mel2wav.ups
+        self.source_downs = model.s3gen.mel2wav.source_downs
+        self.source_resblocks = model.s3gen.mel2wav.source_resblocks
+        self.resblocks = model.s3gen.mel2wav.resblocks
+        self.conv_post = model.s3gen.mel2wav.conv_post
+        self.istft = istft
+    
+    def cond_forward(self, x, mask, mu, t, spks, cond) -> torch.Tensor:
+        """Forward pass of the UNet1DConditional model.
+
+        Args:
+            x (torch.Tensor): shape (batch_size, in_channels, time)
+            mask (_type_): shape (batch_size, 1, time)
+            t (_type_): shape (batch_size)
+            spks (_type_, optional): shape: (batch_size, condition_channels). Defaults to None.
+            cond (_type_, optional): placeholder for future use. Defaults to None.
+        """
+
+        t = self.time_embeddings(t).to(t.dtype)
+        t = self.time_mlp(t)
+
+        x = torch.cat([x, mu], dim=1)
+        spks = spks.unsqueeze(-1).expand(-1, -1, x.shape[-1])
+        x = torch.cat([x, spks], dim=1)
+        x = torch.cat([x, cond], dim=1)
+
+        # Cast mask to x.dtype here, before it enters the upstream Block1D
+        # blocks. Block1D.forward does `x * mask` internally — eager mode
+        # handles bool→float promotion, but torch.onnx.export's trace puts
+        # the promoted intermediate on cpu while x stays on cuda, producing
+        # a device-mismatch error. Pre-casting to float keeps everything
+        # on the same device through the trace.
+        mask = mask.to(x.dtype)
+
+        masks = [mask]
+        resnet, transformer_blocks, downsample = self.down_blocks[0]
+        mask_down = masks[-1]
+        x = resnet(x, mask_down, t)
+        x = x.permute(0, 2, 1).contiguous()
+        attn_mask = mask_to_bias(mask_down.bool() == 1, x.dtype)
+        for transformer_block in transformer_blocks:
+            x = transformer_block(
+                hidden_states=x,
+                attention_mask=attn_mask,
+                timestep=t,
+            )
+        x = x.permute(0, 2, 1).contiguous()
+        residual = x  # Save hidden states for skip connections
+        x = downsample(x * mask_down)
+        masks.append(mask_down[:, :, ::2])
+        masks = masks[:-1]
+        mask_mid = masks[-1]
+
+        for resnet, transformer_blocks in self.mid_blocks:
+            x = resnet(x, mask_mid, t)
+            x = x.permute(0, 2, 1).contiguous()
+            attn_mask = mask_to_bias(mask_mid.bool() == 1, x.dtype)
+            for transformer_block in transformer_blocks:
+                x = transformer_block(
+                    hidden_states=x,
+                    attention_mask=attn_mask,
+                    timestep=t,
+                )
+            x = x.permute(0, 2, 1).contiguous() 
+
+        resnet, transformer_blocks, upsample = self.up_blocks[0]
+        mask_up = masks.pop()
+        x = torch.cat([x[:, :, :residual.shape[-1]], residual], dim=1)
+        x = resnet(x, mask_up, t)
+        x = x.permute(0, 2, 1).contiguous()
+        attn_mask = mask_to_bias(mask_up.bool() == 1, x.dtype)
+        for transformer_block in transformer_blocks:
+            x = transformer_block(
+                hidden_states=x,
+                attention_mask=attn_mask,
+                timestep=t,
+            )
+        x = x.permute(0, 2, 1).contiguous()
+        x = upsample(x * mask_up)
+        x = self.final_block(x, mask_up)
+        output = self.final_proj(x * mask_up)
+        return output
+
+    def flow_forward(self, speech_tokens, token_len, mask, embedding, prompt_feat):
+        # xvec projection
+        embedding = F.normalize(embedding, dim=1)
+        embedding = self.spk_embed_affine_layer(embedding)
+
+        # concat text and prompt_text
+        speech_tokens = self.input_embedding(torch.clamp(speech_tokens, min=0))
+        speech_tokens = speech_tokens * mask
+
+        # text encode
+        text_encoded, _ = self.encoder(speech_tokens, token_len)
+        mel_len1, mel_len2 = prompt_feat.shape[1], text_encoded.shape[1] - prompt_feat.shape[1]
+        text_encoded = self.encoder_proj(text_encoded)
+
+        # get conditions
+        conds = torch.zeros(
+            [1, mel_len1 + mel_len2, self.output_size],
+            device=text_encoded.device, dtype=text_encoded.dtype,
+        )
+        conds[:, :mel_len1] = prompt_feat
+        conds = conds.transpose(1, 2)
+
+        mu = text_encoded
+        spks = embedding
+        if not isinstance(mel_len1, torch.Tensor):
+            mel_len1 = torch.tensor(mel_len1, device=speech_tokens.device)
+        if not isinstance(mel_len2, torch.Tensor):
+            mel_len2 = torch.tensor(mel_len2, device=speech_tokens.device)
+        return mel_len1, mel_len2, mu, spks, conds
+
+    def decode(self, x: torch.Tensor, s_stft: torch.Tensor) -> torch.Tensor:
+        x = self.conv_pre(x)
+
+        # ---- Upsample 0 ----
+        x = F.leaky_relu(x, self.lrelu_slope)
+        x = self.ups[0](x)
+
+        si = self.source_downs[0](s_stft)
+        si = self.source_resblocks[0](si)
+        x = x + si
+
+        xs0 = self.resblocks[0](x) + self.resblocks[1](x) + self.resblocks[2](x)
+        x = xs0 / 3
+
+        # ---- Upsample 1 ----
+        x = F.leaky_relu(x, self.lrelu_slope)
+        x = self.ups[1](x)
+
+        si = self.source_downs[1](s_stft)
+        si = self.source_resblocks[1](si)
+        x = x + si
+
+        xs1 = self.resblocks[3](x) + self.resblocks[4](x) + self.resblocks[5](x)
+        x = xs1 / 3
+
+        # ---- Upsample 2 ----
+        x = F.leaky_relu(x, self.lrelu_slope)
+        x = self.ups[2](x)
+        x = self.reflection_pad(x)
+
+        si = self.source_downs[2](s_stft)
+        si = self.source_resblocks[2](si)
+        x = x + si
+
+        xs2 = self.resblocks[6](x) + self.resblocks[7](x) + self.resblocks[8](x)
+        x = xs2 / 3
+
+        # ---- Final layers ----
+        x = F.leaky_relu(x)
+        x = self.conv_post(x)
+
+        magnitude = torch.exp(x[:, :self.n_fft // 2 + 1, :])
+        phase = torch.sin(x[:, self.n_fft // 2 + 1:, :])
+
+        return magnitude, phase
+
+    def forward(self, speech_tokens, speaker_embeddings, speaker_features):
+        token_len = torch.full((speech_tokens.size(0),), speech_tokens.size(1), dtype=torch.long, device=speech_tokens.device)
+        mask = (~make_pad_mask(token_len)).unsqueeze(-1)
+        mel_len1, mel_len2, mu, spks, cond = self.flow_forward(speech_tokens, token_len, mask, speaker_embeddings, speaker_features)
+        mu = mu.transpose(1, 2).contiguous()
+        total_len = mel_len1.add(mel_len2).unsqueeze(0)
+        mask = (~make_pad_mask(total_len)).unsqueeze(0)
+        n_timesteps = 10
+        temperature = 1.0
+        x = torch.randn_like(mu, dtype=mu.dtype) * temperature
+        t_span = torch.linspace(0, 1, n_timesteps+1, device=mu.device, dtype=mu.dtype)
+        t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
+        dt_all = t_span[1:] - t_span[:-1]
+
+        t = t_span[0:1]
+        dt = dt_all[0:1]
+
+        x_in = torch.cat([x, torch.zeros_like(x)], dim=0) 
+        mask_in = torch.cat([mask, torch.zeros_like(mask)], dim=0) 
+        mu_in = torch.cat([mu, torch.zeros_like(mu)], dim=0) 
+        t_in = torch.cat([t, torch.zeros_like(t)], dim=0) 
+        spks_in = torch.cat([spks, torch.zeros_like(spks)], dim=0) 
+        cond_in = torch.cat([cond, torch.zeros_like(cond)], dim=0)
+
+        ## Classifier-Free Guidance inference introduced in VoiceBox
+        # step 1
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[1 + 1] - t
+
+        # step 2
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[2 + 1] - t
+
+        # step 3
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[3 + 1] - t
+
+        # step 4
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[4 + 1] - t
+
+        # step 5
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[5 + 1] - t
+
+        # step 6
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[6 + 1] - t
+
+        # step 7
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[7 + 1] - t
+
+        # step 8
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[8 + 1] - t
+
+        # step 9
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        t = t + dt
+        dt = t_span[9 + 1] - t
+
+        # step 10
+        x_in[:].copy_(x.squeeze(0)) 
+        mask_in[:].copy_(mask.squeeze(0))
+        mu_in[0].copy_(mu.squeeze(0))
+        t_in[:].copy_(t.squeeze(0))
+        spks_in[0].copy_(spks.squeeze(0))
+        cond_in[0].copy_(cond.squeeze(0))
+        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
+        x = x + dt * dphi_dt
+        output = x.float()
+        speech_feat = torch.narrow(output, dim=2, start=mel_len1, length=output.size(2) - mel_len1)
+        #mel->f0
+        f0 = self.f0_predictor(speech_feat)
+        # f0->source
+        s = self.f0_upsamp(f0[:, None]).transpose(1, 2)  # bs,n,t
+        s, _, _ = self.m_source(s)
+        output_sources = s.transpose(1, 2).squeeze(1)
+        spec = torch.stft(
+            output_sources,
+            self.n_fft, 
+            self.hop_len, 
+            self.n_fft, 
+            window=self.stft_window.to(output_sources.device),
+            return_complex=False)
+        s_stft_real, s_stft_imag = spec[..., 0], spec[..., 1]
+        output_sources = torch.cat([s_stft_real, s_stft_imag], dim=1)
+        magnitude, phase = self.decode(x=speech_feat, s_stft=output_sources)
+        magnitude = torch.clip(magnitude, max=1e2)
+        real = magnitude * torch.cos(phase)
+        img = magnitude * torch.sin(phase)
+        recombine_magnitude_phase = torch.cat([real, img], dim=1)
+        output_wavs = self.istft(recombine_magnitude_phase)
+        trim_fade = torch.zeros(2 * self.n_trim, device=output_wavs.device)
+        cosine_window = (torch.cos(
+            torch.linspace(torch.pi, 0, self.n_trim, device=output_wavs.device)
+        ) + 1) / 2
+        trim_fade[self.n_trim:] = cosine_window
+        output_wavs[:, :trim_fade.size(0)] *= trim_fade
+        return output_wavs
+

--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -104,7 +104,6 @@ class PrepareConditionalsModel(torch.nn.Module):
     def __init__(self, chatterbox):
         super().__init__()
 
-        # TODO: Move loading elsewhere
         # Use upstream chatterbox.s3gen.tokenizer directly. The vendored
         # S3Tokenizer chain (verified mathematically identical via
         # parity test, see Run 6 in docs/chatterbox_investigation.md)
@@ -357,15 +356,8 @@ class PrepareConditionalsModel(torch.nn.Module):
         ref_wav_24 = audio_values[..., :DEC_COND_LEN]
         speaker_features = self.mel_spectrogram(ref_wav_24).transpose(1, 2)
 
-        # Resample to 16kHz
-        ref_wav_16 = self.resampler(audio_values) # resample uncropped audio
-
-        # Speech cond prompt tokens
-        # TODO START REMOVE
-        # -- AT EXPORT, WE MUST SWAP THIS WITH self.resampler(audio_values)
-        # ref_wav_16 = librosa.resample(audio_values.cpu().numpy(), orig_sr=S3GEN_SR, target_sr=S3_SR)
-        # ref_wav_16 = torch.from_numpy(ref_wav_16).to(audio_values.device)
-        # TODO END REMOVE
+        # Resample to 16kHz (ta.Resample, not librosa — ONNX-traceable)
+        ref_wav_16 = self.resampler(audio_values)
 
         feature = self.extract_feature(ref_wav_16, num_mel_bins=80) # == Kaldi.fbank(ref_wav_16, num_mel_bins=80)
         feature = feature - feature.mean(dim=0, keepdim=True)
@@ -378,9 +370,11 @@ class PrepareConditionalsModel(torch.nn.Module):
 
         resampled_wav_16 = self.resampler(ref_wav_24) # resample uncropped audio
 
-        # NOTE: For some reason, we do two passes of the s3 tokenizer
-        # TODO: Try reduce this?
-        # Tokenize 16khz reference
+        # Two passes of the s3 tokenizer: the first (above) gets capped
+        # to `speech_cond_prompt_len` for the t3 conditioning embedding;
+        # the second runs uncapped to feed prompt_token into the cond
+        # decoder. Carried over from upstream's split — not an obvious
+        # win to consolidate.
         prompt_token = self.s3(resampled_wav_16, max_len=None)[0]
 
         cond_prompt_speech_emb = self.speech_emb(t3_cond_prompt_tokens) + \

--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -690,9 +690,14 @@ class PrepareConditionalsModel(torch.nn.Module):
         spkr_device = next(self.cond_enc.spkr_enc.parameters()).device
         speaker_emb = torch.zeros(1, self.speaker_embed_size, device=spkr_device)
         with torch.no_grad():
-            self.cond_spkr = self.cond_enc.spkr_enc(
+            cond_spkr_init = self.cond_enc.spkr_enc(
                 speaker_emb.view(-1, self.speaker_embed_size)
             )[:, None].detach()  # (B, 1, dim)
+        # register_buffer so .to(device) / .cpu() actually move it.
+        # Plain-attribute assignment (Vlad's original) leaves it on its
+        # init-time device when the wrapper is moved — broke the
+        # speech_encoder export-on-cpu workaround.
+        self.register_buffer("cond_spkr", cond_spkr_init)
 
     def mel_spectrogram(self, y, n_fft=1920, num_mels=80, sampling_rate=24000, hop_size=480, win_size=1920,
                     fmin=0, fmax=8000, center=False):

--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -40,6 +40,7 @@ Notes:
 """
 from __future__ import annotations
 
+import math
 from typing import Optional, Tuple
 
 import torch
@@ -536,52 +537,45 @@ class ISTFT(torch.nn.Module):
 
         self.register_buffer('inverse_basis', inverse_basis.float())
 
-    @staticmethod
-    def window_sumsquare(
-        window,
-        n_frames,
-        hop_length,
-        win_length,
-        n_fft,
-    ):
-        """Overlap-add of window**2 over n_frames, stride hop_length.
-
-        Vlad's original used `F.conv_transpose1d` driven by
-        `torch.ones(1, 1, n_frames)`. That hits a hard ONNX symbolic
-        limit at opset 17 and 18 ("ONNX export of convolution for kernel
-        of unknown shape") — the trace produces a ConstantOfShape input
-        whose dynamic last dim defeats the conv symbolic. We replace it
-        with a scatter_add formulation that ONNX handles cleanly because
-        the operation is index-based instead of conv-based.
-        """
-        if win_length is None:
-            win_length = n_fft
-
-        n = n_fft + hop_length * (n_frames - 1)
-
-        # Squared window padded to n_fft (no-op when win_length == n_fft).
-        win_sq = window ** 2
-        pad_length = n_fft - win_sq.size(0)
-        pad_left = pad_length // 2
-        pad_right = pad_length - pad_left
-        win_sq = F.pad(win_sq, (pad_left, pad_right), mode='constant', value=0)
-        # win_sq is now (n_fft,)
-
-        # Output position indices: for frame i, sample k → i*hop_length + k.
-        device = window.device
-        frame_idx = torch.arange(n_frames, device=device).unsqueeze(1)  # (n_frames, 1)
-        sample_idx = torch.arange(n_fft, device=device).unsqueeze(0)    # (1, n_fft)
-        out_idx = (frame_idx * hop_length + sample_idx).flatten()       # (n_frames*n_fft,)
-
-        values = win_sq.unsqueeze(0).expand(n_frames, n_fft).reshape(-1)  # (n_frames*n_fft,)
-
-        x = torch.zeros(n, dtype=window.dtype, device=device)
-        x = x.scatter_add(0, out_idx, values)
-        return x
+        # Precompute window_sumsquare for a large fixed max length;
+        # slice to actual length at forward time.
+        #
+        # Why precompute: PyTorch's scatter_add and index_add both map
+        # to ONNX symbolics that don't handle duplicate indices
+        # correctly. F.fold needs static output_size. conv_transpose1d
+        # fails ONNX symbolic with dynamic input length. None of the
+        # PyTorch overlap-add primitives ONNX-export cleanly with
+        # dynamic length.
+        #
+        # A precomputed buffer has correct values across the full
+        # interior. The rightmost n_fft samples of any actual-length
+        # slice will have *saturation* values rather than the proper
+        # ramp-down (because the precomputed treats those positions as
+        # interior of the longer max-length). For n_fft=16 that's a
+        # 16-sample (~0.7 ms) edge artifact at the very end — well below
+        # perceptual threshold.
+        # Need to cover the LONGEST possible inverse_transform — for
+        # the HiFi-GAN n_fft=16/hop=4 path that means up to ~hop * n_frames
+        # = output_audio_samples / 4 frames. For a 60 s chunk at 24 kHz
+        # = 1.44 M output samples => ~360 K frames. We pre-allocate
+        # 1 M frames (~16 MB buffer) — covers any per-chunk synthesis
+        # well past the MVP "continuous reading" target of 30 s chunks.
+        max_window_n_frames = 1_000_000
+        max_n = n_fft + hop_length * (max_window_n_frames - 1)
+        win_sq = torch_fft_window ** 2
+        # Compute via ones-conv-transpose (works at __init__ time on a
+        # known shape; only fails ONNX with *dynamic* input length).
+        ones = torch.ones(1, 1, max_window_n_frames, dtype=torch.float32)
+        precomputed = F.conv_transpose1d(
+            ones,
+            win_sq.unsqueeze(0).unsqueeze(0),
+            stride=hop_length,
+        ).squeeze()  # (max_n,)
+        self.register_buffer("window_sumsquare_precomputed", precomputed)
+        self.max_window_sumsquare_len = max_n
 
     def forward(self, recombine_magnitude_phase):
         assert recombine_magnitude_phase.dim() == 3, 'must be [B, 2 * N, T]'
-        num_frames = recombine_magnitude_phase.size(-1)
 
         inverse_transform = F.conv_transpose1d(
             recombine_magnitude_phase,
@@ -590,30 +584,25 @@ class ISTFT(torch.nn.Module):
             padding=0,
         )
 
-        window_sum = self.window_sumsquare(
-            self.window,
-            n_frames=num_frames,
-            hop_length=self.hop_length,
-            win_length=self.win_length,
-            n_fft=self.filter_length,
-        )
+        # Divide by the position-dependent window_sumsquare. We slice
+        # the precomputed buffer to the inverse_transform's length.
+        # Last n_fft samples will have wrong (saturation-region) values
+        # instead of proper ramp-down — ~0.7 ms of edge artifact at
+        # n_fft=16, perceptually inaudible.
+        n = inverse_transform.shape[-1]
+        denom = self.window_sumsquare_precomputed[:n]
+        # Avoid divide-by-tiny in left-edge ramp-up region.
+        tiny = torch.finfo(denom.dtype).tiny
+        denom = torch.where(denom > tiny, denom, torch.ones_like(denom))
+        inverse_transform = inverse_transform / denom
 
-        tiny_value = torch.finfo(window_sum.dtype).tiny
-
-        denom = torch.where(
-            window_sum > tiny_value,
-            window_sum,
-            torch.tensor(1.0, dtype=window_sum.dtype, device=window_sum.device),
-        )
-        # Apply the transformation
-        inverse_transform /= denom
-
-        # scale by hop ratio
-        inverse_transform *= self.filter_length / self.hop_length
+        # Scale by hop ratio (matches Vlad's reference)
+        inverse_transform = inverse_transform * self.filter_length / self.hop_length
 
         q = self.filter_length // 2
         inverse_transform = inverse_transform[:, 0, q:-q]
         return inverse_transform
+
 
 istft = ISTFT(ISTFT_PARAMS["n_fft"], ISTFT_PARAMS["hop_len"], ISTFT_PARAMS["n_fft"])
 
@@ -654,376 +643,63 @@ def mask_to_bias(mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
     return mask
 
 
+
+
 class ConditionalDecoder(nn.Module):
+    """Thin wrapper that delegates to upstream chatterbox.s3gen.
+
+    Vlad's vendored version reimplemented `cond_forward`, `flow_forward`,
+    `decode`, and the CFM solve loop inline (~360 LOC). Upstream
+    `s3gen.flow.inference()` and `s3gen.mel2wav.inference()` together
+    do exactly the same work — we just call them. Plus a fade-in to
+    suppress reference-clip spillover (taken from upstream's
+    `s3gen.inference()` implementation).
+
+    Patches in `_export_patches.py::patched_cond_decoder_for_export`
+    cover the upstream ONNX-unfriendly ops (inference_mode decorators,
+    complex-tensor STFT/iSTFT). `mel2wav._istft` is rerouted through
+    our `ISTFT` class (Conv1d + scatter_add window_sumsquare).
+    """
+
     def __init__(self, model):
         super().__init__()
-        self.output_size = model.s3gen.flow.output_size
-        self.input_embedding = model.s3gen.flow.input_embedding
-        self.spk_embed_affine_layer = model.s3gen.flow.spk_embed_affine_layer
-        self.encoder = model.s3gen.flow.encoder
-        self.encoder_proj = model.s3gen.flow.encoder_proj
-        self.time_embeddings = model.s3gen.flow.decoder.estimator.time_embeddings
-        self.time_mlp = model.s3gen.flow.decoder.estimator.time_mlp
-        self.up_blocks = model.s3gen.flow.decoder.estimator.up_blocks
-        self.static_chunk_size = model.s3gen.flow.decoder.estimator.static_chunk_size
-        self.mid_blocks = model.s3gen.flow.decoder.estimator.mid_blocks
-        self.down_blocks = model.s3gen.flow.decoder.estimator.down_blocks
-        self.final_block = model.s3gen.flow.decoder.estimator.final_block
-        self.final_proj = model.s3gen.flow.decoder.estimator.final_proj
-        self.n_fft = ISTFT_PARAMS["n_fft"]
-        self.hop_len = ISTFT_PARAMS["hop_len"]
-        self.n_trim = S3GEN_SR // 50
-        self.stft_window = model.s3gen.mel2wav.stft_window
-        self.f0_predictor = model.s3gen.mel2wav.f0_predictor
-        self.f0_upsamp = model.s3gen.mel2wav.f0_upsamp
-        self.m_source = model.s3gen.mel2wav.m_source
-        self.inference_cfg_rate = 0.7
-        self.conv_pre = model.s3gen.mel2wav.conv_pre
-        self.lrelu_slope = model.s3gen.mel2wav.lrelu_slope
-        self.reflection_pad = model.s3gen.mel2wav.reflection_pad
-        self.ups = model.s3gen.mel2wav.ups
-        self.source_downs = model.s3gen.mel2wav.source_downs
-        self.source_resblocks = model.s3gen.mel2wav.source_resblocks
-        self.resblocks = model.s3gen.mel2wav.resblocks
-        self.conv_post = model.s3gen.mel2wav.conv_post
-        self.istft = istft
-    
-    def cond_forward(self, x, mask, mu, t, spks, cond) -> torch.Tensor:
-        """Forward pass of the UNet1DConditional model.
-
-        Args:
-            x (torch.Tensor): shape (batch_size, in_channels, time)
-            mask (_type_): shape (batch_size, 1, time)
-            t (_type_): shape (batch_size)
-            spks (_type_, optional): shape: (batch_size, condition_channels). Defaults to None.
-            cond (_type_, optional): placeholder for future use. Defaults to None.
-        """
-
-        t = self.time_embeddings(t).to(t.dtype)
-        t = self.time_mlp(t)
-
-        x = torch.cat([x, mu], dim=1)
-        spks = spks.unsqueeze(-1).expand(-1, -1, x.shape[-1])
-        x = torch.cat([x, spks], dim=1)
-        x = torch.cat([x, cond], dim=1)
-
-        # Cast mask to x.dtype here, before it enters the upstream Block1D
-        # blocks. Block1D.forward does `x * mask` internally — eager mode
-        # handles bool→float promotion, but torch.onnx.export's trace puts
-        # the promoted intermediate on cpu while x stays on cuda, producing
-        # a device-mismatch error. Pre-casting to float keeps everything
-        # on the same device through the trace.
-        mask = mask.to(x.dtype)
-
-        masks = [mask]
-        resnet, transformer_blocks, downsample = self.down_blocks[0]
-        mask_down = masks[-1]
-        x = resnet(x, mask_down, t)
-        x = x.permute(0, 2, 1).contiguous()
-        attn_mask = mask_to_bias(mask_down.bool() == 1, x.dtype)
-        for transformer_block in transformer_blocks:
-            x = transformer_block(
-                hidden_states=x,
-                attention_mask=attn_mask,
-                timestep=t,
-            )
-        x = x.permute(0, 2, 1).contiguous()
-        residual = x  # Save hidden states for skip connections
-        x = downsample(x * mask_down)
-        masks.append(mask_down[:, :, ::2])
-        masks = masks[:-1]
-        mask_mid = masks[-1]
-
-        for resnet, transformer_blocks in self.mid_blocks:
-            x = resnet(x, mask_mid, t)
-            x = x.permute(0, 2, 1).contiguous()
-            attn_mask = mask_to_bias(mask_mid.bool() == 1, x.dtype)
-            for transformer_block in transformer_blocks:
-                x = transformer_block(
-                    hidden_states=x,
-                    attention_mask=attn_mask,
-                    timestep=t,
-                )
-            x = x.permute(0, 2, 1).contiguous() 
-
-        resnet, transformer_blocks, upsample = self.up_blocks[0]
-        mask_up = masks.pop()
-        x = torch.cat([x[:, :, :residual.shape[-1]], residual], dim=1)
-        x = resnet(x, mask_up, t)
-        x = x.permute(0, 2, 1).contiguous()
-        attn_mask = mask_to_bias(mask_up.bool() == 1, x.dtype)
-        for transformer_block in transformer_blocks:
-            x = transformer_block(
-                hidden_states=x,
-                attention_mask=attn_mask,
-                timestep=t,
-            )
-        x = x.permute(0, 2, 1).contiguous()
-        x = upsample(x * mask_up)
-        x = self.final_block(x, mask_up)
-        output = self.final_proj(x * mask_up)
-        return output
-
-    def flow_forward(self, speech_tokens, token_len, mask, embedding, prompt_feat):
-        # xvec projection
-        embedding = F.normalize(embedding, dim=1)
-        embedding = self.spk_embed_affine_layer(embedding)
-
-        # concat text and prompt_text
-        speech_tokens = self.input_embedding(torch.clamp(speech_tokens, min=0))
-        speech_tokens = speech_tokens * mask
-
-        # text encode
-        text_encoded, _ = self.encoder(speech_tokens, token_len)
-        mel_len1, mel_len2 = prompt_feat.shape[1], text_encoded.shape[1] - prompt_feat.shape[1]
-        text_encoded = self.encoder_proj(text_encoded)
-
-        # get conditions
-        conds = torch.zeros(
-            [1, mel_len1 + mel_len2, self.output_size],
-            device=text_encoded.device, dtype=text_encoded.dtype,
-        )
-        conds[:, :mel_len1] = prompt_feat
-        conds = conds.transpose(1, 2)
-
-        mu = text_encoded
-        spks = embedding
-        if not isinstance(mel_len1, torch.Tensor):
-            mel_len1 = torch.tensor(mel_len1, device=speech_tokens.device)
-        if not isinstance(mel_len2, torch.Tensor):
-            mel_len2 = torch.tensor(mel_len2, device=speech_tokens.device)
-        return mel_len1, mel_len2, mu, spks, conds
-
-    def decode(self, x: torch.Tensor, s_stft: torch.Tensor) -> torch.Tensor:
-        x = self.conv_pre(x)
-
-        # ---- Upsample 0 ----
-        x = F.leaky_relu(x, self.lrelu_slope)
-        x = self.ups[0](x)
-
-        si = self.source_downs[0](s_stft)
-        si = self.source_resblocks[0](si)
-        x = x + si
-
-        xs0 = self.resblocks[0](x) + self.resblocks[1](x) + self.resblocks[2](x)
-        x = xs0 / 3
-
-        # ---- Upsample 1 ----
-        x = F.leaky_relu(x, self.lrelu_slope)
-        x = self.ups[1](x)
-
-        si = self.source_downs[1](s_stft)
-        si = self.source_resblocks[1](si)
-        x = x + si
-
-        xs1 = self.resblocks[3](x) + self.resblocks[4](x) + self.resblocks[5](x)
-        x = xs1 / 3
-
-        # ---- Upsample 2 ----
-        x = F.leaky_relu(x, self.lrelu_slope)
-        x = self.ups[2](x)
-        x = self.reflection_pad(x)
-
-        si = self.source_downs[2](s_stft)
-        si = self.source_resblocks[2](si)
-        x = x + si
-
-        xs2 = self.resblocks[6](x) + self.resblocks[7](x) + self.resblocks[8](x)
-        x = xs2 / 3
-
-        # ---- Final layers ----
-        x = F.leaky_relu(x)
-        x = self.conv_post(x)
-
-        magnitude = torch.exp(x[:, :self.n_fft // 2 + 1, :])
-        phase = torch.sin(x[:, self.n_fft // 2 + 1:, :])
-
-        return magnitude, phase
+        self.flow = model.s3gen.flow
+        self.mel2wav = model.s3gen.mel2wav
+        # trim_fade is a precomputed (960,) buffer that fades in the
+        # output to suppress ref-clip spillover. Cloned so .to(device)
+        # works without affecting the upstream model's buffer.
+        self.register_buffer("trim_fade", model.s3gen.trim_fade.detach().clone())
 
     def forward(self, speech_tokens, speaker_embeddings, speaker_features):
-        token_len = torch.full((speech_tokens.size(0),), speech_tokens.size(1), dtype=torch.long, device=speech_tokens.device)
-        mask = (~make_pad_mask(token_len)).unsqueeze(-1)
-        mel_len1, mel_len2, mu, spks, cond = self.flow_forward(speech_tokens, token_len, mask, speaker_embeddings, speaker_features)
-        mu = mu.transpose(1, 2).contiguous()
-        total_len = mel_len1.add(mel_len2).unsqueeze(0)
-        mask = (~make_pad_mask(total_len)).unsqueeze(0)
-        n_timesteps = 10
-        temperature = 1.0
-        x = torch.randn_like(mu, dtype=mu.dtype) * temperature
-        t_span = torch.linspace(0, 1, n_timesteps+1, device=mu.device, dtype=mu.dtype)
-        t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
-        dt_all = t_span[1:] - t_span[:-1]
+        B = speech_tokens.shape[0]
+        device = speech_tokens.device
+        token_len = torch.full((B,), speech_tokens.shape[1],
+                               dtype=torch.long, device=device)
+        # Upstream concatenates prompt_token + token internally; pass
+        # empty prompt to keep it a no-op (Vlad's vendored flow_forward
+        # didn't have a prompt-token concat path).
+        prompt_token = torch.zeros((B, 0), dtype=torch.long, device=device)
+        prompt_token_len = torch.zeros((B,), dtype=torch.long, device=device)
+        prompt_feat = speaker_features
+        prompt_feat_len = torch.full((B,), prompt_feat.shape[1],
+                                     dtype=torch.long, device=device)
 
-        t = t_span[0:1]
-        dt = dt_all[0:1]
-
-        x_in = torch.cat([x, torch.zeros_like(x)], dim=0) 
-        mask_in = torch.cat([mask, torch.zeros_like(mask)], dim=0) 
-        mu_in = torch.cat([mu, torch.zeros_like(mu)], dim=0) 
-        t_in = torch.cat([t, torch.zeros_like(t)], dim=0) 
-        spks_in = torch.cat([spks, torch.zeros_like(spks)], dim=0) 
-        cond_in = torch.cat([cond, torch.zeros_like(cond)], dim=0)
-
-        ## Classifier-Free Guidance inference introduced in VoiceBox
-        # step 1
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[1 + 1] - t
-
-        # step 2
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[2 + 1] - t
-
-        # step 3
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[3 + 1] - t
-
-        # step 4
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[4 + 1] - t
-
-        # step 5
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[5 + 1] - t
-
-        # step 6
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[6 + 1] - t
-
-        # step 7
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[7 + 1] - t
-
-        # step 8
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[8 + 1] - t
-
-        # step 9
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        t = t + dt
-        dt = t_span[9 + 1] - t
-
-        # step 10
-        x_in[:].copy_(x.squeeze(0)) 
-        mask_in[:].copy_(mask.squeeze(0))
-        mu_in[0].copy_(mu.squeeze(0))
-        t_in[:].copy_(t.squeeze(0))
-        spks_in[0].copy_(spks.squeeze(0))
-        cond_in[0].copy_(cond.squeeze(0))
-        dphi_dt = self.cond_forward(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
-        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
-        dphi_dt = (1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt
-        x = x + dt * dphi_dt
-        output = x.float()
-        speech_feat = torch.narrow(output, dim=2, start=mel_len1, length=output.size(2) - mel_len1)
-        #mel->f0
-        f0 = self.f0_predictor(speech_feat)
-        # f0->source
-        s = self.f0_upsamp(f0[:, None]).transpose(1, 2)  # bs,n,t
-        s, _, _ = self.m_source(s)
-        output_sources = s.transpose(1, 2).squeeze(1)
-        spec = torch.stft(
-            output_sources,
-            self.n_fft, 
-            self.hop_len, 
-            self.n_fft, 
-            window=self.stft_window.to(output_sources.device),
-            return_complex=False)
-        s_stft_real, s_stft_imag = spec[..., 0], spec[..., 1]
-        output_sources = torch.cat([s_stft_real, s_stft_imag], dim=1)
-        magnitude, phase = self.decode(x=speech_feat, s_stft=output_sources)
-        magnitude = torch.clip(magnitude, max=1e2)
-        real = magnitude * torch.cos(phase)
-        img = magnitude * torch.sin(phase)
-        recombine_magnitude_phase = torch.cat([real, img], dim=1)
-        output_wavs = self.istft(recombine_magnitude_phase)
-        trim_fade = torch.zeros(2 * self.n_trim, device=output_wavs.device)
-        cosine_window = (torch.cos(
-            torch.linspace(torch.pi, 0, self.n_trim, device=output_wavs.device)
-        ) + 1) / 2
-        trim_fade[self.n_trim:] = cosine_window
-        output_wavs[:, :trim_fade.size(0)] *= trim_fade
-        return output_wavs
-
+        feat, _ = self.flow.inference(
+            token=speech_tokens,
+            token_len=token_len,
+            prompt_token=prompt_token,
+            prompt_token_len=prompt_token_len,
+            prompt_feat=prompt_feat,
+            prompt_feat_len=prompt_feat_len,
+            embedding=speaker_embeddings,
+            finalize=True,
+        )
+        wav, _ = self.mel2wav.inference(speech_feat=feat)
+        # Apply trim_fade to suppress ref-clip spillover. Replace the
+        # in-place index assignment with a `cat` of (faded_head, tail) —
+        # avoids ONNX's "Removing mutation from node aten::copy_" warning
+        # which "changes graph semantics" silently.
+        n = self.trim_fade.shape[0]
+        head = wav[:, :n] * self.trim_fade
+        tail = wav[:, n:]
+        return torch.cat([head, tail], dim=1)

--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -30,11 +30,6 @@ chatterbox submodules that present an ONNX-export-friendly interface:
 
 Notes:
 
-  * The global `torch.Tensor.item = lambda x: x` monkeypatch from Vlad's
-    script is INTENTIONALLY OMITTED. If the export raises on a `.item()`
-    call, apply the patch via the scoped context manager in
-    `export_chatterbox_to_onnx.py::item_no_op_patch` rather than as a
-    global mutation.
   * `EXAGGERATION_TOKEN = 6563` verified against upstream constants
     (`chatterbox.models.t3.t3`).
 """

--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -1,44 +1,46 @@
 #!/usr/bin/env python3
-"""Chatterbox export internals — vendored from VladOS95-cyber's MIT-licensed
-reference and adapted for Vernacula's export pipeline.
+"""Chatterbox export wrappers.
 
-Source: https://github.com/VladOS95-cyber/onnx_conversion_scripts/tree/main/chatterbox
-        (file `chatterbox_to_onnx_conversion_script.py`, fetched May 2026)
-License: MIT — see upstream repo for full text.
+Originally vendored from VladOS95-cyber's MIT-licensed conversion
+script (https://github.com/VladOS95-cyber/onnx_conversion_scripts/tree/main/chatterbox).
+The ~600 lines of vendored S3Tokenizer / FSMN / FSQ / AudioEncoderV2 model
+code are gone — replaced by direct use of upstream `chatterbox.s3gen.tokenizer`
+plus four scoped patches in `_export_patches.py` that are mathematically
+verified equivalent (parity test passes bit-perfect; see Run 6 in
+`docs/chatterbox_investigation.md`).
 
-This is the v0 starting point per `chatterbox.scratch.md` Stage 0. Each
-nn.Module here is either:
+What remains here is the *orchestration* — wrappers around upstream
+chatterbox submodules that present an ONNX-export-friendly interface:
 
-  (a) an export-time wrapper (`PrepareConditionalsModel`, `InputsEmbeds`,
-      `ConditionalDecoder`, `SafeDenseLayer`, `ISTFT`) that re-implements
-      Chatterbox's forward pass in an ONNX-friendly way; or
+  * `SafeDenseLayer` — kept as a STUB only; the original substitution
+    drifted speaker_embeddings by 93% per parity (Run 5). The export
+    script raises if anyone tries to apply it.
+  * `PrepareConditionalsModel` — speech encoder + S3 tokenizer + cond
+    prep pipeline, returns the four outputs the speech_encoder.onnx
+    graph emits. `self.s3` is a direct reference to upstream
+    `chatterbox.s3gen.tokenizer` (no vendoring).
+  * `InputsEmbeds` — flat-tensor dispatch over text / speech /
+    exaggeration tokens via bool masks (export-friendly).
+  * `ISTFT` + `make_pad_mask` + `mask_to_bias` — vocoder helpers used
+    by `ConditionalDecoder`. ISTFT uses scatter_add for window_sumsquare
+    (Run 3 fix #12); not yet replaceable with upstream.
+  * `ConditionalDecoder` — orchestrates `chatterbox.s3gen.flow` +
+    `mel2wav` for speech-tokens → waveform. Several upstream-trace
+    workarounds inline.
 
-  (b) a vendored re-declaration of a Chatterbox internal class
-      (`S3Tokenizer` and its FSMN/FSQ/AudioEncoder dependency chain)
-      needed to construct (a). Vlad re-declared these to swap out
-      training-time ops (e.g. BatchNorm1d → LayerNorm via SafeDenseLayer)
-      that don't survive torch.onnx.export.
+Notes:
 
-Items flagged for E2 validation / E5 cleanup:
-
-  * `SafeDenseLayer` substitution is asserted-safe at inference time by
-    Vlad ("we can safely do that because it does not affect inference as
-    we do not need matching training dynamics"). E2 parity must verify
-    this numerically — not trusted on author's word.
-  * The global `torch.Tensor.item = lambda x: x` monkeypatch in Vlad's
-    script is INTENTIONALLY OMITTED here. It is load-bearing during
-    `torch.onnx.export` tracing (some Chatterbox internals call `.item()`
-    and the no-op makes the value traceable). If the export raises on a
-    `.item()` call, apply the patch via an explicit context manager
-    around the export() call, not as a global mutation.
-  * `EXAGGERATION_TOKEN = 6563` — verified against upstream constants in
-    `chatterbox.models.t3.t3` (E1 inspection, 2026-05-15).
+  * The global `torch.Tensor.item = lambda x: x` monkeypatch from Vlad's
+    script is INTENTIONALLY OMITTED. If the export raises on a `.item()`
+    call, apply the patch via the scoped context manager in
+    `export_chatterbox_to_onnx.py::item_no_op_patch` rather than as a
+    global mutation.
+  * `EXAGGERATION_TOKEN = 6563` verified against upstream constants
+    (`chatterbox.models.t3.t3`).
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Optional, Tuple
-import math
 
 import torch
 import torch.nn as nn
@@ -47,13 +49,9 @@ import torch.nn.functional as F
 import torchaudio as ta
 from torchaudio.compliance.kaldi import get_mel_banks
 
-from s3tokenizer.model import Conv1d, LayerNorm, Linear, MultiHeadAttention
-from s3tokenizer.utils import mask_to_bias as _s3tok_mask_to_bias  # noqa: F401  - kept to mirror Vlad's surface
-
 import numpy as np
 import librosa
 from librosa.filters import mel as librosa_mel_fn
-from tqdm import tqdm  # noqa: F401  - imported by some vendored loops
 # Sampling rate of the inputs to S3TokenizerV2
 S3GEN_SR = 24000
 S3_SR = 16_000
@@ -79,547 +77,6 @@ CFM_PARAMS = {
     "reg_loss_type": "l1"
 }
 ISTFT_PARAMS = {"n_fft": 16, "hop_len": 4}
-
-# override certain torch functions
-
-
-@dataclass
-class ModelConfig:
-    n_mels: int = 128
-    n_audio_ctx: int = 1500
-    n_audio_state: int = 1280
-    n_audio_head: int = 20
-    n_audio_layer: int = 6
-    n_codebook_size: int = 3**8
-
-    use_sdpa: bool = False
-
-def make_non_pad_mask(lengths: torch.Tensor, max_len: int = 0) -> torch.Tensor:
-    """Make mask tensor containing indices of non-padded part.
-
-    The sequences in a batch may have different lengths. To enable
-    batch computing, padding is need to make all sequence in same
-    size. To avoid the padding part pass value to context dependent
-    block such as attention or convolution , this padding part is
-    masked.
-
-    1 for non-padded part and 0 for padded part.
-
-    Parameters
-    ----------
-        lengths (torch.Tensor): Batch of lengths (B,).
-
-    Returns:
-    -------
-        torch.Tensor: Mask tensor containing indices of padded part (B, max_T).
-
-    Examples:
-        >>> import torch
-        >>> import s3tokenizer
-        >>> lengths = torch.tensor([5, 3, 2])
-        >>> masks = s3tokenizer.make_non_pad_mask(lengths)
-        masks = [[1, 1, 1, 1, 1],
-                 [1, 1, 1, 0, 0],
-                 [1, 1, 0, 0, 0]]
-    """
-    batch_size = lengths.size(0)
-    # max_len = max_len if max_len > 0 else lengths.max()
-    max_len_2 = lengths.max()
-    seq_range = torch.arange(0,
-                             max_len_2,
-                             dtype=torch.int64,
-                             device=lengths.device)
-    seq_range_expand = seq_range.unsqueeze(0).expand(batch_size, max_len_2)
-    seq_length_expand = lengths.unsqueeze(-1)
-    return seq_range_expand < seq_length_expand
-
-
-def precompute_freqs_cis(dim: int,
-                         end: int,
-                         theta: float = 10000.0,
-                         scaling=None):
-    freqs = 1.0 / (theta**(torch.arange(0, dim, 2)[:(dim // 2)].float() / dim))
-    t = torch.arange(end, device=freqs.device)  # type: ignore
-    if scaling is not None:
-        t = t * scaling
-    freqs = torch.outer(t, freqs).float()  # type: ignore
-    
-    cos = freqs.cos()
-    sin = freqs.sin()
-    
-    cos = torch.cat((cos, cos), dim=-1)
-    sin = torch.cat((sin, sin), dim=-1)
-    return cos, sin
-
-
-def apply_rotary_emb(
-    xq: torch.Tensor,
-    xk: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    cos = cos.unsqueeze(0).unsqueeze(2)
-    sin = sin.unsqueeze(0).unsqueeze(2)
-
-    D = xq.shape[-1]
-    half_l, half_r = xq[:, :, :, :D // 2], xq[:, :, :, D // 2:]
-    xq_r = torch.cat((-half_r, half_l), dim=-1)
-
-    D = xk.shape[-1]
-
-    half_l, half_r = xk[:, :, :, :D // 2], xk[:, :, :, D // 2:]
-    xk_r = torch.cat((-half_r, half_l), dim=-1)
-
-    return xq * cos + xq_r * sin, xk * cos + xk_r * sin
-
-
-def reshape_for_broadcast(freqs_cis: torch.Tensor, x: torch.Tensor):
-    ndim = x.ndim
-    assert 0 <= 1 < ndim
-    assert freqs_cis.shape == (x.shape[1], x.shape[-1])
-    shape = [
-        d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(x.shape)
-    ]
-    return freqs_cis.view(*shape)
-
-
-class FSQCodebook(nn.Module):
-
-    def __init__(self, dim: int, level: int = 3):
-        super().__init__()
-        self.project_down = nn.Linear(dim, 8)
-        self.level = level
-        self.embed = None
-
-    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
-    def preprocess(self, x: torch.Tensor) -> torch.Tensor:
-        # x = rearrange(x, "... d -> (...) d")
-        x = x.reshape(-1, x.shape[-1])
-        return x
-
-    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
-    def encode(self, x: torch.Tensor) -> torch.Tensor:
-        x_shape = x.shape
-        # pre-process
-        x = self.preprocess(x)
-        # quantize
-        h = self.project_down(x).float()
-        h = h.tanh()
-        h = h * 0.9990000128746033
-        h = h.round() + 1
-        # h = ((self.level - 1) * h).round()  # range [-k, k]
-        powers = torch.pow(
-            self.level,
-            torch.arange(2**self.level, device=x.device, dtype=h.dtype))
-        mu = torch.sum(h * powers.unsqueeze(0), dim=-1)
-        ind = mu.reshape(x_shape[0], x_shape[1])
-        return ind
-
-    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
-    def decode(self, embed_ind: torch.Tensor) -> torch.Tensor:
-        raise NotImplementedError(
-            'There is no official up project component provided')
-
-
-class FSQVectorQuantization(nn.Module):
-    """Vector quantization implementation (inference-only).
-    Args:
-        dim (int): Dimension
-        codebook_size (int): Codebook size
-    """
-
-    def __init__(
-        self,
-        dim: int,
-        codebook_size: int,
-    ):
-        super().__init__()
-        assert 3**8 == codebook_size
-        self._codebook = FSQCodebook(dim=dim, level=3)
-        self.codebook_size = codebook_size
-
-    @property
-    def codebook(self):
-        return self._codebook.embed
-
-    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
-    def encode(self, x: torch.Tensor) -> torch.Tensor:
-        return self._codebook.encode(x)
-
-    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
-    def decode(self, embed_ind: torch.Tensor) -> torch.Tensor:
-        quantize = self._codebook.decode(embed_ind)
-        # quantize = rearrange(quantize, "b n d -> b d n")
-        quantize = quantize.permute(0, 2, 1)
-        return quantize
-
-
-class FSMNMultiHeadAttention(MultiHeadAttention):
-
-    def __init__(
-        self,
-        n_state: int,
-        n_head: int,
-        kernel_size: int = 31,
-        use_sdpa: bool = False,
-    ):
-        super().__init__(n_state, n_head)
-
-        self.fsmn_block = nn.Conv1d(n_state,
-                                          n_state,
-                                          kernel_size,
-                                          stride=1,
-                                          padding=0,
-                                          groups=n_state,
-                                          bias=False)
-        self.left_padding = (kernel_size - 1) // 2
-        self.right_padding = kernel_size - 1 - self.left_padding
-        self.pad_fn = nn.ConstantPad1d(
-            (self.left_padding, self.right_padding), 0.0)
-
-        self.use_sdpa = use_sdpa
-
-    def forward_fsmn(self,
-                     inputs: torch.Tensor,
-                     mask: Optional[torch.Tensor] = None):
-        b, t, _, _ = inputs.size()
-        inputs = inputs.view(b, t, -1)
-        if mask is not None and mask.size(2) > 0:  # time2 > 0
-            inputs = inputs * mask
-        x = inputs.transpose(1, 2)
-        x = self.pad_fn(x)
-        x = self.fsmn_block(x)
-        x = x.transpose(1, 2)
-        x += inputs
-        return x * mask
-
-    def qkv_attention(self,
-                      q: torch.Tensor,
-                      k: torch.Tensor,
-                      v: torch.Tensor,
-                      mask: Optional[torch.Tensor] = None,
-                      mask_pad: Optional[torch.Tensor] = None,
-                      cos: Optional[torch.Tensor] = None,
-                      sin: Optional[torch.Tensor] = None):
-        _, _, D = q.shape
-        scale = (D // self.n_head)**-0.25
-        q = q.view(*q.shape[:2], self.n_head, -1)
-        k = k.view(*k.shape[:2], self.n_head, -1)
-        v = v.view(*v.shape[:2], self.n_head, -1)
-
-        if cos is not None and sin is not None:
-            q, k = apply_rotary_emb(q, k, cos=cos, sin=sin)
-
-        fsm_memory = self.forward_fsmn(v, mask_pad)
-
-        q = q.permute(0, 2, 1, 3) * scale
-        v = v.permute(0, 2, 1, 3)
-
-        if not self.use_sdpa:
-            k = k.permute(0, 2, 3, 1) * scale
-            qk = q @ k  # (B, n_head, T, T)
-            if mask is not None:
-                qk = qk + mask
-            qk = qk.float()
-            w = F.softmax(qk, dim=-1).to(q.dtype)
-            return (w @ v).permute(
-                0, 2, 1, 3).flatten(start_dim=2), qk.detach(), fsm_memory
-        else:
-            k = k.permute(0, 2, 1, 3) * scale
-            assert mask is not None
-            output = F.scaled_dot_product_attention(
-                q,
-                k,
-                v,
-                attn_mask=mask,
-                dropout_p=0.,
-                scale=1.,
-            )
-            output = (output.transpose(1,
-                                       2).contiguous().view(q.size(0), -1, D)
-                      )  # (batch, time1, d_model)
-            return output, None, fsm_memory
-
-    def forward(self,
-                x: torch.Tensor,
-                mask: Optional[torch.Tensor] = None,
-                mask_pad: Optional[torch.Tensor] = None,
-                cos: Optional[torch.Tensor] = None,
-                sin: Optional[torch.Tensor] = None):
-
-        q = self.query(x)
-        k = self.key(x)
-        v = self.value(x)
-
-        wv, qk, fsm_memory = self.qkv_attention(q, k, v, mask, mask_pad,
-                                                cos, sin)
-        return self.out(wv) + fsm_memory, qk
-
-
-class ResidualAttentionBlock(nn.Module):
-
-    def __init__(
-        self,
-        n_state: int,
-        n_head: int,
-        kernel_size: int = 31,
-        use_sdpa: bool = False,
-    ):
-        super().__init__()
-
-        self.attn = FSMNMultiHeadAttention(n_state,
-                                           n_head,
-                                           kernel_size,
-                                           use_sdpa=use_sdpa)
-        self.attn_ln = LayerNorm(n_state, eps=1e-6)
-
-        n_mlp = n_state * 4
-
-        self.mlp = nn.Sequential(Linear(n_state, n_mlp), nn.GELU(),
-                                       Linear(n_mlp, n_state))
-        self.mlp_ln = LayerNorm(n_state)
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        mask: Optional[torch.Tensor] = None,
-        mask_pad: Optional[torch.Tensor] = None,
-        cos: Optional[torch.Tensor] = None,
-        sin: Optional[torch.Tensor] = None,
-    ):
-        x = x + self.attn(
-            self.attn_ln(x), mask=mask, mask_pad=mask_pad,
-            cos=cos, sin=sin)[0]
-
-        x = x + self.mlp(self.mlp_ln(x))
-        return x
-
-
-class AudioEncoderV2(nn.Module):
-
-    def __init__(
-        self,
-        n_mels: int,
-        n_state: int,
-        n_head: int,
-        n_layer: int,
-        stride: int,
-        use_sdpa: bool,
-    ):
-        super().__init__()
-        self.stride = stride
-
-        self.conv1 = Conv1d(n_mels,
-                            n_state,
-                            kernel_size=3,
-                            stride=stride,
-                            padding=1)
-        self.conv2 = Conv1d(n_state,
-                            n_state,
-                            kernel_size=3,
-                            stride=2,
-                            padding=1)
-        cos, sin = precompute_freqs_cis(64, 1024 * 2)
-        self.register_buffer("cos", cos)
-        self.register_buffer("sin", sin)
-
-        self.blocks = nn.ModuleList([
-            ResidualAttentionBlock(n_state, n_head, use_sdpa=use_sdpa)
-            for _ in range(n_layer)
-        ])
-
-    def forward(self, x: torch.Tensor,
-                x_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        x : torch.Tensor, shape = (batch_size, n_mels, T)
-            the mel spectrogram of the audio
-        x_len: torch.Tensor, shape = (batch_size,)
-            length of each audio in x
-        """
-        mask = make_non_pad_mask(x_len).unsqueeze(1)
-        x = F.gelu(self.conv1(x * mask))
-        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // self.stride + 1
-        mask = make_non_pad_mask(x_len).unsqueeze(1)
-        x = F.gelu(self.conv2(x * mask))
-        x_len = (x_len + 2 - 1 * (3 - 1) - 1) // 2 + 1
-        mask = make_non_pad_mask(x_len).unsqueeze(1)
-        x = x.permute(0, 2, 1)  # (B, T // 2, n_state)
-        # NOTE: .contiguous() is essential for dynamo export!
-        x = x.contiguous()
-
-        
-        cos = self.cos[:x.size(1)].to(x.device)
-        sin = self.sin[:x.size(1)].to(x.device)
-
-        mask_pad = mask.transpose(1, 2)
-        mask = mask_to_bias(mask, x.dtype).unsqueeze(1)
-
-        for block in self.blocks:
-            x = block(x, mask, mask_pad, cos, sin)
-
-        return x, x_len
-
-
-class S3TokenizerV2(nn.Module):
-    """S3 tokenizer v2 implementation (inference-only).
-    Args:
-        config (ModelConfig): Config
-    """
-
-    def __init__(self):
-        super().__init__()
-        # self.name = name  # Store model name for token_rate determination
-        self.config = ModelConfig()
-        self.encoder = AudioEncoderV2(
-            self.config.n_mels,
-            self.config.n_audio_state,
-            self.config.n_audio_head,
-            self.config.n_audio_layer,
-            2,
-            self.config.use_sdpa,
-        )
-        self.quantizer = FSQVectorQuantization(
-            self.config.n_audio_state,
-            self.config.n_codebook_size,
-        )
-
-    def forward(self, mel: torch.Tensor,
-                mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        return self.quantize(mel, mel_len)
-
-    @torch.no_grad()  # was @torch.inference_mode() — breaks ONNX tracing
-    def quantize(self, mel: torch.Tensor,
-                 mel_len: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Quantize mel spectrogram to tokens, with automatic long audio handling.
-
-        Args:
-            mel: mel spectrogram tensor, shape (batch_size, n_mels, T)
-            mel_len: mel length tensor, shape (batch_size,)
-
-        Returns:
-            code: quantized tokens, shape (batch_size, T')
-            code_len: token length, shape (batch_size,)
-        """
-        # Check if any audio in the batch exceeds 30 seconds
-        # Assuming 16kHz sample rate and hop_length=160, 30s = 30*16000/160 = 3000 frames
-        # max_frames = 3000
-
-        # Check which samples are long audio
-        # assert (mel_len <= max_frames).all()
-
-        # All short audio - use original method
-        hidden, code_len = self.encoder(mel, mel_len)
-        code = self.quantizer.encode(hidden).long()
-        return code, code_len
-
-    @property
-    def device(self):
-        return next(self.parameters()).device
-
-    def freeze(self):
-        for _, param in self.named_parameters():
-            param.requires_grad = False
-
-
-class S3Tokenizer(S3TokenizerV2):
-    """
-    s3tokenizer.S3TokenizerV2 with the following changes:
-    - a more integrated `forward`
-    - compute `log_mel_spectrogram` using `_mel_filters` and `window` in `register_buffers`
-    """
-
-    ignore_state_dict_missing = ("_mel_filters", "window")
-
-    def __init__(
-        self,
-        config: ModelConfig = ModelConfig()
-    ):
-        super().__init__()
-
-        self.n_fft = 400
-        _mel_filters = librosa.filters.mel(
-            sr=S3_SR,
-            n_fft=self.n_fft,
-            n_mels=config.n_mels
-        )
-        self.register_buffer(
-            "_mel_filters",
-            torch.FloatTensor(_mel_filters),
-        )
-
-        self.register_buffer(
-            "window",
-            torch.hann_window(self.n_fft),
-        )
-
-    @torch.no_grad()
-    def forward(
-        self,
-        wavs: torch.Tensor,
-        max_len,
-    ) -> torch.Tensor:
-        """
-        NOTE: mel-spec has a hop size of 160 points (100 frame/sec).
-
-        Args
-        ----
-        - `wavs`: 16 kHz speech audio
-        """
-        mels = self.log_mel_spectrogram(wavs)  # [B, F, T]
-        if max_len is not None:
-            mels = mels[..., :max_len * 4]
-        mel_lens = torch.full((mels.shape[0],), mels.shape[-1], dtype=torch.int32, device=self.device)
-
-        speech_tokens, _ = self.quantize(mels, mel_lens)
-        return speech_tokens
-
-    def log_mel_spectrogram(
-        self,
-        audio: torch.Tensor,
-        padding: int = 0,
-    ):
-        """
-        Compute the log-Mel spectrogram of
-
-        Parameters
-        ----------
-        audio: torch.Tensor, shape = (*)
-            The path to audio or either a NumPy array or Tensor containing the
-            audio waveform in 16 kHz
-
-        padding: int
-            Number of zero samples to pad to the right
-
-        Returns
-        -------
-        torch.Tensor, shape = (128, n_frames)
-            A Tensor that contains the Mel spectrogram
-        """
-
-        if audio.dim() == 1:
-            audio = audio.unsqueeze(0)
-
-        audio = audio.to(self.device)
-        if padding > 0:
-            audio = F.pad(audio, (0, padding))
-        stft = torch.stft(
-            audio, self.n_fft, S3_HOP,
-            window=self.window.to(self.device),
-            return_complex=False
-        )
-        # remove Nyquist bin
-        stft = stft[..., :-1, :]
-        # compute magnitude squared
-        magnitudes = stft[..., 0]**2 + stft[..., 1]**2
-
-        mel_spec = self._mel_filters.to(self.device) @ magnitudes
-
-        log_spec = torch.clamp(mel_spec, min=1e-10).log10()
-        log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
-        log_spec = (log_spec + 4.0) / 4.0
-        return log_spec
-
 
 class SafeDenseLayer(torch.nn.Module):
     def __init__(self, in_channels, out_channels, bias=False):
@@ -647,8 +104,14 @@ class PrepareConditionalsModel(torch.nn.Module):
         super().__init__()
 
         # TODO: Move loading elsewhere
-        self.s3 = S3Tokenizer()
-        self.s3.load_state_dict(chatterbox.s3gen.tokenizer.state_dict(), strict=False)
+        # Use upstream chatterbox.s3gen.tokenizer directly. The vendored
+        # S3Tokenizer chain (verified mathematically identical via
+        # parity test, see Run 6 in docs/chatterbox_investigation.md)
+        # was replaced by four scoped patches in `_export_patches.py`
+        # (`patched_s3tokenizer_for_export` + `patched_rotary_for_export`).
+        # Active during the speech_encoder ONNX export only — eager
+        # PyTorch usage is unaffected.
+        self.s3 = chatterbox.s3gen.tokenizer
 
         self.speaker_encoder = chatterbox.s3gen.speaker_encoder
         self.flow = chatterbox.s3gen.flow
@@ -907,14 +370,17 @@ class PrepareConditionalsModel(torch.nn.Module):
         feature = feature - feature.mean(dim=0, keepdim=True)
         speaker_embeddings = self.speaker_encoder(feature.unsqueeze(0))
 
-        t3_cond_prompt_tokens = self.s3(ref_wav_16[..., :ENC_COND_LEN], max_len=self.speech_cond_prompt_len)
+        # Upstream chatterbox.s3gen.tokenizer returns (tokens, lens);
+        # Vlad's vendored S3Tokenizer returned just tokens. Take [0]
+        # to drop the lens — they're not consumed downstream.
+        t3_cond_prompt_tokens = self.s3(ref_wav_16[..., :ENC_COND_LEN], max_len=self.speech_cond_prompt_len)[0]
 
         resampled_wav_16 = self.resampler(ref_wav_24) # resample uncropped audio
 
         # NOTE: For some reason, we do two passes of the s3 tokenizer
         # TODO: Try reduce this?
         # Tokenize 16khz reference
-        prompt_token = self.s3(resampled_wav_16, max_len=None)
+        prompt_token = self.s3(resampled_wav_16, max_len=None)[0]
 
         cond_prompt_speech_emb = self.speech_emb(t3_cond_prompt_tokens) + \
                      self.speech_pos_emb(t3_cond_prompt_tokens)

--- a/scripts/chatterbox_export/_common.py
+++ b/scripts/chatterbox_export/_common.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Shared helpers for the Chatterbox ONNX export and parity scripts.
+
+Mirrors the conventions in `scripts/vibevoice_export/_common.py`. Keep
+helpers narrow — anything Chatterbox-specific (wrapper nn.Modules,
+monkeypatches) stays in the export script itself or a dedicated
+`_chatterbox_internals.py` once we decide how much of the Vlad-script
+model code we need to vendor.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+try:
+    import ml_dtypes
+except ImportError:  # pragma: no cover - optional until BF16 path is used
+    ml_dtypes = None
+
+
+# Chatterbox-wide constants extracted from the upstream Python package /
+# Vlad's reference script. Keep these in sync with `chatterbox-tts`.
+S3GEN_SR = 24000
+SPEECH_VOCAB_SIZE = 6561
+START_SPEECH_TOKEN = 6561
+STOP_SPEECH_TOKEN = 6562
+EXAGGERATION_TOKEN = 6563
+S3_SR = 16_000
+LLM_NUM_LAYERS = 30
+LLM_NUM_KV_HEADS = 16
+LLM_HEAD_DIM = 64
+
+
+def fail(message: str):
+    raise SystemExit(message)
+
+
+def ensure_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_device(torch: Any, requested: str) -> str:
+    if requested == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if requested == "cuda" and not torch.cuda.is_available():
+        fail("CUDA was requested but torch.cuda.is_available() is False.")
+    return requested
+
+
+def resolve_dtype(torch: Any, name: str) -> Any:
+    mapping = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    return mapping[name]
+
+
+def torch_dtype_name(dtype: Any) -> str:
+    for name in ("bfloat16", "float32", "float16"):
+        if str(dtype).endswith(name):
+            return name
+    return str(dtype)
+
+
+def ensure_output_dir(path: Path, overwrite: bool, export_files: list[str]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if overwrite:
+        return
+    collisions = [name for name in export_files if (path / name).exists()]
+    if collisions:
+        fail(
+            "Output directory already contains Chatterbox export targets. "
+            "Re-run with --overwrite to replace them.\n"
+            f"Existing files: {', '.join(collisions)}"
+        )
+
+
+def json_dump(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_export_report(model_dir: Path) -> dict[str, Any]:
+    report_path = model_dir / "export-report.json"
+    if not report_path.exists():
+        fail(f"Missing export-report.json in {model_dir}")
+    return load_json(report_path)
+
+
+def kv_input_names(num_layers: int) -> list[str]:
+    """LM input names for `past_key_values`, matching the HF-standard
+    transformers exporter shape used by the published `onnx-community`
+    `language_model.onnx`. The HF schema is
+    `past_key_values.{layer}.{key|value}`, so we emit those literal names.
+    """
+    names: list[str] = []
+    for idx in range(num_layers):
+        names.append(f"past_key_values.{idx}.key")
+        names.append(f"past_key_values.{idx}.value")
+    return names
+
+
+def kv_output_names(num_layers: int) -> list[str]:
+    names: list[str] = []
+    for idx in range(num_layers):
+        names.append(f"present.{idx}.key")
+        names.append(f"present.{idx}.value")
+    return names
+
+
+def load_audio_mono_24k(audio_path: Path) -> tuple[np.ndarray, int]:
+    import librosa
+    import soundfile as sf
+
+    waveform, sr = sf.read(str(audio_path), always_2d=False)
+    if waveform.ndim == 2:
+        waveform = waveform.mean(axis=1)
+    waveform = waveform.astype(np.float32, copy=False)
+    if sr != S3GEN_SR:
+        waveform = librosa.resample(waveform, orig_sr=sr, target_sr=S3GEN_SR).astype(np.float32, copy=False)
+        sr = S3GEN_SR
+    return waveform, sr
+
+
+def choose_onnx_providers(runtime: str) -> list[str]:
+    runtime = runtime.lower()
+    if runtime == "cpu":
+        return ["CPUExecutionProvider"]
+    if runtime == "cuda":
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if runtime == "tensorrt":
+        return ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]
+    fail(f"Unsupported runtime '{runtime}'.")
+
+
+def read_ort_available_providers() -> list[str]:
+    import onnxruntime as ort
+    return list(ort.get_available_providers())
+
+
+def nvidia_smi_query() -> dict[str, str] | None:
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,driver_version,memory.total,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+    if not out:
+        return None
+
+    first = out.splitlines()[0]
+    name, driver_version, memory_total, memory_used = [part.strip() for part in first.split(",")]
+    return {
+        "name": name,
+        "driver_version": driver_version,
+        "memory_total_mib": memory_total,
+        "memory_used_mib": memory_used,
+    }
+
+
+def save_export_report(
+    path: Path,
+    *,
+    repo_id: str,
+    revision: str | None,
+    device: str,
+    dtype: str,
+    opset_embed_tokens: int,
+    opset_speech_encoder: int,
+    opset_language_model: int,
+    opset_conditional_decoder: int,
+    lm_graph_mode: str,
+    safe_dense_layer_patched: bool,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    payload = {
+        "repo_id": repo_id,
+        "revision": revision,
+        "device": device,
+        "dtype": dtype,
+        "opsets": {
+            "embed_tokens": opset_embed_tokens,
+            "speech_encoder": opset_speech_encoder,
+            "language_model": opset_language_model,
+            "conditional_decoder": opset_conditional_decoder,
+        },
+        "lm_graph_mode": lm_graph_mode,
+        "safe_dense_layer_patched": safe_dense_layer_patched,
+        "constants": {
+            "s3gen_sr": S3GEN_SR,
+            "start_speech_token": START_SPEECH_TOKEN,
+            "stop_speech_token": STOP_SPEECH_TOKEN,
+            "llm_num_layers": LLM_NUM_LAYERS,
+            "llm_num_kv_heads": LLM_NUM_KV_HEADS,
+            "llm_head_dim": LLM_HEAD_DIM,
+        },
+    }
+    if extra:
+        payload.update(extra)
+    json_dump(path, payload)
+
+
+def add_local_script_path() -> None:
+    script_dir = Path(__file__).resolve().parent
+    if str(script_dir) not in sys.path:
+        sys.path.insert(0, str(script_dir))

--- a/scripts/chatterbox_export/_common.py
+++ b/scripts/chatterbox_export/_common.py
@@ -26,14 +26,33 @@ except ImportError:  # pragma: no cover - optional until BF16 path is used
 # Chatterbox-wide constants extracted from the upstream Python package /
 # Vlad's reference script. Keep these in sync with `chatterbox-tts`.
 S3GEN_SR = 24000
-SPEECH_VOCAB_SIZE = 6561
+S3_SR = 16_000
+
+# Speech-token vocabulary.
+#   - SPEECH_BASE_VOCAB_SIZE is the count of "real" speech tokens (ids
+#     0..SPEECH_BASE_VOCAB_SIZE-1) emitted by the S3 tokenizer.
+#   - The three special ids that follow it happen to share numeric
+#     adjacency, but the names refer to different concepts: don't use
+#     `SPEECH_BASE_VOCAB_SIZE` as a token id.
+SPEECH_BASE_VOCAB_SIZE = 6561
 START_SPEECH_TOKEN = 6561
 STOP_SPEECH_TOKEN = 6562
 EXAGGERATION_TOKEN = 6563
-S3_SR = 16_000
+
+# Llama backbone dims (verified at runtime against
+# chatterbox.t3.tfmr.config — 30 layers, 16 KV heads, 64 head_dim).
+LLM_HIDDEN_SIZE = 1024
 LLM_NUM_LAYERS = 30
 LLM_NUM_KV_HEADS = 16
-LLM_HEAD_DIM = 64
+LLM_NUM_ATTN_HEADS = 16
+LLM_HEAD_DIM = LLM_HIDDEN_SIZE // LLM_NUM_ATTN_HEADS  # 64
+
+# Output projection dims (verified against chatterbox.t3.speech_head and
+# .text_head Linear layers). The LM emits 8194 speech-vocab logits per
+# step; only the lower SPEECH_BASE_VOCAB_SIZE + 3 are "named". The
+# remaining 1630 are reserved/unused — likely a power-of-2-adjacent pad.
+SPEECH_HEAD_OUTPUT_DIM = 8194
+TEXT_HEAD_OUTPUT_DIM = 704
 
 
 def fail(message: str):

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Minimal targeted patches that make upstream chatterbox modules ONNX-exportable.
+
+Goal: drop the 600+ lines of vendored model code in `_chatterbox_internals.py`
+(S3Tokenizer family + helpers) by patching only the specific upstream ops
+that don't survive torch.onnx.export. Each patch is scoped via a
+context manager so it does NOT mutate global module state.
+
+Each patch lists:
+  * The exact upstream symbol it overrides
+  * The op it works around and why ONNX can't handle the original
+  * A parity invariant: the patched code path is numerically identical to
+    the unpatched version up to floating-point round-off, asserted by the
+    parity test in test_chatterbox_parity.py.
+"""
+from __future__ import annotations
+
+import types
+from contextlib import contextmanager
+
+import torch
+import torch.nn.functional as F
+
+
+# ── S3Tokenizer.log_mel_spectrogram ────────────────────────────────────
+# Upstream calls `torch.stft(..., return_complex=True)` then does
+# `stft.abs()**2`. ONNX symbolic doesn't support complex tensors as of
+# opset 20 ("STFT does not currently support complex types"). The fix
+# is to use `return_complex=False`, which returns a real tensor of shape
+# (*, freq, time, 2) where the last dim is [real, imag], and compute
+# magnitudes manually: `real**2 + imag**2`. Mathematically identical
+# to `complex_stft.abs()**2`.
+
+S3_HOP = 160  # matches chatterbox.models.s3tokenizer.s3tokenizer.S3_HOP
+
+
+def _log_mel_spectrogram_real_stft(self, audio, padding=0):
+    """Drop-in replacement that uses return_complex=False.
+
+    Numerically equivalent to the upstream original; see module-level
+    docstring for why ONNX requires this.
+    """
+    if not torch.is_tensor(audio):
+        audio = torch.from_numpy(audio)
+
+    audio = audio.to(self.device)
+    if padding > 0:
+        audio = F.pad(audio, (0, padding))
+
+    # Real-format STFT: shape (*, freq, time, 2), last dim = [real, imag]
+    stft_real = torch.stft(
+        audio, self.n_fft, S3_HOP,
+        window=self.window.to(self.device),
+        return_complex=False,
+    )
+    real = stft_real[..., 0]
+    imag = stft_real[..., 1]
+    # `stft.abs()**2` on the complex tensor equals `real**2 + imag**2`
+    # on the real-format tensor. Identity, not approximation.
+    magnitudes_full = real * real + imag * imag
+    magnitudes = magnitudes_full[..., :-1]
+
+    mel_spec = self._mel_filters.to(self.device) @ magnitudes
+
+    log_spec = torch.clamp(mel_spec, min=1e-10).log10()
+    log_spec = torch.maximum(log_spec, log_spec.max() - 8.0)
+    log_spec = (log_spec + 4.0) / 4.0
+    return log_spec
+
+
+# ── S3Tokenizer.forward ────────────────────────────────────────────────
+# Upstream's forward iterates over `wavs` as a Python list, computing
+# `log_mel_spectrogram` per element and concatenating with
+# `s3tokenizer.utils.padding` (which uses `torch.nn.utils.rnn.pad_sequence`).
+# ONNX doesn't export `aten::pad_sequence` (it operates on Python lists,
+# not tensors). Replacement: accept a (B, N) tensor directly, batch
+# through log_mel_spectrogram + quantize.
+#
+# Parity note: log_mel_spectrogram applies a global
+# `torch.maximum(log_spec, log_spec.max() - 8.0)` normalization. Per-wav
+# (upstream) this is computed within each utterance. Batched (ours)
+# this reduces across the whole batch. For batch=1 the behaviors are
+# identical — confirmed by the parity test. For batch>1 the behavior
+# diverges slightly, but our export and runtime use batch=1
+# (autoregressive TTS), so the divergence is moot for the current
+# deployment.
+
+def _forward_batched_for_export(self, wavs, max_len=None):
+    """Drop-in replacement for S3Tokenizer.forward.
+
+    Accepts a (B, N) tensor directly — no Python list iteration, no
+    pad_sequence call. log_mel_spectrogram and quantize are both
+    batch-aware, so this is a no-op transformation for batch=1.
+    """
+    if not torch.is_tensor(wavs):
+        wavs = torch.from_numpy(wavs)
+    if wavs.dim() == 1:
+        wavs = wavs.unsqueeze(0)
+    wavs = wavs.to(self.device)
+
+    mel = self.log_mel_spectrogram(wavs)  # (B, n_mels, T)
+    if max_len is not None:
+        mel = mel[..., :max_len * 4]
+    mel_lens = torch.full(
+        (mel.shape[0],), mel.shape[-1],
+        dtype=torch.int32, device=mel.device,
+    )
+
+    speech_tokens, speech_token_lens = self.quantize(mel, mel_lens)
+    return speech_tokens.long(), speech_token_lens.long()
+
+
+# ── Rotary embeddings: s3tokenizer.model_v2.{precompute_freqs_cis,
+#    apply_rotary_emb} ────────────────────────────────────────────────
+# Upstream represents rotary as `freqs_cis = torch.polar(ones, freqs)`
+# (a complex64 tensor) and consumes it in apply_rotary_emb via
+# `torch.view_as_real(freqs_cis)`. ONNX has no scalar type for
+# ComplexFloat, so both ops fail to symbolic-convert.
+#
+# Replacement: store freqs as a real (T, D, 2) tensor with last-dim
+# layout [cos, sin]. Mathematically identical — `polar(1, θ)` is
+# `cos(θ) + i sin(θ)`, and `view_as_real(complex64)` returns the same
+# (cos, sin) pair. apply_rotary_emb reads the (T, D, 2) tensor
+# directly.
+#
+# The patch has two parts:
+#   1. Replace the stored `self.freqs_cis` on each AudioEncoderV2-style
+#      module (converts complex → real-format in-place).
+#   2. Swap `s3tokenizer.model_v2.apply_rotary_emb` to a version that
+#      reads the real-format tensor.
+
+def _apply_rotary_emb_real(xq, xk, freqs_cis):
+    """Real-tensor replacement for s3tokenizer.model_v2.apply_rotary_emb.
+
+    freqs_cis must be a real (T, D, 2) tensor where last dim is [cos, sin]
+    — produced by `_freqs_cis_to_real(...)` below.
+    """
+    cos = freqs_cis[..., 0]  # (T, D)
+    sin = freqs_cis[..., 1]
+    cos = cos.unsqueeze(0).unsqueeze(2).to(xq.dtype)
+    sin = sin.unsqueeze(0).unsqueeze(2).to(xq.dtype)
+
+    D = xq.shape[-1]
+    half_l, half_r = xq[:, :, :, :D // 2], xq[:, :, :, D // 2:]
+    xq_r = torch.cat((-half_r, half_l), dim=-1)
+
+    D = xk.shape[-1]
+    half_l, half_r = xk[:, :, :, :D // 2], xk[:, :, :, D // 2:]
+    xk_r = torch.cat((-half_r, half_l), dim=-1)
+
+    return xq * cos + xq_r * sin, xk * cos + xk_r * sin
+
+
+def _freqs_cis_to_real(freqs_cis_complex):
+    """Convert a complex64 freqs_cis tensor (T, D) to real (T, D, 2)
+    with last-dim [cos, sin]. Done with `.real` / `.imag` which produce
+    real tensors directly. Safe to run on a loaded model's buffer
+    BEFORE the ONNX trace — the conversion is a one-time CPU op, not
+    part of the traced graph.
+    """
+    real = freqs_cis_complex.real.contiguous()
+    imag = freqs_cis_complex.imag.contiguous()
+    return torch.stack([real, imag], dim=-1)
+
+
+def _convert_freqs_cis_buffers(root_module):
+    """Walk a model and convert any complex `freqs_cis` attribute on
+    submodules to real-format (T, D, 2). Returns a dict of
+    {module: original_complex_freqs_cis} for restoration.
+    """
+    saved = {}
+    for m in root_module.modules():
+        if hasattr(m, "freqs_cis") and torch.is_tensor(m.freqs_cis) and m.freqs_cis.is_complex():
+            saved[m] = m.freqs_cis
+            m.freqs_cis = _freqs_cis_to_real(m.freqs_cis)
+    return saved
+
+
+@contextmanager
+def patched_rotary_for_export(root_module):
+    """Patch rotary embeddings under the given root module for ONNX export.
+
+    1. Walk root_module to find every submodule with a complex `freqs_cis`
+       attribute; replace with real-format (T, D, 2).
+    2. Monkey-patch s3tokenizer.model_v2.apply_rotary_emb to read the
+       real format. Restore on exit.
+    """
+    import s3tokenizer.model_v2 as _m2
+    original_apply = _m2.apply_rotary_emb
+    saved_freqs = _convert_freqs_cis_buffers(root_module)
+    _m2.apply_rotary_emb = _apply_rotary_emb_real
+    try:
+        yield root_module
+    finally:
+        _m2.apply_rotary_emb = original_apply
+        for module, original in saved_freqs.items():
+            module.freqs_cis = original
+
+
+@contextmanager
+def patched_s3tokenizer_for_export(tokenizer):
+    """Temporarily swap log_mel_spectrogram + forward for export-friendly versions.
+
+    Usage:
+        with patched_s3tokenizer_for_export(chatterbox_model.s3gen.tokenizer):
+            torch.onnx.export(my_wrapper, ...)
+
+    Originals are restored on context exit; trace and eager runs
+    outside the `with` block see the unpatched methods.
+    """
+    orig_log_mel = tokenizer.log_mel_spectrogram
+    orig_forward = tokenizer.forward
+    tokenizer.log_mel_spectrogram = types.MethodType(_log_mel_spectrogram_real_stft, tokenizer)
+    tokenizer.forward = types.MethodType(_forward_batched_for_export, tokenizer)
+    try:
+        yield tokenizer
+    finally:
+        tokenizer.log_mel_spectrogram = orig_log_mel
+        tokenizer.forward = orig_forward

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -406,6 +406,186 @@ def _make_mel2wav_istft_via_our_istft(istft_module):
     return _mel2wav_istft_patched
 
 
+# ── SineGen noise/phase determinism (DIAGNOSTIC PROBE) ────────────────
+# Upstream `SineGen.forward` has two random sources:
+#   1. `phase_vec = Uniform(-pi, pi).sample(...)` — random initial phase
+#      per call
+#   2. `noise = noise_amp * torch.randn_like(sine_waves)` — random noise
+#      mixed into the sine signal
+# Both are stochastic per call in PyTorch eager. ONNX traces them as
+# RandomNormal/RandomUniform ops which ORT runs with its own RNG —
+# uncorrelated with PyTorch's. The result: eager and ONNX use different
+# random samples even with same input → outputs diverge in the noise
+# component, which the resblocks may amplify.
+#
+# This patch zeros both random sources for diagnostic purposes — if
+# dec parity becomes good with this active, NSF random is the cause
+# and the production fix is to precompute the noise as a buffer.
+
+def _sinegen_forward_deterministic(self, f0):
+    """Deterministic replacement for SineGen.forward — zero noise, zero phase."""
+    import numpy as np
+    import torch
+
+    F_mat = torch.zeros(f0.size(0), self.harmonic_num + 1, f0.size(-1),
+                        device=f0.device)
+    for i in range(self.harmonic_num + 1):
+        F_mat[:, i:i + 1, :] = f0 * (i + 1) / self.sampling_rate
+
+    theta_mat = 2 * np.pi * (torch.cumsum(F_mat, dim=-1) % 1)
+    # phase_vec ZEROED (was: u_dist.sample(...) — random per call)
+    phase_vec = torch.zeros(
+        f0.size(0), self.harmonic_num + 1, 1,
+        device=f0.device, dtype=F_mat.dtype,
+    )
+
+    sine_waves = self.sine_amp * torch.sin(theta_mat + phase_vec)
+    uv = self._f02uv(f0)
+    # noise ZEROED (was: noise_amp * torch.randn_like(sine_waves))
+    noise = torch.zeros_like(sine_waves)
+    sine_waves = sine_waves * uv + noise
+    return sine_waves, uv, noise
+
+
+@contextmanager
+def patched_sinegen_deterministic(mel2wav):
+    """Make SineGen deterministic for diagnostic/parity work."""
+    sine_gen = mel2wav.m_source.l_sin_gen
+    original = sine_gen.forward
+    sine_gen.forward = types.MethodType(_sinegen_forward_deterministic, sine_gen)
+    try:
+        yield sine_gen
+    finally:
+        sine_gen.forward = original
+
+
+# ── flow.inference dynamic-shape rewrite ──────────────────────────────
+# Upstream `flow.inference` does Python-int arithmetic on tensor
+# shapes:
+#     mel_len1, mel_len2 = prompt_feat.shape[1], h.shape[1] - prompt_feat.shape[1]
+#     conds = torch.zeros([1, mel_len1 + mel_len2, self.output_size], ...)
+#     ...
+#     feat = feat[:, :, mel_len1:]
+# These Python ints get baked into the ONNX trace as static constants.
+# At runtime, inputs with different lengths fail with shape-mismatch
+# errors (LeftShape vs RightShape on Mul). The export's `dynamic_axes`
+# spec doesn't help because the shape values were captured pre-graph.
+#
+# Replacement uses tensor-shape-preserving construction: `h.new_zeros`
+# with `h.shape[1]` (a SymInt during trace), and `narrow` slicing
+# that keeps the start index symbolic.
+
+def _solve_euler_dynamic(self, x, t_span, mu, mask, spks, cond):
+    """Replacement for CausalConditionalCFM.solve_euler.
+
+    Upstream allocates the CFG _in buffers via
+    `torch.zeros([2, 80, x.size(2)], ...)` — `x.size(2)` becomes a
+    Python int, baking the time dimension into the trace. Replace
+    with `torch.cat([zeros_like(x), zeros_like(x)])` style
+    construction that propagates symbolic shapes through ONNX.
+    """
+    t, _, dt = t_span[0], t_span[-1], t_span[1] - t_span[0]
+    t = t.unsqueeze(dim=0)
+
+    sol = []
+
+    # Build CFG-pair tensors via cat-of-zeros_like to keep last dim symbolic.
+    x_in = torch.cat([torch.zeros_like(x), torch.zeros_like(x)], dim=0)
+    mask_in = torch.cat([torch.zeros_like(mask), torch.zeros_like(mask)], dim=0)
+    mu_in = torch.cat([torch.zeros_like(mu), torch.zeros_like(mu)], dim=0)
+    t_in = torch.zeros(2, device=x.device, dtype=x.dtype)
+    spks_in = torch.cat([torch.zeros_like(spks), torch.zeros_like(spks)], dim=0)
+    cond_in = torch.cat([torch.zeros_like(cond), torch.zeros_like(cond)], dim=0)
+
+    for step in range(1, len(t_span)):
+        x_in[:] = x
+        mask_in[:] = mask
+        mu_in[0] = mu
+        t_in[:] = t.unsqueeze(0)
+        spks_in[0] = spks
+        cond_in[0] = cond
+        dphi_dt = self.forward_estimator(
+            x_in, mask_in,
+            mu_in, t_in,
+            spks_in,
+            cond_in,
+        )
+        dphi_dt, cfg_dphi_dt = torch.split(dphi_dt, [x.size(0), x.size(0)], dim=0)
+        dphi_dt = ((1.0 + self.inference_cfg_rate) * dphi_dt - self.inference_cfg_rate * cfg_dphi_dt)
+        x = x + dt * dphi_dt
+        t = t + dt
+        sol.append(x)
+        if step < len(t_span) - 1:
+            dt = t_span[step + 1] - t
+
+    return sol[-1].float()
+
+
+def _flow_inference_dynamic(self,
+                            token, token_len,
+                            prompt_token, prompt_token_len,
+                            prompt_feat, prompt_feat_len,
+                            embedding,
+                            finalize):
+    print(f"[patched _flow_inference_dynamic called, token shape={tuple(token.shape)}]")  # DEBUG
+    """Drop-in replacement for chatterbox.s3gen.flow.MaskedDiffWithXvec.inference.
+
+    Mathematically identical to upstream for the single-batch
+    no-padding case (which is our entire deployment). Mask construction
+    uses shape-derived `ones_like` to keep ONNX dynamic — upstream's
+    `make_pad_mask(...)` does `lengths.max()` which collapses to a
+    Python int and bakes the time dim.
+    """
+    import torch.nn.functional as F
+
+    embedding = F.normalize(embedding, dim=1)
+    embedding = self.spk_embed_affine_layer(embedding)
+
+    token = torch.cat([prompt_token, token], dim=1)
+    # Embed first so we have a tensor with the time dim symbolic.
+    token = self.input_embedding(
+        torch.clamp(token, min=0, max=self.input_embedding.num_embeddings - 1)
+    )
+    # All-True mask of shape (B, T, 1), derived from `token`'s shape via
+    # ones_like on a sliced view. Avoids make_pad_mask's lengths.max()
+    # int-collapse.
+    mask = torch.ones_like(token[:, :, :1])
+    token = token * mask
+
+    # Encoder needs token_len. We pass the int-level length through but
+    # use token's symbolic shape for downstream mask construction.
+    h, h_lengths = self.encoder(token, prompt_token_len + (token_len.new_tensor([0]) + token.shape[1]))
+    if finalize is False:
+        h = h[:, :-self.pre_lookahead_len * self.token_mel_ratio]
+
+    h = self.encoder_proj(h)
+    prompt_len = prompt_feat.shape[1]
+
+    # conds: zeros of shape (B, total_len, output_size) where
+    # total_len = h.shape[1]. Constructed via a new_zeros that takes
+    # h.shape[0:1] + Size((output_size,)) — symbolic through ONNX.
+    conds_tail_len_tensor = h.shape[1] - prompt_len
+    conds_head = prompt_feat  # (B, prompt_len, output_size)
+    # tail zeros derived from h's shape, using symbolic subtraction
+    # via narrow on h itself.
+    conds_tail = torch.zeros_like(h.narrow(1, 0, conds_tail_len_tensor)[..., :self.output_size])
+    conds = torch.cat([conds_head, conds_tail], dim=1).transpose(1, 2)
+
+    # Mask for decoder: all-True (B, 1, total_len) derived from h.
+    mask2 = torch.ones_like(h[:, :, :1]).transpose(1, 2)  # (B, 1, total_len)
+
+    feat, _ = self.decoder(
+        mu=h.transpose(1, 2).contiguous(),
+        mask=mask2,
+        spks=embedding,
+        cond=conds,
+        n_timesteps=10,
+    )
+    # Slice off the prompt portion via narrow to keep dim symbolic.
+    feat = feat.narrow(2, prompt_len, feat.shape[2] - prompt_len)
+    return feat.float(), None
+
+
 @contextmanager
 def patched_cond_decoder_for_export(s3gen, istft_module):
     """Patch upstream s3gen.flow + mel2wav for ONNX export.
@@ -422,16 +602,21 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
     saved = {
         "flow.inference": flow.inference,
         "flow.decoder.forward": flow.decoder.forward,
+        "flow.decoder.solve_euler": flow.decoder.solve_euler,
         "mel2wav.inference": mel2wav.inference,
         "mel2wav._stft": mel2wav._stft,
         "mel2wav._istft": mel2wav._istft,
     }
 
-    # Strip inference_mode and rebind as bound methods
-    flow.inference = types.MethodType(_strip_inference_mode(flow.inference.__func__), flow)
+    # Strip inference_mode and swap flow.inference for the
+    # dynamic-shape rewrite. Also patch solve_euler to use shape-
+    # preserving zero allocation (zeros_like instead of torch.zeros
+    # with .size() ints).
+    flow.inference = types.MethodType(_flow_inference_dynamic, flow)
     flow.decoder.forward = types.MethodType(
         _strip_inference_mode(flow.decoder.forward.__func__), flow.decoder
     )
+    flow.decoder.solve_euler = types.MethodType(_solve_euler_dynamic, flow.decoder)
     mel2wav.inference = types.MethodType(
         _strip_inference_mode(mel2wav.inference.__func__), mel2wav
     )
@@ -447,6 +632,7 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
     finally:
         flow.inference = saved["flow.inference"]
         flow.decoder.forward = saved["flow.decoder.forward"]
+        flow.decoder.solve_euler = saved["flow.decoder.solve_euler"]
         mel2wav.inference = saved["mel2wav.inference"]
         mel2wav._stft = saved["mel2wav._stft"]
         mel2wav._istft = saved["mel2wav._istft"]

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -633,6 +633,21 @@ def _cfm_forward_dynamic(self, mu, mask, n_timesteps, temperature=1.0, spks=None
     return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond), None
 
 
+# Canonical seed for the CFM rand_noise. Used in both ONNX export and
+# parity tests so the two are bit-comparable. Chosen arbitrarily; the
+# exact value doesn't matter, only that it's stable across runs.
+CFM_RAND_NOISE_SEED = 0xC4F
+
+
+def _seeded_rand_noise_like(t: "torch.Tensor") -> "torch.Tensor":
+    """Deterministic rand_noise: same shape and dtype as upstream's
+    `torch.randn([1, 80, 15000])`, but seeded so every call returns the
+    same tensor. CPU generator on purpose — keeps the value independent
+    of the device the model happens to live on."""
+    g = torch.Generator(device="cpu").manual_seed(CFM_RAND_NOISE_SEED)
+    return torch.randn(t.shape, dtype=t.dtype, generator=g).to(t.device)
+
+
 @contextmanager
 def patched_cond_decoder_for_export(s3gen, istft_module):
     """Patch upstream s3gen.flow + mel2wav for ONNX export.
@@ -643,6 +658,15 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
       reusing the supplied `istft_module` (our scatter_add ISTFT).
     - Replaces ConditionalDecoder.forward (the CFM estimator) with a
       symbolic-broadcast version that avoids einops.repeat's T-baking.
+    - Pins `flow.decoder.rand_noise` to a deterministic seeded value.
+      Upstream sets `self.rand_noise = torch.randn(...)` as a plain
+      attribute (not a registered buffer) in `CausalConditionalCFM.__init__`,
+      so every `ChatterboxTTS.from_pretrained()` call gets a different
+      random init. Without pinning, the rand_noise baked into the ONNX
+      at export time differs from the rand_noise present at parity-test
+      time, making `parity_dec` an apples-to-oranges comparison (and
+      previously masquerading as "0.78 mel envelope drift"). See
+      docs/chatterbox_investigation.md Run 11.
     """
     flow = s3gen.flow
     mel2wav = s3gen.mel2wav
@@ -652,6 +676,7 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
         "flow.inference": flow.inference,
         "flow.decoder.forward": flow.decoder.forward,
         "flow.decoder.solve_euler": flow.decoder.solve_euler,
+        "flow.decoder.rand_noise": flow.decoder.rand_noise,
         "mel2wav.inference": mel2wav.inference,
         "mel2wav._stft": mel2wav._stft,
         "mel2wav._istft": mel2wav._istft,
@@ -666,6 +691,7 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
     flow.inference = types.MethodType(_flow_inference_dynamic, flow)
     flow.decoder.forward = types.MethodType(_cfm_forward_dynamic, flow.decoder)
     flow.decoder.solve_euler = types.MethodType(_solve_euler_dynamic, flow.decoder)
+    flow.decoder.rand_noise = _seeded_rand_noise_like(flow.decoder.rand_noise)
     mel2wav.inference = types.MethodType(
         _strip_inference_mode(mel2wav.inference.__func__), mel2wav
     )
@@ -682,6 +708,7 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
         flow.inference = saved["flow.inference"]
         flow.decoder.forward = saved["flow.decoder.forward"]
         flow.decoder.solve_euler = saved["flow.decoder.solve_euler"]
+        flow.decoder.rand_noise = saved["flow.decoder.rand_noise"]
         mel2wav.inference = saved["mel2wav.inference"]
         mel2wav._stft = saved["mel2wav._stft"]
         mel2wav._istft = saved["mel2wav._istft"]

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -338,6 +338,120 @@ def patched_dense_layer_for_export(speaker_encoder):
             setattr(parent, name, original)
 
 
+# ── Cond-decoder patches for chatterbox.s3gen.flow + mel2wav ─────────
+# Upstream provides `flow.inference(...)` and `mel2wav.inference(...)`
+# that together do what Vlad's vendored ConditionalDecoder
+# reimplemented in ~360 LOC. To use them, we need to bypass three
+# upstream ONNX-unfriendly patterns:
+#
+#   1. `@torch.inference_mode()` on `flow.inference`,
+#      `CausalConditionalCFM.forward`, `mel2wav.inference`. Inference
+#      mode poisons tensors with a flag that JIT trace's
+#      save_for_backward chokes on. (Same fix as the FSQ codebook in
+#      the S3Tokenizer chain — replace with @torch.no_grad.)
+#
+#   2. `mel2wav._stft` uses `torch.stft(return_complex=True)` then
+#      `view_as_real`. Same issue as S3Tokenizer.log_mel_spectrogram.
+#      Replacement uses `return_complex=False` and indexes [..., 0]/
+#      [..., 1] for real/imag.
+#
+#   3. `mel2wav._istft` builds `torch.complex(real, img)` then calls
+#      `torch.istft(...)`. ONNX has neither op. Replacement uses our
+#      existing `ISTFT` class (in `_chatterbox_internals.py`) which
+#      implements iSTFT via Conv1d + scatter_add window_sumsquare.
+
+
+def _strip_inference_mode(method):
+    """Wrap a method so its @torch.inference_mode decorator is skipped.
+
+    Returns the raw function from the decorated method; callers should
+    rebind via `types.MethodType`. The decorator chain wraps a _DecoratorContextManager
+    around the original function, accessible via `__wrapped__`.
+    """
+    while hasattr(method, "__wrapped__"):
+        method = method.__wrapped__
+    return method
+
+
+def _mel2wav_stft_real_format(self, x):
+    """Replacement for `mel2wav._stft` — return_complex=False, no view_as_real."""
+    spec = torch.stft(
+        x,
+        self.istft_params["n_fft"],
+        self.istft_params["hop_len"],
+        self.istft_params["n_fft"],
+        window=self.stft_window.to(x.device),
+        return_complex=False,
+    )  # (B, F, TT, 2)
+    return spec[..., 0], spec[..., 1]
+
+
+def _make_mel2wav_istft_via_our_istft(istft_module):
+    """Build a replacement for `mel2wav._istft` that uses our ISTFT
+    (Conv1d + scatter_add window_sumsquare) instead of torch.istft +
+    torch.complex.
+
+    Closes over the istft module so the patched method has access to it.
+    """
+
+    def _mel2wav_istft_patched(self, magnitude, phase):
+        magnitude = torch.clip(magnitude, max=1e2)
+        real = magnitude * torch.cos(phase)
+        img = magnitude * torch.sin(phase)
+        # Stack real/imag along channel dim → (B, 2F, TT) — the format
+        # our ISTFT class expects (recombine_magnitude_phase).
+        spec = torch.cat([real, img], dim=1)
+        return istft_module(spec)
+
+    return _mel2wav_istft_patched
+
+
+@contextmanager
+def patched_cond_decoder_for_export(s3gen, istft_module):
+    """Patch upstream s3gen.flow + mel2wav for ONNX export.
+
+    - Strips `@torch.inference_mode()` from flow.inference,
+      flow.decoder.forward (CausalConditionalCFM), mel2wav.inference.
+    - Patches mel2wav._stft and mel2wav._istft to avoid complex tensors,
+      reusing the supplied `istft_module` (our scatter_add ISTFT).
+    """
+    flow = s3gen.flow
+    mel2wav = s3gen.mel2wav
+
+    # Save originals
+    saved = {
+        "flow.inference": flow.inference,
+        "flow.decoder.forward": flow.decoder.forward,
+        "mel2wav.inference": mel2wav.inference,
+        "mel2wav._stft": mel2wav._stft,
+        "mel2wav._istft": mel2wav._istft,
+    }
+
+    # Strip inference_mode and rebind as bound methods
+    flow.inference = types.MethodType(_strip_inference_mode(flow.inference.__func__), flow)
+    flow.decoder.forward = types.MethodType(
+        _strip_inference_mode(flow.decoder.forward.__func__), flow.decoder
+    )
+    mel2wav.inference = types.MethodType(
+        _strip_inference_mode(mel2wav.inference.__func__), mel2wav
+    )
+
+    # Swap STFT/iSTFT
+    mel2wav._stft = types.MethodType(_mel2wav_stft_real_format, mel2wav)
+    mel2wav._istft = types.MethodType(
+        _make_mel2wav_istft_via_our_istft(istft_module), mel2wav
+    )
+
+    try:
+        yield s3gen
+    finally:
+        flow.inference = saved["flow.inference"]
+        flow.decoder.forward = saved["flow.decoder.forward"]
+        mel2wav.inference = saved["mel2wav.inference"]
+        mel2wav._stft = saved["mel2wav._stft"]
+        mel2wav._istft = saved["mel2wav._istft"]
+
+
 @contextmanager
 def patched_s3tokenizer_for_export(tokenizer):
     """Temporarily swap log_mel_spectrogram + forward for export-friendly versions.

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -496,32 +496,38 @@ def patched_sinegen_deterministic(mel2wav):
 def _solve_euler_dynamic(self, x, t_span, mu, mask, spks, cond):
     """Replacement for CausalConditionalCFM.solve_euler.
 
-    Upstream allocates the CFG _in buffers via
-    `torch.zeros([2, 80, x.size(2)], ...)` — `x.size(2)` becomes a
-    Python int, baking the time dimension into the trace. Replace
-    with `torch.cat([zeros_like(x), zeros_like(x)])` style
-    construction that propagates symbolic shapes through ONNX.
+    Upstream allocates `torch.zeros([2, 80, x.size(2)])` buffers and
+    fills them via in-place broadcasts (`x_in[:] = x`, `mu_in[0] = mu`).
+    Both patterns bake T into the trace:
+      1. The zeros allocation bakes T via `x.size(2)` int collapse.
+      2. The broadcast assign `x_in[:] = x` traces as
+         `Reshape(x, [80, T]) → Expand(_, [2, 80, T])`, baking T in
+         the Reshape's shape constant.
+
+    Fix: build the CFG-pair tensors via `torch.cat` of the actual
+    tensors (no broadcast). For CFG rows: `cat([cond_row, zeros_like])`
+    matches upstream's "row 0 = real, row 1 = zeros" CFG pattern with
+    no broadcast involved, so the trace stays symbolic.
     """
     t, _, dt = t_span[0], t_span[-1], t_span[1] - t_span[0]
     t = t.unsqueeze(dim=0)
 
     sol = []
 
-    # Build CFG-pair tensors via cat-of-zeros_like to keep last dim symbolic.
-    x_in = torch.cat([torch.zeros_like(x), torch.zeros_like(x)], dim=0)
-    mask_in = torch.cat([torch.zeros_like(mask), torch.zeros_like(mask)], dim=0)
-    mu_in = torch.cat([torch.zeros_like(mu), torch.zeros_like(mu)], dim=0)
-    t_in = torch.zeros(2, device=x.device, dtype=x.dtype)
-    spks_in = torch.cat([torch.zeros_like(spks), torch.zeros_like(spks)], dim=0)
-    cond_in = torch.cat([torch.zeros_like(cond), torch.zeros_like(cond)], dim=0)
+    # CFG-pair tensors that are constant across solve iterations.
+    # Row 0 = real, row 1 = zeros for unconditional pass (mu, spks, cond).
+    # mask is the same in both rows (upstream did `mask_in[:] = mask`).
+    mu_in = torch.cat([mu, torch.zeros_like(mu)], dim=0)
+    spks_in = torch.cat([spks, torch.zeros_like(spks)], dim=0)
+    cond_in = torch.cat([cond, torch.zeros_like(cond)], dim=0)
+    mask_in = torch.cat([mask, mask], dim=0)
 
     for step in range(1, len(t_span)):
-        x_in[:] = x
-        mask_in[:] = mask
-        mu_in[0] = mu
-        t_in[:] = t.unsqueeze(0)
-        spks_in[0] = spks
-        cond_in[0] = cond
+        # x and t are updated each iteration; rebuild their CFG-pairs.
+        x_in = torch.cat([x, x], dim=0)
+        t_cur = t.unsqueeze(0)
+        t_in = torch.cat([t_cur, t_cur], dim=0).view(2)
+
         dphi_dt = self.forward_estimator(
             x_in, mask_in,
             mu_in, t_in,
@@ -545,7 +551,6 @@ def _flow_inference_dynamic(self,
                             prompt_feat, prompt_feat_len,
                             embedding,
                             finalize):
-    print(f"[patched _flow_inference_dynamic called, token shape={tuple(token.shape)}]")  # DEBUG
     """Drop-in replacement for chatterbox.s3gen.flow.MaskedDiffWithXvec.inference.
 
     Mathematically identical to upstream for the single-batch
@@ -604,6 +609,30 @@ def _flow_inference_dynamic(self,
     return feat.float(), None
 
 
+def _cfm_forward_dynamic(self, mu, mask, n_timesteps, temperature=1.0, spks=None, cond=None):
+    """Replacement for CausalConditionalCFM.forward.
+
+    Upstream slices a precomputed `rand_noise: (1, 80, 15000)` buffer
+    by `mu.size(2)`:
+
+        z = self.rand_noise[:, :, :mu.size(2)] * temperature
+
+    `mu.size(2)` collapses to a Python int via torch.jit.trace, baking
+    T into 35 downstream Reshape/Equal/Where/Expand ops (the whole CFM
+    solve loop inherits z's baked shape). Replace with `narrow`, which
+    accepts a SymInt-derived length.
+    """
+    # narrow(dim, start, length) preserves symbolic length when length
+    # is derived from a Shape/Gather chain. `mu.shape[2]` here is
+    # symbolic in the trace; only `mu.size(2)` collapses.
+    # narrow with a SymInt-derived length keeps the slice symbolic.
+    z = self.rand_noise.narrow(2, 0, mu.shape[2]).to(mu.device).to(mu.dtype) * temperature
+    t_span = torch.linspace(0, 1, n_timesteps + 1, device=mu.device, dtype=mu.dtype)
+    if self.t_scheduler == 'cosine':
+        t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
+    return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond), None
+
+
 @contextmanager
 def patched_cond_decoder_for_export(s3gen, istft_module):
     """Patch upstream s3gen.flow + mel2wav for ONNX export.
@@ -612,6 +641,8 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
       flow.decoder.forward (CausalConditionalCFM), mel2wav.inference.
     - Patches mel2wav._stft and mel2wav._istft to avoid complex tensors,
       reusing the supplied `istft_module` (our scatter_add ISTFT).
+    - Replaces ConditionalDecoder.forward (the CFM estimator) with a
+      symbolic-broadcast version that avoids einops.repeat's T-baking.
     """
     flow = s3gen.flow
     mel2wav = s3gen.mel2wav
@@ -626,18 +657,15 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
         "mel2wav._istft": mel2wav._istft,
     }
 
-    # Strip inference_mode and swap flow.inference for the
-    # dynamic-shape rewrite. Also patch solve_euler to use shape-
-    # preserving zero allocation (zeros_like instead of torch.zeros
-    # with .size() ints).
+    # Strip inference_mode from flow.inference and swap it for the
+    # dynamic-shape rewrite. flow.decoder.forward (CausalConditionalCFM)
+    # is replaced with `_cfm_forward_dynamic`, which slices rand_noise
+    # symbolically (the upstream `rand_noise[:, :, :mu.size(2)]` bakes
+    # T into the whole CFM solve graph — see _cfm_forward_dynamic
+    # docstring). solve_euler stays patched for its own CFG bake.
     flow.inference = types.MethodType(_flow_inference_dynamic, flow)
-    flow.decoder.forward = types.MethodType(
-        _strip_inference_mode(flow.decoder.forward.__func__), flow.decoder
-    )
+    flow.decoder.forward = types.MethodType(_cfm_forward_dynamic, flow.decoder)
     flow.decoder.solve_euler = types.MethodType(_solve_euler_dynamic, flow.decoder)
-    # NOTE: cond decoder estimator uses diffusers Attention internally,
-    # which has its own shape-baking. Not patched here — see module
-    # docstring above _solve_euler_dynamic for the deferred-work note.
     mel2wav.inference = types.MethodType(
         _strip_inference_mode(mel2wav.inference.__func__), mel2wav
     )

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -475,6 +475,24 @@ def patched_sinegen_deterministic(mel2wav):
 # with `h.shape[1]` (a SymInt during trace), and `narrow` slicing
 # that keeps the start index symbolic.
 
+# NOTE on dynamic-shape limits:
+# The cond decoder uses `diffusers.models.attention_processor.Attention`
+# (HuggingFace diffusers library) for its mid_blocks / up_blocks /
+# down_blocks attention. We patched solve_euler + flow.inference's
+# mask construction, which fixed several baked time-dim values, but
+# additional shape-baking happens inside diffusers' Attention (and
+# possibly elsewhere). Patching diffusers' attention has too large a
+# surface area (multiple attention processors: SDPA, xformers,
+# default; many code paths each).
+#
+# Pragmatic resolution: cond decoder ONNX is *trace-shape-only* for
+# now — pad input to a fixed length at runtime (the C# orchestrator
+# can pad speech_tokens to a max chunk length, decode, trim audio).
+# A future fix could use `torch.onnx.dynamo_export` (PyTorch 2.x's
+# newer ONNX path) which is designed for dynamic shapes — left as
+# E5+ work.
+
+
 def _solve_euler_dynamic(self, x, t_span, mu, mask, spks, cond):
     """Replacement for CausalConditionalCFM.solve_euler.
 
@@ -617,6 +635,9 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
         _strip_inference_mode(flow.decoder.forward.__func__), flow.decoder
     )
     flow.decoder.solve_euler = types.MethodType(_solve_euler_dynamic, flow.decoder)
+    # NOTE: cond decoder estimator uses diffusers Attention internally,
+    # which has its own shape-baking. Not patched here — see module
+    # docstring above _solve_euler_dynamic for the deferred-work note.
     mel2wav.inference = types.MethodType(
         _strip_inference_mode(mel2wav.inference.__func__), mel2wav
     )

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -176,18 +176,71 @@ def _convert_freqs_cis_buffers(root_module):
     return saved
 
 
+def _audio_encoder_v2_forward_real_freqs(self, x, x_len):
+    """Replacement for `s3tokenizer.model_v2.AudioEncoderV2.forward`.
+
+    Upstream calls `torch.view_as_real(freqs_cis)` inline (line 344).
+    Even with our converted real-format buffer, that op fails ONNX
+    export ("view_as_real is only supported for complex tensors").
+    The cos/sin computed from view_as_real are then **never used**
+    downstream — they look like leftover refactoring debris. The
+    actual rotary application happens inside MultiHeadAttention via
+    `apply_rotary_emb(q, k, freqs_cis=freqs_cis)`, which we patch
+    separately.
+
+    This replacement is byte-for-byte identical to upstream EXCEPT
+    that it omits the dead view_as_real / cos / sin block.
+    """
+    T = x.shape[-1]
+    from s3tokenizer.model_v2 import make_non_pad_mask, mask_to_bias
+    mask = make_non_pad_mask(x_len, T).unsqueeze(1)
+    x = torch.nn.functional.gelu(self.conv1(x * mask))
+    x_len = (x_len + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+    x_slen = (T + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+    mask = make_non_pad_mask(x_len, x_slen).unsqueeze(1)
+    x = torch.nn.functional.gelu(self.conv2(x * mask))
+    x_len = (x_len + 2 - 1 * (3 - 1) - 1) // 2 + 1
+    x_slen = (x_slen + 2 - 1 * (3 - 1) - 1) // self.stride + 1
+    mask = make_non_pad_mask(x_len, x_slen).unsqueeze(1)
+    x = x.permute(0, 2, 1)  # (B, T // 2, n_state)
+    freqs_cis = self.freqs_cis.to(x.device)  # already real-format (T, D, 2)
+    mask_pad = mask.transpose(1, 2)
+    mask = mask_to_bias(mask, x.dtype)
+
+    for block in self.blocks:
+        x = block(x, mask.unsqueeze(1), mask_pad, freqs_cis[:x.size(1)])
+
+    return x, x_len
+
+
 @contextmanager
 def patched_rotary_for_export(root_module):
     """Patch rotary embeddings under the given root module for ONNX export.
 
-    1. Walk root_module to find every submodule with a complex `freqs_cis`
-       attribute; replace with real-format (T, D, 2).
-    2. Monkey-patch s3tokenizer.model_v2.apply_rotary_emb to read the
-       real format. Restore on exit.
+    Three-part patch:
+
+    1. Walk root_module to find every submodule with a complex
+       `freqs_cis` attribute; replace with real-format (T, D, 2).
+    2. Monkey-patch `s3tokenizer.model_v2.apply_rotary_emb` (the
+       function called by MultiHeadAttention) to read the real format.
+    3. Monkey-patch `AudioEncoderV2.forward` to skip its inline
+       `torch.view_as_real(freqs_cis)` call — that's dead code anyway,
+       the cos/sin it computes are never consumed.
+
+    All three are restored on context exit.
     """
     import s3tokenizer.model_v2 as _m2
+    from s3tokenizer.model_v2 import AudioEncoderV2
+
     original_apply = _m2.apply_rotary_emb
     saved_freqs = _convert_freqs_cis_buffers(root_module)
+
+    saved_aev2_forward = {}
+    for m in root_module.modules():
+        if isinstance(m, AudioEncoderV2):
+            saved_aev2_forward[m] = m.forward
+            m.forward = types.MethodType(_audio_encoder_v2_forward_real_freqs, m)
+
     _m2.apply_rotary_emb = _apply_rotary_emb_real
     try:
         yield root_module
@@ -195,6 +248,8 @@ def patched_rotary_for_export(root_module):
         _m2.apply_rotary_emb = original_apply
         for module, original in saved_freqs.items():
             module.freqs_cis = original
+        for module, original in saved_aev2_forward.items():
+            module.forward = original
 
 
 # ── chatterbox.models.s3gen.xvector.DenseLayer.forward ────────────────

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -197,6 +197,92 @@ def patched_rotary_for_export(root_module):
             module.freqs_cis = original
 
 
+# ── chatterbox.models.s3gen.xvector.DenseLayer.forward ────────────────
+# Upstream's DenseLayer.forward branches on `if len(x.shape) == 2` to
+# handle both 2D and 3D inputs. The branch produces an ONNX `If` node
+# whose output channel size is unknown to the symbolic checker, which
+# then refuses BatchNorm1d ("ONNX export of batch_norm for unknown
+# channel size"). Probe (probe_dense_shape.py) showed only one
+# DenseLayer instance in the speech_encoder pipeline and it's always
+# called with 2D input. Specialize the forward to the 2D branch and
+# the symbolic check passes.
+#
+# Parity note: the if-branch only changes shape handling; mathematics
+# is identical for inputs of any rank. Specializing to 2D drops the
+# rank-3 path that's never taken in practice. Verified by parity:
+# upstream eager 3D input would now fail, but no downstream caller
+# uses 3D, so the specialization is safe at inference.
+
+class _DenseLayerExportShim(torch.nn.Module):
+    """Drop-in replacement for chatterbox DenseLayer used during ONNX
+    export only. Same math, no opaque ops.
+
+    Upstream's DenseLayer wraps Conv1d-with-kernel-1 plus a
+    `if len(x.shape) == 2:` branch, then a Sequential containing
+    BatchNorm1d (`affine=False`). Three nested ONNX-shape-inference
+    failures cascade through:
+      - The if-branch produces an `If` node hiding the channel dim
+      - The squeeze(-1) is shape-conditional, producing another `If`
+      - Even after replacing both with explicit Linear+Reshape, ONNX
+        shape inference still can't propagate channel info to BatchNorm,
+        which refuses with "unknown channel size".
+    Workaround: inline the entire BatchNorm math as arithmetic ops.
+    BatchNorm1d at inference (affine=False) is just
+        y = (x - running_mean) / sqrt(running_var + eps)
+    — pure ops with statically-shaped buffers, no symbolic gymnastics.
+    Weights and BN running stats are copied byte-for-byte.
+    """
+
+    def __init__(self, upstream_dense):
+        super().__init__()
+        # Linear weights from the Conv1d-kernel-1
+        weight = upstream_dense.linear.weight.detach()  # (C_out, C_in, 1)
+        c_out, c_in = weight.shape[0], weight.shape[1]
+        bias = upstream_dense.linear.bias.detach() if upstream_dense.linear.bias is not None else None
+        self.linear = torch.nn.Linear(c_in, c_out, bias=bias is not None)
+        with torch.no_grad():
+            self.linear.weight.copy_(weight.squeeze(-1))
+            if bias is not None:
+                self.linear.bias.copy_(bias)
+
+        # Inline BatchNorm1d: pull running stats from the upstream BN.
+        # We assume affine=False (verified for chatterbox xvector dense).
+        # If a different config appears, this needs to learn weight/bias.
+        bn = upstream_dense.nonlinear.batchnorm
+        assert not bn.affine, "DenseLayerExportShim assumes BatchNorm1d(affine=False)"
+        self.register_buffer("bn_running_mean", bn.running_mean.detach().clone())
+        self.register_buffer("bn_running_var", bn.running_var.detach().clone())
+        self.bn_eps = float(bn.eps)
+
+    def forward(self, x):
+        y = self.linear(x)  # (B, C_out)
+        # Inline BatchNorm: y = (y - mean) / sqrt(var + eps)
+        y = (y - self.bn_running_mean) * torch.rsqrt(self.bn_running_var + self.bn_eps)
+        return y
+
+
+@contextmanager
+def patched_dense_layer_for_export(speaker_encoder):
+    """Swap every DenseLayer under speaker_encoder for the export shim.
+
+    Restoration is by parent-attribute reassignment — captured at patch
+    time so the original module returns to its slot on context exit.
+    """
+    from chatterbox.models.s3gen.xvector import DenseLayer
+    swaps = []  # list of (parent, attr_name, original_module)
+    for parent in speaker_encoder.modules():
+        for name, child in parent.named_children():
+            if isinstance(child, DenseLayer):
+                shim = _DenseLayerExportShim(child).to(next(child.parameters()).device).eval()
+                swaps.append((parent, name, child))
+                setattr(parent, name, shim)
+    try:
+        yield speaker_encoder
+    finally:
+        for parent, name, original in swaps:
+            setattr(parent, name, original)
+
+
 @contextmanager
 def patched_s3tokenizer_for_export(tokenizer):
     """Temporarily swap log_mel_spectrogram + forward for export-friendly versions.

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Export Chatterbox TTS to ONNX.
+
+Stage 0 step E2: implements three of the four graphs by orchestrating
+the wrapper modules vendored in `_chatterbox_internals.py`:
+
+  * `embed_tokens.onnx`        — text token embedding + position handling
+  * `speech_encoder.onnx`      — speech encoder + S3 tokenizer + cond prep
+  * `conditional_decoder.onnx` — speech tokens + conditioning → waveform
+
+The Llama language model graph lands in step E3 (separate work — we own
+that export from scratch, not adapted from Vlad's reference).
+
+Run:
+
+    python scripts/chatterbox_export/export_chatterbox_to_onnx.py \\
+        --output-dir ./models/chatterbox_export \\
+        --device cuda --dtype float32
+
+`--skip-language-model` is set by default at the CLI layer until E3 lands.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from _common import (
+    add_local_script_path,
+    ensure_output_dir,
+    nvidia_smi_query,
+    read_ort_available_providers,
+    resolve_device,
+    resolve_dtype,
+    save_export_report,
+    EXAGGERATION_TOKEN,
+    START_SPEECH_TOKEN,
+    S3GEN_SR,
+)
+
+add_local_script_path()
+
+
+DEFAULT_REPO_ID = "ResembleAI/chatterbox"
+EXPORT_FILES = [
+    "embed_tokens.onnx",
+    "speech_encoder.onnx",
+    "language_model.onnx",
+    "conditional_decoder.onnx",
+    "export-report.json",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo-id", default=DEFAULT_REPO_ID)
+    p.add_argument("--revision", default=None)
+    p.add_argument("--output-dir", type=Path, required=True)
+    p.add_argument("--device", default="auto", choices=["auto", "cpu", "cuda"])
+    p.add_argument("--dtype", default="float32", choices=["float32", "float16", "bfloat16"])
+    p.add_argument("--opset-embed-tokens", type=int, default=20)
+    p.add_argument("--opset-speech-encoder", type=int, default=20)
+    p.add_argument("--opset-language-model", type=int, default=18)
+    p.add_argument("--opset-conditional-decoder", type=int, default=17)
+    p.add_argument("--lm-graph-mode", default="unified", choices=["unified", "prefill+step"])
+    p.add_argument("--skip-embed-tokens", action="store_true")
+    p.add_argument("--skip-speech-encoder", action="store_true")
+    p.add_argument("--skip-language-model", action="store_true", default=True,
+                   help="(default: skipped until E3 lands)")
+    p.add_argument("--skip-conditional-decoder", action="store_true")
+    p.add_argument("--overwrite", action="store_true")
+    p.add_argument("--audio-prompt", type=Path, default=None,
+                   help="Reference audio at any sample rate. If omitted, a 13 s torch.randn dummy is used "
+                        "(fine for smoke tests, not for parity).")
+    p.add_argument("--no-onnxslim", action="store_true",
+                   help="Skip the onnxslim + external-data pass after export")
+    p.add_argument("--with-item-patch", action="store_true",
+                   help="Apply Vlad's `torch.Tensor.item = lambda x: x` monkeypatch around "
+                        "torch.onnx.export. Off by default; turn on if tracing fails on .item() calls.")
+    return p.parse_args()
+
+
+@contextmanager
+def item_no_op_patch(enabled: bool):
+    """Context manager for Vlad's `.item()` no-op trick. Scoped, not global."""
+    import torch
+    if not enabled:
+        yield
+        return
+    original = torch.Tensor.item
+    torch.Tensor.item = lambda self: self  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        torch.Tensor.item = original  # type: ignore[method-assign]
+
+
+def stage_environment() -> dict:
+    """Print + collect environment info for export-report.json."""
+    import torch
+    import onnxruntime as ort
+    env = {
+        "torch": torch.__version__,
+        "torch_cuda_available": bool(torch.cuda.is_available()),
+        "onnxruntime": ort.__version__,
+        "ort_providers": read_ort_available_providers(),
+    }
+    print(f"torch: {env['torch']}  cuda_available={env['torch_cuda_available']}")
+    print(f"onnxruntime: {env['onnxruntime']}")
+    print(f"  providers available: {env['ort_providers']}")
+    smi = nvidia_smi_query()
+    if smi:
+        env["nvidia_smi"] = smi
+        print(f"GPU: {smi['name']} (driver {smi['driver_version']}, "
+              f"{smi['memory_used_mib']}/{smi['memory_total_mib']} MiB)")
+    return env
+
+
+def hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_audio_prompt(path: Path | None, target_sr: int, device, dtype):
+    """Return a 1xN audio tensor at target_sr. If path is None, return
+    random noise sized for the dummy export (~13 s at 24 kHz, matching
+    Vlad's reference dummy size for trace shape stability).
+    """
+    import torch
+    if path is None:
+        # 312_936 samples == 13.039 s at 24 kHz, matching Vlad's dummy
+        return torch.randn(1, 312_936, device=device, dtype=dtype)
+    import librosa
+    waveform, _sr = librosa.load(str(path), sr=target_sr, mono=True)
+    return torch.from_numpy(waveform).unsqueeze(0).to(device=device, dtype=dtype)
+
+
+def build_reference_input_ids(device):
+    """Vlad's hardcoded 79-token reference prompt with the trailing
+    `START_SPEECH_TOKEN, START_SPEECH_TOKEN` pair retained per his
+    compatibility note ('most likely by accident, but we keep it').
+    """
+    import torch
+    return torch.tensor([[
+        EXAGGERATION_TOKEN, 255, 281,  39,  46,  56,   2,  53,   2, 286,  41,  37,   2, 136, 122,
+        49,   2, 152,   2, 103,   2, 277,  21, 101,   7,   2, 301,  55,  34,
+        28,   7,   2,  53,   2, 296,  18,  18, 115,   2,  51,   2,  33, 245,
+        2,  17, 190,   2,  42,   2,  50,  18, 125,   4,  32,   2, 290, 169,
+        142,   2,  41,   2,  43,   2,  18,  29,  91,   2,  25, 186,   8,  20,
+        14,  80,   2,  29,  86, 213, 216,   9,   0, START_SPEECH_TOKEN, START_SPEECH_TOKEN
+    ]], dtype=torch.long, device=device)
+
+
+def apply_safe_dense_patch(chatterbox_model, SafeDenseLayer):
+    """Replace `s3gen.speaker_encoder.xvector.dense` (DenseLayer wrapping
+    BatchNorm1d) with `SafeDenseLayer` (LayerNorm). Required for the
+    speech_encoder graph to export. Vlad asserts this is inference-equivalent;
+    E2 parity test must verify numerically.
+    """
+    old = chatterbox_model.s3gen.speaker_encoder.xvector.dense
+    new = SafeDenseLayer(old.linear.in_channels, old.linear.out_channels)
+    new.linear.weight.data.copy_(old.linear.weight.data)
+    chatterbox_model.s3gen.speaker_encoder.xvector.dense = new
+    return True
+
+
+def export_embed_tokens(embed_tokens_mod, input_ids, position_ids, exaggeration,
+                        out_path: Path, opset: int, item_patch: bool):
+    import torch
+    print(f"  exporting embed_tokens.onnx (opset {opset}) ...")
+    t0 = time.perf_counter()
+    with item_no_op_patch(item_patch):
+        torch.onnx.export(
+            embed_tokens_mod,
+            (input_ids, position_ids, exaggeration),
+            str(out_path),
+            export_params=True,
+            opset_version=opset,
+            input_names=["input_ids", "position_ids", "exaggeration"],
+            output_names=["inputs_embeds"],
+            dynamic_axes={
+                "input_ids": {0: "batch_size", 1: "sequence_length"},
+                "position_ids": {0: "batch_size", 1: "sequence_length"},
+                "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+                "exaggeration": {0: "batch_size"},
+            },
+        )
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path,
+                          opset: int, item_patch: bool):
+    import torch
+    print(f"  exporting speech_encoder.onnx (opset {opset}) ...")
+    t0 = time.perf_counter()
+    with item_no_op_patch(item_patch):
+        torch.onnx.export(
+            prepare_conditionals_mod,
+            (audio_values,),
+            str(out_path),
+            export_params=True,
+            opset_version=opset,
+            input_names=["audio_values"],
+            output_names=["audio_features", "audio_tokens", "speaker_embeddings", "speaker_features"],
+            dynamic_axes={
+                "audio_values": {0: "batch_size", 1: "num_samples"},
+                "audio_features": {0: "batch_size", 1: "sequence_length"},
+                "audio_tokens": {0: "batch_size", 1: "audio_sequence_length"},
+                "speaker_embeddings": {0: "batch_size"},
+                "speaker_features": {0: "batch_size", 1: "feature_dim"},
+            },
+        )
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddings,
+                               speaker_features, out_path: Path, opset: int, item_patch: bool):
+    """Export the conditional decoder.
+
+    On CUDA, torch.jit.trace (used internally by torch.onnx.export) fails
+    inside upstream chatterbox `CausalBlock1D.block(x * mask)` with a
+    spurious cuda:0/cpu device-mismatch — confirmed by repro outside ONNX
+    via direct torch.jit.trace. Eager mode runs the same code path
+    cleanly. Workaround: move the module + inputs to CPU just for the
+    export. The resulting ONNX graph is device-independent; ORT will run
+    it on CUDA at session-load time.
+
+    `set_default_device("cpu")` is also pinned for the duration of the
+    export so any intermediates the tracer materializes land on CPU.
+    """
+    import torch
+    print(f"  exporting conditional_decoder.onnx (opset {opset}) ...")
+    t0 = time.perf_counter()
+    cond_decoder_mod = cond_decoder_mod.cpu()
+    speech_tokens_cpu = speech_tokens.cpu()
+    speaker_embeddings_cpu = speaker_embeddings.cpu()
+    speaker_features_cpu = speaker_features.cpu()
+    # The vendored `istft` singleton is held by reference inside cond_decoder.
+    import _chatterbox_internals as ci  # noqa - already imported in main; reimport keeps the function self-contained
+    ci.istft.cpu()
+    prev_default = torch.get_default_device() if hasattr(torch, "get_default_device") else None
+    torch.set_default_device("cpu")
+    try:
+        with item_no_op_patch(item_patch):
+            torch.onnx.export(
+                cond_decoder_mod,
+                (speech_tokens_cpu, speaker_embeddings_cpu, speaker_features_cpu),
+                str(out_path),
+                export_params=True,
+                opset_version=opset,
+                input_names=["speech_tokens", "speaker_embeddings", "speaker_features"],
+                output_names=["waveform"],
+                dynamic_axes={
+                    "speech_tokens": {0: "batch_size", 1: "num_speech_tokens"},
+                    "speaker_embeddings": {0: "batch_size"},
+                    "speaker_features": {0: "batch_size", 1: "feature_dim"},
+                    "waveform": {0: "batch_size", 1: "num_samples"},
+                },
+            )
+    finally:
+        if prev_default is not None:
+            torch.set_default_device(prev_default)
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def slim_and_externalize(output_dir: Path, filenames: list[str]) -> None:
+    """Post-export onnxslim pass + external data save.
+
+    Matches Vlad's post-processing block (`ONNXSLIM_THRESHOLD=1e10` to
+    disable size-threshold pruning, then save all tensors into a single
+    sidecar). If onnxslim's shape inference raises — typically on large
+    graphs whose proto-serialized size exceeds protobuf's 2 GB limit —
+    we fall back to externalizing the raw export. The slim is an
+    optimization, not load-bearing; correctness comes from torch.onnx.export.
+    """
+    import onnx
+    import onnxslim
+    os.environ["ONNXSLIM_THRESHOLD"] = "10000000000"
+    for fn in filenames:
+        path = output_dir / fn
+        if not path.exists():
+            continue
+        slimmed = None
+        try:
+            print(f"  slimming {fn} ...")
+            slimmed = onnxslim.slim(str(path))
+        except Exception as e:
+            print(f"    slim failed for {fn}: {type(e).__name__}: {e}")
+            print(f"    falling back to raw externalization")
+        if slimmed is None:
+            # Re-load the raw export (torch.onnx.export wrote it inline)
+            # and rewrite with external data.
+            slimmed = onnx.load(str(path))
+        onnx.save_model(
+            slimmed, str(path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=f"{fn}_data",
+        )
+
+
+def main() -> None:
+    args = parse_args()
+
+    print("Chatterbox ONNX export — Stage 0 / E2")
+    print(f"  repo_id: {args.repo_id}")
+    print(f"  revision: {args.revision or '(latest)'}")
+    print(f"  output_dir: {args.output_dir}")
+    print(f"  device: {args.device}  dtype: {args.dtype}")
+    print()
+
+    env = stage_environment()
+    print()
+
+    ensure_output_dir(args.output_dir, args.overwrite, EXPORT_FILES)
+
+    # Lazy imports so --help works without paying the chatterbox/torch load cost
+    import torch
+    from chatterbox.tts import ChatterboxTTS
+    import _chatterbox_internals as ci
+
+    device = resolve_device(torch, args.device)
+    dtype = resolve_dtype(torch, args.dtype)
+    if dtype is not torch.float32:
+        # Vlad's reference exports fp32. Float16/bfloat16 paths are an E2 stretch
+        # — leave fp32 as the smoke-test default; the 3090 ship target casts the
+        # exported fp32 graph at session load time via ORT.
+        print(f"  WARN: dtype={args.dtype} not yet validated; export proceeds but may fail.")
+
+    print(f"Loading ChatterboxTTS from {args.repo_id} (revision={args.revision or 'latest'}) ...")
+    t0 = time.perf_counter()
+    chatterbox_model = ChatterboxTTS.from_pretrained(device=device)
+    print(f"  loaded in {time.perf_counter() - t0:.1f}s")
+    param_count = (
+        sum(p.numel() for p in chatterbox_model.s3gen.parameters())
+        + sum(p.numel() for p in chatterbox_model.t3.parameters())
+    )
+    print(f"  s3gen + t3 parameter count: {param_count:,}")
+
+    print("Applying SafeDenseLayer monkeypatch on speaker_encoder.xvector.dense ...")
+    patched = apply_safe_dense_patch(chatterbox_model, ci.SafeDenseLayer)
+
+    print("Building export wrappers ...")
+    prepare_conditionals = ci.PrepareConditionalsModel(chatterbox_model).eval().to(device)
+    embed_tokens = ci.InputsEmbeds(chatterbox_model).eval().to(device)
+    cond_decoder = ci.ConditionalDecoder(chatterbox_model).eval().to(device)
+    # The vendored `istft` is a module-level singleton; its hann_window
+    # buffer must also follow the export device or torch.stft crashes
+    # during trace.
+    ci.istft.to(device)
+    print("  PrepareConditionalsModel, InputsEmbeds, ConditionalDecoder built")
+
+    # Build canonical inputs
+    audio_values = load_audio_prompt(args.audio_prompt, target_sr=S3GEN_SR,
+                                     device=device, dtype=torch.float32)
+    prompt_label = "random noise" if args.audio_prompt is None else args.audio_prompt
+    print(f"  audio_values: shape={tuple(audio_values.shape)} (prompt={prompt_label})")
+
+    input_ids = build_reference_input_ids(device)
+    position_ids = torch.where(
+        input_ids >= START_SPEECH_TOKEN,
+        torch.zeros_like(input_ids),
+        torch.arange(input_ids.shape[1], device=device).unsqueeze(0) - 1,
+    )
+    exaggeration = torch.tensor([0.5], device=device)
+    print(f"  input_ids: shape={tuple(input_ids.shape)}  position_ids: {tuple(position_ids.shape)}")
+
+    graphs_exported: list[str] = []
+
+    if not args.skip_embed_tokens:
+        export_embed_tokens(
+            embed_tokens, input_ids, position_ids, exaggeration,
+            args.output_dir / "embed_tokens.onnx",
+            opset=args.opset_embed_tokens, item_patch=args.with_item_patch,
+        )
+        graphs_exported.append("embed_tokens.onnx")
+
+    if not args.skip_speech_encoder:
+        export_speech_encoder(
+            prepare_conditionals, audio_values,
+            args.output_dir / "speech_encoder.onnx",
+            opset=args.opset_speech_encoder, item_patch=args.with_item_patch,
+        )
+        graphs_exported.append("speech_encoder.onnx")
+
+    if not args.skip_conditional_decoder:
+        # Cond decoder needs real speech tokens + speaker conditioning. Run
+        # PrepareConditionalsModel + InputsEmbeds + (eager Llama LM) to get
+        # them, then feed to the cond decoder export. Mirrors Vlad's flow.
+        print("Running PyTorch reference pipeline to build cond decoder inputs ...")
+        with torch.no_grad():
+            cond_emb, prompt_token, speaker_embeddings, speaker_features = \
+                prepare_conditionals(audio_values=audio_values)
+            text_emb = embed_tokens(input_ids=input_ids, position_ids=position_ids, exaggeration=exaggeration)
+            inputs_embeds = torch.cat((cond_emb, text_emb), dim=1)
+
+            # chatterbox.t3 uses a split LlamaModel + speech_head layout:
+            # `tfmr` is the bare backbone (returns BaseModelOutputWithPast
+            # with `last_hidden_state` only), and `speech_head` projects the
+            # last hidden state to the speech vocab. Vlad sidestepped this
+            # by loading his own `vladislavbro/llama_backbone_0.5`
+            # LlamaForCausalLM mirror; we keep provenance at ResembleAI by
+            # composing the backbone + head ourselves.
+            llm = chatterbox_model.t3.tfmr
+            speech_head = chatterbox_model.t3.speech_head
+            llm.eval()
+            speech_head.eval()
+            from transformers import RepetitionPenaltyLogitsProcessor
+            rep_proc = RepetitionPenaltyLogitsProcessor(penalty=1.2)
+            generate_tokens = torch.tensor([[START_SPEECH_TOKEN]], dtype=torch.long, device=device)
+            past_key_values = None
+            max_new_tokens = 256
+            from tqdm import tqdm
+            for i in tqdm(range(max_new_tokens), desc="Sampling", dynamic_ncols=True):
+                out = llm(inputs_embeds=inputs_embeds, past_key_values=past_key_values)
+                past_key_values = out.past_key_values
+                next_logits = speech_head(out.last_hidden_state[:, -1, :])
+                next_logits = rep_proc(generate_tokens, next_logits)
+                next_token = torch.argmax(next_logits, dim=-1).unsqueeze(-1)
+                generate_tokens = torch.cat((generate_tokens, next_token), dim=-1)
+                if (next_token.view(-1) == ci.STOP_SPEECH_TOKEN).all():
+                    break
+                pos = torch.full((input_ids.shape[0], 1), i + 1, dtype=torch.long, device=device)
+                inputs_embeds = embed_tokens(next_token, pos, exaggeration)
+            speech_tokens = torch.cat([prompt_token, generate_tokens[:, 1:-1]], dim=1)
+            print(f"  speech_tokens: shape={tuple(speech_tokens.shape)}")
+
+        export_conditional_decoder(
+            cond_decoder, speech_tokens, speaker_embeddings, speaker_features,
+            args.output_dir / "conditional_decoder.onnx",
+            opset=args.opset_conditional_decoder, item_patch=args.with_item_patch,
+        )
+        graphs_exported.append("conditional_decoder.onnx")
+
+    if graphs_exported and not args.no_onnxslim:
+        print("\nPost-export: onnxslim + external data ...")
+        slim_and_externalize(args.output_dir, graphs_exported)
+
+    if args.skip_language_model:
+        print("\n[skipped] language_model.onnx (E3 work — not yet implemented)")
+
+    # Provenance: hash everything we emitted
+    hashes = {}
+    for fn in graphs_exported:
+        p = args.output_dir / fn
+        if p.exists():
+            hashes[fn] = {"sha256": hash_file(p), "size_bytes": p.stat().st_size}
+        data_path = args.output_dir / f"{fn}_data"
+        if data_path.exists():
+            hashes[f"{fn}_data"] = {"sha256": hash_file(data_path), "size_bytes": data_path.stat().st_size}
+
+    report_path = args.output_dir / "export-report.json"
+    save_export_report(
+        report_path,
+        repo_id=args.repo_id,
+        revision=args.revision,
+        device=device,
+        dtype=args.dtype,
+        opset_embed_tokens=args.opset_embed_tokens,
+        opset_speech_encoder=args.opset_speech_encoder,
+        opset_language_model=args.opset_language_model,
+        opset_conditional_decoder=args.opset_conditional_decoder,
+        lm_graph_mode=args.lm_graph_mode,
+        safe_dense_layer_patched=patched,
+        extra={
+            "stage": "E2-graphs-only",
+            "graphs_exported": graphs_exported,
+            "artifact_hashes": hashes,
+            "environment": env,
+            "audio_prompt": str(args.audio_prompt) if args.audio_prompt else None,
+            "audio_prompt_samples": int(audio_values.shape[1]),
+            "input_ids_length": int(input_ids.shape[1]),
+            "max_lm_steps_used": 256,  # for the cond-decoder input gen
+        },
+    )
+    print(f"\nWrote {report_path}")
+    print(f"Graphs emitted: {graphs_exported}")
+    if not graphs_exported:
+        print("(no graphs requested — passed --skip-* for all four)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -303,7 +303,7 @@ def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddin
     Resulting ONNX is device-independent.
     """
     import torch
-    from _export_patches import patched_cond_decoder_for_export
+    from _export_patches import patched_cond_decoder_for_export, patched_sinegen_deterministic
     print(f"  exporting conditional_decoder.onnx (opset {opset}) ...")
     t0 = time.perf_counter()
     cond_decoder_mod = cond_decoder_mod.cpu()
@@ -320,7 +320,8 @@ def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddin
     torch.set_default_device("cpu")
     try:
         with item_no_op_patch(item_patch), \
-             patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft):
+             patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft), \
+             patched_sinegen_deterministic(chatterbox_model.s3gen.mel2wav):
             torch.onnx.export(
                 cond_decoder_mod,
                 (speech_tokens_cpu, speaker_embeddings_cpu, speaker_features_cpu),

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -45,7 +45,6 @@ from _common import (
     LLM_NUM_LAYERS,
     LLM_NUM_KV_HEADS,
     LLM_HEAD_DIM,
-    SPEECH_HEAD_OUTPUT_DIM,
 )
 
 add_local_script_path()
@@ -174,16 +173,29 @@ def build_reference_input_ids(device):
 
 
 def apply_safe_dense_patch(chatterbox_model, SafeDenseLayer):
-    """Replace `s3gen.speaker_encoder.xvector.dense` (DenseLayer wrapping
-    BatchNorm1d) with `SafeDenseLayer` (LayerNorm). Required for the
-    speech_encoder graph to export. Vlad asserts this is inference-equivalent;
-    E2 parity test must verify numerically.
+    """REMOVED — DO NOT USE.
+
+    Vlad's `SafeDenseLayer` (BatchNorm1d→LayerNorm substitution) was
+    introduced to work around an apparent ONNX export issue with the
+    upstream `DenseLayer`. Direct testing (probe_dense.py) showed that
+    the upstream layer ONNX-exports cleanly on CPU; the original
+    failure was the same CUDA-side `torch.jit.trace` bug we hit on
+    the cond decoder, not a symbolic-conversion problem.
+
+    The substitution drops BatchNorm1d's running mean/var (which
+    encode learned activation statistics) and replaces with a
+    randomly-initialized LayerNorm. Parity test E4 confirmed this
+    drifts speaker_embeddings by 93% of dynamic range (cosine sim
+    0.81 instead of 1.0), silently degrading voice-clone quality.
+
+    Function preserved as a stub so callers fail loudly if it's ever
+    re-introduced. The export script now skips this call entirely.
     """
-    old = chatterbox_model.s3gen.speaker_encoder.xvector.dense
-    new = SafeDenseLayer(old.linear.in_channels, old.linear.out_channels)
-    new.linear.weight.data.copy_(old.linear.weight.data)
-    chatterbox_model.s3gen.speaker_encoder.xvector.dense = new
-    return True
+    raise RuntimeError(
+        "SafeDenseLayer substitution was removed after parity test "
+        "showed it drifts speaker_embeddings by ~93%. Use upstream "
+        "DenseLayer directly (export speech_encoder on CPU)."
+    )
 
 
 def export_embed_tokens(embed_tokens_mod, input_ids, position_ids, exaggeration,
@@ -211,27 +223,54 @@ def export_embed_tokens(embed_tokens_mod, input_ids, position_ids, exaggeration,
 
 
 def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path,
-                          opset: int, item_patch: bool):
+                          opset: int, item_patch: bool, chatterbox_model):
+    """Export the speech encoder on CPU.
+
+    On CUDA, `torch.jit.trace` hits the same kind of spurious
+    cuda:0/cpu device mismatch as the cond decoder (probe via
+    `probe_dense.py`). Eager mode works on CUDA. Workaround: move the
+    module + inputs to CPU just for the export. ONNX graph is
+    device-independent; ORT can still run it on CUDA EP at session load.
+
+    Also applies a scoped patch to `DenseLayer.forward` to specialize
+    away the `if len(x.shape) == 2` branch, which makes ONNX BatchNorm
+    fail with "unknown channel size" (the if-node hides the channel
+    dim from the symbolic checker). The patched forward assumes 2D
+    input; only the 2D branch is ever exercised by the pipeline
+    (verified via probe_dense_shape.py).
+    """
     import torch
+    from _export_patches import patched_dense_layer_for_export
     print(f"  exporting speech_encoder.onnx (opset {opset}) ...")
     t0 = time.perf_counter()
-    with item_no_op_patch(item_patch):
-        torch.onnx.export(
-            prepare_conditionals_mod,
-            (audio_values,),
-            str(out_path),
-            export_params=True,
-            opset_version=opset,
-            input_names=["audio_values"],
-            output_names=["audio_features", "audio_tokens", "speaker_embeddings", "speaker_features"],
-            dynamic_axes={
-                "audio_values": {0: "batch_size", 1: "num_samples"},
-                "audio_features": {0: "batch_size", 1: "sequence_length"},
-                "audio_tokens": {0: "batch_size", 1: "audio_sequence_length"},
-                "speaker_embeddings": {0: "batch_size"},
-                "speaker_features": {0: "batch_size", 1: "feature_dim"},
-            },
-        )
+    orig_device = next(prepare_conditionals_mod.parameters()).device
+    prepare_conditionals_mod.cpu()
+    audio_values_cpu = audio_values.cpu()
+    prev_default = torch.get_default_device() if hasattr(torch, "get_default_device") else None
+    torch.set_default_device("cpu")
+    try:
+        with item_no_op_patch(item_patch), \
+             patched_dense_layer_for_export(chatterbox_model.s3gen.speaker_encoder):
+            torch.onnx.export(
+                prepare_conditionals_mod,
+                (audio_values_cpu,),
+                str(out_path),
+                export_params=True,
+                opset_version=opset,
+                input_names=["audio_values"],
+                output_names=["audio_features", "audio_tokens", "speaker_embeddings", "speaker_features"],
+                dynamic_axes={
+                    "audio_values": {0: "batch_size", 1: "num_samples"},
+                    "audio_features": {0: "batch_size", 1: "sequence_length"},
+                    "audio_tokens": {0: "batch_size", 1: "audio_sequence_length"},
+                    "speaker_embeddings": {0: "batch_size"},
+                    "speaker_features": {0: "batch_size", 1: "feature_dim"},
+                },
+            )
+    finally:
+        if prev_default is not None:
+            torch.set_default_device(prev_default)
+        prepare_conditionals_mod.to(orig_device)
     print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
 
 
@@ -304,7 +343,6 @@ def build_lm_wrapper(chatterbox_model, device):
     `language_model.onnx` so consumers (and our own C# orchestrator)
     can swap our export for theirs.
     """
-    import torch
     import torch.nn as nn
 
     class LMWithSpeechHead(nn.Module):
@@ -463,8 +501,12 @@ def main() -> None:
     )
     print(f"  s3gen + t3 parameter count: {param_count:,}")
 
-    print("Applying SafeDenseLayer monkeypatch on speaker_encoder.xvector.dense ...")
-    patched = apply_safe_dense_patch(chatterbox_model, ci.SafeDenseLayer)
+    # SafeDenseLayer monkey-patch removed — see apply_safe_dense_patch
+    # docstring. Upstream DenseLayer with BatchNorm1d ONNX-exports
+    # cleanly on CPU. The substitution silently degraded voice cloning.
+    # tracked in export-report.json so old reports stay comparable;
+    # future cleanup can drop the field.
+    patched = False
 
     print("Building export wrappers ...")
     prepare_conditionals = ci.PrepareConditionalsModel(chatterbox_model).eval().to(device)
@@ -506,6 +548,7 @@ def main() -> None:
             prepare_conditionals, audio_values,
             args.output_dir / "speech_encoder.onnx",
             opset=args.opset_speech_encoder, item_patch=args.with_item_patch,
+            chatterbox_model=chatterbox_model,
         )
         graphs_exported.append("speech_encoder.onnx")
 

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -25,7 +25,6 @@ import hashlib
 import os
 import sys
 import time
-from contextlib import contextmanager
 from pathlib import Path
 
 from _common import (
@@ -87,25 +86,7 @@ def parse_args() -> argparse.Namespace:
                         "(fine for smoke tests, not for parity).")
     p.add_argument("--no-onnxslim", action="store_true",
                    help="Skip the onnxslim + external-data pass after export")
-    p.add_argument("--with-item-patch", action="store_true",
-                   help="Apply Vlad's `torch.Tensor.item = lambda x: x` monkeypatch around "
-                        "torch.onnx.export. Off by default; turn on if tracing fails on .item() calls.")
     return p.parse_args()
-
-
-@contextmanager
-def item_no_op_patch(enabled: bool):
-    """Context manager for Vlad's `.item()` no-op trick. Scoped, not global."""
-    import torch
-    if not enabled:
-        yield
-        return
-    original = torch.Tensor.item
-    torch.Tensor.item = lambda self: self  # type: ignore[method-assign]
-    try:
-        yield
-    finally:
-        torch.Tensor.item = original  # type: ignore[method-assign]
 
 
 def stage_environment() -> dict:
@@ -203,31 +184,30 @@ def apply_safe_dense_patch(chatterbox_model, SafeDenseLayer):
 
 
 def export_embed_tokens(embed_tokens_mod, input_ids, position_ids, exaggeration,
-                        out_path: Path, opset: int, item_patch: bool):
+                        out_path: Path, opset: int):
     import torch
     print(f"  exporting embed_tokens.onnx (opset {opset}) ...")
     t0 = time.perf_counter()
-    with item_no_op_patch(item_patch):
-        torch.onnx.export(
-            embed_tokens_mod,
-            (input_ids, position_ids, exaggeration),
-            str(out_path),
-            export_params=True,
-            opset_version=opset,
-            input_names=["input_ids", "position_ids", "exaggeration"],
-            output_names=["inputs_embeds"],
-            dynamic_axes={
-                "input_ids": {0: "batch_size", 1: "sequence_length"},
-                "position_ids": {0: "batch_size", 1: "sequence_length"},
-                "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
-                "exaggeration": {0: "batch_size"},
-            },
-        )
+    torch.onnx.export(
+        embed_tokens_mod,
+        (input_ids, position_ids, exaggeration),
+        str(out_path),
+        export_params=True,
+        opset_version=opset,
+        input_names=["input_ids", "position_ids", "exaggeration"],
+        output_names=["inputs_embeds"],
+        dynamic_axes={
+            "input_ids": {0: "batch_size", 1: "sequence_length"},
+            "position_ids": {0: "batch_size", 1: "sequence_length"},
+            "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+            "exaggeration": {0: "batch_size"},
+        },
+    )
     print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
 
 
 def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path,
-                          opset: int, item_patch: bool, chatterbox_model):
+                          opset: int, chatterbox_model):
     """Export the speech encoder on CPU.
 
     On CUDA, `torch.jit.trace` hits the same kind of spurious
@@ -258,8 +238,7 @@ def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path
     torch.set_default_device("cpu")
     s3_tokenizer = chatterbox_model.s3gen.tokenizer
     try:
-        with item_no_op_patch(item_patch), \
-             patched_dense_layer_for_export(chatterbox_model.s3gen.speaker_encoder), \
+        with patched_dense_layer_for_export(chatterbox_model.s3gen.speaker_encoder), \
              patched_s3tokenizer_for_export(s3_tokenizer), \
              patched_rotary_for_export(s3_tokenizer):
             torch.onnx.export(
@@ -286,7 +265,7 @@ def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path
 
 
 def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddings,
-                               speaker_features, out_path: Path, opset: int, item_patch: bool,
+                               speaker_features, out_path: Path, opset: int,
                                chatterbox_model):
     """Export the conditional decoder.
 
@@ -319,8 +298,7 @@ def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddin
     prev_default = torch.get_default_device() if hasattr(torch, "get_default_device") else None
     torch.set_default_device("cpu")
     try:
-        with item_no_op_patch(item_patch), \
-             patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft), \
+        with patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft), \
              patched_sinegen_deterministic(chatterbox_model.s3gen.mel2wav):
             torch.onnx.export(
                 cond_decoder_mod,
@@ -397,7 +375,7 @@ def build_lm_wrapper(chatterbox_model, device):
     return LMWithSpeechHead(chatterbox_model.t3.tfmr, chatterbox_model.t3.speech_head).eval().to(device)
 
 
-def export_language_model(lm_mod, out_path: Path, opset: int, device, dtype, item_patch: bool):
+def export_language_model(lm_mod, out_path: Path, opset: int, device, dtype):
     """Export the Llama-with-speech-head graph with KV-cache I/O.
 
     Uses small dummy shapes for the trace (batch=1, seq=4, past=0). The
@@ -432,17 +410,16 @@ def export_language_model(lm_mod, out_path: Path, opset: int, device, dtype, ite
     for name in kv_output_names(LLM_NUM_LAYERS):
         dynamic_axes[name] = {0: "batch_size", 2: "total_sequence_length"}
 
-    with item_no_op_patch(item_patch):
-        torch.onnx.export(
-            lm_mod,
-            (inputs_embeds, attention_mask, *past_kv_flat),
-            str(out_path),
-            export_params=True,
-            opset_version=opset,
-            input_names=input_names,
-            output_names=output_names,
-            dynamic_axes=dynamic_axes,
-        )
+    torch.onnx.export(
+        lm_mod,
+        (inputs_embeds, attention_mask, *past_kv_flat),
+        str(out_path),
+        export_params=True,
+        opset_version=opset,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes=dynamic_axes,
+    )
     print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
 
 
@@ -558,7 +535,7 @@ def main() -> None:
         export_embed_tokens(
             embed_tokens, input_ids, position_ids, exaggeration,
             args.output_dir / "embed_tokens.onnx",
-            opset=args.opset_embed_tokens, item_patch=args.with_item_patch,
+            opset=args.opset_embed_tokens,
         )
         graphs_exported.append("embed_tokens.onnx")
 
@@ -566,7 +543,7 @@ def main() -> None:
         export_speech_encoder(
             prepare_conditionals, audio_values,
             args.output_dir / "speech_encoder.onnx",
-            opset=args.opset_speech_encoder, item_patch=args.with_item_patch,
+            opset=args.opset_speech_encoder,
             chatterbox_model=chatterbox_model,
         )
         graphs_exported.append("speech_encoder.onnx")
@@ -580,7 +557,6 @@ def main() -> None:
         export_language_model(
             lm_mod, args.output_dir / "language_model.onnx",
             opset=args.opset_language_model, device=device, dtype=torch.float32,
-            item_patch=args.with_item_patch,
         )
         graphs_exported.append("language_model.onnx")
         del lm_mod  # release the wrapper; tfmr/speech_head are still owned by chatterbox_model
@@ -630,7 +606,7 @@ def main() -> None:
         export_conditional_decoder(
             cond_decoder, speech_tokens, speaker_embeddings, speaker_features,
             args.output_dir / "conditional_decoder.onnx",
-            opset=args.opset_conditional_decoder, item_patch=args.with_item_patch,
+            opset=args.opset_conditional_decoder,
             chatterbox_model=chatterbox_model,
         )
         graphs_exported.append("conditional_decoder.onnx")

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -240,7 +240,11 @@ def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path
     (verified via probe_dense_shape.py).
     """
     import torch
-    from _export_patches import patched_dense_layer_for_export
+    from _export_patches import (
+        patched_dense_layer_for_export,
+        patched_s3tokenizer_for_export,
+        patched_rotary_for_export,
+    )
     print(f"  exporting speech_encoder.onnx (opset {opset}) ...")
     t0 = time.perf_counter()
     orig_device = next(prepare_conditionals_mod.parameters()).device
@@ -248,9 +252,12 @@ def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path
     audio_values_cpu = audio_values.cpu()
     prev_default = torch.get_default_device() if hasattr(torch, "get_default_device") else None
     torch.set_default_device("cpu")
+    s3_tokenizer = chatterbox_model.s3gen.tokenizer
     try:
         with item_no_op_patch(item_patch), \
-             patched_dense_layer_for_export(chatterbox_model.s3gen.speaker_encoder):
+             patched_dense_layer_for_export(chatterbox_model.s3gen.speaker_encoder), \
+             patched_s3tokenizer_for_export(s3_tokenizer), \
+             patched_rotary_for_export(s3_tokenizer):
             torch.onnx.export(
                 prepare_conditionals_mod,
                 (audio_values_cpu,),

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -70,7 +70,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--opset-embed-tokens", type=int, default=20)
     p.add_argument("--opset-speech-encoder", type=int, default=20)
     p.add_argument("--opset-language-model", type=int, default=18)
-    p.add_argument("--opset-conditional-decoder", type=int, default=17)
+    p.add_argument("--opset-conditional-decoder", type=int, default=18,
+                   help="Cond decoder needs opset 18+ for the Col2Im op "
+                        "(F.fold-based window_sumsquare in our ISTFT). "
+                        "Lower opset triggers a scatter_add path that has "
+                        "ONNX duplicate-index correctness issues.")
     p.add_argument("--lm-graph-mode", default="unified", choices=["unified", "prefill+step"])
     p.add_argument("--skip-embed-tokens", action="store_true")
     p.add_argument("--skip-speech-encoder", action="store_true")
@@ -282,34 +286,41 @@ def export_speech_encoder(prepare_conditionals_mod, audio_values, out_path: Path
 
 
 def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddings,
-                               speaker_features, out_path: Path, opset: int, item_patch: bool):
+                               speaker_features, out_path: Path, opset: int, item_patch: bool,
+                               chatterbox_model):
     """Export the conditional decoder.
 
-    On CUDA, torch.jit.trace (used internally by torch.onnx.export) fails
-    inside upstream chatterbox `CausalBlock1D.block(x * mask)` with a
-    spurious cuda:0/cpu device-mismatch — confirmed by repro outside ONNX
-    via direct torch.jit.trace. Eager mode runs the same code path
-    cleanly. Workaround: move the module + inputs to CPU just for the
-    export. The resulting ONNX graph is device-independent; ORT will run
-    it on CUDA at session-load time.
+    The new ConditionalDecoder is a thin wrapper that delegates to
+    upstream `chatterbox.s3gen.flow.inference()` + `mel2wav.inference()`.
+    We apply `patched_cond_decoder_for_export` to strip
+    `@torch.inference_mode()` from those upstream methods (poisoned
+    tensors break the JIT trace) and to swap `mel2wav._stft` /
+    `_istft` for ONNX-friendly real-format implementations. The iSTFT
+    is rerouted through our `ISTFT` class.
 
-    `set_default_device("cpu")` is also pinned for the duration of the
-    export so any intermediates the tracer materializes land on CPU.
+    Still runs on CPU — same JIT-trace-on-CUDA bug as before
+    (CausalBlock1D `x * mask` device mismatch, confirmed outside ONNX).
+    Resulting ONNX is device-independent.
     """
     import torch
+    from _export_patches import patched_cond_decoder_for_export
     print(f"  exporting conditional_decoder.onnx (opset {opset}) ...")
     t0 = time.perf_counter()
     cond_decoder_mod = cond_decoder_mod.cpu()
     speech_tokens_cpu = speech_tokens.cpu()
     speaker_embeddings_cpu = speaker_embeddings.cpu()
     speaker_features_cpu = speaker_features.cpu()
-    # The vendored `istft` singleton is held by reference inside cond_decoder.
-    import _chatterbox_internals as ci  # noqa - already imported in main; reimport keeps the function self-contained
+    import _chatterbox_internals as ci
     ci.istft.cpu()
+    # Move upstream s3gen submodules to cpu too — patched _istft
+    # references our istft singleton, but the upstream
+    # mel2wav/flow modules need to be on cpu for the trace.
+    chatterbox_model.s3gen.cpu()
     prev_default = torch.get_default_device() if hasattr(torch, "get_default_device") else None
     torch.set_default_device("cpu")
     try:
-        with item_no_op_patch(item_patch):
+        with item_no_op_patch(item_patch), \
+             patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft):
             torch.onnx.export(
                 cond_decoder_mod,
                 (speech_tokens_cpu, speaker_embeddings_cpu, speaker_features_cpu),
@@ -619,6 +630,7 @@ def main() -> None:
             cond_decoder, speech_tokens, speaker_embeddings, speaker_features,
             args.output_dir / "conditional_decoder.onnx",
             opset=args.opset_conditional_decoder, item_patch=args.with_item_patch,
+            chatterbox_model=chatterbox_model,
         )
         graphs_exported.append("conditional_decoder.onnx")
 

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -1,23 +1,22 @@
 #!/usr/bin/env python3
 """Export Chatterbox TTS to ONNX.
 
-Stage 0 step E2: implements three of the four graphs by orchestrating
-the wrapper modules vendored in `_chatterbox_internals.py`:
+Stage 0 implements all four graphs:
 
   * `embed_tokens.onnx`        — text token embedding + position handling
   * `speech_encoder.onnx`      — speech encoder + S3 tokenizer + cond prep
+  * `language_model.onnx`      — Llama backbone + speech_head, KV-cache I/O
   * `conditional_decoder.onnx` — speech tokens + conditioning → waveform
 
-The Llama language model graph lands in step E3 (separate work — we own
-that export from scratch, not adapted from Vlad's reference).
+Graphs 1, 2, 4 were adapted from VladOS95-cyber's MIT-licensed reference
+and vendored in `_chatterbox_internals.py`. Graph 3 (the LM) is fully
+ours — Vlad's script never exported it.
 
 Run:
 
     python scripts/chatterbox_export/export_chatterbox_to_onnx.py \\
         --output-dir ./models/chatterbox_export \\
         --device cuda --dtype float32
-
-`--skip-language-model` is set by default at the CLI layer until E3 lands.
 """
 from __future__ import annotations
 
@@ -32,6 +31,8 @@ from pathlib import Path
 from _common import (
     add_local_script_path,
     ensure_output_dir,
+    kv_input_names,
+    kv_output_names,
     nvidia_smi_query,
     read_ort_available_providers,
     resolve_device,
@@ -40,6 +41,11 @@ from _common import (
     EXAGGERATION_TOKEN,
     START_SPEECH_TOKEN,
     S3GEN_SR,
+    LLM_HIDDEN_SIZE,
+    LLM_NUM_LAYERS,
+    LLM_NUM_KV_HEADS,
+    LLM_HEAD_DIM,
+    SPEECH_HEAD_OUTPUT_DIM,
 )
 
 add_local_script_path()
@@ -69,8 +75,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--lm-graph-mode", default="unified", choices=["unified", "prefill+step"])
     p.add_argument("--skip-embed-tokens", action="store_true")
     p.add_argument("--skip-speech-encoder", action="store_true")
-    p.add_argument("--skip-language-model", action="store_true", default=True,
-                   help="(default: skipped until E3 lands)")
+    p.add_argument("--skip-language-model", action="store_true",
+                   help="Skip the LM graph (it's the heaviest — ~2 GB fp32)")
     p.add_argument("--skip-conditional-decoder", action="store_true")
     p.add_argument("--overwrite", action="store_true")
     p.add_argument("--audio-prompt", type=Path, default=None,
@@ -279,6 +285,110 @@ def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddin
     print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
 
 
+def build_lm_wrapper(chatterbox_model, device):
+    """Wrap chatterbox.t3.tfmr + .speech_head into a single nn.Module
+    that exposes the HF KV-cache I/O schema.
+
+    Inputs (one positional arg per ONNX input):
+      - inputs_embeds: (B, S, LLM_HIDDEN_SIZE=1024)
+      - attention_mask: (B, S_total) where S_total = past_kv_len + S
+      - past_key_values.{N}.key, past_key_values.{N}.value  for N in 0..29
+            each: (B, LLM_NUM_KV_HEADS=16, past_kv_len, LLM_HEAD_DIM=64)
+
+    Outputs:
+      - logits: (B, S, SPEECH_HEAD_OUTPUT_DIM=8194)
+      - present.{N}.key, present.{N}.value  for N in 0..29
+            each: (B, 16, past_kv_len + S, 64)
+
+    Schema matches the published `onnx-community/chatterbox-ONNX`
+    `language_model.onnx` so consumers (and our own C# orchestrator)
+    can swap our export for theirs.
+    """
+    import torch
+    import torch.nn as nn
+
+    class LMWithSpeechHead(nn.Module):
+        def __init__(self, tfmr, speech_head):
+            super().__init__()
+            self.tfmr = tfmr
+            self.speech_head = speech_head
+
+        def forward(self, inputs_embeds, attention_mask, *past_kv_flat):
+            # Reshape flat (key0, value0, key1, value1, ...) into HF's
+            # legacy tuple-of-tuples format. transformers 4.46.3 accepts
+            # both this and the new Cache class; we use the legacy form
+            # to match Vlad's flow and the published bundle. Transformers
+            # 4.47+ removes legacy; that's a follow-up.
+            past_kv = tuple(
+                (past_kv_flat[2 * i], past_kv_flat[2 * i + 1])
+                for i in range(LLM_NUM_LAYERS)
+            )
+            out = self.tfmr(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                past_key_values=past_kv,
+                use_cache=True,
+            )
+            logits = self.speech_head(out.last_hidden_state)
+            # Flatten present_key_values to a positional output tuple.
+            present_flat = []
+            for layer_kv in out.past_key_values:
+                present_flat.append(layer_kv[0])
+                present_flat.append(layer_kv[1])
+            return (logits, *present_flat)
+
+    return LMWithSpeechHead(chatterbox_model.t3.tfmr, chatterbox_model.t3.speech_head).eval().to(device)
+
+
+def export_language_model(lm_mod, out_path: Path, opset: int, device, dtype, item_patch: bool):
+    """Export the Llama-with-speech-head graph with KV-cache I/O.
+
+    Uses small dummy shapes for the trace (batch=1, seq=4, past=0). The
+    dynamic_axes spec lets ORT consume arbitrary batch / sequence /
+    past_length at runtime; the published HF bundle uses the same shape
+    pattern.
+    """
+    import torch
+    print(f"  exporting language_model.onnx (opset {opset}) ...")
+    t0 = time.perf_counter()
+
+    # Dummy inputs. seq=4 / past=0 is the "prefill" config; the graph
+    # supports growing past_kv_len at runtime via the dynamic axis.
+    B, S, past_len = 1, 4, 0
+    inputs_embeds = torch.randn(B, S, LLM_HIDDEN_SIZE, device=device, dtype=dtype)
+    attention_mask = torch.ones(B, past_len + S, dtype=torch.int64, device=device)
+    past_kv_flat = []
+    for _ in range(LLM_NUM_LAYERS):
+        past_kv_flat.append(torch.zeros(B, LLM_NUM_KV_HEADS, past_len, LLM_HEAD_DIM, device=device, dtype=dtype))
+        past_kv_flat.append(torch.zeros(B, LLM_NUM_KV_HEADS, past_len, LLM_HEAD_DIM, device=device, dtype=dtype))
+
+    input_names = ["inputs_embeds", "attention_mask"] + kv_input_names(LLM_NUM_LAYERS)
+    output_names = ["logits"] + kv_output_names(LLM_NUM_LAYERS)
+
+    dynamic_axes = {
+        "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+        "attention_mask": {0: "batch_size", 1: "total_sequence_length"},
+        "logits": {0: "batch_size", 1: "sequence_length"},
+    }
+    for name in kv_input_names(LLM_NUM_LAYERS):
+        dynamic_axes[name] = {0: "batch_size", 2: "past_sequence_length"}
+    for name in kv_output_names(LLM_NUM_LAYERS):
+        dynamic_axes[name] = {0: "batch_size", 2: "total_sequence_length"}
+
+    with item_no_op_patch(item_patch):
+        torch.onnx.export(
+            lm_mod,
+            (inputs_embeds, attention_mask, *past_kv_flat),
+            str(out_path),
+            export_params=True,
+            opset_version=opset,
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
+        )
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
 def slim_and_externalize(output_dir: Path, filenames: list[str]) -> None:
     """Post-export onnxslim pass + external data save.
 
@@ -399,6 +509,20 @@ def main() -> None:
         )
         graphs_exported.append("speech_encoder.onnx")
 
+    if not args.skip_language_model:
+        # LM export uses tiny dummy inputs (B=1, S=4, past=0); shape
+        # generality comes from dynamic_axes. Runs on the same device as
+        # the rest of the chatterbox model — t3.tfmr stays on cuda
+        # because cond_decoder.cpu() in the next step only touches s3gen.
+        lm_mod = build_lm_wrapper(chatterbox_model, device)
+        export_language_model(
+            lm_mod, args.output_dir / "language_model.onnx",
+            opset=args.opset_language_model, device=device, dtype=torch.float32,
+            item_patch=args.with_item_patch,
+        )
+        graphs_exported.append("language_model.onnx")
+        del lm_mod  # release the wrapper; tfmr/speech_head are still owned by chatterbox_model
+
     if not args.skip_conditional_decoder:
         # Cond decoder needs real speech tokens + speaker conditioning. Run
         # PrepareConditionalsModel + InputsEmbeds + (eager Llama LM) to get
@@ -452,9 +576,6 @@ def main() -> None:
         print("\nPost-export: onnxslim + external data ...")
         slim_and_externalize(args.output_dir, graphs_exported)
 
-    if args.skip_language_model:
-        print("\n[skipped] language_model.onnx (E3 work — not yet implemented)")
-
     # Provenance: hash everything we emitted
     hashes = {}
     for fn in graphs_exported:
@@ -479,7 +600,7 @@ def main() -> None:
         lm_graph_mode=args.lm_graph_mode,
         safe_dense_layer_patched=patched,
         extra={
-            "stage": "E2-graphs-only",
+            "stage": "E3-all-four-graphs",
             "graphs_exported": graphs_exported,
             "artifact_hashes": hashes,
             "environment": env,

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -128,15 +128,24 @@ def hash_file(path: Path) -> str:
     return h.hexdigest()
 
 
+DUMMY_AUDIO_SAMPLES = 312_936  # 13.039 s at 24 kHz, matches Vlad's dummy
+DUMMY_AUDIO_SEED = 0
+
+
 def load_audio_prompt(path: Path | None, target_sr: int, device, dtype):
-    """Return a 1xN audio tensor at target_sr. If path is None, return
-    random noise sized for the dummy export (~13 s at 24 kHz, matching
-    Vlad's reference dummy size for trace shape stability).
+    """Return a 1xN audio tensor at target_sr.
+
+    If `path` is None, generate a *deterministic* random-noise prompt
+    by seeding a fresh Generator. Re-running the same command without
+    --audio-prompt produces byte-identical audio bytes → byte-identical
+    speech tokens → byte-identical conditional_decoder.onnx hashes.
+    Required for the parity test in E4 and for the artifact_hashes in
+    export-report.json to be reproducible across runs.
     """
     import torch
     if path is None:
-        # 312_936 samples == 13.039 s at 24 kHz, matching Vlad's dummy
-        return torch.randn(1, 312_936, device=device, dtype=dtype)
+        gen = torch.Generator(device=device).manual_seed(DUMMY_AUDIO_SEED)
+        return torch.randn(1, DUMMY_AUDIO_SAMPLES, device=device, dtype=dtype, generator=gen)
     import librosa
     waveform, _sr = librosa.load(str(path), sr=target_sr, mono=True)
     return torch.from_numpy(waveform).unsqueeze(0).to(device=device, dtype=dtype)
@@ -293,7 +302,7 @@ def slim_and_externalize(output_dir: Path, filenames: list[str]) -> None:
             slimmed = onnxslim.slim(str(path))
         except Exception as e:
             print(f"    slim failed for {fn}: {type(e).__name__}: {e}")
-            print(f"    falling back to raw externalization")
+            print("    falling back to raw externalization")
         if slimmed is None:
             # Re-load the raw export (torch.onnx.export wrote it inline)
             # and rewrite with external data.

--- a/scripts/chatterbox_export/requirements.txt
+++ b/scripts/chatterbox_export/requirements.txt
@@ -1,0 +1,31 @@
+chatterbox-tts==0.1.5
+transformers==4.46.3
+torch==2.6.0
+torchaudio==2.6.0
+# Pin numpy to chatterbox-tts's allowed range (0.1.4-0.1.6 cap at <1.26).
+# This needs Python 3.10 — no prebuilt numpy<1.26 wheels exist for cp312.
+# Stay on 0.1.5 rather than 0.1.4 because 0.1.4 depends on raw `pkuseg`
+# which requires Python.h at build time; 0.1.5 switched to
+# `spacy-pkuseg` which ships prebuilt wheels. transformers==4.46.3 is
+# kept identical to Vlad's reference; 0.1.7+ bumped to transformers 5.x
+# and breaks his wrapper API.
+numpy>=1.24,<1.26
+librosa==0.11.0
+soundfile>=0.12,<1
+huggingface_hub>=0.34,<2
+accelerate>=1.10,<2
+onnx==1.18.0
+# Both Vlad's pinned onnxslim versions (0.1.59, 0.1.68) require
+# sympy>=1.13.3, conflicting with torch 2.6.0 (sympy==1.13.1). 0.1.93
+# relaxed to sympy>=1.13.1. The post-export slim pass should be
+# version-tolerant; re-verify the cmd compares clean against
+# Vlad's reference if we hit a regression.
+onnxslim>=0.1.93,<0.2
+onnxscript>=0.3,<1
+onnxruntime-gpu>=1.22,<2
+ml_dtypes>=0.5,<1
+safetensors>=0.5,<1
+# resemble-perth (transitive via chatterbox-tts) uses pkg_resources,
+# removed in setuptools 80+. Pin to keep PerthImplicitWatermarker
+# importable at chatterbox model construction time.
+setuptools<80

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -512,10 +512,19 @@ def parity_solve_euler(tolerance: float = 1e-5) -> ParityResult:
     from chatterbox.tts import ChatterboxTTS
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     import _chatterbox_internals as ci
-    from _export_patches import patched_cond_decoder_for_export
+    from _export_patches import patched_cond_decoder_for_export, _seeded_rand_noise_like
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = ChatterboxTTS.from_pretrained(device=device)
+
+    # Pin rand_noise to the SAME deterministic seed on both sides. Without
+    # this, upstream uses the model-instance's random init while the
+    # patched run uses the context-manager's seeded value — different z
+    # entering solve_euler → different mels (it's not a math drift,
+    # just the rand_noise confounder from docs/.../Run 11).
+    model.s3gen.flow.decoder.rand_noise = _seeded_rand_noise_like(
+        model.s3gen.flow.decoder.rand_noise
+    )
 
     # Realistic-shaped dummy inputs. T = 1010 is the natural mel-frame
     # count for a 505-token speech sequence (2x upsample); picking a

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -1,86 +1,357 @@
 #!/usr/bin/env python3
-"""End-to-end parity check: ONNX export vs PyTorch reference.
+"""Per-graph numerical parity: each ONNX export vs upstream PyTorch.
 
-Stage 0 / step E4: skeleton only. Wires up once the export script
-emits real artifacts.
+Stage 0 step E4. For each of the four exported ONNX graphs, run it
+through ONNX Runtime and compare its outputs against the equivalent
+upstream `chatterbox` PyTorch forward on identical inputs.
 
-The parity protocol is three layers, in order of strictness:
+Why this matters: torch.onnx.export returning 0 only proves the graph
+*traces*. It says nothing about whether the graph *computes the same
+function* as the PyTorch model. The vendored wrappers in
+`_chatterbox_internals.py` make several non-obvious substitutions
+(`SafeDenseLayer` BatchNorm→LayerNorm, scatter-add window_sumsquare,
+the bool-mask InputsEmbeds dispatch) — we have no a-priori reason to
+trust them numerically.
 
-  1. **Speech-token sequence parity (LM):** same prompt + same reference
-     audio through PyTorch and through our ONNX pipeline; assert
-     near-identical token sequences (modulo numerical drift in early
-     positions; allow first-divergence > N tokens). Same idiom as
-     `scripts/vibevoice_export/test_static_kv_parity.py`.
+Test layers, smallest blast radius first:
 
-  2. **Decoder waveform parity:** feed identical speech-tokens +
-     speaker conditioning to the PyTorch decoder and our ONNX decoder.
-     Compare via mel-spectral distance — bit-exact is unrealistic for a
-     vocoder.
+  * `lm`     — language_model.onnx vs chatterbox.t3.tfmr + speech_head.
+                Both sides come from upstream; expect bit-identity (or
+                near it modulo float ordering).
+  * `embed`  — embed_tokens.onnx vs the vendored InputsEmbeds running
+                in eager. Confirms the export trace didn't drift from
+                the wrapper it traced.
+  * `enc`    — speech_encoder.onnx vs running upstream chatterbox.s3gen
+                eager. Reveals whether SafeDenseLayer and the vendored
+                S3Tokenizer chain agree numerically with upstream.
+  * `dec`    — conditional_decoder.onnx vs upstream chatterbox.s3gen
+                flow + mel2wav. Compare waveforms via spectral distance
+                (bit-equality is unrealistic for a vocoder).
 
-  3. **End-to-end audio parity:** full pipeline both ways, spectral
-     distance + a short listen-test sample dumped to disk for the
-     investigation doc.
-
-Layers 1 and 2 are CI-gateable. Layer 3 is informational.
+Each test reports max-abs-diff, max-rel-diff, mean-abs-diff and a
+pass/fail verdict against a configurable tolerance.
 """
 from __future__ import annotations
 
 import argparse
+import sys
+from dataclasses import dataclass
 from pathlib import Path
+
+import numpy as np
 
 from _common import (
     add_local_script_path,
     choose_onnx_providers,
     fail,
     read_export_report,
+    LLM_HIDDEN_SIZE,
+    LLM_NUM_LAYERS,
+    LLM_NUM_KV_HEADS,
+    LLM_HEAD_DIM,
 )
 
 add_local_script_path()
+
+
+@dataclass
+class ParityResult:
+    name: str
+    passed: bool
+    max_abs_diff: float
+    max_rel_diff: float
+    mean_abs_diff: float
+    tolerance: float
+    notes: str = ""
+
+    def summary(self) -> str:
+        verdict = "PASS" if self.passed else "FAIL"
+        line = (
+            f"  [{verdict}] {self.name}  "
+            f"max_abs={self.max_abs_diff:.3e}  "
+            f"max_rel={self.max_rel_diff:.3e}  "
+            f"mean_abs={self.mean_abs_diff:.3e}  "
+            f"(tol={self.tolerance:.0e})"
+        )
+        if self.notes:
+            line += f"  // {self.notes}"
+        return line
+
+
+def diff_metrics(ours: np.ndarray, theirs: np.ndarray) -> tuple[float, float, float]:
+    """Element-wise abs and rel diff between two arrays of the same shape."""
+    if ours.shape != theirs.shape:
+        return float("inf"), float("inf"), float("inf")
+    diff = np.abs(ours.astype(np.float64) - theirs.astype(np.float64))
+    denom = np.maximum(np.abs(theirs.astype(np.float64)), 1e-12)
+    rel = diff / denom
+    return float(diff.max()), float(rel.max()), float(diff.mean())
+
+
+def parity_lm(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) -> ParityResult:
+    """language_model.onnx vs chatterbox.t3.tfmr + speech_head eager.
+
+    Both sides come from the same upstream weights — no vendored model
+    code in this path. Differences are pure ONNX-runtime numerical
+    drift (mainly different SDPA / softmax kernels).
+
+    Pass criterion is two-part:
+
+      1. max-abs-diff in logits ≤ tolerance (default 1e-2). This is
+         lenient because SDPA kernels diverge ~1e-3 routinely.
+      2. **Argmax tokens must match exactly.** For TTS sampling we
+         care that the LM's preferred next token is the same. If
+         logit drift doesn't reorder the top-1, the model is
+         functionally equivalent.
+
+    Either failure flips the verdict; the report shows both metrics so
+    the failure mode is unambiguous.
+    """
+    import torch
+    import onnxruntime as ort
+    from chatterbox.tts import ChatterboxTTS
+
+    onnx_path = onnx_dir / "language_model.onnx"
+    if not onnx_path.exists():
+        return ParityResult("lm", False, float("inf"), float("inf"), float("inf"),
+                            tolerance, notes=f"missing {onnx_path}")
+
+    chatterbox_model = ChatterboxTTS.from_pretrained(device="cuda")
+    tfmr = chatterbox_model.t3.tfmr
+    speech_head = chatterbox_model.t3.speech_head
+    tfmr.eval()
+    speech_head.eval()
+
+    torch.manual_seed(0)
+    B, S = 1, 8
+    inputs_embeds = torch.randn(B, S, LLM_HIDDEN_SIZE, device="cuda", dtype=torch.float32)
+    attention_mask = torch.ones(B, S, dtype=torch.int64, device="cuda")
+    past_kv = tuple(
+        (torch.zeros(B, LLM_NUM_KV_HEADS, 0, LLM_HEAD_DIM, device="cuda"),
+         torch.zeros(B, LLM_NUM_KV_HEADS, 0, LLM_HEAD_DIM, device="cuda"))
+        for _ in range(LLM_NUM_LAYERS)
+    )
+
+    with torch.no_grad():
+        out = tfmr(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=past_kv,
+            use_cache=True,
+        )
+        upstream_logits = speech_head(out.last_hidden_state).cpu().numpy()
+
+    sess = ort.InferenceSession(str(onnx_path), providers=providers)
+    feed = {
+        "inputs_embeds": inputs_embeds.cpu().numpy(),
+        "attention_mask": attention_mask.cpu().numpy(),
+    }
+    for layer in range(LLM_NUM_LAYERS):
+        feed[f"past_key_values.{layer}.key"] = past_kv[layer][0].cpu().numpy()
+        feed[f"past_key_values.{layer}.value"] = past_kv[layer][1].cpu().numpy()
+    onnx_logits = sess.run(["logits"], feed)[0]
+
+    max_abs, max_rel, mean_abs = diff_metrics(onnx_logits, upstream_logits)
+
+    onnx_argmax = onnx_logits.argmax(axis=-1)
+    upstream_argmax = upstream_logits.argmax(axis=-1)
+    tokens_agree = bool(np.array_equal(onnx_argmax, upstream_argmax))
+
+    logit_range = (float(upstream_logits.min()), float(upstream_logits.max()))
+    passed = (max_abs <= tolerance) and tokens_agree
+    notes = (
+        f"shape={tuple(onnx_logits.shape)}  "
+        f"logit_range=[{logit_range[0]:.1f}, {logit_range[1]:.1f}]  "
+        f"argmax_agree={tokens_agree}"
+    )
+    return ParityResult("lm", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
+
+
+def parity_embed(onnx_dir: Path, providers: list[str], tolerance: float = 1e-4) -> ParityResult:
+    """embed_tokens.onnx vs the vendored InputsEmbeds running eager.
+
+    Sanity check that ONNX trace faithfully captured the wrapper's
+    forward pass. Both sides run the same Python code; the only
+    difference is ORT vs PyTorch CUDA kernels for the underlying
+    `embedding` and `where` ops. Expect very tight agreement (1e-4 or
+    better) since the wrapper has no SDPA, no softmax, just lookups
+    and masked selections.
+
+    Doesn't validate that the wrapper's math is *correct* — that
+    requires comparing to a known-good independent implementation
+    (deferred to a future test). For now, the wrapper's behavior is
+    self-consistent across runtimes.
+    """
+    import torch
+    import onnxruntime as ort
+    from chatterbox.tts import ChatterboxTTS
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import _chatterbox_internals as ci
+
+    onnx_path = onnx_dir / "embed_tokens.onnx"
+    if not onnx_path.exists():
+        return ParityResult("embed", False, float("inf"), float("inf"), float("inf"),
+                            tolerance, notes=f"missing {onnx_path}")
+
+    chatterbox_model = ChatterboxTTS.from_pretrained(device="cuda")
+    embed = ci.InputsEmbeds(chatterbox_model).eval().to("cuda")
+
+    torch.manual_seed(0)
+    from _common import START_SPEECH_TOKEN as ST, EXAGGERATION_TOKEN as ET
+    input_ids = torch.tensor([[
+        ET, 255, 281, 39, 46, 56, 2, 53, 2, 286, 41, 37, 2, 136, 122,
+        49, 2, 152, 2, 103, 2, 277, 21, 101, 7, 2, 301, 55, 34,
+        28, 7, 2, 53, 2, 296, 18, 18, 115, 2, 51, 2, 33, 245,
+        2, 17, 190, 2, 42, 2, 50, 18, 125, 4, 32, 2, 290, 169,
+        142, 2, 41, 2, 43, 2, 18, 29, 91, 2, 25, 186, 8, 20,
+        14, 80, 2, 29, 86, 213, 216, 9, 0, ST, ST,
+    ]], dtype=torch.long, device="cuda")
+    position_ids = torch.where(
+        input_ids >= ST,
+        torch.zeros_like(input_ids),
+        torch.arange(input_ids.shape[1], device="cuda").unsqueeze(0) - 1,
+    )
+    exaggeration = torch.tensor([0.5], device="cuda")
+
+    with torch.no_grad():
+        eager_out = embed(input_ids, position_ids, exaggeration).cpu().numpy()
+
+    sess = ort.InferenceSession(str(onnx_path), providers=providers)
+    onnx_out = sess.run(["inputs_embeds"], {
+        "input_ids": input_ids.cpu().numpy(),
+        "position_ids": position_ids.cpu().numpy(),
+        "exaggeration": exaggeration.cpu().numpy(),
+    })[0]
+
+    max_abs, max_rel, mean_abs = diff_metrics(onnx_out, eager_out)
+    passed = max_abs <= tolerance
+    return ParityResult(
+        "embed", passed, max_abs, max_rel, mean_abs, tolerance,
+        notes=f"shape={tuple(onnx_out.shape)}  range=[{eager_out.min():.2f}, {eager_out.max():.2f}]",
+    )
+
+
+def parity_enc(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) -> ParityResult:
+    """SafeDenseLayer impact on the speaker_encoder.
+
+    Vlad asserts the BatchNorm1d→LayerNorm substitution in
+    `s3gen.speaker_encoder.xvector.dense` is "safe at inference". This
+    test validates the claim:
+
+      A: upstream speaker_encoder(features) UNPATCHED  (ground truth)
+      B: same encoder + same features WITH SafeDenseLayer applied
+
+    Pass criterion: max-abs-diff in speaker_embeddings ≤ tolerance.
+    Fail means SafeDenseLayer is not actually inference-equivalent and
+    the speaker_encoder.onnx we ship produces drifted speaker
+    embeddings — which would degrade voice cloning quality silently.
+
+    Doesn't include ONNX comparison directly; the eager-vs-eager A/B
+    is the load-bearing claim. If the substitution is benign, the
+    ONNX trace also fine. If it isn't, ONNX trace is irrelevant
+    because the upstream wasn't faithfully preserved.
+    """
+    import torch
+    from chatterbox.tts import ChatterboxTTS
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import _chatterbox_internals as ci
+
+    chatterbox_model = ChatterboxTTS.from_pretrained(device="cuda")
+    enc = chatterbox_model.s3gen.speaker_encoder
+    enc.eval()
+
+    # Realistic-shaped input. The xvector encoder takes (B, T, F=80)
+    # where F is the mel-bin count from Kaldi fbank. Use random with
+    # standard-normal statistics so BatchNorm hits its trained range.
+    torch.manual_seed(0)
+    features = torch.randn(1, 200, 80, device="cuda")
+
+    # A: unpatched
+    with torch.no_grad():
+        out_a = enc(features).clone()
+
+    # B: patched
+    orig_dense = enc.xvector.dense
+    new_dense = ci.SafeDenseLayer(orig_dense.linear.in_channels,
+                                  orig_dense.linear.out_channels).to("cuda")
+    new_dense.linear.weight.data.copy_(orig_dense.linear.weight.data)
+    enc.xvector.dense = new_dense
+
+    try:
+        with torch.no_grad():
+            out_b = enc(features).clone()
+    finally:
+        # Always restore to leave the module in a clean state for any
+        # subsequent tests in the same run.
+        enc.xvector.dense = orig_dense
+
+    a = out_a.cpu().numpy()
+    b = out_b.cpu().numpy()
+    max_abs, max_rel, mean_abs = diff_metrics(b, a)
+
+    passed = max_abs <= tolerance
+    notes = (
+        f"shape={tuple(a.shape)}  "
+        f"range=[{a.min():.3f}, {a.max():.3f}]  "
+        f"cosine_sim={float(np.dot(a.flatten(), b.flatten()) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12)):.6f}"
+    )
+    return ParityResult("enc[safe-dense]", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
 
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--onnx-dir", type=Path, required=True,
                    help="Directory produced by export_chatterbox_to_onnx.py")
-    p.add_argument("--audio", type=Path, required=True,
-                   help="Reference voice clip (any sample rate, mono or stereo)")
-    p.add_argument("--text", type=str, default="The Lord of the Rings is the greatest work of literature.",
-                   help="Prompt text for parity comparison")
-    p.add_argument("--max-tokens", type=int, default=256,
-                   help="Max LM steps for token-parity check (default: 256)")
-    p.add_argument("--runtime", default="cuda", choices=["cpu", "cuda", "tensorrt"],
-                   help="ONNX Runtime EP family (default: cuda)")
-    p.add_argument("--no-decoder-parity", action="store_true",
-                   help="Skip layer 2 (decoder waveform parity)")
-    p.add_argument("--no-end-to-end", action="store_true",
-                   help="Skip layer 3 (end-to-end audio comparison)")
+    p.add_argument("--runtime", default="cuda", choices=["cpu", "cuda", "tensorrt"])
+    p.add_argument("--tests", default="lm",
+                   help="Comma-separated subset: lm,embed,enc,dec,all (default: lm)")
+    p.add_argument("--tolerance", type=float, default=1e-2,
+                   help="Max-abs-diff threshold for pass (default: 1e-2). "
+                        "Each test layer has its own appropriate default; this is a "
+                        "global override. SDPA-based models routinely drift ~1e-3 "
+                        "between PyTorch and ORT even with matching weights.")
     return p.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-
+    if not args.onnx_dir.exists():
+        fail(f"ONNX dir not found: {args.onnx_dir}")
     report = read_export_report(args.onnx_dir)
-    graphs = report.get("graphs_exported", [])
-    if not graphs:
-        fail("export-report.json reports no graphs exported yet. Run the export script first.")
-
-    providers = choose_onnx_providers(args.runtime)
-    print(f"Parity check against {args.onnx_dir}")
-    print(f"  graphs available: {graphs}")
-    print(f"  providers: {providers}")
+    print(f"Parity check vs {args.onnx_dir}")
+    print(f"  graphs in report: {report.get('graphs_exported', [])}")
+    print(f"  runtime: {args.runtime}  tolerance: {args.tolerance:.0e}")
     print()
 
-    # TODO E4 — Layer 1: token-sequence parity
-    print("[ ] Layer 1 (LM token sequence parity) — not implemented yet")
+    providers = choose_onnx_providers(args.runtime)
+    tests = {t.strip() for t in args.tests.split(",")}
+    if "all" in tests:
+        tests = {"lm", "embed", "enc", "dec"}
 
-    # TODO E4 — Layer 2: decoder waveform parity
-    if not args.no_decoder_parity:
-        print("[ ] Layer 2 (decoder waveform spectral parity) — not implemented yet")
+    results: list[ParityResult] = []
 
-    # TODO E4 — Layer 3: end-to-end audio
-    if not args.no_end_to_end:
-        print("[ ] Layer 3 (end-to-end audio comparison) — not implemented yet")
+    if "lm" in tests:
+        print("[lm] language_model.onnx vs chatterbox.t3.tfmr + speech_head")
+        results.append(parity_lm(args.onnx_dir, providers, args.tolerance))
+        print(results[-1].summary())
+
+    if "embed" in tests:
+        print("[embed] embed_tokens.onnx vs vendored InputsEmbeds eager")
+        results.append(parity_embed(args.onnx_dir, providers, args.tolerance))
+        print(results[-1].summary())
+    if "enc" in tests:
+        print("[enc] SafeDenseLayer impact on speaker_encoder")
+        results.append(parity_enc(args.onnx_dir, providers, args.tolerance))
+        print(results[-1].summary())
+    if "dec" in tests:
+        print("[dec] conditional_decoder parity — not implemented yet")
+
+    print()
+    failed = [r for r in results if not r.passed]
+    if failed:
+        print(f"PARITY FAILED: {len(failed)}/{len(results)} test(s)")
+        sys.exit(1)
+    print(f"PARITY OK: {len(results)}/{len(results)} test(s) passed")
 
 
 if __name__ == "__main__":

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -396,7 +396,7 @@ def parity_dec(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) ->
     from chatterbox.tts import ChatterboxTTS
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     import _chatterbox_internals as ci
-    from _export_patches import patched_cond_decoder_for_export
+    from _export_patches import patched_cond_decoder_for_export, patched_sinegen_deterministic
 
     onnx_path = onnx_dir / "conditional_decoder.onnx"
     if not onnx_path.exists():
@@ -442,8 +442,11 @@ def parity_dec(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) ->
 
         # Apply the same patches the ONNX export used, so we're
         # comparing patched-eager vs patched-ONNX (rather than
-        # mixing in upstream's torch.istft path here).
-        with patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft):
+        # mixing in upstream's torch.istft path here). Includes the
+        # deterministic SineGen probe to remove NSF stochasticity as
+        # a confound.
+        with patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft), \
+             patched_sinegen_deterministic(chatterbox_model.s3gen.mel2wav):
             wav_eager = cd_eager(speech_tokens, spk_emb, spk_feat).cpu().numpy()
 
     # Run ONNX

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -45,6 +45,8 @@ from _common import (
     choose_onnx_providers,
     fail,
     read_export_report,
+    EXAGGERATION_TOKEN,
+    START_SPEECH_TOKEN,
     LLM_HIDDEN_SIZE,
     LLM_NUM_LAYERS,
     LLM_NUM_KV_HEADS,
@@ -364,6 +366,122 @@ def parity_enc(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) ->
     return ParityResult("enc[safe-dense]", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
 
 
+def parity_dec(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) -> ParityResult:
+    """conditional_decoder.onnx waveform vs upstream eager.
+
+    Build the same speech_tokens / speaker_emb / speaker_features
+    pipeline both ways:
+      A: upstream eager (cond decoder runs upstream flow.inference
+         + mel2wav.inference in PyTorch)
+      C: ONNX via ORT (same wrapper, exported with the four cond-
+         decoder patches active).
+
+    Compare with **mel-spectral distance**, NOT time-domain cosine.
+
+    Why: upstream HiFi-GAN-NSF's SourceModule injects fresh
+    `torch.randn_like` noise on every call (line in SineGen.forward).
+    Time-domain waveforms are inherently non-deterministic — two
+    consecutive eager runs already differ by ~4e-2 max-abs and
+    cosine ~0.12, before ONNX is involved. The randomness is
+    perceptually inaudible (envelope unchanged, noise-floor only),
+    but it makes time-domain bit-comparison meaningless.
+
+    Mel-spectral distance compares the spectral envelope, which is
+    what the model actually controls. A pass means the ONNX wav is
+    perceptually identical to the eager wav up to the inherent
+    upstream stochasticity.
+    """
+    import torch
+    import onnxruntime as ort
+    from chatterbox.tts import ChatterboxTTS
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import _chatterbox_internals as ci
+    from _export_patches import patched_cond_decoder_for_export
+
+    onnx_path = onnx_dir / "conditional_decoder.onnx"
+    if not onnx_path.exists():
+        return ParityResult("dec", False, float("inf"), float("inf"), float("inf"),
+                            tolerance, notes=f"missing {onnx_path}")
+
+    chatterbox_model = ChatterboxTTS.from_pretrained(device="cuda")
+    prep = ci.PrepareConditionalsModel(chatterbox_model).eval().to("cuda")
+    et = ci.InputsEmbeds(chatterbox_model).eval().to("cuda")
+    cd_eager = ci.ConditionalDecoder(chatterbox_model).eval().to("cuda")
+    ci.istft.to("cuda")
+
+    # Same audio prompt as the export uses
+    torch.manual_seed(0)
+    audio = torch.randn(1, 312_936, device="cuda")
+    ids = torch.tensor([[EXAGGERATION_TOKEN] + [255, 281, 39, 46, 56, 2, 53, 2, 286, 41, 37, 2, 136, 122,
+        49, 2, 152, 2, 103, 2, 277, 21, 101, 7, 2, 301, 55, 34, 28, 7, 2, 53, 2, 296, 18, 18, 115, 2, 51, 2, 33, 245,
+        2, 17, 190, 2, 42, 2, 50, 18, 125, 4, 32, 2, 290, 169, 142, 2, 41, 2, 43, 2, 18, 29, 91, 2, 25, 186, 8, 20,
+        14, 80, 2, 29, 86, 213, 216, 9, 0, START_SPEECH_TOKEN, START_SPEECH_TOKEN]], dtype=torch.long, device="cuda")
+    pos = torch.where(ids >= START_SPEECH_TOKEN, torch.zeros_like(ids),
+                      torch.arange(ids.shape[1], device="cuda").unsqueeze(0) - 1)
+    ex = torch.tensor([0.5], device="cuda")
+
+    with torch.no_grad():
+        cond_emb, prompt_token, spk_emb, spk_feat = prep(audio_values=audio)
+        text_emb = et(ids, pos, ex)
+        inputs_embeds = torch.cat((cond_emb, text_emb), dim=1)
+        llm = chatterbox_model.t3.tfmr
+        sh = chatterbox_model.t3.speech_head
+        gt = torch.tensor([[START_SPEECH_TOKEN]], dtype=torch.long, device="cuda")
+        pkv = None
+        for i in range(256):
+            o = llm(inputs_embeds=inputs_embeds, past_key_values=pkv)
+            pkv = o.past_key_values
+            nl = sh(o.last_hidden_state[:, -1, :])
+            nt = torch.argmax(nl, dim=-1).unsqueeze(-1)
+            gt = torch.cat((gt, nt), dim=-1)
+            if (nt.view(-1) == 6562).all():
+                break
+            p = torch.full((ids.shape[0], 1), i + 1, dtype=torch.long, device="cuda")
+            inputs_embeds = et(nt, p, ex)
+        speech_tokens = torch.cat([prompt_token, gt[:, 1:-1]], dim=1)
+
+        # Apply the same patches the ONNX export used, so we're
+        # comparing patched-eager vs patched-ONNX (rather than
+        # mixing in upstream's torch.istft path here).
+        with patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft):
+            wav_eager = cd_eager(speech_tokens, spk_emb, spk_feat).cpu().numpy()
+
+    # Run ONNX
+    sess = ort.InferenceSession(str(onnx_path), providers=providers)
+    wav_onnx = sess.run(["waveform"], {
+        "speech_tokens": speech_tokens.cpu().numpy(),
+        "speaker_embeddings": spk_emb.cpu().numpy(),
+        "speaker_features": spk_feat.cpu().numpy(),
+    })[0]
+
+    max_abs, max_rel, mean_abs = diff_metrics(wav_onnx, wav_eager)
+
+    # Mel-spectral L1 — robust to NSF noise. Compare 80-bin log-mel
+    # spectrograms of the two waveforms; this measures envelope match
+    # (what the model actually predicts) and ignores phase + per-call
+    # noise-injection randomness. Threshold 0.5 is conservative — for
+    # bit-equivalent eager runs this is ~0.05 (signed by NSF noise floor).
+    import torchaudio.transforms as T
+    mel_t = T.MelSpectrogram(sample_rate=24000, n_fft=1024, hop_length=256, n_mels=80)
+    log_mel_eager = torch.log(torch.clamp(mel_t(torch.from_numpy(wav_eager[0]).float()), min=1e-5))
+    log_mel_onnx = torch.log(torch.clamp(mel_t(torch.from_numpy(wav_onnx[0]).float()), min=1e-5))
+    mel_l1 = float((log_mel_eager - log_mel_onnx).abs().mean())
+
+    # Cosine on time-domain reported but informational only — not pass-criterion.
+    cos = float(np.dot(wav_eager.flatten(), wav_onnx.flatten())
+                / (np.linalg.norm(wav_eager) * np.linalg.norm(wav_onnx) + 1e-12))
+
+    mel_threshold = 0.5
+    passed = mel_l1 <= mel_threshold
+    notes = (
+        f"shape={tuple(wav_onnx.shape)}  "
+        f"range=[{wav_eager.min():.3f}, {wav_eager.max():.3f}]  "
+        f"mel_log_l1={mel_l1:.4e} (thr={mel_threshold})  "
+        f"cosine_sim={cos:.4f} (informational, NSF noise expected)"
+    )
+    return ParityResult("dec", passed, max_abs, max_rel, mean_abs, mel_threshold, notes=notes)
+
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--onnx-dir", type=Path, required=True,
@@ -412,7 +530,9 @@ def main() -> None:
         # Keep the historical SafeDenseLayer test reachable for diagnostic
         # use; not run by default since SafeDenseLayer was removed.
     if "dec" in tests:
-        print("[dec] conditional_decoder parity — not implemented yet")
+        print("[dec] conditional_decoder.onnx waveform vs upstream eager")
+        results.append(parity_dec(args.onnx_dir, providers, args.tolerance))
+        print(results[-1].summary())
 
     print()
     failed = [r for r in results if not r.passed]

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -449,7 +449,8 @@ def parity_dec(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) ->
              patched_sinegen_deterministic(chatterbox_model.s3gen.mel2wav):
             wav_eager = cd_eager(speech_tokens, spk_emb, spk_feat).cpu().numpy()
 
-    # Run ONNX
+    # Run ONNX at the natural speech_tokens length. The cond decoder is
+    # now fully dynamic-shape (see docs/chatterbox_investigation.md Run 10).
     sess = ort.InferenceSession(str(onnx_path), providers=providers)
     wav_onnx = sess.run(["waveform"], {
         "speech_tokens": speech_tokens.cpu().numpy(),

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -27,6 +27,12 @@ Test layers, smallest blast radius first:
   * `dec`    — conditional_decoder.onnx vs upstream chatterbox.s3gen
                 flow + mel2wav. Compare waveforms via spectral distance
                 (bit-equality is unrealistic for a vocoder).
+  * `solve_euler` — eager-vs-eager regression guard for the CFM solver
+                rewrite that landed in Run 10. Expect bit-identity
+                (max_abs = 0); regressions here mean the cat-only
+                rewrite has drifted from upstream's broadcast-assign
+                semantics. Doesn't touch ONNX, so runs without a
+                cond_decoder.onnx artifact.
 
 Each test reports max-abs-diff, max-rel-diff, mean-abs-diff and a
 pass/fail verdict against a configurable tolerance.
@@ -486,13 +492,71 @@ def parity_dec(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) ->
     return ParityResult("dec", passed, max_abs, max_rel, mean_abs, mel_threshold, notes=notes)
 
 
+def parity_solve_euler(tolerance: float = 1e-5) -> ParityResult:
+    """Eager-vs-eager: our patched solve_euler + cfm.forward vs upstream.
+
+    The dynamic-shape rewrite (docs/chatterbox_investigation.md Run 10)
+    replaced upstream's
+        x_in = zeros([2, 80, x.size(2)]); x_in[:] = x
+    pattern with
+        x_in = torch.cat([x, x], dim=0)
+    to avoid baking T into the trace's Reshape+Expand chain. The rewrite
+    should be mathematically identical to upstream — cat-of-same-shape
+    and broadcast-assign produce the same `[2, 80, T]` tensor.
+
+    This test confirms that equivalence: same mu/mask/spks, same RNG,
+    once with upstream's solve_euler and once with our patched version,
+    expect bit-identical mel output. No ONNX involved — pure eager.
+    """
+    import torch
+    from chatterbox.tts import ChatterboxTTS
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import _chatterbox_internals as ci
+    from _export_patches import patched_cond_decoder_for_export
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = ChatterboxTTS.from_pretrained(device=device)
+
+    # Realistic-shaped dummy inputs. T = 1010 is the natural mel-frame
+    # count for a 505-token speech sequence (2x upsample); picking a
+    # non-trace-time value would also work since both code paths are
+    # eager-symbolic.
+    B, T, n_feats = 1, 1010, 80
+    torch.manual_seed(0)
+    mu = torch.randn(B, n_feats, T, device=device)
+    mask = torch.ones(B, 1, T, device=device)
+    spk_dim = model.s3gen.flow.spk_embed_affine_layer.out_features
+    spks = torch.randn(B, spk_dim, device=device)
+
+    def run(model):
+        with torch.no_grad():
+            mel, _ = model.s3gen.flow.decoder(
+                mu=mu, mask=mask, spks=spks, cond=torch.zeros_like(mu),
+                n_timesteps=10,
+            )
+        return mel.cpu().numpy()
+
+    mel_upstream = run(model)
+    with patched_cond_decoder_for_export(model.s3gen, ci.istft):
+        mel_patched = run(model)
+
+    max_abs, max_rel, mean_abs = diff_metrics(mel_patched, mel_upstream)
+    passed = max_abs <= tolerance
+    notes = (
+        f"shape={mel_upstream.shape}  "
+        f"range=[{mel_upstream.min():.3f}, {mel_upstream.max():.3f}]  "
+        f"(eager-vs-eager: bit-identity is the expected outcome)"
+    )
+    return ParityResult("solve_euler", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
+
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--onnx-dir", type=Path, required=True,
                    help="Directory produced by export_chatterbox_to_onnx.py")
     p.add_argument("--runtime", default="cuda", choices=["cpu", "cuda", "tensorrt"])
     p.add_argument("--tests", default="lm",
-                   help="Comma-separated subset: lm,embed,enc,dec,all (default: lm)")
+                   help="Comma-separated subset: lm,embed,enc,dec,solve_euler,all (default: lm)")
     p.add_argument("--tolerance", type=float, default=1e-2,
                    help="Max-abs-diff threshold for pass (default: 1e-2). "
                         "Each test layer has its own appropriate default; this is a "
@@ -514,7 +578,7 @@ def main() -> None:
     providers = choose_onnx_providers(args.runtime)
     tests = {t.strip() for t in args.tests.split(",")}
     if "all" in tests:
-        tests = {"lm", "embed", "enc", "dec"}
+        tests = {"lm", "embed", "enc", "dec", "solve_euler"}
 
     results: list[ParityResult] = []
 
@@ -536,6 +600,10 @@ def main() -> None:
     if "dec" in tests:
         print("[dec] conditional_decoder.onnx waveform vs upstream eager")
         results.append(parity_dec(args.onnx_dir, providers, args.tolerance))
+        print(results[-1].summary())
+    if "solve_euler" in tests:
+        print("[solve_euler] patched cat-only solve_euler vs upstream (eager)")
+        results.append(parity_solve_euler())
         print(results[-1].summary())
 
     print()

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -231,6 +231,72 @@ def parity_embed(onnx_dir: Path, providers: list[str], tolerance: float = 1e-4) 
     )
 
 
+def parity_enc_onnx_vs_upstream(onnx_dir: Path, providers: list[str],
+                                tolerance: float = 1e-3) -> ParityResult:
+    """speech_encoder.onnx speaker_embeddings vs upstream eager.
+
+    The downstream-most parity check: does our exported ONNX
+    speech_encoder produce the same speaker embedding (component of
+    its 4-tuple output) as running the upstream chatterbox
+    speaker_encoder directly on the same input features?
+
+    This is what changed when we dropped SafeDenseLayer: the previous
+    `enc[safe-dense]` test showed substituting BatchNorm1d→randomly-
+    initialized LayerNorm drifted embeddings by 93%. After dropping
+    the substitution and inlining BatchNorm math (so ONNX-export
+    works), this test confirms the resulting ONNX produces upstream-
+    equivalent embeddings.
+
+    Builds the encoder input the same way the vendored
+    PrepareConditionalsModel does (Kaldi fbank from a 16 kHz audio
+    clip), runs both paths, compares.
+    """
+    import torch
+    import onnxruntime as ort
+    from chatterbox.tts import ChatterboxTTS
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import _chatterbox_internals as ci
+
+    onnx_path = onnx_dir / "speech_encoder.onnx"
+    if not onnx_path.exists():
+        return ParityResult("enc[onnx-vs-upstream]", False,
+                            float("inf"), float("inf"), float("inf"),
+                            tolerance, notes=f"missing {onnx_path}")
+
+    chatterbox_model = ChatterboxTTS.from_pretrained(device="cuda")
+
+    # Run our exported ONNX speech_encoder
+    torch.manual_seed(0)
+    audio = torch.randn(1, 312_936)  # matches DUMMY_AUDIO_SAMPLES from export
+    sess = ort.InferenceSession(str(onnx_path), providers=providers)
+    onnx_out = sess.run(
+        ["audio_features", "audio_tokens", "speaker_embeddings", "speaker_features"],
+        {"audio_values": audio.numpy()},
+    )
+    onnx_speaker_embeddings = onnx_out[2]  # the third output
+
+    # Build the equivalent upstream eager output. We use the same
+    # vendored PrepareConditionalsModel here because it's the
+    # well-tested orchestration of upstream submodules — but with
+    # NO SafeDenseLayer patch (our export script also doesn't apply
+    # one anymore). So the encoder runs upstream code path.
+    prep = ci.PrepareConditionalsModel(chatterbox_model).eval().to("cuda")
+    with torch.no_grad():
+        _, _, eager_speaker_embeddings, _ = prep(audio.to("cuda"))
+    eager_speaker_embeddings_np = eager_speaker_embeddings.cpu().numpy()
+
+    max_abs, max_rel, mean_abs = diff_metrics(onnx_speaker_embeddings, eager_speaker_embeddings_np)
+    cos = float(np.dot(onnx_speaker_embeddings.flatten(), eager_speaker_embeddings_np.flatten())
+                / (np.linalg.norm(onnx_speaker_embeddings) * np.linalg.norm(eager_speaker_embeddings_np) + 1e-12))
+    passed = (max_abs <= tolerance) and (cos > 0.999)
+    notes = (
+        f"shape={tuple(onnx_speaker_embeddings.shape)}  "
+        f"range=[{eager_speaker_embeddings_np.min():.3f}, {eager_speaker_embeddings_np.max():.3f}]  "
+        f"cosine_sim={cos:.6f}"
+    )
+    return ParityResult("enc[onnx-vs-upstream]", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
+
+
 def parity_enc(onnx_dir: Path, providers: list[str], tolerance: float = 1e-2) -> ParityResult:
     """SafeDenseLayer impact on the speaker_encoder.
 
@@ -340,9 +406,11 @@ def main() -> None:
         results.append(parity_embed(args.onnx_dir, providers, args.tolerance))
         print(results[-1].summary())
     if "enc" in tests:
-        print("[enc] SafeDenseLayer impact on speaker_encoder")
-        results.append(parity_enc(args.onnx_dir, providers, args.tolerance))
+        print("[enc] speech_encoder.onnx speaker_embeddings vs upstream eager")
+        results.append(parity_enc_onnx_vs_upstream(args.onnx_dir, providers, args.tolerance))
         print(results[-1].summary())
+        # Keep the historical SafeDenseLayer test reachable for diagnostic
+        # use; not run by default since SafeDenseLayer was removed.
     if "dec" in tests:
         print("[dec] conditional_decoder parity — not implemented yet")
 

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""End-to-end parity check: ONNX export vs PyTorch reference.
+
+Stage 0 / step E4: skeleton only. Wires up once the export script
+emits real artifacts.
+
+The parity protocol is three layers, in order of strictness:
+
+  1. **Speech-token sequence parity (LM):** same prompt + same reference
+     audio through PyTorch and through our ONNX pipeline; assert
+     near-identical token sequences (modulo numerical drift in early
+     positions; allow first-divergence > N tokens). Same idiom as
+     `scripts/vibevoice_export/test_static_kv_parity.py`.
+
+  2. **Decoder waveform parity:** feed identical speech-tokens +
+     speaker conditioning to the PyTorch decoder and our ONNX decoder.
+     Compare via mel-spectral distance — bit-exact is unrealistic for a
+     vocoder.
+
+  3. **End-to-end audio parity:** full pipeline both ways, spectral
+     distance + a short listen-test sample dumped to disk for the
+     investigation doc.
+
+Layers 1 and 2 are CI-gateable. Layer 3 is informational.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _common import (
+    add_local_script_path,
+    choose_onnx_providers,
+    fail,
+    read_export_report,
+)
+
+add_local_script_path()
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--onnx-dir", type=Path, required=True,
+                   help="Directory produced by export_chatterbox_to_onnx.py")
+    p.add_argument("--audio", type=Path, required=True,
+                   help="Reference voice clip (any sample rate, mono or stereo)")
+    p.add_argument("--text", type=str, default="The Lord of the Rings is the greatest work of literature.",
+                   help="Prompt text for parity comparison")
+    p.add_argument("--max-tokens", type=int, default=256,
+                   help="Max LM steps for token-parity check (default: 256)")
+    p.add_argument("--runtime", default="cuda", choices=["cpu", "cuda", "tensorrt"],
+                   help="ONNX Runtime EP family (default: cuda)")
+    p.add_argument("--no-decoder-parity", action="store_true",
+                   help="Skip layer 2 (decoder waveform parity)")
+    p.add_argument("--no-end-to-end", action="store_true",
+                   help="Skip layer 3 (end-to-end audio comparison)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    report = read_export_report(args.onnx_dir)
+    graphs = report.get("graphs_exported", [])
+    if not graphs:
+        fail("export-report.json reports no graphs exported yet. Run the export script first.")
+
+    providers = choose_onnx_providers(args.runtime)
+    print(f"Parity check against {args.onnx_dir}")
+    print(f"  graphs available: {graphs}")
+    print(f"  providers: {providers}")
+    print()
+
+    # TODO E4 — Layer 1: token-sequence parity
+    print("[ ] Layer 1 (LM token sequence parity) — not implemented yet")
+
+    # TODO E4 — Layer 2: decoder waveform parity
+    if not args.no_decoder_parity:
+        print("[ ] Layer 2 (decoder waveform spectral parity) — not implemented yet")
+
+    # TODO E4 — Layer 3: end-to-end audio
+    if not args.no_end_to_end:
+        print("[ ] Layer 3 (end-to-end audio comparison) — not implemented yet")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds the full Chatterbox TTS ONNX export pipeline (4 graphs: embed_tokens, speech_encoder, language_model, conditional_decoder), owned in-tree rather than depending on weakly-provenanced third-party scripts.
- Cond decoder is fully dynamic-shape — accepts arbitrary `speech_tokens` length without padding (see `docs/chatterbox_investigation.md` Run 10 for the bake-inventory hunt).
- Per-graph parity test suite (5 tests: lm, embed, enc, dec, solve_euler) with all passing; dec went from `mel_log_l1=0.78` to `0.0102` after Run 11 isolated `rand_noise` (a plain attribute, not a buffer) as the confounder.
- Investigation doc captures the chronological methodology — every patch, dead end, and fix.

## What's in here

| Area | What it does |
|---|---|
| `scripts/chatterbox_export/export_chatterbox_to_onnx.py` | CLI driver exporting all four ONNX graphs from `ResembleAI/chatterbox` |
| `scripts/chatterbox_export/_chatterbox_internals.py` | Thin export wrappers around upstream `s3gen` / `t3`; de-vendored from VladOS95-cyber's MIT script (`-816` LOC vs initial vendoring) |
| `scripts/chatterbox_export/_export_patches.py` | Scoped context-managed monkey-patches needed for the trace (complex-tensor STFT/iSTFT replacements, dynamic-shape solve_euler, deterministic `rand_noise` for reproducibility) |
| `scripts/chatterbox_export/test_chatterbox_parity.py` | Per-graph parity vs upstream eager (5 tests, all PASS) |
| `scripts/_export_utils/scan_bakes.py` | Standalone scanner: walks an ONNX graph and reports nodes consuming baked trace-time shape constants. Used to find the 35 baked dims that Run 8 stalled on |
| `docs/chatterbox_investigation.md` | Chronological log of Runs 1–11, including the dead ends (dynamo experiment, false trails) |

## Key technical points

- **Dynamic shapes**: 35 baked `[80, T]` / `[2, 80, T]` Reshape/Expand pairs were eliminated by rewriting `solve_euler` to use pure `torch.cat` instead of in-place broadcast assigns. The scan-then-patch methodology is more decisive than chasing one runtime error at a time.
- **`rand_noise` reproducibility**: `CausalConditionalCFM.__init__` sets `self.rand_noise = torch.randn(...)` as a plain attribute (not registered as a buffer), so every model load gets a different value. `patched_cond_decoder_for_export` now pins it to a seeded canonical value so every export is reproducible and parity tests are honest.
- **No PyTorch upstream changes required** — all patches are scoped context managers.

## Test plan
- [x] `python scripts/chatterbox_export/test_chatterbox_parity.py --onnx-dir <dir> --tests all` — 5/5 PASS
- [x] `scripts/_export_utils/scan_bakes.py <dir>/conditional_decoder.onnx --suspect <T> <2T>` — 0 baked trace-derived constants
- [x] End-to-end listen test: produces intelligible speech at the natural LM-emitted token length (no padding needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)