### PR TITLE
Cond decoder perf: split into 3 graphs, drive CFM loop in C# (15x e2e)

### DIFF
--- a/scripts/chatterbox_export/_chatterbox_internals.py
+++ b/scripts/chatterbox_export/_chatterbox_internals.py
@@ -692,3 +692,129 @@ class ConditionalDecoder(nn.Module):
         head = wav[:, :n] * self.trim_fade
         tail = wav[:, n:]
         return torch.cat([head, tail], dim=1)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Split-graph cond decoder (Phase 1 of the perf work — see Run 12 of
+# docs/chatterbox_investigation.md). Replaces the monolithic
+# ConditionalDecoder above with three smaller modules that each export
+# to their own ONNX file. The 10× CFM solve unrolling that bloated the
+# monolithic file from 70K nodes lives in C# now (~30 lines of orchestration
+# code), so cfm_estimator.onnx contains exactly one estimator forward.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class FlowEncoderWrapper(nn.Module):
+    """Half of `chatterbox.s3gen.flow.MaskedDiffWithXvec.inference`: everything
+    up to (but not including) the CFM `decoder` call. Outputs the tensors the
+    CFM solve loop needs as inputs (mu, mask, embedding, cond) plus the
+    deterministic initial latent z (sliced from the seeded rand_noise buffer).
+
+    Outputs:
+      - mu          (B, 80, T_mel)   — encoder output, transposed; input to CFM
+      - mask        (B, 1, T_mel)    — all-ones mask (we don't use chunking)
+      - embedding   (B, 80)          — speaker-embedding after spk_embed_affine
+      - cond        (B, 80, T_mel)   — conditioning tensor (prompt_feat + zeros)
+      - z           (B, 80, T_mel)   — initial CFM latent (rand_noise[:, :, :T_mel])
+
+    Caller (C#) drives the CFM solve loop using cfm_estimator.onnx, then
+    trims feat[:, :, prompt_len:] and feeds to mel2wav.onnx.
+
+    Active patches must include `_seeded_rand_noise_like` (for reproducible z)
+    — applied automatically by `patched_cond_decoder_for_export`.
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.flow = model.s3gen.flow
+
+    def forward(self, speech_tokens, speaker_embeddings, speaker_features):
+        import torch.nn.functional as F
+        B = speech_tokens.shape[0]
+        device = speech_tokens.device
+
+        # spk embedding (matches upstream flow.inference)
+        embedding = F.normalize(speaker_embeddings, dim=1)
+        embedding = self.flow.spk_embed_affine_layer(embedding)
+
+        # token → embed → mask. Empty prompt_token (we don't use the prompt-
+        # token concat path); matches what the monolithic ConditionalDecoder
+        # wrapper does.
+        token = self.flow.input_embedding(
+            torch.clamp(speech_tokens, min=0,
+                        max=self.flow.input_embedding.num_embeddings - 1)
+        )
+        mask = torch.ones_like(token[:, :, :1])
+        token = token * mask
+
+        # Encoder — token_len is the int sequence length passed as a 1-D tensor.
+        token_len_int = token_len_tensor(B, speech_tokens.shape[1], device)
+        h, _ = self.flow.encoder(token, token_len_int)
+
+        h = self.flow.encoder_proj(h)
+        prompt_len = speaker_features.shape[1]
+
+        # conds: prompt_feat concatenated with zero-tail (matches upstream)
+        conds_tail_len = h.shape[1] - prompt_len
+        conds_head = speaker_features
+        conds_tail = torch.zeros_like(
+            h.narrow(1, 0, conds_tail_len)[..., :self.flow.output_size]
+        )
+        cond = torch.cat([conds_head, conds_tail], dim=1).transpose(1, 2)
+
+        # Decoder-side mask: all-ones (B, 1, T_mel)
+        mel_mask = torch.ones_like(h[:, :, :1]).transpose(1, 2)
+        mu = h.transpose(1, 2).contiguous()
+
+        # CFM initial latent z. self.flow.decoder.rand_noise has been pinned
+        # to a seeded canonical value by patched_cond_decoder_for_export
+        # (see Run 11) so this is reproducible across exports.
+        z = self.flow.decoder.rand_noise.narrow(2, 0, mu.shape[2]).to(device).to(mu.dtype)
+
+        return mu, mel_mask, embedding, cond, z
+
+
+def token_len_tensor(batch_size, length, device):
+    """The flow encoder's `xs_lens` arg — 1-D length per batch item. Kept as
+    a helper because the +0+shape trick keeps the length symbolic in the trace."""
+    base = torch.full((batch_size,), length, dtype=torch.long, device=device)
+    return base + (base.new_tensor([0]) + 0)
+
+
+class CfmEstimatorWrapper(nn.Module):
+    """Wraps `flow.decoder.estimator` (the matcha-style ConditionalDecoder
+    UNet) as a standalone module. Exports to cfm_estimator.onnx with ONE
+    forward call traced — the C# CFM solve loop calls it N=10 times with
+    different (x_in, t_in) at each iteration. Inputs are CFG-doubled
+    (batch=2) per upstream's solve_euler convention; C# does the CFG split
+    and combine after each call.
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.estimator = model.s3gen.flow.decoder.estimator
+
+    def forward(self, x_in, mask_in, mu_in, t_in, spks_in, cond_in):
+        return self.estimator(x_in, mask_in, mu_in, t_in, spks_in, cond_in)
+
+
+class Mel2WavWrapper(nn.Module):
+    """Wraps `mel2wav.inference` + the trim_fade ref-clip-spillover patch
+    as a standalone module. Inputs the post-solve mel (B, 80, T_mel); outputs
+    the trimmed waveform (B, N_samples).
+
+    The trim_fade buffer is baked into this graph as a constant initializer,
+    so C# doesn't need to know about it.
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.mel2wav = model.s3gen.mel2wav
+        self.register_buffer("trim_fade", model.s3gen.trim_fade.detach().clone())
+
+    def forward(self, mel):
+        wav, _ = self.mel2wav.inference(speech_feat=mel)
+        n = self.trim_fade.shape[0]
+        head = wav[:, :n] * self.trim_fade
+        tail = wav[:, n:]
+        return torch.cat([head, tail], dim=1)

--- a/scripts/chatterbox_export/_export_patches.py
+++ b/scripts/chatterbox_export/_export_patches.py
@@ -633,6 +633,92 @@ def _cfm_forward_dynamic(self, mu, mask, n_timesteps, temperature=1.0, spks=None
     return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond), None
 
 
+class MinimalAttnProcessor:
+    """Minimal drop-in replacement for diffusers' AttnProcessor2_0 — for our
+    specific cond decoder usage only.
+
+    Upstream's AttnProcessor2_0 supports many code paths
+    (input_ndim==4 reshape, spatial_norm, group_norm, norm_cross,
+    residual_connection, rescale_output_factor, prepare_attention_mask's
+    F.pad branch, repeat_interleave for out_dim=3, etc.). None of those
+    apply to our calls into BasicTransformerBlock.attn1/attn2 — we always
+    pass 3D hidden_states with a pre-built (B, T, T) bias mask, and the
+    BasicTransformerBlock owns the residual+norm wrapper. Each upstream
+    code path that traces conditionally still emits ops via torch.jit.trace
+    even when the branch is dead at runtime — that's where the 400+
+    nodes per Attention block come from.
+
+    This processor does the strict minimum: Q/K/V projections, head
+    reshape, SDPA, head un-reshape, output projection. Per
+    docs/chatterbox_investigation.md Run 12 the upstream Attention
+    contributes ~57% of cond_decoder nodes (48 blocks × ~400 nodes each
+    out of ~70K total); replacing it should cut node count roughly in
+    half and pull load time down with it.
+
+    Bit-equivalent to AttnProcessor2_0 in our usage pattern (verified by
+    `parity_attention`). Re-using `attn.to_q/k/v/out` preserves the model
+    weights exactly.
+    """
+    def __call__(self, attn, hidden_states, encoder_hidden_states=None,
+                 attention_mask=None, temb=None, *args, **kwargs):
+        import torch.nn.functional as F
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+
+        B, T, _ = hidden_states.shape
+        H = attn.heads
+
+        # Q from hidden_states; K, V from encoder_hidden_states (self-attn → same tensor).
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+        D = key.shape[-1] // H
+
+        # (B, T, H*D) → (B, H, T, D)
+        query = query.view(B, T, H, D).transpose(1, 2)
+        key = key.view(B, -1, H, D).transpose(1, 2)
+        value = value.view(B, -1, H, D).transpose(1, 2)
+
+        # Mask comes in as (B, T, T) bias — broadcast to (B, 1, T, T) so SDPA
+        # broadcasts across heads. unsqueeze (not expand) keeps the broadcast
+        # virtual; ORT lowers to a single Add inside the SDPA path.
+        if attention_mask is not None and attention_mask.dim() == 3:
+            attention_mask = attention_mask.unsqueeze(1)
+
+        out = F.scaled_dot_product_attention(
+            query, key, value,
+            attn_mask=attention_mask, dropout_p=0.0, is_causal=False,
+        )
+        # (B, H, T, D) → (B, T, H*D)
+        out = out.transpose(1, 2).reshape(B, T, H * D)
+        # Output projection. attn.to_out is a ModuleList: [Linear, Dropout].
+        # Dropout is a no-op in eval; skip explicitly to drop one node.
+        return attn.to_out[0](out)
+
+
+def _install_minimal_attn_processors(estimator):
+    """Set MinimalAttnProcessor on every Attention module in the cond decoder
+    estimator (chatterbox's ConditionalDecoder). Returns a dict mapping
+    `id(module) -> original processor` so the caller can restore.
+    """
+    saved = {}
+    proc = MinimalAttnProcessor()
+    for module in estimator.modules():
+        cls = type(module).__name__
+        if cls == "BasicTransformerBlock":
+            for name in ("attn1", "attn2"):
+                attn = getattr(module, name, None)
+                if attn is not None:
+                    saved[id(attn)] = (attn, attn.processor)
+                    attn.set_processor(proc)
+    return saved
+
+
+def _restore_attn_processors(saved):
+    for attn, orig in saved.values():
+        attn.set_processor(orig)
+
+
 # Canonical seed for the CFM rand_noise. Used in both ONNX export and
 # parity tests so the two are bit-comparable. Chosen arbitrarily; the
 # exact value doesn't matter, only that it's stable across runs.
@@ -692,6 +778,7 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
     flow.decoder.forward = types.MethodType(_cfm_forward_dynamic, flow.decoder)
     flow.decoder.solve_euler = types.MethodType(_solve_euler_dynamic, flow.decoder)
     flow.decoder.rand_noise = _seeded_rand_noise_like(flow.decoder.rand_noise)
+    saved_attn = _install_minimal_attn_processors(flow.decoder.estimator)
     mel2wav.inference = types.MethodType(
         _strip_inference_mode(mel2wav.inference.__func__), mel2wav
     )
@@ -709,6 +796,7 @@ def patched_cond_decoder_for_export(s3gen, istft_module):
         flow.decoder.forward = saved["flow.decoder.forward"]
         flow.decoder.solve_euler = saved["flow.decoder.solve_euler"]
         flow.decoder.rand_noise = saved["flow.decoder.rand_noise"]
+        _restore_attn_processors(saved_attn)
         mel2wav.inference = saved["mel2wav.inference"]
         mel2wav._stft = saved["mel2wav._stft"]
         mel2wav._istft = saved["mel2wav._istft"]

--- a/scripts/chatterbox_export/export_chatterbox_to_onnx.py
+++ b/scripts/chatterbox_export/export_chatterbox_to_onnx.py
@@ -80,6 +80,14 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--skip-language-model", action="store_true",
                    help="Skip the LM graph (it's the heaviest — ~2 GB fp32)")
     p.add_argument("--skip-conditional-decoder", action="store_true")
+    p.add_argument("--split-cond-decoder", action="store_true",
+                   help="Export the cond decoder as three smaller graphs "
+                        "(flow_encoder.onnx, cfm_estimator.onnx, mel2wav.onnx) "
+                        "instead of one monolithic conditional_decoder.onnx. "
+                        "C# orchestrates the CFM solve loop using the smaller "
+                        "graphs. Cuts the largest graph (cfm_estimator) from "
+                        "70K nodes to ~7K — the 10x CFM unroll lives in C# "
+                        "instead. See docs/chatterbox_investigation.md Run 12.")
     p.add_argument("--overwrite", action="store_true")
     p.add_argument("--audio-prompt", type=Path, default=None,
                    help="Reference audio at any sample rate. If omitted, a 13 s torch.randn dummy is used "
@@ -319,6 +327,107 @@ def export_conditional_decoder(cond_decoder_mod, speech_tokens, speaker_embeddin
         if prev_default is not None:
             torch.set_default_device(prev_default)
     print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def _export_on_cpu(model_obj, args_tuple, out_path: Path, opset: int,
+                   input_names: list, output_names: list, dynamic_axes: dict,
+                   chatterbox_model):
+    """Common harness for split cond-decoder sub-graph exports — sets up the
+    patched_cond_decoder_for_export context, moves everything to CPU (same
+    jit-trace-on-CUDA bug as the monolithic path), then calls torch.onnx.export.
+    """
+    import torch
+    from _export_patches import patched_cond_decoder_for_export, patched_sinegen_deterministic
+    import _chatterbox_internals as ci
+    print(f"  exporting {out_path.name} (opset {opset}) ...")
+    t0 = time.perf_counter()
+    model_obj = model_obj.cpu()
+    args_cpu = tuple(a.cpu() if hasattr(a, "cpu") else a for a in args_tuple)
+    ci.istft.cpu()
+    chatterbox_model.s3gen.cpu()
+    prev_default = torch.get_default_device() if hasattr(torch, "get_default_device") else None
+    torch.set_default_device("cpu")
+    try:
+        with patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft), \
+             patched_sinegen_deterministic(chatterbox_model.s3gen.mel2wav):
+            torch.onnx.export(
+                model_obj, args_cpu, str(out_path),
+                export_params=True, opset_version=opset,
+                input_names=input_names, output_names=output_names,
+                dynamic_axes=dynamic_axes,
+            )
+    finally:
+        if prev_default is not None:
+            torch.set_default_device(prev_default)
+    print(f"    done ({time.perf_counter() - t0:.1f}s)  {out_path.stat().st_size / 1e6:.2f} MB")
+
+
+def export_flow_encoder(flow_enc_mod, speech_tokens, speaker_embeddings,
+                        speaker_features, out_path: Path, opset: int,
+                        chatterbox_model):
+    """Phase 1 split: speech_tokens → (mu, mask, embedding, cond, z).
+
+    See `FlowEncoderWrapper` for the contract. C# drives the CFM solve loop
+    using these outputs + cfm_estimator.onnx.
+    """
+    _export_on_cpu(
+        flow_enc_mod, (speech_tokens, speaker_embeddings, speaker_features),
+        out_path, opset,
+        input_names=["speech_tokens", "speaker_embeddings", "speaker_features"],
+        output_names=["mu", "mel_mask", "embedding", "cond", "z"],
+        dynamic_axes={
+            "speech_tokens":      {0: "batch_size", 1: "num_speech_tokens"},
+            "speaker_embeddings": {0: "batch_size"},
+            "speaker_features":   {0: "batch_size", 1: "prompt_len"},
+            "mu":         {0: "batch_size", 2: "num_mel_frames"},
+            "mel_mask":   {0: "batch_size", 2: "num_mel_frames"},
+            "embedding":  {0: "batch_size"},
+            "cond":       {0: "batch_size", 2: "num_mel_frames"},
+            "z":          {0: "batch_size", 2: "num_mel_frames"},
+        },
+        chatterbox_model=chatterbox_model,
+    )
+
+
+def export_cfm_estimator(cfm_est_mod, x_in, mask_in, mu_in, t_in,
+                         spks_in, cond_in, out_path: Path, opset: int,
+                         chatterbox_model):
+    """Phase 1 split: one CFM estimator forward (the body of the solve_euler
+    loop). C# calls this N=10 times per utterance. Inputs are CFG-doubled
+    (batch=2); C# does the cat/split + Euler-step math between calls.
+    """
+    _export_on_cpu(
+        cfm_est_mod, (x_in, mask_in, mu_in, t_in, spks_in, cond_in),
+        out_path, opset,
+        input_names=["x_in", "mask_in", "mu_in", "t_in", "spks_in", "cond_in"],
+        output_names=["dphi_dt"],
+        dynamic_axes={
+            "x_in":     {0: "cfg_batch", 2: "num_mel_frames"},
+            "mask_in":  {0: "cfg_batch", 2: "num_mel_frames"},
+            "mu_in":    {0: "cfg_batch", 2: "num_mel_frames"},
+            "t_in":     {0: "cfg_batch"},
+            "spks_in":  {0: "cfg_batch"},
+            "cond_in":  {0: "cfg_batch", 2: "num_mel_frames"},
+            "dphi_dt":  {0: "cfg_batch", 2: "num_mel_frames"},
+        },
+        chatterbox_model=chatterbox_model,
+    )
+
+
+def export_mel2wav(m2w_mod, mel, out_path: Path, opset: int, chatterbox_model):
+    """Phase 1 split: mel → waveform via the HiFi-GAN mel2wav.inference,
+    with trim_fade pre-baked into the graph as a constant initializer.
+    """
+    _export_on_cpu(
+        m2w_mod, (mel,), out_path, opset,
+        input_names=["mel"],
+        output_names=["waveform"],
+        dynamic_axes={
+            "mel":      {0: "batch_size", 2: "num_mel_frames"},
+            "waveform": {0: "batch_size", 1: "num_samples"},
+        },
+        chatterbox_model=chatterbox_model,
+    )
 
 
 def build_lm_wrapper(chatterbox_model, device):
@@ -603,13 +712,63 @@ def main() -> None:
             speech_tokens = torch.cat([prompt_token, generate_tokens[:, 1:-1]], dim=1)
             print(f"  speech_tokens: shape={tuple(speech_tokens.shape)}")
 
-        export_conditional_decoder(
-            cond_decoder, speech_tokens, speaker_embeddings, speaker_features,
-            args.output_dir / "conditional_decoder.onnx",
-            opset=args.opset_conditional_decoder,
-            chatterbox_model=chatterbox_model,
-        )
-        graphs_exported.append("conditional_decoder.onnx")
+        if args.split_cond_decoder:
+            # Build the three sub-wrappers and synthesize per-stage trace inputs.
+            flow_enc = ci.FlowEncoderWrapper(chatterbox_model).eval().to(device)
+            cfm_est = ci.CfmEstimatorWrapper(chatterbox_model).eval().to(device)
+            m2w = ci.Mel2WavWrapper(chatterbox_model).eval().to(device)
+
+            # 1) flow_encoder: speech_tokens → mu, mask, embedding, cond, z.
+            export_flow_encoder(
+                flow_enc, speech_tokens, speaker_embeddings, speaker_features,
+                args.output_dir / "flow_encoder.onnx",
+                opset=args.opset_conditional_decoder,
+                chatterbox_model=chatterbox_model,
+            )
+            graphs_exported.append("flow_encoder.onnx")
+
+            # 2) cfm_estimator: build CFG-doubled trace inputs by running
+            #    flow_encoder once (eager). The export_flow_encoder call
+            #    above left everything on CPU; flow_enc + its s3gen refs are
+            #    now on CPU, so run with CPU inputs here too.
+            from _export_patches import patched_cond_decoder_for_export as _pcde
+            with torch.no_grad(), _pcde(chatterbox_model.s3gen, ci.istft):
+                _mu, _mask, _emb, _cond, _z = flow_enc(
+                    speech_tokens.cpu(), speaker_embeddings.cpu(), speaker_features.cpu()
+                )
+            x_in_trace = torch.cat([_z, _z], dim=0)
+            mask_in_trace = torch.cat([_mask, _mask], dim=0)
+            mu_in_trace = torch.cat([_mu, torch.zeros_like(_mu)], dim=0)
+            t_in_trace = torch.zeros(2, dtype=_z.dtype)
+            spks_in_trace = torch.cat([_emb, torch.zeros_like(_emb)], dim=0)
+            cond_in_trace = torch.cat([_cond, torch.zeros_like(_cond)], dim=0)
+            export_cfm_estimator(
+                cfm_est, x_in_trace, mask_in_trace, mu_in_trace, t_in_trace,
+                spks_in_trace, cond_in_trace,
+                args.output_dir / "cfm_estimator.onnx",
+                opset=args.opset_conditional_decoder,
+                chatterbox_model=chatterbox_model,
+            )
+            graphs_exported.append("cfm_estimator.onnx")
+
+            # 3) mel2wav: trace with a mel of the same shape the C# loop
+            #    will produce (matching flow_encoder's z, then narrowed
+            #    past prompt_len). For tracing purposes any [B, 80, T]
+            #    mel works; use _mu directly.
+            export_mel2wav(
+                m2w, _mu, args.output_dir / "mel2wav.onnx",
+                opset=args.opset_conditional_decoder,
+                chatterbox_model=chatterbox_model,
+            )
+            graphs_exported.append("mel2wav.onnx")
+        else:
+            export_conditional_decoder(
+                cond_decoder, speech_tokens, speaker_embeddings, speaker_features,
+                args.output_dir / "conditional_decoder.onnx",
+                opset=args.opset_conditional_decoder,
+                chatterbox_model=chatterbox_model,
+            )
+            graphs_exported.append("conditional_decoder.onnx")
 
     if graphs_exported and not args.no_onnxslim:
         print("\nPost-export: onnxslim + external data ...")

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -559,13 +559,75 @@ def parity_solve_euler(tolerance: float = 1e-5) -> ParityResult:
     return ParityResult("solve_euler", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
 
 
+def parity_attention(tolerance: float = 1e-5) -> ParityResult:
+    """Eager-vs-eager: MinimalAttnProcessor vs diffusers AttnProcessor2_0.
+
+    BasicTransformerBlock.attn1 is the heaviest single source of nodes
+    in cond_decoder.onnx (~400 nodes per block × 48 blocks ≈ 57% of the
+    graph). MinimalAttnProcessor is a drop-in that does only the work
+    our model needs (3D input, self-attn, (B,T,T) bias mask, no
+    residual/rescale/norm pre/post-processing). To be safe to swap in
+    at export time, it must produce bit-identical output to upstream
+    on a realistic block.
+
+    Test: pick a real BasicTransformerBlock from the cond decoder
+    estimator, call it once with the original processor, once with the
+    minimal one, compare. Same mask, same input.
+    """
+    import torch
+    from chatterbox.tts import ChatterboxTTS
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _export_patches import MinimalAttnProcessor
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = ChatterboxTTS.from_pretrained(device=device)
+
+    block = None
+    for n, m in model.s3gen.flow.decoder.estimator.named_modules():
+        if type(m).__name__ == "BasicTransformerBlock":
+            block = m
+            break
+    if block is None:
+        return ParityResult("attention", False, float("inf"), float("inf"),
+                            float("inf"), tolerance, notes="no BasicTransformerBlock found")
+
+    # Synthetic input matching the shapes BasicTransformerBlock sees in
+    # the actual CFM solve loop: B = 2 (CFG-doubled), T = 1010 (mel
+    # frames), C = inner_dim (whatever the first attn1 expects).
+    B, T = 2, 1010
+    inner_dim = block.attn1.to_q.in_features
+    torch.manual_seed(0)
+    hidden = torch.randn(B, T, inner_dim, device=device)
+    attn_mask = torch.zeros(B, T, T, device=device)  # all-zero bias = unmasked
+
+    # Baseline: upstream processor (whatever was on the block)
+    orig_proc = block.attn1.processor
+    with torch.no_grad():
+        out_upstream = block.attn1(hidden, attention_mask=attn_mask).cpu().numpy()
+
+    # Swap to minimal; same input
+    block.attn1.set_processor(MinimalAttnProcessor())
+    with torch.no_grad():
+        out_minimal = block.attn1(hidden, attention_mask=attn_mask).cpu().numpy()
+    block.attn1.set_processor(orig_proc)  # restore
+
+    max_abs, max_rel, mean_abs = diff_metrics(out_minimal, out_upstream)
+    passed = max_abs <= tolerance
+    notes = (
+        f"shape={out_upstream.shape}  "
+        f"upstream_proc={type(orig_proc).__name__}  "
+        f"range=[{out_upstream.min():.3f}, {out_upstream.max():.3f}]"
+    )
+    return ParityResult("attention", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
+
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--onnx-dir", type=Path, required=True,
                    help="Directory produced by export_chatterbox_to_onnx.py")
     p.add_argument("--runtime", default="cuda", choices=["cpu", "cuda", "tensorrt"])
     p.add_argument("--tests", default="lm",
-                   help="Comma-separated subset: lm,embed,enc,dec,solve_euler,all (default: lm)")
+                   help="Comma-separated subset: lm,embed,enc,dec,solve_euler,attention,all (default: lm)")
     p.add_argument("--tolerance", type=float, default=1e-2,
                    help="Max-abs-diff threshold for pass (default: 1e-2). "
                         "Each test layer has its own appropriate default; this is a "
@@ -587,7 +649,7 @@ def main() -> None:
     providers = choose_onnx_providers(args.runtime)
     tests = {t.strip() for t in args.tests.split(",")}
     if "all" in tests:
-        tests = {"lm", "embed", "enc", "dec", "solve_euler"}
+        tests = {"lm", "embed", "enc", "dec", "solve_euler", "attention"}
 
     results: list[ParityResult] = []
 
@@ -613,6 +675,10 @@ def main() -> None:
     if "solve_euler" in tests:
         print("[solve_euler] patched cat-only solve_euler vs upstream (eager)")
         results.append(parity_solve_euler())
+        print(results[-1].summary())
+    if "attention" in tests:
+        print("[attention] MinimalAttnProcessor vs diffusers AttnProcessor (eager)")
+        results.append(parity_attention())
         print(results[-1].summary())
 
     print()

--- a/scripts/chatterbox_export/test_chatterbox_parity.py
+++ b/scripts/chatterbox_export/test_chatterbox_parity.py
@@ -559,6 +559,162 @@ def parity_solve_euler(tolerance: float = 1e-5) -> ParityResult:
     return ParityResult("solve_euler", passed, max_abs, max_rel, mean_abs, tolerance, notes=notes)
 
 
+def parity_split_pipeline(
+    onnx_dir: Path,
+    providers: list[str],
+    tolerance: float = 1e-2,
+) -> ParityResult:
+    """End-to-end parity for the split cond decoder (Phase 1).
+
+    Orchestrates flow_encoder.onnx + cfm_estimator.onnx + mel2wav.onnx
+    in Python — the exact pattern the C# code will use. Compares the
+    final waveform against the patched-eager monolithic
+    `ConditionalDecoder` pipeline. Differences should be at the
+    float-precision level (max_abs < 1e-3) because the split is a pure
+    refactor: same math, just spread across three graphs with the CFM
+    loop in Python instead of unrolled inside the ONNX trace.
+
+    Test PASSES if all three graphs are present and ONNX output matches
+    eager within `tolerance`. SKIPS if the split artifacts aren't there
+    (caller forgot --split-cond-decoder).
+    """
+    import torch
+    import onnxruntime as ort
+    from chatterbox.tts import ChatterboxTTS
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import _chatterbox_internals as ci
+    from _export_patches import patched_cond_decoder_for_export, patched_sinegen_deterministic
+
+    enc_p = onnx_dir / "flow_encoder.onnx"
+    est_p = onnx_dir / "cfm_estimator.onnx"
+    m2w_p = onnx_dir / "mel2wav.onnx"
+    if not (enc_p.exists() and est_p.exists() and m2w_p.exists()):
+        return ParityResult(
+            "split_pipeline", False, float("inf"), float("inf"), float("inf"),
+            tolerance,
+            notes=f"missing split artifacts in {onnx_dir} (re-export with --split-cond-decoder)",
+        )
+
+    # Same seed/audio/tokens setup as parity_dec so the comparison is
+    # apples-to-apples with the rest of the suite.
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    chatterbox_model = ChatterboxTTS.from_pretrained(device=device)
+    prep = ci.PrepareConditionalsModel(chatterbox_model).eval().to(device)
+    et = ci.InputsEmbeds(chatterbox_model).eval().to(device)
+    cd_eager = ci.ConditionalDecoder(chatterbox_model).eval().to(device)
+    ci.istft.to(device)
+
+    torch.manual_seed(0)
+    audio = torch.randn(1, 312_936, device=device)
+    ids = torch.tensor([[EXAGGERATION_TOKEN,
+        255, 281, 39, 46, 56, 2, 53, 2, 286, 41, 37, 2, 136, 122,
+        49, 2, 152, 2, 103, 2, 277, 21, 101, 7, 2, 301, 55, 34, 28, 7,
+        2, 53, 2, 296, 18, 18, 115, 2, 51, 2, 33, 245, 2, 17, 190, 2,
+        42, 2, 50, 18, 125, 4, 32, 2, 290, 169, 142, 2, 41, 2, 43, 2,
+        18, 29, 91, 2, 25, 186, 8, 20, 14, 80, 2, 29, 86, 213, 216, 9,
+        0, START_SPEECH_TOKEN, START_SPEECH_TOKEN]],
+        dtype=torch.long, device=device)
+    pos = torch.where(ids >= START_SPEECH_TOKEN, torch.zeros_like(ids),
+                      torch.arange(ids.shape[1], device=device).unsqueeze(0) - 1)
+    ex = torch.tensor([0.5], device=device)
+
+    with torch.no_grad():
+        _, prompt_token, spk_emb, spk_feat = prep(audio_values=audio)
+        text_emb = et(ids, pos, ex)
+        cond_emb_lm, _, _, _ = prep(audio_values=audio)
+        inputs_embeds = torch.cat((cond_emb_lm, text_emb), dim=1)
+        llm = chatterbox_model.t3.tfmr
+        sh = chatterbox_model.t3.speech_head
+        gt = torch.tensor([[START_SPEECH_TOKEN]], dtype=torch.long, device=device)
+        pkv = None
+        for i in range(256):
+            o = llm(inputs_embeds=inputs_embeds, past_key_values=pkv)
+            pkv = o.past_key_values
+            nl = sh(o.last_hidden_state[:, -1, :])
+            nt = torch.argmax(nl, dim=-1).unsqueeze(-1)
+            gt = torch.cat((gt, nt), dim=-1)
+            if (nt.view(-1) == 6562).all():
+                break
+            p = torch.full((ids.shape[0], 1), i + 1, dtype=torch.long, device=device)
+            inputs_embeds = et(nt, p, ex)
+        speech_tokens = torch.cat([prompt_token, gt[:, 1:-1]], dim=1)
+
+        # Baseline: monolithic patched-eager pipeline
+        with patched_cond_decoder_for_export(chatterbox_model.s3gen, ci.istft), \
+             patched_sinegen_deterministic(chatterbox_model.s3gen.mel2wav):
+            wav_eager = cd_eager(speech_tokens, spk_emb, spk_feat).cpu().numpy()
+
+    # Run the 3 split graphs in Python (mirrors the planned C# loop)
+    enc_sess = ort.InferenceSession(str(enc_p), providers=providers)
+    est_sess = ort.InferenceSession(str(est_p), providers=providers)
+    m2w_sess = ort.InferenceSession(str(m2w_p), providers=providers)
+
+    feed_enc = {
+        "speech_tokens": speech_tokens.cpu().numpy(),
+        "speaker_embeddings": spk_emb.cpu().numpy(),
+        "speaker_features": spk_feat.cpu().numpy(),
+    }
+    mu, mask, embedding, cond, z = enc_sess.run(
+        ["mu", "mel_mask", "embedding", "cond", "z"], feed_enc)
+
+    # CFM solve loop — mirrors _solve_euler_dynamic exactly (10 cosine-scheduled steps)
+    import numpy as np
+    n_timesteps = 10
+    t_span = np.linspace(0, 1, n_timesteps + 1, dtype=mu.dtype)
+    t_span = 1.0 - np.cos(t_span * 0.5 * np.pi)
+    cfg = 0.7
+    x = z.copy()
+    t = float(t_span[0])
+    dt = float(t_span[1] - t_span[0])
+    for step in range(1, n_timesteps + 1):
+        x_in = np.concatenate([x, x], axis=0)
+        mask_in = np.concatenate([mask, mask], axis=0)
+        mu_in = np.concatenate([mu, np.zeros_like(mu)], axis=0)
+        spks_in = np.concatenate([embedding, np.zeros_like(embedding)], axis=0)
+        cond_in = np.concatenate([cond, np.zeros_like(cond)], axis=0)
+        t_in = np.array([t, t], dtype=mu.dtype)
+        dphi = est_sess.run(["dphi_dt"], {
+            "x_in": x_in, "mask_in": mask_in, "mu_in": mu_in,
+            "t_in": t_in, "spks_in": spks_in, "cond_in": cond_in,
+        })[0]
+        cond_part, uncond_part = np.split(dphi, 2, axis=0)
+        combined = (1.0 + cfg) * cond_part - cfg * uncond_part
+        x = x + dt * combined
+        t = float(t_span[step])
+        if step < n_timesteps:
+            dt = float(t_span[step + 1] - t)
+
+    # Trim mel (drop the prompt portion that flow.inference would have stripped)
+    prompt_len = spk_feat.shape[1]
+    feat = x[:, :, prompt_len:]
+
+    wav_split = m2w_sess.run(["waveform"], {"mel": feat})[0]
+
+    # Shape gate first
+    if wav_split.shape != wav_eager.shape:
+        return ParityResult(
+            "split_pipeline", False, float("inf"), float("inf"), float("inf"),
+            tolerance,
+            notes=f"shape mismatch: split={wav_split.shape}, eager={wav_eager.shape}",
+        )
+
+    max_abs, max_rel, mean_abs = diff_metrics(wav_split, wav_eager)
+
+    # Mel-spectral L1 (same convention as parity_dec)
+    import torchaudio.transforms as T
+    mel_t = T.MelSpectrogram(sample_rate=24000, n_fft=1024, hop_length=256, n_mels=80)
+    log_e = torch.log(torch.clamp(mel_t(torch.from_numpy(wav_eager[0]).float()), min=1e-5))
+    log_s = torch.log(torch.clamp(mel_t(torch.from_numpy(wav_split[0]).float()), min=1e-5))
+    mel_l1 = float((log_e - log_s).abs().mean())
+
+    mel_threshold = 0.5
+    passed = mel_l1 <= mel_threshold
+    notes = (f"shape={wav_split.shape}  "
+             f"mel_log_l1={mel_l1:.4e} (thr={mel_threshold})  "
+             f"eager_range=[{wav_eager.min():.3f}, {wav_eager.max():.3f}]")
+    return ParityResult("split_pipeline", passed, max_abs, max_rel, mean_abs, mel_threshold, notes=notes)
+
+
 def parity_attention(tolerance: float = 1e-5) -> ParityResult:
     """Eager-vs-eager: MinimalAttnProcessor vs diffusers AttnProcessor2_0.
 
@@ -627,7 +783,7 @@ def parse_args() -> argparse.Namespace:
                    help="Directory produced by export_chatterbox_to_onnx.py")
     p.add_argument("--runtime", default="cuda", choices=["cpu", "cuda", "tensorrt"])
     p.add_argument("--tests", default="lm",
-                   help="Comma-separated subset: lm,embed,enc,dec,solve_euler,attention,all (default: lm)")
+                   help="Comma-separated subset: lm,embed,enc,dec,solve_euler,attention,split_pipeline,all (default: lm)")
     p.add_argument("--tolerance", type=float, default=1e-2,
                    help="Max-abs-diff threshold for pass (default: 1e-2). "
                         "Each test layer has its own appropriate default; this is a "
@@ -649,7 +805,7 @@ def main() -> None:
     providers = choose_onnx_providers(args.runtime)
     tests = {t.strip() for t in args.tests.split(",")}
     if "all" in tests:
-        tests = {"lm", "embed", "enc", "dec", "solve_euler", "attention"}
+        tests = {"lm", "embed", "enc", "dec", "solve_euler", "attention", "split_pipeline"}
 
     results: list[ParityResult] = []
 
@@ -679,6 +835,10 @@ def main() -> None:
     if "attention" in tests:
         print("[attention] MinimalAttnProcessor vs diffusers AttnProcessor (eager)")
         results.append(parity_attention())
+        print(results[-1].summary())
+    if "split_pipeline" in tests:
+        print("[split_pipeline] split flow_encoder+cfm_estimator+mel2wav vs monolithic eager")
+        results.append(parity_split_pipeline(args.onnx_dir, providers, args.tolerance))
         print(results[-1].summary())
 
     print()

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.ML.OnnxRuntime;
 using Vernacula.Base.Models;
 
@@ -90,5 +92,109 @@ public static class OrtSessionBuilder
         }
 
         return opts;
