### PR TITLE
LM KV cache via IoBinding: 3.5x LM step speedup

### DIFF
--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -71,15 +71,18 @@ internal static class Program
         string? outPath = "/tmp/chatterbox_out_cs.wav";
         string ep = "cuda";
         string? diagDir = null;
+        bool useIoBinding = true;
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
             {
-                case "--onnx-dir": onnxDir = args[++i]; break;
-                case "--voice":    voicePath = args[++i]; break;
-                case "--out":      outPath = args[++i]; break;
-                case "--ep":       ep = args[++i].ToLowerInvariant(); break;
-                case "--diag":     diagDir = args[++i]; break;
+                case "--onnx-dir":      onnxDir = args[++i]; break;
+                case "--voice":         voicePath = args[++i]; break;
+                case "--out":           outPath = args[++i]; break;
+                case "--ep":            ep = args[++i].ToLowerInvariant(); break;
+                case "--diag":          diagDir = args[++i]; break;
+                case "--io-binding":    useIoBinding = true; break;
+                case "--no-io-binding": useIoBinding = false; break;
                 default:
                     Console.Error.WriteLine($"Unknown arg: {args[i]}");
                     return 2;
@@ -192,123 +195,13 @@ internal static class Program
         var inputsEmbeds = ConcatSeq(condEmb, textEmbTensor, LlmHidden);  // [1, sTotal, 1024]
 
         // ── LM autoregressive loop ────────────────────────────────────────
-        // attention_mask starts at sTotal, grows by 1 per step.
-        // past_kv starts empty (T_past=0), grows by sTotal at step 0 then by 1 per step.
-        // generate_tokens accumulates the sampled speech tokens.
-        var attentionMask = new long[sTotal];
-        Array.Fill(attentionMask, 1);
-        var pastKv = new float[LlmLayers * 2][];          // pairs of (key, value) per layer
-        var pastKvShape = new int[] { 1, LlmKvHeads, 0, LlmHeadDim };
-        for (int k = 0; k < pastKv.Length; k++) pastKv[k] = [];
-
-        var generateTokens = new List<long> { StartSpeechToken };
-        var lmSw = new Stopwatch();
-        lmSw.Start();
-        int actualSteps = 0;
-        for (int step = 0; step < MaxLmSteps; step++)
-        {
-            // Build LM input dict for this step.
-            var inputs = new List<NamedOnnxValue>(2 + 2 * LlmLayers);
-            int seqIn = step == 0 ? sTotal : 1;
-            inputs.Add(NamedOnnxValue.CreateFromTensor("inputs_embeds",
-                new DenseTensor<float>(inputsEmbeds, [1, seqIn, LlmHidden])));
-            inputs.Add(NamedOnnxValue.CreateFromTensor("attention_mask",
-                new DenseTensor<long>(attentionMask, [1, attentionMask.Length])));
-            int tPast = pastKvShape[2];
-            for (int layer = 0; layer < LlmLayers; layer++)
-            {
-                inputs.Add(NamedOnnxValue.CreateFromTensor(
-                    $"past_key_values.{layer}.key",
-                    new DenseTensor<float>(pastKv[2 * layer], pastKvShape)));
-                inputs.Add(NamedOnnxValue.CreateFromTensor(
-                    $"past_key_values.{layer}.value",
-                    new DenseTensor<float>(pastKv[2 * layer + 1], pastKvShape)));
-            }
-
-            using var lmOut = lm.Run(inputs);
-            var outList = lmOut.ToList();
-            var logits = outList[0].AsTensor<float>();  // [1, seqIn, vocab]
-
-            // Slice logits of the LAST position; apply repetition penalty in-place.
-            int vocab = logits.Dimensions[2];
-            var lastLogits = new float[vocab];
-            int logitsOffset = (seqIn - 1) * vocab;
-            // logits is row-major: [1, seqIn, vocab]; copy out the [-1, :] row.
-            var logitsBuf = logits.ToArray();
-            Array.Copy(logitsBuf, logitsOffset, lastLogits, 0, vocab);
-
-            if (diagDir is not null && step <= 1)
-            {
-                // Dump per-step logits + LM-input snapshot so the Python
-                // compare_lm_step{0,1}.py scripts can replay-and-compare for
-                // the LM-divergence investigation. Step 0 isolates the prefill;
-                // step 1 isolates the KV-refeed cycle. Only fires when --diag
-                // is passed; otherwise this branch is dead.
-                Console.WriteLine($"[step{step}] logits[-1, :10] (pre-penalty): "
-                    + string.Join(", ", lastLogits.Take(10).Select(x => x.ToString("F6"))));
-                Console.WriteLine($"[step{step}] logits sum: {lastLogits.Sum():F4}, argmax(pre-penalty): {Argmax(lastLogits)}");
-                File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_logits.bin"),
-                    MemoryMarshal.AsBytes<float>(lastLogits).ToArray());
-                File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_inputs_embeds.bin"),
-                    MemoryMarshal.AsBytes<float>(inputsEmbeds).ToArray());
-                File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_attention_mask.bin"),
-                    MemoryMarshal.AsBytes<long>(attentionMask).ToArray());
-                if (step == 1)
-                {
-                    // Dump the first KV layer so we can verify the KV-refeed
-                    // roundtrip didn't corrupt anything.
-                    File.WriteAllBytes(Path.Combine(diagDir, "cs_step1_past_kv_l0_key.bin"),
-                        MemoryMarshal.AsBytes<float>(pastKv[0]).ToArray());
-                    File.WriteAllBytes(Path.Combine(diagDir, "cs_step1_past_kv_l0_value.bin"),
-                        MemoryMarshal.AsBytes<float>(pastKv[1]).ToArray());
-                    Console.WriteLine($"[step1] past_kv shape={ShapeStr(pastKvShape)}  "
-                        + $"l0_key sum={pastKv[0].Sum():F4}  l0_value sum={pastKv[1].Sum():F4}");
-                }
-            }
-
-            foreach (var t in generateTokens)
-            {
-                if (lastLogits[t] > 0) lastLogits[t] /= RepetitionPenalty;
-            }
-            long nextToken = Argmax(lastLogits);
-            generateTokens.Add(nextToken);
-            if (nextToken == StopSpeechToken) { actualSteps = step + 1; break; }
-
-            // Stash present_kv into past_kv for next iter. The output shape's
-            // T grows by seqIn each step (sTotal on step 0, then 1).
-            // TODO(perf): IoBinding to keep KV GPU-resident. The .AsTensor<float>().ToArray()
-            // pair below copies GPU→CPU→GPU 60 times per step (30 layers × {key,value}),
-            // dominating the ~32 ms/step. WhisperTurbo.cs:601-624 is the template — it
-            // binds present.{layer}.* outputs to CUDA memory and chains them as the next
-            // step's past_key_values inputs via OrtValue, eliminating the host round-trip.
-            int tPresent = tPast + seqIn;
-            pastKvShape = [1, LlmKvHeads, tPresent, LlmHeadDim];
-            for (int layer = 0; layer < LlmLayers; layer++)
-            {
-                pastKv[2 * layer]     = outList[1 + 2 * layer].AsTensor<float>().ToArray();
-                pastKv[2 * layer + 1] = outList[2 + 2 * layer].AsTensor<float>().ToArray();
-            }
-
-            // Re-embed the new token at position (step + 1).
-            var nextIdT = new DenseTensor<long>(new long[] { nextToken }, [1, 1]);
-            var nextPosT = new DenseTensor<long>(new long[] { (long)(step + 1) }, [1, 1]);
-            var nextExagT = new DenseTensor<float>(new float[] { Exaggeration }, [1]);
-            using var nextEmbOut = emb.Run([
-                NamedOnnxValue.CreateFromTensor("input_ids", nextIdT),
-                NamedOnnxValue.CreateFromTensor("position_ids", nextPosT),
-                NamedOnnxValue.CreateFromTensor("exaggeration", nextExagT),
-            ]);
-            inputsEmbeds = nextEmbOut.First().AsTensor<float>().ToArray();
-
-            // Grow attention_mask by 1.
-            var grown = new long[attentionMask.Length + 1];
-            Array.Copy(attentionMask, grown, attentionMask.Length);
-            grown[^1] = 1;
-            attentionMask = grown;
-            actualSteps = step + 1;
-        }
+        var lmSw = Stopwatch.StartNew();
+        var (generateTokens, actualSteps) = useIoBinding
+            ? RunLmLoopIoBinding(lm, emb, inputsEmbeds, sTotal, diagDir)
+            : RunLmLoopBasic(lm, emb, inputsEmbeds, sTotal, diagDir);
         lmSw.Stop();
