### PR TITLE
Document voice-prompt resampler difference (closes #53)

### DIFF
--- a/tests/ChatterboxSmoke/README.md
+++ b/tests/ChatterboxSmoke/README.md
@@ -95,21 +95,6 @@ Flags:
   the Python reference).
 - The full pipeline runs end-to-end without any Python in the loop.
 
-### Voice-prompt resampling note (cross-implementation parity)
-
-C# uses NAudio's `WdlResamplingSampleProvider` to convert audio to 24 kHz;
-Python's `listen_test.py` uses `librosa.load(..., sr=24000)` which goes
-through librosa's kaiser_best resampler. The two resamplers produce
-*different* 24 kHz samples from the same 16 kHz input, which yields
-different speaker embeddings → different LM token sequences (without
-changing perceived audio quality).
-
-For reproducibility / cross-implementation regression testing, pre-resample
-the voice prompt to 24 kHz once (any standard tool — librosa, ffmpeg, sox)
-and feed the 24 kHz file to both pipelines. They'll then agree to within
-ORT cross-version drift (1 token in our testing). See issue #53 for the
-investigation.
-
 **Doesn't prove:**
 - Text tokenization. We hardcode the same `InputIds` array the Python
   listen test uses. A real CLI needs an in-process text→tokens pipeline.
@@ -125,6 +110,21 @@ investigation.
   `WhisperTurbo.cs::TranscribeBatch`) is the optimization path.
 - Forced alignment. The eventual app needs word-level timestamps for
   highlighting; that's a separate pass via the ASR aligner.
+
+## Cross-implementation parity: voice-prompt resampling
+
+C# uses NAudio's `WdlResamplingSampleProvider` to convert audio to 24 kHz;
+Python's `listen_test.py` uses `librosa.load(..., sr=24000)` which goes
+through librosa's kaiser_best resampler. The two resamplers produce
+*different* 24 kHz samples from the same 16 kHz input, which yields
+different speaker embeddings → different LM token sequences (without
+changing perceived audio quality).
+
+For reproducibility / cross-implementation regression testing, pre-resample
+the voice prompt to 24 kHz once (any standard tool — librosa, ffmpeg, sox)
+and feed the 24 kHz file to both pipelines. They'll then agree to within
+ORT cross-version drift (1 token for the Ezreal sentence in our testing;
+your inputs may vary). See issue #53 for the full investigation.
 
 ## Next steps (in `chatterbox.scratch.md` order)
 

--- a/tests/ChatterboxSmoke/README.md
+++ b/tests/ChatterboxSmoke/README.md
@@ -95,6 +95,21 @@ Flags:
   the Python reference).
 - The full pipeline runs end-to-end without any Python in the loop.
 
+### Voice-prompt resampling note (cross-implementation parity)
+
+C# uses NAudio's `WdlResamplingSampleProvider` to convert audio to 24 kHz;
+Python's `listen_test.py` uses `librosa.load(..., sr=24000)` which goes
+through librosa's kaiser_best resampler. The two resamplers produce
+*different* 24 kHz samples from the same 16 kHz input, which yields
+different speaker embeddings → different LM token sequences (without
+changing perceived audio quality).
+
+For reproducibility / cross-implementation regression testing, pre-resample
+the voice prompt to 24 kHz once (any standard tool — librosa, ffmpeg, sox)
+and feed the 24 kHz file to both pipelines. They'll then agree to within
+ORT cross-version drift (1 token in our testing). See issue #53 for the
+investigation.
+
 **Doesn't prove:**
 - Text tokenization. We hardcode the same `InputIds` array the Python
   listen test uses. A real CLI needs an in-process text→tokens pipeline.


### PR DESCRIPTION
## Summary

One-paragraph addition to `tests/ChatterboxSmoke/README.md` explaining that C# (NAudio's `WdlResamplingSampleProvider`) and Python listen_test (`librosa.load(..., sr=24000)` = kaiser_best) use different audio resamplers, producing different 24 kHz samples from the same 16 kHz input — which yields different speaker embeddings, which diverges the LM token sequence.

For cross-implementation regression testing, pre-resample audio to 24 kHz once and feed the 24 kHz file to both pipelines.

## Investigation chain (closes #53)

The full diagnostic walk is in issue #53. Short version:

1. Ruled out cache via `VERNACULA_ORT_NO_CACHE=1` (still 174 steps)
2. Verified Python is deterministic across runs (always 206 steps)
3. Wrote a Python lockstep replay using C#'s saved step-0 inputs → produces **identical** 175-token sequence to C# (proves LM itself isn't divergent)
4. Diffed Python listen_test's LM step-0 inputs vs C#'s:
   - `text_emb` (from embed_tokens): max_abs = 0 (bit-identical)
   - `cond_emb` (from speech_encoder): max_abs = 1.46 (large divergence)
5. Traced cond_emb divergence to the audio resampler
6. Confirmed by pre-resampling VCTK_p303 to 24 kHz once: gap closed from 32 steps to 1 step

The remaining 1-step difference is genuine ORT 1.23-vs-1.24 cross-version drift — the noise floor we can't reduce without aligning versions.

## Not fixing

NAudio's resampler is production-quality for voice cloning. The numerical difference from librosa doesn't degrade perceived audio quality — both implementations produce intelligible voice-cloned output. Implementing a librosa-equivalent resampler in C# is high-effort, low-value.

## Test plan
- [x] Verified gap closes with pre-resampled audio: 174 → 207 vs 206
- [x] README note clear and actionable for future readers
- [x] Issue #53 closed with full investigation summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)