+    }
+
+    /// <summary>
+    /// Create an <see cref="InferenceSession"/> backed by a disk-cached
+    /// post-optimization graph. First call loads <paramref name="modelPath"/>,
+    /// runs graph optimization at <paramref name="optLevel"/>, and writes the
+    /// optimized graph next to the source as <c>{stem}.opt.{ep}.{ortver}.onnx</c>
+    /// (with a <c>.opt_data</c> sidecar for tensors above
+    /// <paramref name="externalInitializersMinBytes"/>). Subsequent calls find
+    /// the cached file, skip optimization (<c>ORT_DISABLE_ALL</c>), and load
+    /// directly — typically 5–10× faster for large graphs.
+    ///
+    /// Cache key embeds EP, ORT version, and source-file mtime+size, so source
+    /// changes or ORT upgrades automatically invalidate. Stale optimized files
+    /// are NOT auto-cleaned — callers can `rm <stem>.opt.*` to reset.
+    ///
+    /// Set <c>VERNACULA_ORT_NO_CACHE=1</c> to bypass the cache entirely
+    /// (forces a fresh full-optimization load every time; useful when debugging
+    /// graph-level surprises).
+    /// </summary>
+    public static InferenceSession CreateCachedSession(
+        string modelPath,
+        ExecutionProvider ep,
+        GraphOptimizationLevel optLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+        long externalInitializersMinBytes = 1024 * 1024)
+        => CreateCachedSession(modelPath, ep, out _, optLevel, externalInitializersMinBytes);
+
+    /// <inheritdoc cref="CreateCachedSession(string, ExecutionProvider, GraphOptimizationLevel, long)"/>
+    /// <param name="cacheHit">True if a valid pre-optimized file was found and
+    /// reused; false if a fresh optimization happened (and was written to disk
+    /// for next time).</param>
+    public static InferenceSession CreateCachedSession(
+        string modelPath,
+        ExecutionProvider ep,
+        out bool cacheHit,
+        GraphOptimizationLevel optLevel = GraphOptimizationLevel.ORT_ENABLE_ALL,
+        long externalInitializersMinBytes = 1024 * 1024)
+    {
+        cacheHit = false;
+        if (!File.Exists(modelPath))
+            throw new FileNotFoundException($"Model file not found: {modelPath}");
+
+        bool bypassCache = Environment.GetEnvironmentVariable("VERNACULA_ORT_NO_CACHE") == "1";
+        string cachePath = bypassCache ? "" : ComputeCachePath(modelPath, ep, optLevel);
+        string cacheDataPath = cachePath + "_data";
+
+        if (!bypassCache && File.Exists(cachePath))
+        {
+            // Cache hit: load pre-optimized graph with optimization DISABLED
+            // (the graph is already optimized; re-running passes is wasted work
+            // and may hit unsupported-op errors on a fused graph).
+            var hitOpts = Create(ep, GraphOptimizationLevel.ORT_DISABLE_ALL, enableProfiling: false, out _);
+            try
+            {
+                var session = new InferenceSession(cachePath, hitOpts);
+                cacheHit = true;
+                return session;
+            }
+            catch
+            {
+                // Cache file is corrupt or incompatible — fall through to fresh load.
+                hitOpts.Dispose();
+                try { File.Delete(cachePath); } catch { /* best-effort */ }
+                try { File.Delete(cacheDataPath); } catch { /* best-effort */ }
+            }
+        }
+
+        // Cache miss (or bypass): load source, optimize, save the result.
+        var opts = Create(ep, optLevel, enableProfiling: false, out _);
+        if (!bypassCache)
+        {
+            opts.OptimizedModelFilePath = cachePath;
+            // For >2GB graphs, force the optimized weights to an external-data
+            // sidecar; otherwise the serializer hits protobuf's 2GB limit.
+            opts.AddSessionConfigEntry(
+                "session.optimized_model_external_initializers_file_name",
+                Path.GetFileName(cacheDataPath));
+            opts.AddSessionConfigEntry(
+                "session.optimized_model_external_initializers_min_size_in_bytes",
+                externalInitializersMinBytes.ToString());
+        }
+        return new InferenceSession(modelPath, opts);
+    }
+
+    private static string ComputeCachePath(
+        string modelPath, ExecutionProvider ep, GraphOptimizationLevel optLevel)
+    {
+        var fi = new FileInfo(modelPath);
+        var ortVer = typeof(InferenceSession).Assembly.GetName().Version?.ToString() ?? "unknown";
+        var epTag = ep switch
+        {
+            ExecutionProvider.Cpu => "cpu",
+            ExecutionProvider.Cuda or ExecutionProvider.Auto => "cuda",
+            ExecutionProvider.DirectML => "dml",
+            _ => "auto",
+        };
+        // Include mtime+size in a short hash so source edits invalidate.
+        var keyBytes = Encoding.UTF8.GetBytes(
+            $"{fi.LastWriteTimeUtc.Ticks}|{fi.Length}|{epTag}|{optLevel}|{ortVer}");
+        var hash = SHA256.HashData(keyBytes).AsSpan(0, 6);
+        var hashHex = Convert.ToHexString(hash).ToLowerInvariant();
+        var dir = fi.DirectoryName ?? ".";
+        var stem = Path.GetFileNameWithoutExtension(modelPath);
+        return Path.Combine(dir, $"{stem}.opt.{epTag}.{hashHex}.onnx");
     }
 }