-        Console.WriteLine($"LM: {actualSteps} steps, generated {generateTokens.Count - 1} tokens (incl. STOP/no-STOP)  [{lmSw.ElapsedMilliseconds} ms, {lmSw.ElapsedMilliseconds / (double)actualSteps:F1} ms/step]");
+        Console.WriteLine($"LM ({(useIoBinding ? "io-binding" : "basic")}): {actualSteps} steps, generated {generateTokens.Count - 1} tokens "
+            + $"[{lmSw.ElapsedMilliseconds} ms, {lmSw.ElapsedMilliseconds / (double)actualSteps:F1} ms/step]");
 
         if (diagDir is not null)
         {
@@ -367,6 +260,264 @@ internal static class Program
         totalSw.Stop();
         Console.WriteLine($"Wrote {outPath}  [total {totalSw.ElapsedMilliseconds / 1000.0:F1}s]");
         return 0;
+    }
+
+    /// <summary>
+    /// LM autoregressive loop, basic Run path. Each step builds 60
+    /// NamedOnnxValue inputs (30 layers × {key,value}) from CPU-resident
+    /// past_kv arrays, runs the session, copies all 60 KV outputs back
+    /// to CPU via .AsTensor&lt;float&gt;().ToArray(). On a 3090, ~32 ms/step
+    /// dominated by the host roundtrip. Kept for A/B comparison vs the
+    /// IoBinding version below.
+    /// </summary>
+    private static (List<long> tokens, int steps) RunLmLoopBasic(
+        InferenceSession lm, InferenceSession emb,
+        float[] inputsEmbeds, int sTotal, string? diagDir)
+    {
+        var attentionMask = new long[sTotal];
+        Array.Fill(attentionMask, 1);
+        var pastKv = new float[LlmLayers * 2][];
+        var pastKvShape = new int[] { 1, LlmKvHeads, 0, LlmHeadDim };
+        for (int k = 0; k < pastKv.Length; k++) pastKv[k] = [];
+
+        var generateTokens = new List<long> { StartSpeechToken };
+        int actualSteps = 0;
+        for (int step = 0; step < MaxLmSteps; step++)
+        {
+            var inputs = new List<NamedOnnxValue>(2 + 2 * LlmLayers);
+            int seqIn = step == 0 ? sTotal : 1;
+            inputs.Add(NamedOnnxValue.CreateFromTensor("inputs_embeds",
+                new DenseTensor<float>(inputsEmbeds, [1, seqIn, LlmHidden])));
+            inputs.Add(NamedOnnxValue.CreateFromTensor("attention_mask",
+                new DenseTensor<long>(attentionMask, [1, attentionMask.Length])));
+            int tPast = pastKvShape[2];
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                inputs.Add(NamedOnnxValue.CreateFromTensor($"past_key_values.{layer}.key",
+                    new DenseTensor<float>(pastKv[2 * layer], pastKvShape)));
+                inputs.Add(NamedOnnxValue.CreateFromTensor($"past_key_values.{layer}.value",
+                    new DenseTensor<float>(pastKv[2 * layer + 1], pastKvShape)));
+            }
+
+            using var lmOut = lm.Run(inputs);
+            var outList = lmOut.ToList();
+            var logits = outList[0].AsTensor<float>();
+            int vocab = logits.Dimensions[2];
+            var lastLogits = new float[vocab];
+            int logitsOffset = (seqIn - 1) * vocab;
+            var logitsBuf = logits.ToArray();
+            Array.Copy(logitsBuf, logitsOffset, lastLogits, 0, vocab);
+
+            MaybeDumpStep(diagDir, step, lastLogits, inputsEmbeds, attentionMask,
+                          pastKv, pastKvShape);
+
+            foreach (var t in generateTokens)
+                if (lastLogits[t] > 0) lastLogits[t] /= RepetitionPenalty;
+            long nextToken = Argmax(lastLogits);
+            generateTokens.Add(nextToken);
+            if (nextToken == StopSpeechToken) { actualSteps = step + 1; break; }
+
+            int tPresent = tPast + seqIn;
+            pastKvShape = [1, LlmKvHeads, tPresent, LlmHeadDim];
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                pastKv[2 * layer]     = outList[1 + 2 * layer].AsTensor<float>().ToArray();
+                pastKv[2 * layer + 1] = outList[2 + 2 * layer].AsTensor<float>().ToArray();
+            }
+
+            var nextIdT = new DenseTensor<long>(new long[] { nextToken }, [1, 1]);
+            var nextPosT = new DenseTensor<long>(new long[] { (long)(step + 1) }, [1, 1]);
+            var nextExagT = new DenseTensor<float>(new float[] { Exaggeration }, [1]);
+            using var nextEmbOut = emb.Run([
+                NamedOnnxValue.CreateFromTensor("input_ids", nextIdT),
+                NamedOnnxValue.CreateFromTensor("position_ids", nextPosT),
+                NamedOnnxValue.CreateFromTensor("exaggeration", nextExagT),
+            ]);
+            inputsEmbeds = nextEmbOut.First().AsTensor<float>().ToArray();
+
+            var grown = new long[attentionMask.Length + 1];
+            Array.Copy(attentionMask, grown, attentionMask.Length);
+            grown[^1] = 1;
+            attentionMask = grown;
+            actualSteps = step + 1;
+        }
+        return (generateTokens, actualSteps);
+    }
+
+    /// <summary>
+    /// LM autoregressive loop, IoBinding path. KV cache stays GPU-resident
+    /// across steps — each step's `present.{layer}.{key,value}` outputs are
+    /// bound to CUDA memory, then the NEXT step's `past_key_values.{layer}.*`
+    /// inputs reference those same OrtValues directly. Logits are bound to
+    /// CPU memory so we can do argmax + rep-penalty on host. Embeds stay on
+    /// host (small, cheap to copy per step). Pattern is adapted from
+    /// WhisperTurbo.cs::TranscribeBatch's step loop.
+    /// </summary>
+    private static (List<long> tokens, int steps) RunLmLoopIoBinding(
+        InferenceSession lm, InferenceSession emb,
+        float[] inputsEmbeds, int sTotal, string? diagDir)
+    {
+        using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var cpuMemInfo  = new OrtMemoryInfo("Cpu",  OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var runOpts     = new RunOptions();
+
+        var attentionMask = new long[sTotal];
+        Array.Fill(attentionMask, 1);
+        var generateTokens = new List<long> { StartSpeechToken };
+
+        // Prefill (step 0): empty past_kv. The empty OrtValues live for the
+        // lifetime of the prefill binding only (we replace them with prefill
+        // outputs on step 1).
+        var emptyPastValues = new List<OrtValue>(LlmLayers * 2);
+        for (int i = 0; i < LlmLayers * 2; i++)
+            emptyPastValues.Add(OrtValue.CreateTensorValueFromMemory(
+                Array.Empty<float>(), [1L, LlmKvHeads, 0L, LlmHeadDim]));
+
+        IDisposableReadOnlyCollection<OrtValue> prefillOutputs;
+        {
+            using var prefillEmbeds = OrtValue.CreateTensorValueFromMemory(
+                inputsEmbeds, [1L, sTotal, LlmHidden]);
+            using var prefillMask = OrtValue.CreateTensorValueFromMemory(
+                attentionMask, [1L, sTotal]);
+            using var binding = lm.CreateIoBinding();
+            binding.BindInput("inputs_embeds", prefillEmbeds);
+            binding.BindInput("attention_mask", prefillMask);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                binding.BindInput($"past_key_values.{layer}.key",   emptyPastValues[2 * layer]);
+                binding.BindInput($"past_key_values.{layer}.value", emptyPastValues[2 * layer + 1]);
+            }
+            binding.BindOutputToDevice("logits", cpuMemInfo);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                binding.BindOutputToDevice($"present.{layer}.key",   cudaMemInfo);
+                binding.BindOutputToDevice($"present.{layer}.value", cudaMemInfo);
+            }
+            lm.RunWithBinding(runOpts, binding);
+            prefillOutputs = binding.GetOutputValues();
+        }
+        foreach (var v in emptyPastValues) v.Dispose();
+
+        // First argmax: prefill logits has shape [1, sTotal, vocab]; we want the [-1, :] row.
+        var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+        int vocab = prefillLogitsSpan.Length / sTotal;
+        var lastLogits = prefillLogitsSpan.Slice((sTotal - 1) * vocab, vocab).ToArray();
+        MaybeDumpStep(diagDir, 0, lastLogits, inputsEmbeds, attentionMask, null, null);
+        foreach (var t in generateTokens)
+            if (lastLogits[t] > 0) lastLogits[t] /= RepetitionPenalty;
+        long nextToken = Argmax(lastLogits);
+        generateTokens.Add(nextToken);
+        if (nextToken == StopSpeechToken)
+        {
+            prefillOutputs.Dispose();
+            return (generateTokens, 1);
+        }
+
+        // Embed the new token (CPU output).
+        inputsEmbeds = EmbedOne(emb, nextToken, 1);
+        attentionMask = Grow(attentionMask, 1);
+
+        // Step loop. prevStep[1..60] = present_kv (CUDA), prevStep[0] = logits (CPU).
+        IDisposableReadOnlyCollection<OrtValue> prevStep = prefillOutputs;
+        int actualSteps = 1;
+        for (int step = 1; step < MaxLmSteps; step++)
+        {
+            using var stepEmbeds = OrtValue.CreateTensorValueFromMemory(
+                inputsEmbeds, [1L, 1L, LlmHidden]);
+            using var stepMask = OrtValue.CreateTensorValueFromMemory(
+                attentionMask, [1L, attentionMask.Length]);
+            using var binding = lm.CreateIoBinding();
+            binding.BindInput("inputs_embeds", stepEmbeds);
+            binding.BindInput("attention_mask", stepMask);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                // Chain prev step's CUDA-resident KV directly — no host roundtrip.
+                binding.BindInput($"past_key_values.{layer}.key",   prevStep[1 + 2 * layer]);
+                binding.BindInput($"past_key_values.{layer}.value", prevStep[1 + 2 * layer + 1]);
+            }
+            binding.BindOutputToDevice("logits", cpuMemInfo);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                binding.BindOutputToDevice($"present.{layer}.key",   cudaMemInfo);
+                binding.BindOutputToDevice($"present.{layer}.value", cudaMemInfo);
+            }
+            lm.RunWithBinding(runOpts, binding);
+            var curStep = binding.GetOutputValues();
+
+            // prevStep's OrtValues are no longer referenced; safe to dispose.
+            prevStep.Dispose();
+            prevStep = curStep;
+
+            // Argmax on step logits ([1, 1, vocab]).
+            var stepLogitsSpan = curStep[0].GetTensorDataAsSpan<float>();
+            lastLogits = stepLogitsSpan.Slice(0, vocab).ToArray();
+            MaybeDumpStep(diagDir, step, lastLogits, inputsEmbeds, attentionMask, null, null);
+            foreach (var t in generateTokens)
+                if (lastLogits[t] > 0) lastLogits[t] /= RepetitionPenalty;
+            nextToken = Argmax(lastLogits);
+            generateTokens.Add(nextToken);
+            if (nextToken == StopSpeechToken) { actualSteps = step + 1; break; }
+
+            inputsEmbeds = EmbedOne(emb, nextToken, step + 1);
+            attentionMask = Grow(attentionMask, 1);
+            actualSteps = step + 1;
+        }
+        prevStep.Dispose();
+        return (generateTokens, actualSteps);
+    }
+
+    /// <summary>Run embed_tokens.onnx for a single token at the given position. CPU output.</summary>
+    private static float[] EmbedOne(InferenceSession emb, long token, int position)
+    {
+        var idT  = new DenseTensor<long>(new long[] { token }, [1, 1]);
+        var posT = new DenseTensor<long>(new long[] { (long)position }, [1, 1]);
+        var exT  = new DenseTensor<float>(new float[] { Exaggeration }, [1]);
+        using var o = emb.Run([
+            NamedOnnxValue.CreateFromTensor("input_ids", idT),
+            NamedOnnxValue.CreateFromTensor("position_ids", posT),
+            NamedOnnxValue.CreateFromTensor("exaggeration", exT),
+        ]);
+        return o.First().AsTensor<float>().ToArray();
+    }
+
+    /// <summary>Grow attention_mask by `n` trailing 1s.</summary>
+    private static long[] Grow(long[] mask, int n)
+    {
+        var grown = new long[mask.Length + n];
+        Array.Copy(mask, grown, mask.Length);
+        for (int i = mask.Length; i < grown.Length; i++) grown[i] = 1;
+        return grown;
+    }
+
+    /// <summary>
+    /// Diagnostic dump for LM step 0/1 — shared by both basic and IoBinding
+    /// LM-loop paths. Only fires when diagDir is non-null. The basic path passes
+    /// past_kv (CPU arrays); the IoBinding path passes null since KV lives on
+    /// CUDA and host extraction would defeat the purpose.
+    /// </summary>
+    private static void MaybeDumpStep(string? diagDir, int step,
+        float[] lastLogits, float[] inputsEmbeds, long[] attentionMask,
+        float[][]? pastKv, int[]? pastKvShape)
+    {
+        if (diagDir is null || step > 1) return;
+        Console.WriteLine($"[step{step}] logits[-1, :10] (pre-penalty): "
+            + string.Join(", ", lastLogits.Take(10).Select(x => x.ToString("F6"))));
+        Console.WriteLine($"[step{step}] logits sum: {lastLogits.Sum():F4}, argmax(pre-penalty): {Argmax(lastLogits)}");
+        File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_logits.bin"),
+            MemoryMarshal.AsBytes<float>(lastLogits).ToArray());
+        File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_inputs_embeds.bin"),
+            MemoryMarshal.AsBytes<float>(inputsEmbeds).ToArray());
+        File.WriteAllBytes(Path.Combine(diagDir, $"cs_step{step}_attention_mask.bin"),
+            MemoryMarshal.AsBytes<long>(attentionMask).ToArray());
+        if (step == 1 && pastKv is not null && pastKvShape is not null)
+        {
+            File.WriteAllBytes(Path.Combine(diagDir, "cs_step1_past_kv_l0_key.bin"),
+                MemoryMarshal.AsBytes<float>(pastKv[0]).ToArray());
+            File.WriteAllBytes(Path.Combine(diagDir, "cs_step1_past_kv_l0_value.bin"),
+                MemoryMarshal.AsBytes<float>(pastKv[1]).ToArray());
+            Console.WriteLine($"[step1] past_kv shape={ShapeStr(pastKvShape)}  "
+                + $"l0_key sum={pastKv[0].Sum():F4}  l0_value sum={pastKv[1].Sum():F4}");
+        }
     }
 
     /// <summary>

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -93,6 +93,12 @@ internal static class Program
             diagDir = ExpandHome(diagDir);
             Directory.CreateDirectory(diagDir);
             Console.WriteLine($"[diag] dumping LM step-0/step-1 + token sequence to {diagDir}");