--- a/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
+++ b/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Vernacula.ChatterboxSmoke</RootNamespace>
+    <AssemblyName>ChatterboxSmoke</AssemblyName>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- .Gpu includes CPU as fallback; covers both EP modes (cpu and cuda). -->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.4" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
+      <Private>true</Private>
+      <SetConfiguration>EP=Cuda</SetConfiguration>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -1,0 +1,408 @@
+// Chatterbox TTS — C# smoke test (port of scripts/chatterbox_export/.../listen_test.py).
+//
+// Loads the four ONNX graphs produced by export_chatterbox_to_onnx.py
+// and runs them end-to-end to produce a WAV. Hardcodes the same text
+// token sequence the Python listen test uses (a tokenizer port is a
+// separate concern; see chatterbox.scratch.md Stage 1 step 1).
+//
+// Usage:
+//   dotnet run --project tests/ChatterboxSmoke -- \
+//       --onnx-dir /tmp/cb_dyn5 \
+//       --voice ~/Downloads/VCTK_p303.wav \
+//       --out   /tmp/chatterbox_out_cs.wav \
+//       --ep    cuda
+//
+// Output should be acoustically close to the Python /tmp/chatterbox_out.wav
+// (modulo ORT-vs-PyTorch CUDA kernel drift, ~1e-5).
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using Vernacula.Base;
+using Vernacula.Base.Inference;
+using Vernacula.Base.Models;
+
+namespace Vernacula.ChatterboxSmoke;
+
+internal static class Program
+{
+    // Constants — must match scripts/chatterbox_export/_common.py.
+    private const int StartSpeechToken = 6561;
+    private const int StopSpeechToken = 6562;
+    private const int ExaggerationToken = 6563;
+    private const int LlmLayers = 30;
+    private const int LlmKvHeads = 16;
+    private const int LlmHeadDim = 64;
+    private const int LlmHidden = 1024;
+    private const int S3GenSr = 24_000;
+    private const int DummyAudioSamples = 312_936;  // 13.04 s @ 24 kHz
+
+    // The Ezreal-and-Jinx sentence, pre-tokenized via chatterbox's EnTokenizer.
+    // Wrapping: [EXAGGERATION_TOKEN, ...text..., START_SPEECH_TOKEN, START_SPEECH_TOKEN].
+    private static readonly long[] InputIds =
+    [
+        ExaggerationToken,
+        255, 281, 39, 46, 56, 2, 53, 2, 286, 41, 37, 2, 136, 122,
+        49, 2, 152, 2, 103, 2, 277, 21, 101, 7, 2, 301, 55, 34, 28, 7,
+        2, 53, 2, 296, 18, 18, 115, 2, 51, 2, 33, 245, 2, 17, 190, 2,
+        42, 2, 50, 18, 125, 4, 32, 2, 290, 169, 142, 2, 41, 2, 43, 2,
+        18, 29, 91, 2, 25, 186, 8, 20, 14, 80, 2, 29, 86, 213, 216, 9,
+        0, StartSpeechToken, StartSpeechToken,
+    ];
+
+    private const float Exaggeration = 0.5f;
+    private const float RepetitionPenalty = 1.2f;
+    private const int MaxLmSteps = 256;
+
+    private static int Main(string[] args)
+    {
+        string? onnxDir = null;
+        string? voicePath = null;
+        string? outPath = "/tmp/chatterbox_out_cs.wav";
+        string ep = "cuda";
+        bool skipDec = false;
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--onnx-dir": onnxDir = args[++i]; break;
+                case "--voice":    voicePath = args[++i]; break;
+                case "--out":      outPath = args[++i]; break;
+                case "--ep":       ep = args[++i].ToLowerInvariant(); break;
+                case "--skip-cond-decoder": skipDec = true; break;
+                default:
+                    Console.Error.WriteLine($"Unknown arg: {args[i]}");
+                    return 2;
+            }
+        }
+        if (onnxDir is null || voicePath is null || outPath is null)
+        {
+            Console.Error.WriteLine(
+                "Usage: --onnx-dir <dir> --voice <wav> [--out <wav>] [--ep cpu|cuda]");
+            return 2;
+        }
+        if (ep is not ("cpu" or "cuda"))
+        {
+            Console.Error.WriteLine($"Unknown EP: {ep}. Choose cpu or cuda.");
+            return 2;
+        }
+
+        // Expand ~ to $HOME.
+        voicePath = ExpandHome(voicePath);
+        outPath = ExpandHome(outPath);
+
+        var totalSw = Stopwatch.StartNew();
+        var sw = new Stopwatch();
+        var epEnum = ep == "cuda" ? ExecutionProvider.Auto : ExecutionProvider.Cpu;
+
+        // ── Load the four sessions ────────────────────────────────────────
+        InferenceSession LoadOne(string name)
+        {
+            sw.Restart();
+            var s = OrtSessionBuilder.CreateCachedSession(
+                Path.Combine(onnxDir, name), epEnum, out var hit);
+            sw.Stop();
+            var sz = new FileInfo(Path.Combine(onnxDir, name)).Length;
+            Console.WriteLine($"  {name}: {sw.ElapsedMilliseconds} ms  cache={Hit(hit)}  src={sz / 1e6:F0} MB");
+            return s;
+        }
+        var totalLoadSw = Stopwatch.StartNew();
+        var enc = LoadOne("speech_encoder.onnx");
+        var emb = LoadOne("embed_tokens.onnx");
+        var lm  = LoadOne("language_model.onnx");
+        var dec = LoadOne("conditional_decoder.onnx");
+        totalLoadSw.Stop();
+        Console.WriteLine($"Loaded 4 sessions in {totalLoadSw.ElapsedMilliseconds} ms total  (ep={ep})");
+        using var _enc = enc; using var _emb = emb; using var _lm = lm; using var _dec = dec;
+
+        // ── Voice prompt → 24 kHz mono, padded/cropped to 312_936 ─────────
+        sw.Restart();
+        var audio = LoadVoicePrompt(voicePath);
+        sw.Stop();
+        Console.WriteLine($"Loaded voice {voicePath}: {audio.Length} samples ({audio.Length / (float)S3GenSr:F2}s)  [{sw.ElapsedMilliseconds} ms]");
+
+        // ── speech_encoder.onnx ──────────────────────────────────────────
+        sw.Restart();
+        var audioT = new DenseTensor<float>(audio, [1, audio.Length]);
+        using var encOut = enc.Run([NamedOnnxValue.CreateFromTensor("audio_values", audioT)]);
+        var encList = encOut.ToList();
+        var condEmb = encList[0].AsTensor<float>();          // [1, S_cond, 1024]
+        var audioTokens = encList[1].AsTensor<long>();       // [1, T_audio]
+        var spkEmb = encList[2].AsTensor<float>();           // [1, 192]
+        var spkFeat = encList[3].AsTensor<float>();          // [1, 500, 80]
+        sw.Stop();
+        Console.WriteLine($"speech_encoder: cond_emb={ShapeStr(condEmb.Dimensions)}  audio_tokens={ShapeStr(audioTokens.Dimensions)}  [{sw.ElapsedMilliseconds} ms]");
+
+        // ── embed_tokens.onnx — text prompt to embeddings ─────────────────
+        sw.Restart();
+        int sText = InputIds.Length;
+        var positionIds = new long[sText];
+        for (int i = 0; i < sText; i++)
+            positionIds[i] = InputIds[i] >= StartSpeechToken ? 0 : i - 1;
+        var inputIdsT = new DenseTensor<long>(InputIds.ToArray(), [1, sText]);
+        var posIdsT = new DenseTensor<long>(positionIds, [1, sText]);
+        var exagT = new DenseTensor<float>(new float[] { Exaggeration }, [1]);
+        using var embOut = emb.Run([
+            NamedOnnxValue.CreateFromTensor("input_ids", inputIdsT),
+            NamedOnnxValue.CreateFromTensor("position_ids", posIdsT),
+            NamedOnnxValue.CreateFromTensor("exaggeration", exagT),
+        ]);
+        var textEmbTensor = embOut.First().AsTensor<float>();  // [1, sText, 1024]
+        sw.Stop();
+        Console.WriteLine($"embed_tokens: text_emb={ShapeStr(textEmbTensor.Dimensions)}  [{sw.ElapsedMilliseconds} ms]");
+
+        // Concat cond_emb + text_emb along sequence dim → inputs_embeds.
+        int sCond = condEmb.Dimensions[1];
+        int sTotal = sCond + sText;
+        var inputsEmbeds = ConcatSeq(condEmb, textEmbTensor, LlmHidden);  // [1, sTotal, 1024]
+
+        // ── LM autoregressive loop ────────────────────────────────────────
+        // attention_mask starts at sTotal, grows by 1 per step.
+        // past_kv starts empty (T_past=0), grows by sTotal at step 0 then by 1 per step.
+        // generate_tokens accumulates the sampled speech tokens.
+        var attentionMask = new long[sTotal];
+        Array.Fill(attentionMask, 1);
+        var pastKv = new float[LlmLayers * 2][];          // pairs of (key, value) per layer
+        var pastKvShape = new int[] { 1, LlmKvHeads, 0, LlmHeadDim };
+        for (int k = 0; k < pastKv.Length; k++) pastKv[k] = [];
+
+        var generateTokens = new List<long> { StartSpeechToken };
+        var lmSw = new Stopwatch();
+        lmSw.Start();
+        int actualSteps = 0;
+        for (int step = 0; step < MaxLmSteps; step++)
+        {
+            // Build LM input dict for this step.
+            var inputs = new List<NamedOnnxValue>(2 + 2 * LlmLayers);
+            int seqIn = step == 0 ? sTotal : 1;
+            inputs.Add(NamedOnnxValue.CreateFromTensor("inputs_embeds",
+                new DenseTensor<float>(inputsEmbeds, [1, seqIn, LlmHidden])));
+            inputs.Add(NamedOnnxValue.CreateFromTensor("attention_mask",
+                new DenseTensor<long>(attentionMask, [1, attentionMask.Length])));
+            int tPast = pastKvShape[2];
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                inputs.Add(NamedOnnxValue.CreateFromTensor(
+                    $"past_key_values.{layer}.key",
+                    new DenseTensor<float>(pastKv[2 * layer], pastKvShape)));
+                inputs.Add(NamedOnnxValue.CreateFromTensor(
+                    $"past_key_values.{layer}.value",
+                    new DenseTensor<float>(pastKv[2 * layer + 1], pastKvShape)));
+            }
+
+            using var lmOut = lm.Run(inputs);
+            var outList = lmOut.ToList();
+            var logits = outList[0].AsTensor<float>();  // [1, seqIn, vocab]
+
+            // Slice logits of the LAST position; apply repetition penalty in-place.
+            int vocab = logits.Dimensions[2];
+            var lastLogits = new float[vocab];
+            int logitsOffset = (seqIn - 1) * vocab;
+            // logits is row-major: [1, seqIn, vocab]; copy out the [-1, :] row.
+            var logitsBuf = logits.ToArray();
+            Array.Copy(logitsBuf, logitsOffset, lastLogits, 0, vocab);
+
+            if (step <= 1)
+            {
+                // DIAGNOSTIC: dump per-step logits + LM-input snapshot for cross-check
+                // vs Python listen_test. Step 0 isolates the prefill; step 1 isolates
+                // the KV-refeed cycle. Remove once parity is established.
+                Console.WriteLine($"[step{step}] logits[-1, :10] (pre-penalty): "
+                    + string.Join(", ", lastLogits.Take(10).Select(x => x.ToString("F6"))));
+                Console.WriteLine($"[step{step}] logits sum: {lastLogits.Sum():F4}, argmax(pre-penalty): {Argmax(lastLogits)}");
+                File.WriteAllBytes($"/tmp/cs_step{step}_logits.bin", MemoryMarshal.AsBytes<float>(lastLogits).ToArray());
+                File.WriteAllBytes($"/tmp/cs_step{step}_inputs_embeds.bin", MemoryMarshal.AsBytes<float>(inputsEmbeds).ToArray());
+                File.WriteAllBytes($"/tmp/cs_step{step}_attention_mask.bin", MemoryMarshal.AsBytes<long>(attentionMask).ToArray());
+                if (step == 1)
+                {
+                    // Dump the first KV (key+value) layer so we can verify the
+                    // KV-refeed roundtrip didn't corrupt anything.
+                    File.WriteAllBytes("/tmp/cs_step1_past_kv_l0_key.bin",
+                        MemoryMarshal.AsBytes<float>(pastKv[0]).ToArray());
+                    File.WriteAllBytes("/tmp/cs_step1_past_kv_l0_value.bin",
+                        MemoryMarshal.AsBytes<float>(pastKv[1]).ToArray());
+                    Console.WriteLine($"[step1] past_kv shape={ShapeStr(pastKvShape)}  "
+                        + $"l0_key sum={pastKv[0].Sum():F4}  l0_value sum={pastKv[1].Sum():F4}");
+                }
+            }
+
+            foreach (var t in generateTokens)
+            {
+                if (lastLogits[t] > 0) lastLogits[t] /= RepetitionPenalty;
+            }
+            long nextToken = Argmax(lastLogits);
+            generateTokens.Add(nextToken);
+            if (nextToken == StopSpeechToken) { actualSteps = step + 1; break; }
+
+            // Stash present_kv into past_kv for next iter. The output shape's
+            // T grows by seqIn each step (sTotal on step 0, then 1).
+            int tPresent = tPast + seqIn;
+            pastKvShape = [1, LlmKvHeads, tPresent, LlmHeadDim];
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                pastKv[2 * layer]     = outList[1 + 2 * layer].AsTensor<float>().ToArray();
+                pastKv[2 * layer + 1] = outList[2 + 2 * layer].AsTensor<float>().ToArray();
+            }
+
+            // Re-embed the new token at position (step + 1).
+            var nextIdT = new DenseTensor<long>(new long[] { nextToken }, [1, 1]);
+            var nextPosT = new DenseTensor<long>(new long[] { (long)(step + 1) }, [1, 1]);
+            var nextExagT = new DenseTensor<float>(new float[] { Exaggeration }, [1]);
+            using var nextEmbOut = emb.Run([
+                NamedOnnxValue.CreateFromTensor("input_ids", nextIdT),
+                NamedOnnxValue.CreateFromTensor("position_ids", nextPosT),
+                NamedOnnxValue.CreateFromTensor("exaggeration", nextExagT),
+            ]);
+            inputsEmbeds = nextEmbOut.First().AsTensor<float>().ToArray();
+
+            // Grow attention_mask by 1.
+            var grown = new long[attentionMask.Length + 1];
+            Array.Copy(attentionMask, grown, attentionMask.Length);
+            grown[^1] = 1;
+            attentionMask = grown;
+            actualSteps = step + 1;
+        }
+        lmSw.Stop();
+        Console.WriteLine($"LM: {actualSteps} steps, generated {generateTokens.Count - 1} tokens (incl. STOP/no-STOP)  [{lmSw.ElapsedMilliseconds} ms, {lmSw.ElapsedMilliseconds / (double)actualSteps:F1} ms/step]");
+
+        // DIAGNOSTIC: dump full token sequence for divergence hunting.
+        File.WriteAllBytes("/tmp/cs_tokens.bin",
+            MemoryMarshal.AsBytes<long>(generateTokens.ToArray()).ToArray());
+        Console.WriteLine($"[diag] wrote /tmp/cs_tokens.bin ({generateTokens.Count} tokens)");
+
+        // ── Build speech_tokens: [audio_tokens, generated[1:-1]] ──────────
+        // Strip START_SPEECH at front; strip STOP at back if present.
+        int genStart = 1;
+        int genEnd = generateTokens[^1] == StopSpeechToken ? generateTokens.Count - 1 : generateTokens.Count;
+        int genCount = genEnd - genStart;
+        var audioTokArr = audioTokens.ToArray();
+        var speechTokens = new long[audioTokArr.Length + genCount];
+        Array.Copy(audioTokArr, speechTokens, audioTokArr.Length);
+        for (int i = 0; i < genCount; i++)
+            speechTokens[audioTokArr.Length + i] = generateTokens[genStart + i];
+        Console.WriteLine($"speech_tokens: shape=(1, {speechTokens.Length})  ({audioTokArr.Length} from voice + {genCount} from LM)");
+
+        // ── conditional_decoder.onnx → waveform ───────────────────────────
+        sw.Restart();
+        var speechTokT = new DenseTensor<long>(speechTokens, [1, speechTokens.Length]);
+        var spkEmbT = new DenseTensor<float>(spkEmb.ToArray(), spkEmb.Dimensions.ToArray());
+        var spkFeatT = new DenseTensor<float>(spkFeat.ToArray(), spkFeat.Dimensions.ToArray());
+        using var decOut = dec.Run([
+            NamedOnnxValue.CreateFromTensor("speech_tokens", speechTokT),
+            NamedOnnxValue.CreateFromTensor("speaker_embeddings", spkEmbT),
+            NamedOnnxValue.CreateFromTensor("speaker_features", spkFeatT),
+        ]);
+        var wavTensor = decOut.First().AsTensor<float>();    // [1, N]
+        sw.Stop();
+        int nSamples = wavTensor.Dimensions[1];
+        Console.WriteLine($"cond_decoder: waveform=(1, {nSamples}) → {nSamples / (float)S3GenSr:F2}s  [{sw.ElapsedMilliseconds} ms]");
+
+        // ── Write WAV ─────────────────────────────────────────────────────
+        var samples = wavTensor.ToArray();
+        var fmt = WaveFormat.CreateIeeeFloatWaveFormat(S3GenSr, 1);
+        using (var writer = new WaveFileWriter(outPath, fmt))
+        {
+            writer.WriteSamples(samples, 0, samples.Length);
+        }
+        totalSw.Stop();
+        Console.WriteLine($"Wrote {outPath}  [total {totalSw.ElapsedMilliseconds / 1000.0:F1}s]");
+        return 0;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Load a WAV at any sample rate / channel count and return a 24 kHz mono
+    /// float32 array, padded with zeros or cropped to DummyAudioSamples (the
+    /// trace-time canonical length the speech_encoder was exported with).
+    /// </summary>
+    private static float[] LoadVoicePrompt(string path)
+    {
+        var (raw, sr, channels) = AudioUtils.ReadAudio(path);
+        float[] mono = AudioUtils.DownmixToMono(raw, channels);
+
+        float[] at24k;
+        if (sr == S3GenSr)
+        {
+            at24k = ReferenceEquals(mono, raw) ? (float[])mono.Clone() : mono;
+        }
+        else
+        {
+            var srcFmt = WaveFormat.CreateIeeeFloatWaveFormat(sr, 1);
+            var provider = new FloatArraySampleProvider(mono, srcFmt);
+            var resampler = new WdlResamplingSampleProvider(provider, S3GenSr);
+            var outList = new List<float>((int)((long)mono.Length * S3GenSr / sr + 1024));
+            var buf = new float[8192];
+            int n;
+            while ((n = resampler.Read(buf, 0, buf.Length)) > 0)
+                for (int i = 0; i < n; i++) outList.Add(buf[i]);
+            at24k = outList.ToArray();
+        }
+
+        if (at24k.Length >= DummyAudioSamples)
+            return at24k.AsSpan(0, DummyAudioSamples).ToArray();
+
+        var padded = new float[DummyAudioSamples];
+        Array.Copy(at24k, padded, at24k.Length);
+        return padded;
+    }
+
+    /// <summary>
+    /// NAudio float-array source mirroring Vernacula.Base's internal helper.
+    /// Lives here too because that class is internal to Vernacula.Base.
+    /// </summary>
+    private sealed class FloatArraySampleProvider : ISampleProvider
+    {
+        private readonly float[] _data;
+        private int _pos;
+        public FloatArraySampleProvider(float[] data, WaveFormat fmt) { _data = data; WaveFormat = fmt; }
+        public WaveFormat WaveFormat { get; }
+        public int Read(float[] buffer, int offset, int count)
+        {
+            int remain = _data.Length - _pos;
+            int take = Math.Min(remain, count);
+            if (take <= 0) return 0;
+            Array.Copy(_data, _pos, buffer, offset, take);
+            _pos += take;
+            return take;
+        }
+    }
+
+    /// <summary>
+    /// Concatenate two [1, S_i, D] tensors along the sequence dim, returning
+    /// a flat float[] of length (S_a + S_b) * D, row-major.
+    /// </summary>
+    private static float[] ConcatSeq(Tensor<float> a, Tensor<float> b, int hiddenDim)
+    {
+        int sa = a.Dimensions[1];
+        int sb = b.Dimensions[1];
+        var aArr = a.ToArray();
+        var bArr = b.ToArray();
+        var outArr = new float[(sa + sb) * hiddenDim];
+        Array.Copy(aArr, 0, outArr, 0, sa * hiddenDim);
+        Array.Copy(bArr, 0, outArr, sa * hiddenDim, sb * hiddenDim);
+        return outArr;
+    }
+
+    private static long Argmax(float[] arr)
+    {
+        int best = 0;
+        float bestVal = arr[0];
+        for (int i = 1; i < arr.Length; i++)
+        {
+            if (arr[i] > bestVal) { bestVal = arr[i]; best = i; }
+        }
+        return best;
+    }
+
+    private static string ShapeStr(ReadOnlySpan<int> dims)
+        => "(" + string.Join(", ", dims.ToArray()) + ")";
+
+    private static string ExpandHome(string path)
+        => path.StartsWith("~/") ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), path[2..]) : path;
+
+    private static string Hit(bool b) => b ? "HIT" : "miss";
+}

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -29,20 +29,23 @@ namespace Vernacula.ChatterboxSmoke;
 
 internal static class Program
 {
-    // Constants — must match scripts/chatterbox_export/_common.py.
-    private const int StartSpeechToken = 6561;
-    private const int StopSpeechToken = 6562;
-    private const int ExaggerationToken = 6563;
-    private const int LlmLayers = 30;
-    private const int LlmKvHeads = 16;
-    private const int LlmHeadDim = 64;
-    private const int LlmHidden = 1024;
-    private const int S3GenSr = 24_000;
-    private const int DummyAudioSamples = 312_936;  // 13.04 s @ 24 kHz
-    private const int MelBins = 80;
-    private const int PromptLen = 500;     // spk_feat.shape[1], fixed
-    private const int CfmSteps = 10;       // n_timesteps for solve_euler
-    private const float CfgRate = 0.7f;    // inference_cfg_rate (= flow.decoder.inference_cfg_rate)
+    // Constants — must match scripts/chatterbox_export/_common.py and the
+    // chatterbox upstream values it pulls from. Each entry below cites the
+    // Python source-of-truth. If those change, this list silently drifts;
+    // a future pass should read the dynamic ones from export-report.json.
+    private const int StartSpeechToken = 6561;   // _common.py::START_SPEECH_TOKEN
+    private const int StopSpeechToken = 6562;    // _common.py::STOP_SPEECH_TOKEN
+    private const int ExaggerationToken = 6563;  // _common.py::EXAGGERATION_TOKEN
+    private const int LlmLayers = 30;            // _common.py::LLM_NUM_LAYERS
+    private const int LlmKvHeads = 16;           // _common.py::LLM_NUM_KV_HEADS
+    private const int LlmHeadDim = 64;           // _common.py::LLM_HEAD_DIM
+    private const int LlmHidden = 1024;          // _common.py::LLM_HIDDEN_SIZE
+    private const int S3GenSr = 24_000;          // _common.py::S3GEN_SR
+    private const int DummyAudioSamples = 312_936;  // _common.py::DUMMY_AUDIO_SAMPLES (13.04 s @ 24 kHz)
+    private const int MelBins = 80;              // chatterbox.s3gen.flow.output_size
+    private const int PromptLen = 500;           // speaker_features.shape[1], fixed by the speech_encoder export contract
+    private const int CfmSteps = 10;             // flow.decoder n_timesteps; chatterbox tunes for this value
+    private const float CfgRate = 0.7f;          // chatterbox.s3gen.flow.decoder.inference_cfg_rate
 
     // The Ezreal-and-Jinx sentence, pre-tokenized via chatterbox's EnTokenizer.
     // Wrapping: [EXAGGERATION_TOKEN, ...text..., START_SPEECH_TOKEN, START_SPEECH_TOKEN].
@@ -57,9 +60,9 @@ internal static class Program
         0, StartSpeechToken, StartSpeechToken,
     ];
 
-    private const float Exaggeration = 0.5f;
-    private const float RepetitionPenalty = 1.2f;
-    private const int MaxLmSteps = 256;
+    private const float Exaggeration = 0.5f;     // listen_test.py::EXAGGERATION (default-ish)
+    private const float RepetitionPenalty = 1.2f;  // listen_test.py LM-loop rep-penalty divisor
+    private const int MaxLmSteps = 256;          // listen_test.py LM-loop max_new_tokens
 
     private static int Main(string[] args)
     {
@@ -67,6 +70,7 @@ internal static class Program
         string? voicePath = null;
         string? outPath = "/tmp/chatterbox_out_cs.wav";
         string ep = "cuda";
+        string? diagDir = null;
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
@@ -75,10 +79,17 @@ internal static class Program
                 case "--voice":    voicePath = args[++i]; break;
                 case "--out":      outPath = args[++i]; break;
                 case "--ep":       ep = args[++i].ToLowerInvariant(); break;
+                case "--diag":     diagDir = args[++i]; break;
                 default:
                     Console.Error.WriteLine($"Unknown arg: {args[i]}");
                     return 2;
             }
+        }
+        if (diagDir is not null)
+        {
+            diagDir = ExpandHome(diagDir);
+            Directory.CreateDirectory(diagDir);
+            Console.WriteLine($"[diag] dumping LM step-0/step-1 + token sequence to {diagDir}");
         }
         if (onnxDir is null || voicePath is null || outPath is null)
         {
@@ -226,24 +237,29 @@ internal static class Program
             var logitsBuf = logits.ToArray();
             Array.Copy(logitsBuf, logitsOffset, lastLogits, 0, vocab);
 
-            if (step <= 1)
+            if (diagDir is not null && step <= 1)
             {
-                // DIAGNOSTIC: dump per-step logits + LM-input snapshot for cross-check
-                // vs Python listen_test. Step 0 isolates the prefill; step 1 isolates
-                // the KV-refeed cycle. Remove once parity is established.
+                // Dump per-step logits + LM-input snapshot so the Python
+                // compare_lm_step{0,1}.py scripts can replay-and-compare for
+                // the LM-divergence investigation. Step 0 isolates the prefill;
+                // step 1 isolates the KV-refeed cycle. Only fires when --diag
+                // is passed; otherwise this branch is dead.
                 Console.WriteLine($"[step{step}] logits[-1, :10] (pre-penalty): "
                     + string.Join(", ", lastLogits.Take(10).Select(x => x.ToString("F6"))));
                 Console.WriteLine($"[step{step}] logits sum: {lastLogits.Sum():F4}, argmax(pre-penalty): {Argmax(lastLogits)}");
-                File.WriteAllBytes($"/tmp/cs_step{step}_logits.bin", MemoryMarshal.AsBytes<float>(lastLogits).ToArray());
-                File.WriteAllBytes($"/tmp/cs_step{step}_inputs_embeds.bin", MemoryMarshal.AsBytes<float>(inputsEmbeds).ToArray());
-                File.WriteAllBytes($"/tmp/cs_step{step}_attention_mask.bin", MemoryMarshal.AsBytes<long>(attentionMask).ToArray());
+                File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_logits.bin"),
+                    MemoryMarshal.AsBytes<float>(lastLogits).ToArray());
+                File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_inputs_embeds.bin"),
+                    MemoryMarshal.AsBytes<float>(inputsEmbeds).ToArray());
+                File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_attention_mask.bin"),
+                    MemoryMarshal.AsBytes<long>(attentionMask).ToArray());
                 if (step == 1)
                 {
-                    // Dump the first KV (key+value) layer so we can verify the
-                    // KV-refeed roundtrip didn't corrupt anything.
-                    File.WriteAllBytes("/tmp/cs_step1_past_kv_l0_key.bin",
+                    // Dump the first KV layer so we can verify the KV-refeed
+                    // roundtrip didn't corrupt anything.
+                    File.WriteAllBytes(Path.Combine(diagDir, "cs_step1_past_kv_l0_key.bin"),
                         MemoryMarshal.AsBytes<float>(pastKv[0]).ToArray());
-                    File.WriteAllBytes("/tmp/cs_step1_past_kv_l0_value.bin",
+                    File.WriteAllBytes(Path.Combine(diagDir, "cs_step1_past_kv_l0_value.bin"),
                         MemoryMarshal.AsBytes<float>(pastKv[1]).ToArray());
                     Console.WriteLine($"[step1] past_kv shape={ShapeStr(pastKvShape)}  "
                         + $"l0_key sum={pastKv[0].Sum():F4}  l0_value sum={pastKv[1].Sum():F4}");
@@ -260,6 +276,11 @@ internal static class Program
 
             // Stash present_kv into past_kv for next iter. The output shape's
             // T grows by seqIn each step (sTotal on step 0, then 1).
+            // TODO(perf): IoBinding to keep KV GPU-resident. The .AsTensor<float>().ToArray()
+            // pair below copies GPU→CPU→GPU 60 times per step (30 layers × {key,value}),
+            // dominating the ~32 ms/step. WhisperTurbo.cs:601-624 is the template — it
+            // binds present.{layer}.* outputs to CUDA memory and chains them as the next
+            // step's past_key_values inputs via OrtValue, eliminating the host round-trip.
             int tPresent = tPast + seqIn;
             pastKvShape = [1, LlmKvHeads, tPresent, LlmHeadDim];
             for (int layer = 0; layer < LlmLayers; layer++)
@@ -289,10 +310,14 @@ internal static class Program
         lmSw.Stop();
         Console.WriteLine($"LM: {actualSteps} steps, generated {generateTokens.Count - 1} tokens (incl. STOP/no-STOP)  [{lmSw.ElapsedMilliseconds} ms, {lmSw.ElapsedMilliseconds / (double)actualSteps:F1} ms/step]");
 
-        // DIAGNOSTIC: dump full token sequence for divergence hunting.
-        File.WriteAllBytes("/tmp/cs_tokens.bin",
-            MemoryMarshal.AsBytes<long>(generateTokens.ToArray()).ToArray());
-        Console.WriteLine($"[diag] wrote /tmp/cs_tokens.bin ({generateTokens.Count} tokens)");
+        if (diagDir is not null)
+        {
+            // Full token sequence for divergence-hunting (line up against
+            // Python's listen_test sequence to find the first differing step).
+            File.WriteAllBytes(Path.Combine(diagDir, "cs_tokens.bin"),
+                MemoryMarshal.AsBytes<long>(generateTokens.ToArray()).ToArray());
+            Console.WriteLine($"[diag] wrote {diagDir}/cs_tokens.bin ({generateTokens.Count} tokens)");
+        }
 
         // ── Build speech_tokens: [audio_tokens, generated[1:-1]] ──────────
         // Strip START_SPEECH at front; strip STOP at back if present.

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -39,6 +39,10 @@ internal static class Program
     private const int LlmHidden = 1024;
     private const int S3GenSr = 24_000;
     private const int DummyAudioSamples = 312_936;  // 13.04 s @ 24 kHz
+    private const int MelBins = 80;
+    private const int PromptLen = 500;     // spk_feat.shape[1], fixed
+    private const int CfmSteps = 10;       // n_timesteps for solve_euler
+    private const float CfgRate = 0.7f;    // inference_cfg_rate (= flow.decoder.inference_cfg_rate)
 
     // The Ezreal-and-Jinx sentence, pre-tokenized via chatterbox's EnTokenizer.
     // Wrapping: [EXAGGERATION_TOKEN, ...text..., START_SPEECH_TOKEN, START_SPEECH_TOKEN].
@@ -63,7 +67,6 @@ internal static class Program
         string? voicePath = null;
         string? outPath = "/tmp/chatterbox_out_cs.wav";
         string ep = "cuda";
-        bool skipDec = false;
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
@@ -72,7 +75,6 @@ internal static class Program
                 case "--voice":    voicePath = args[++i]; break;
                 case "--out":      outPath = args[++i]; break;
                 case "--ep":       ep = args[++i].ToLowerInvariant(); break;
-                case "--skip-cond-decoder": skipDec = true; break;
                 default:
                     Console.Error.WriteLine($"Unknown arg: {args[i]}");
                     return 2;
@@ -109,14 +111,33 @@ internal static class Program
             Console.WriteLine($"  {name}: {sw.ElapsedMilliseconds} ms  cache={Hit(hit)}  src={sz / 1e6:F0} MB");
             return s;
         }
+        // Detect cond decoder layout: prefer 3-graph split if all 3 are present,
+        // else fall back to the monolithic conditional_decoder.onnx.
+        bool splitMode = File.Exists(Path.Combine(onnxDir, "flow_encoder.onnx"))
+                      && File.Exists(Path.Combine(onnxDir, "cfm_estimator.onnx"))
+                      && File.Exists(Path.Combine(onnxDir, "mel2wav.onnx"));
+        Console.WriteLine($"Cond decoder mode: {(splitMode ? "SPLIT (3 graphs)" : "MONOLITHIC (1 graph)")}");
+
         var totalLoadSw = Stopwatch.StartNew();
         var enc = LoadOne("speech_encoder.onnx");
         var emb = LoadOne("embed_tokens.onnx");
         var lm  = LoadOne("language_model.onnx");
-        var dec = LoadOne("conditional_decoder.onnx");
+        InferenceSession? dec = null, flowEnc = null, cfmEst = null, m2w = null;
+        if (splitMode)
+        {
+            flowEnc = LoadOne("flow_encoder.onnx");
+            cfmEst  = LoadOne("cfm_estimator.onnx");
+            m2w     = LoadOne("mel2wav.onnx");
+        }
+        else
+        {
+            dec = LoadOne("conditional_decoder.onnx");
+        }
         totalLoadSw.Stop();
-        Console.WriteLine($"Loaded 4 sessions in {totalLoadSw.ElapsedMilliseconds} ms total  (ep={ep})");
-        using var _enc = enc; using var _emb = emb; using var _lm = lm; using var _dec = dec;
+        int sessionCount = 3 + (splitMode ? 3 : 1);
+        Console.WriteLine($"Loaded {sessionCount} sessions in {totalLoadSw.ElapsedMilliseconds} ms total  (ep={ep})");
+        using var _enc = enc; using var _emb = emb; using var _lm = lm;
+        using var _dec = dec; using var _flowEnc = flowEnc; using var _cfmEst = cfmEst; using var _m2w = m2w;
 
         // ── Voice prompt → 24 kHz mono, padded/cropped to 312_936 ─────────
         sw.Restart();
@@ -285,23 +306,34 @@ internal static class Program
             speechTokens[audioTokArr.Length + i] = generateTokens[genStart + i];
         Console.WriteLine($"speech_tokens: shape=(1, {speechTokens.Length})  ({audioTokArr.Length} from voice + {genCount} from LM)");
 
-        // ── conditional_decoder.onnx → waveform ───────────────────────────
+        // ── Cond decoder: split path (3 graphs + CFM loop in C#) or monolithic ──
         sw.Restart();
         var speechTokT = new DenseTensor<long>(speechTokens, [1, speechTokens.Length]);
         var spkEmbT = new DenseTensor<float>(spkEmb.ToArray(), spkEmb.Dimensions.ToArray());
         var spkFeatT = new DenseTensor<float>(spkFeat.ToArray(), spkFeat.Dimensions.ToArray());
-        using var decOut = dec.Run([
-            NamedOnnxValue.CreateFromTensor("speech_tokens", speechTokT),
-            NamedOnnxValue.CreateFromTensor("speaker_embeddings", spkEmbT),
-            NamedOnnxValue.CreateFromTensor("speaker_features", spkFeatT),
-        ]);
-        var wavTensor = decOut.First().AsTensor<float>();    // [1, N]
-        sw.Stop();
-        int nSamples = wavTensor.Dimensions[1];
-        Console.WriteLine($"cond_decoder: waveform=(1, {nSamples}) → {nSamples / (float)S3GenSr:F2}s  [{sw.ElapsedMilliseconds} ms]");
+
+        float[] samples;
+        int nSamples;
+        if (splitMode)
+        {
+            samples = RunSplitCondDecoder(flowEnc!, cfmEst!, m2w!, speechTokT, spkEmbT, spkFeatT, sw);
+            nSamples = samples.Length;
+        }
+        else
+        {
+            using var decOut = dec!.Run([
+                NamedOnnxValue.CreateFromTensor("speech_tokens", speechTokT),
+                NamedOnnxValue.CreateFromTensor("speaker_embeddings", spkEmbT),
+                NamedOnnxValue.CreateFromTensor("speaker_features", spkFeatT),
+            ]);
+            var wavTensor = decOut.First().AsTensor<float>();
+            sw.Stop();
+            nSamples = wavTensor.Dimensions[1];
+            Console.WriteLine($"cond_decoder (monolithic): waveform=(1, {nSamples}) → {nSamples / (float)S3GenSr:F2}s  [{sw.ElapsedMilliseconds} ms]");
+            samples = wavTensor.ToArray();
+        }
 
         // ── Write WAV ─────────────────────────────────────────────────────
-        var samples = wavTensor.ToArray();
         var fmt = WaveFormat.CreateIeeeFloatWaveFormat(S3GenSr, 1);
         using (var writer = new WaveFileWriter(outPath, fmt))
         {
@@ -310,6 +342,128 @@ internal static class Program
         totalSw.Stop();
         Console.WriteLine($"Wrote {outPath}  [total {totalSw.ElapsedMilliseconds / 1000.0:F1}s]");
         return 0;
+    }
+
+    /// <summary>
+    /// Orchestrate the 3-graph split cond decoder: run flow_encoder, then
+    /// the CFM solve loop (10 cosine-scheduled Euler steps with CFG, one
+    /// cfm_estimator.onnx call per step), trim the prompt prefix from the
+    /// final mel, then run mel2wav. Mirrors parity_split_pipeline in
+    /// scripts/chatterbox_export/test_chatterbox_parity.py.
+    /// </summary>
+    private static float[] RunSplitCondDecoder(
+        InferenceSession flowEnc, InferenceSession cfmEst, InferenceSession m2w,
+        DenseTensor<long> speechTokT, DenseTensor<float> spkEmbT, DenseTensor<float> spkFeatT,
+        Stopwatch sw)
+    {
+        // 1) flow_encoder: speech_tokens → mu, mel_mask, embedding, cond, z
+        sw.Restart();
+        using var encOut = flowEnc.Run([
+            NamedOnnxValue.CreateFromTensor("speech_tokens", speechTokT),
+            NamedOnnxValue.CreateFromTensor("speaker_embeddings", spkEmbT),
+            NamedOnnxValue.CreateFromTensor("speaker_features", spkFeatT),
+        ]);
+        var encList = encOut.ToList();
+        var muT       = encList[0].AsTensor<float>();   // [1, 80, T_mel]
+        var maskT     = encList[1].AsTensor<float>();   // [1, 1,  T_mel]
+        var embedT    = encList[2].AsTensor<float>();   // [1, 80]
+        var condT     = encList[3].AsTensor<float>();   // [1, 80, T_mel]
+        var zT        = encList[4].AsTensor<float>();   // [1, 80, T_mel]
+        int tMel = muT.Dimensions[2];
+        sw.Stop();
+        Console.WriteLine($"flow_encoder: mu={ShapeStr(muT.Dimensions)}  T_mel={tMel}  [{sw.ElapsedMilliseconds} ms]");
+
+        // Materialize to flat arrays once; the CFM loop builds CFG-doubled
+        // copies per step (cat-along-batch) without re-reading the originals.
+        float[] mu      = muT.ToArray();
+        float[] mask    = maskT.ToArray();
+        float[] embed   = embedT.ToArray();
+        float[] cond    = condT.ToArray();
+        float[] x       = zT.ToArray();    // current CFM state, evolves each step
+
+        // 2) CFM solve loop. Cosine-scheduled t_span (matches upstream's
+        //    t_scheduler='cosine'). 10 Euler steps. Per step: CFG-double
+        //    the inputs along batch, run cfm_estimator, split + combine
+        //    with CFG rate, take an Euler step.
+        sw.Restart();
+        var tSpan = new float[CfmSteps + 1];
+        for (int i = 0; i <= CfmSteps; i++)
+        {
+            float linear = i / (float)CfmSteps;
+            tSpan[i] = 1.0f - MathF.Cos(linear * 0.5f * MathF.PI);
+        }
+        float t = tSpan[0];
+        float dt = tSpan[1] - tSpan[0];
+        int muLen = mu.Length;       // = T_mel * 80
+        int maskLen = mask.Length;   // = T_mel
+        int embedLen = embed.Length; // = 80
+        for (int step = 1; step <= CfmSteps; step++)
+        {
+            // CFG-double along batch dim 0. Each "_in" is shape [2, ...].
+            var xIn = CatBatch(x, x);
+            var maskIn = CatBatch(mask, mask);
+            var muIn = CatBatch(mu, new float[muLen]);             // row 0 = mu, row 1 = zeros
+            var condIn = CatBatch(cond, new float[cond.Length]);
+            var spksIn = CatBatch(embed, new float[embedLen]);
+            var tIn = new float[] { t, t };
+
+            using var estOut = cfmEst.Run([
+                NamedOnnxValue.CreateFromTensor("x_in",     new DenseTensor<float>(xIn, [2, MelBins, tMel])),
+                NamedOnnxValue.CreateFromTensor("mask_in",  new DenseTensor<float>(maskIn, [2, 1, tMel])),
+                NamedOnnxValue.CreateFromTensor("mu_in",    new DenseTensor<float>(muIn, [2, MelBins, tMel])),
+                NamedOnnxValue.CreateFromTensor("t_in",     new DenseTensor<float>(tIn, [2])),
+                NamedOnnxValue.CreateFromTensor("spks_in",  new DenseTensor<float>(spksIn, [2, MelBins])),
+                NamedOnnxValue.CreateFromTensor("cond_in",  new DenseTensor<float>(condIn, [2, MelBins, tMel])),
+            ]);
+            var dphi = estOut.First().AsTensor<float>().ToArray();  // [2, 80, T_mel]
+            int half = dphi.Length / 2;
+            // CFG combine: (1+cfg) * cond_part - cfg * uncond_part; Euler step.
+            float a = 1.0f + CfgRate;
+            for (int i = 0; i < half; i++)
+            {
+                float c = dphi[i];
+                float u = dphi[half + i];
+                x[i] = x[i] + dt * (a * c - CfgRate * u);
+            }
+            t = tSpan[step];
+            if (step < CfmSteps) dt = tSpan[step + 1] - t;
+        }
+        sw.Stop();
+        Console.WriteLine($"cfm_solve_loop: {CfmSteps} steps  [{sw.ElapsedMilliseconds} ms, {sw.ElapsedMilliseconds / (double)CfmSteps:F1} ms/step]");
+
+        // 3) Trim mel: drop the prompt prefix (the first PromptLen mel frames).
+        //    x is row-major [1, 80, T_mel]; we want [1, 80, T_mel - PromptLen]
+        //    keeping the tail along the last dim.
+        int tTrim = tMel - PromptLen;
+        var feat = new float[MelBins * tTrim];
+        for (int c = 0; c < MelBins; c++)
+        {
+            Array.Copy(x, c * tMel + PromptLen, feat, c * tTrim, tTrim);
+        }
+
+        // 4) mel2wav: trimmed mel → waveform (trim_fade is baked into the graph).
+        sw.Restart();
+        using var m2wOut = m2w.Run([
+            NamedOnnxValue.CreateFromTensor("mel", new DenseTensor<float>(feat, [1, MelBins, tTrim])),
+        ]);
+        var wavTensor = m2wOut.First().AsTensor<float>();
+        sw.Stop();
+        int n = wavTensor.Dimensions[1];
+        Console.WriteLine($"mel2wav: waveform=(1, {n}) → {n / (float)S3GenSr:F2}s  [{sw.ElapsedMilliseconds} ms]");
+        return wavTensor.ToArray();
+    }
+
+    /// <summary>
+    /// Concatenate two flat tensors of identical size along (implicit) dim 0.
+    /// Used to build the CFG-pair tensors for cfm_estimator: row 0 = real,
+    /// row 1 = the other half (zeros for mu/cond/spks; same as row 0 for x/mask).
+    /// </summary>
+    private static float[] CatBatch(float[] a, float[] b)
+    {
+        var r = new float[a.Length + b.Length];
+        Array.Copy(a, 0, r, 0, a.Length);
+        Array.Copy(b, 0, r, a.Length, b.Length);
+        return r;
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/tests/ChatterboxSmoke/README.md
+++ b/tests/ChatterboxSmoke/README.md
@@ -8,9 +8,12 @@ into `Chatterbox.Base` / `Chatterbox.CLI` / `Chatterbox.Avalonia`.
 
 ## What it does
 
-1. Loads `speech_encoder.onnx`, `embed_tokens.onnx`, `language_model.onnx`,
-   `conditional_decoder.onnx` via `OrtSessionBuilder.Create` (CUDA EP with
-   CPU fallback).
+1. Loads ORT sessions via `OrtSessionBuilder.CreateCachedSession` (CUDA EP
+   with CPU fallback; pre-optimization cache next to each `.onnx`).
+   Auto-detects cond decoder layout — uses the 3-graph **split path**
+   (`flow_encoder.onnx`, `cfm_estimator.onnx`, `mel2wav.onnx`) if those
+   files are present, otherwise falls back to the monolithic
+   `conditional_decoder.onnx`.
 2. Reads a voice prompt WAV, resamples to 24 kHz mono via NAudio's
    `WdlResamplingSampleProvider`, pads/crops to 312,936 samples (the
    trace-time canonical input length).
@@ -24,8 +27,26 @@ into `Chatterbox.Base` / `Chatterbox.CLI` / `Chatterbox.Avalonia`.
    256 steps, applying upstream's repetition-penalty (1.2 if logit > 0
    else no-op). Stops on `STOP_SPEECH_TOKEN = 6562`.
 6. Concatenates `audio_tokens` (from the voice clone) with the generated
-   speech tokens; runs `conditional_decoder.onnx` to get the waveform.
+   speech tokens, then runs the cond decoder. In **split mode**:
+   `flow_encoder.onnx` → CFM solve loop in C# (10 cosine-scheduled
+   Euler steps, each one call of `cfm_estimator.onnx` on a CFG-doubled
+   batch, then a CFG-combine + Euler step) → trim mel prompt prefix →
+   `mel2wav.onnx`. In monolithic mode: single `conditional_decoder.onnx`
+   call.
 7. Writes the result as a 24 kHz mono float32 WAV via `NAudio.WaveFileWriter`.
+
+## Performance notes
+
+Tested on RTX 3090, ORT 1.24.4, warm pre-optimization caches:
+
+| Path | Total | Session load | LM (174 steps) | CFM (10 steps) | mel2wav |
+|---|---|---|---|---|---|
+| Monolithic (1 cond decoder onnx) | ~180s | ~175s | 5.6s | (inside dec) | (inside dec) |
+| Split (3 cond decoder graphs)    | **12s** | **3.3s** | 5.6s | 0.5s | 0.24s |
+
+The 50× session-load speedup comes from `cfm_estimator.onnx` containing
+ONE Euler-step forward (3K nodes) instead of the 10× unrolled estimator
+(70K nodes in the monolithic). Same math; the loop is just in C# now.
 
 ## Usage
 

--- a/tests/ChatterboxSmoke/README.md
+++ b/tests/ChatterboxSmoke/README.md
@@ -1,0 +1,80 @@
+# ChatterboxSmoke
+
+C# port of `scripts/chatterbox_export/.../listen_test.py`. Loads the four
+ONNX graphs produced by `export_chatterbox_to_onnx.py` and runs them
+end-to-end to produce a WAV. Proves the ORT-C# orchestration matches the
+PyTorch reference within numerical drift before we factor the pipeline
+into `Chatterbox.Base` / `Chatterbox.CLI` / `Chatterbox.Avalonia`.
+
+## What it does
+
+1. Loads `speech_encoder.onnx`, `embed_tokens.onnx`, `language_model.onnx`,
+   `conditional_decoder.onnx` via `OrtSessionBuilder.Create` (CUDA EP with
+   CPU fallback).
+2. Reads a voice prompt WAV, resamples to 24 kHz mono via NAudio's
+   `WdlResamplingSampleProvider`, pads/crops to 312,936 samples (the
+   trace-time canonical input length).
+3. Runs `speech_encoder` to get `audio_tokens`, `speaker_embeddings`,
+   `speaker_features`, and the conditioning `cond_emb` for the LM.
+4. Runs `embed_tokens` with a **hardcoded text token sequence** (the
+   "Ezreal and Jinx teamed up..." sentence from the Python listen test).
+   Text tokenization in C# is a separate concern (Stage 1 step 1 of
+   `chatterbox.scratch.md`).
+5. Runs the Llama LM autoregressively with a growing KV-cache for up to
+   256 steps, applying upstream's repetition-penalty (1.2 if logit > 0
+   else no-op). Stops on `STOP_SPEECH_TOKEN = 6562`.
+6. Concatenates `audio_tokens` (from the voice clone) with the generated
+   speech tokens; runs `conditional_decoder.onnx` to get the waveform.
+7. Writes the result as a 24 kHz mono float32 WAV via `NAudio.WaveFileWriter`.
+
+## Usage
+
+```bash
+dotnet run --project tests/ChatterboxSmoke -- \
+    --onnx-dir /path/to/cb_dyn5 \
+    --voice ~/Downloads/voice_prompt.wav \
+    --out /tmp/chatterbox_out_cs.wav \
+    --ep cuda
+```
+
+Flags:
+- `--onnx-dir` — directory containing the four `.onnx` files.
+- `--voice` — reference WAV at any sample rate / channel count.
+- `--out` — output WAV path (default `/tmp/chatterbox_out_cs.wav`).
+- `--ep cpu | cuda` — execution provider. `cuda` requires
+  `Microsoft.ML.OnnxRuntime.Gpu`; falls back to CPU if CUDA unavailable.
+
+## What this proves (and doesn't)
+
+**Proves:**
+- All four ONNX graphs load and run via ORT-C# with the expected I/O
+  contract.
+- The KV-cache step loop in C# produces a valid speech-token stream
+  (verified by listening — the output should be acoustically close to
+  the Python reference).
+- The full pipeline runs end-to-end without any Python in the loop.
+
+**Doesn't prove:**
+- Text tokenization. We hardcode the same `InputIds` array the Python
+  listen test uses. A real CLI needs an in-process text→tokens pipeline.
+- Streaming. The current implementation generates the whole utterance
+  before writing audio; chunked synthesis and gapless concatenation are
+  Stage 1 steps 8 and beyond.
+- Performance. The implementation uses `Run()` with `NamedOnnxValue` for
+  readability — every LM step copies KV tensors to/from host memory via
+  `.ToArray()`. The Python reference uses CUDA tensor chaining; the
+  Python listen test takes ~3 minutes per LM run on a 3090 because of
+  the unbatched step loop, and this C# version will be in the same
+  ballpark or slower. `IoBinding` + `OrtValue` chaining (see
+  `WhisperTurbo.cs::TranscribeBatch`) is the optimization path.
+- Forced alignment. The eventual app needs word-level timestamps for
+  highlighting; that's a separate pass via the ASR aligner.
+
+## Next steps (in `chatterbox.scratch.md` order)
+
+1. Text tokenizer port (so we can pass `--text "any sentence"`).
+2. Factor the orchestration into `Chatterbox.Base` as `SpeakerEmbedder` +
+   `AcousticLM` + `Vocoder` classes.
+3. `Chatterbox.CLI` consumes the Base library; `--text-file` for
+   markdown input; chunked synthesis.
+4. `IoBinding` perf pass on the LM step loop.