+            if (useIoBinding)
+            {
+                Console.WriteLine("[diag] --io-binding is on: past_kv at step 1 is GPU-resident "
+                    + "and will NOT be dumped (extracting would defeat IoBinding). "
+                    + "Use --no-io-binding for full past_kv diag artifacts.");
+            }
         }
         if (onnxDir is null || voicePath is null || outPath is null)
         {
@@ -399,8 +405,11 @@ internal static class Program
         foreach (var v in emptyPastValues) v.Dispose();
 
         // First argmax: prefill logits has shape [1, sTotal, vocab]; we want the [-1, :] row.
+        // Read vocab from tensor metadata directly (robust against future batch>1
+        // changes that would silently miscompute as `batch_size * vocab` if derived
+        // from span length).
+        int vocab = (int)prefillOutputs[0].GetTensorTypeAndShape().Shape[2];
         var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
-        int vocab = prefillLogitsSpan.Length / sTotal;
         var lastLogits = prefillLogitsSpan.Slice((sTotal - 1) * vocab, vocab).ToArray();
         MaybeDumpStep(diagDir, 0, lastLogits, inputsEmbeds, attentionMask, null, null);
         foreach (var t in generateTokens)
@@ -444,7 +453,11 @@ internal static class Program
             lm.RunWithBinding(runOpts, binding);
             var curStep = binding.GetOutputValues();
 
-            // prevStep's OrtValues are no longer referenced; safe to dispose.
+            // Safe to dispose prevStep here even though `binding` (which holds
+            // BindInput references to prevStep's OrtValues) is still alive:
+            // RunWithBinding has completed and ORT only reads the input
+            // OrtValues during the Run call, not afterward. Same pattern as
+            // WhisperTurbo.cs::TranscribeBatch — established in this codebase.
             prevStep.Dispose();
             prevStep = curStep;
 

--- a/tests/ChatterboxSmoke/README.md
+++ b/tests/ChatterboxSmoke/README.md
@@ -41,12 +41,20 @@ Tested on RTX 3090, ORT 1.24.4, warm pre-optimization caches:
 
 | Path | Total | Session load | LM (174 steps) | CFM (10 steps) | mel2wav |
 |---|---|---|---|---|---|
-| Monolithic (1 cond decoder onnx) | ~180s | ~175s | 5.6s | (inside dec) | (inside dec) |
-| Split (3 cond decoder graphs)    | **12s** | **3.3s** | 5.6s | 0.5s | 0.24s |
+| Monolithic (1 cond decoder onnx, basic Run)   | ~180s | ~175s | 5.6s | (inside dec) | (inside dec) |
+| Split (3 cond decoder graphs, basic Run)      | 10.0s | 3.2s  | 5.4s | 0.5s | 0.23s |
+| Split + `--io-binding` (default)              | **6.1s** | **3.1s** | **1.5s** | 0.5s | 0.23s |
 
 The 50× session-load speedup comes from `cfm_estimator.onnx` containing
 ONE Euler-step forward (3K nodes) instead of the 10× unrolled estimator
 (70K nodes in the monolithic). Same math; the loop is just in C# now.
+
+The 3.5× LM speedup (`--io-binding`) comes from chaining the LM's KV-cache
+outputs as the next step's inputs via `OrtValue` references instead of
+copying GPU→CPU→GPU each step. Pattern adapted from
+`WhisperTurbo.cs::TranscribeBatch`. Toggle off with `--no-io-binding` if
+you want to A/B (both paths produce bit-identical token sequences;
+verified per-step logits match to max_abs=0).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Reworks the LM step loop in ChatterboxSmoke to use ORT `IoBinding`, keeping the KV cache GPU-resident across steps instead of round-tripping 60 tensors GPU→CPU→GPU per step.
- **LM ms/step: 30.8 → 8.8 (3.5×)**, **e2e: 10.0s → 6.1s (1.6×)** on top of the Phase 1 cond-decoder split that just merged in #50.
- Verified bit-identical token output vs the basic Run path (step 0 + step 1 logits match max_abs=0, full 175-token sequence diff = 0 positions).
- Was flagged as the next-biggest perf gap in the #50 review (TODO comment at the KV copy hotspot pointing at `WhisperTurbo.cs:601-624` as the template).

## Numbers

RTX 3090, ORT 1.24.4, warm pre-optimization cache, same VCTK_p303 reference voice + Ezreal sentence:

| Path | LM 174 steps | ms/step | Total e2e |
|---|---|---|---|
| Basic (NamedOnnxValue + .ToArray() per step) | 5353 ms | 30.8 | 10.0s |
| **IoBinding** (KV chained as OrtValue refs) | **1533 ms** | **8.8** | **6.1s** |
| **Speedup** | **3.5×** | **3.5×** | **1.6×** |

Cumulative wins on this branch + Phase 1:
- C# end-to-end **180s → 6.1s** (~30× total speedup over the pre-perf-work baseline).

## What's in here

Single file changed — `tests/ChatterboxSmoke/Program.cs`:

- `RunLmLoopBasic`: extracted from inline main(). Existing CPU-resident path. Kept as fallback and for A/B regression-guarding via `--no-io-binding`.
- `RunLmLoopIoBinding`: new. Pattern adapted from `WhisperTurbo.cs::TranscribeBatch`:
  - Prefill: bind 60 empty past_kv as inputs, bind logits→CPU and present_kv→CUDA outputs, `RunWithBinding`, capture `GetOutputValues()`.
  - Step N: bind prev step's present_kv OrtValues directly as past_key_values inputs (zero copies). Same output bindings. Dispose prev after current binding is constructed.
  - Logits stay on CPU so argmax + rep-penalty work on host.
- `--io-binding | --no-io-binding` CLI flag, default on.
- Small DRY helpers: `EmbedOne` (per-step embed_tokens), `Grow` (attention_mask), `MaybeDumpStep` (shared diag dump across both paths).
- README updated with the new perf table.

## What this is **not**

- Not changing any Python export code. The graph contract is identical.
- Not changing `OrtSessionBuilder` or any reusable infra. This is entirely localized to ChatterboxSmoke; lifting the pattern into `Chatterbox.Base` is a follow-up when we factor the smoke test into a library.
- Not yet applying IoBinding to the cond_decoder pipeline (flow_encoder + cfm_estimator × 10 + mel2wav). The CFM loop's per-step compute is small enough that IoBinding wins less there; mel2wav and flow_encoder are one-shot. Could revisit if needed.

## Test plan
- [x] `--no-io-binding` vs `--io-binding`: token sequences identical (175 tokens, 0 diverging positions)
- [x] Per-step logits at step 0 and step 1 bit-identical (max_abs = 0)
- [x] Two consecutive `--io-binding` runs differ only by inherent ORT CUDA non-determinism in the cond decoder pipeline (~7e-2 max_abs, cosine 0.9999) — same magnitude as basic-vs-io diff, confirming IoBinding adds no new variance
- [x] Audio output cosine 0.9999 vs basic path; rms 0.2265 vs 0.2266 (essentially identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)