### PR DESCRIPTION
## Summary
- The monolithic `conditional_decoder.onnx` had **67K nodes**, dominated by `torch.jit.trace` unrolling the 10-step CFM Euler solve loop into 10 copies of the estimator (~50 BasicTransformerBlocks each). ORT spent ~170s setting up each node binding, making C# cold-start painful (and warm-cache wins from `OptimizedModelFilePath` were tiny).
- **Phase 1 (this PR)**: gated behind `--split-cond-decoder`, the export emits three smaller graphs:
  - `flow_encoder.onnx` — speech_tokens → (mu, mask, embedding, cond, z)
  - `cfm_estimator.onnx` — one CFG-doubled forward of the CFM estimator
  - `mel2wav.onnx` — mel → waveform with `trim_fade` baked in
  C# orchestrates the CFM loop: 10 calls of `cfm_estimator.onnx` with CFG-combine + Euler-step math between each (~30 LOC).
- **Phase 2 (planned)**: a Python ONNX graph-surgery script will stitch the three graphs into one with a `Loop` op as the CFM body, giving a single artifact without TorchScript wrestling. Pre-built groundwork in this PR makes that a small follow-up.

## Numbers

| | Monolithic | Split |
|---|---|---|
| Total cond decoder nodes | ~67,500 | 4,653 (863 + 2,988 + 802) |
| Python ORT load (all 3/1 graphs) | ~120s | **1.2s** (~100×) |
| C# session load (warm cache, all 6 sessions) | 178s | **3.3s** (~54×) |
| C# end-to-end (warm cache) | ~180s | **12.3s** (~15×) |
| Audio rms (vs monolithic baseline) | 0.2265 | 0.2266 |
| `parity_split_pipeline` mel_log_l1 | n/a | **0.0106** (vs 0.0102 for monolithic dec parity) |

Both monolithic and split paths produce the same audio within float-precision drift. The split is a pure refactor — same math, different graph layout.

## What's in here

| Area | What it does |
|---|---|
| `_chatterbox_internals.py` | New `FlowEncoderWrapper`, `CfmEstimatorWrapper`, `Mel2WavWrapper` modules (kept alongside the existing monolithic `ConditionalDecoder`) |
| `export_chatterbox_to_onnx.py` | New `export_flow_encoder/cfm_estimator/mel2wav` functions, shared `_export_on_cpu` helper, `--split-cond-decoder` flag |
| `test_chatterbox_parity.py` | New `parity_split_pipeline` test: orchestrates the 3 graphs in Python (mirroring the C# loop), compares against monolithic patched-eager. Plus `parity_attention` from earlier — verifies the `MinimalAttnProcessor` swap |
| `_export_patches.py` | `MinimalAttnProcessor` (~5% node reduction vs diffusers' `AttnProcessor2_0`); helper to install it via `set_processor` |
| `OrtSessionBuilder.cs` | New `CreateCachedSession` that writes the post-optimization graph next to the source on first load and reads it back with `ORT_DISABLE_ALL` on subsequent loads. Generally useful, not just for Chatterbox |
| `tests/ChatterboxSmoke/` | C# port of `listen_test.py` — proves the four-graph orchestration works in ORT-C# end-to-end. Auto-detects split vs monolithic layout |

## What this is **not** doing

- Not changing the default export path. Monolithic stays the default; `--split-cond-decoder` opts in. A follow-up PR can flip the default once Phase 2 lands.
- Not addressing the LM step-loop divergence (C# emits STOP at step 174 vs Python ~206 even though steps 0 and 1 are bit-identical) — instrumentation is in `tests/ChatterboxSmoke/Program.cs` but the investigation is paused on this branch.
- Not yet using `IoBinding` for the LM KV-cache loop. The split-graph work is unblocking here; the LM IoBinding optimization is its own perf story.

## Test plan
- [x] `python scripts/chatterbox_export/test_chatterbox_parity.py --onnx-dir <dir> --tests all` — 7/7 PASS (lm, embed, enc, dec, solve_euler, attention, split_pipeline)
- [x] `dotnet run --project tests/ChatterboxSmoke -- --onnx-dir <split-dir> --voice <wav>` — produces audio acoustically equivalent to monolithic
- [x] Both wav outputs (monolithic and split) have matching rms and duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)