### PR TITLE
Real fix for #56: layered .onnx → .ort → sentinel cache

### DIFF
--- a/docs/ort_loop_cache_investigation.md
+++ b/docs/ort_loop_cache_investigation.md
@@ -1,0 +1,121 @@
+# ORT optimization-cache round-trip for Loop-bearing graphs (issue #56)
+
+Background: `conditional_decoder_loop.onnx` (Phase 2 merged graph) can be
+written via `OptimizedModelFilePath` but ORT can't load the result back —
+body-scope initializers appear duplicated in the outer namespace,
+triggering "initializer name is not unique". PR #58 shipped a defensive
+sentinel workaround that stops the disk churn but leaves the merged
+graph paying ~2 s of optimization on every load.
+
+This investigation tries the two untested approaches from issue #56's
+"Possible fixes" list:
+- (2) Lower opt level on the WRITE pass — does `ORT_ENABLE_EXTENDED` (or
+  lower) skip whichever optimization pass causes the body→outer
+  initializer duplication?
+- (3) ORT's binary `.ort` format — does its serializer encode subgraphs
+  differently than the `.onnx` path?
+
+If either works we ship it; if neither does, we document and the
+sentinel stays.
+
+## Run 1 — 2026-05-16 18:07 — Probe matrix: format × opt level
+
+Built a small Python harness (`/tmp/probe_ort_loop_cache.py`) that for
+each `GraphOptimizationLevel` × file format tries `InferenceSession`
+with `OptimizedModelFilePath`, then attempts to reload the written
+file with `ORT_DISABLE_ALL`. Run against ORT 1.23.2 on the merged
+graph (`/tmp/cb_dyn5/conditional_decoder_loop.onnx`).
+
+| level             | `.onnx` reload | `.ort` reload |
+|---|---|---|
+| `DISABLE_ALL`     | RELOAD-FAIL    | **OK** (1.4 s) |
+| `ENABLE_BASIC`    | RELOAD-FAIL    | **OK** (1.3 s) |
+| `ENABLE_EXTENDED` | RELOAD-FAIL    | **OK** (1.2 s) |
+| `ENABLE_ALL`      | RELOAD-FAIL    | **OK** (1.2 s) |
+
+Two findings:
+
+1. **Opt level doesn't matter.** Even `DISABLE_ALL` produces an
+   unreadable `.onnx` — so the bug is in the writer itself, not a
+   specific optimization pass that's hoisting body initializers
+   incorrectly. (This rules out workaround #2 from issue #56 entirely.)
+2. **`.ort` round-trips at every level.** The binary serializer is a
+   different code path in ORT that doesn't share the bug. Reload comes
+   back in ~1.2 s — well under the ~2.1 s we currently pay for cold
+   re-optimization on every load. (Workaround #3 wins.)
+
+Bonus side observation: ORT spits hundreds of `Duplicate initializer
+'const_transpose_optimizer_token_NN'` warnings while loading the source
+graph. These names are *created by ORT's transpose optimizer pass* —
+their `const_transpose_optimizer_` prefix is internal ORT naming. I
+counted initializer name duplicates in every sub-graph and in the
+merged file at every scope (outer + body subgraph) — **zero
+duplicates anywhere in the files we produce**. The duplicates are
+purely ORT's optimization-pass output naming itself. They're also not
+the round-trip cause: the failure happens at `DISABLE_ALL` where the
+transpose optimizer never runs. Cosmetic noise.
+
+**Implication:** there is no merge-script change that would help —
+the bug lives entirely in ORT's `.onnx` Loop-subgraph serializer.
+
+## Run 2 — 2026-05-16 18:24 — First implementation: always `.ort`
+
+Trivial change to `OrtSessionBuilder`: extension `.onnx` → `.ort`,
+add `session.save_model_format = "ORT"` config entry. Wiped cache,
+ran cold then warm.
+
+| graph | old `.onnx` HIT | new `.ort` HIT | delta |
+|---|---|---|---|
+| speech_encoder | 1129 ms | 1872 ms | +743 ms |
+| embed_tokens | 32 ms | 50 ms | +18 ms |
+| language_model | 875 ms | 2275 ms | **+1400 ms** |
+| conditional_decoder_loop | 2098 ms (miss) | 1626 ms (HIT) | −472 ms |
+| **total** | **4134 ms** | **5823 ms** | **+1689 ms (NET LOSS)** |
+
+Re-ran for run 3 — same numbers, so it's not page-cache warmup.
+The `.ort` format embeds all initializers inline (no `_data`
+sidecar), which means ORT can't lazy-load / mmap weights from disk
+on demand the way it does with `.onnx` external-data sidecars. For
+the 2 GB LM graph that's the difference between 875 ms and 2275 ms.
+
+**Verdict: always-`.ort` is the wrong design.** Need per-graph format
+selection — use `.onnx` where it works, `.ort` only as a fallback.
+
+## Run 3 — 2026-05-16 18:28 — Layered cache: `.onnx` → `.ort` → sentinel
+
+Restructured `CreateCachedSession` as a 3-state machine per cache key:
+
+1. `.onnx` (primary). Default for every graph.
+2. `.ort` (fallback, marked by a `.use-ort` hint file). Selected after
+   a `.onnx` round-trip failure.
+3. No cache (last resort, marked by a `.cache-disabled` sentinel).
+   Selected after a `.ort` round-trip failure. Untested by any real
+   graph but the path exists as defense-in-depth.
+
+Convergence:
+- Run 1 (cold): write `.onnx` for all four graphs.
+- Run 2 (warm): 3 graphs HIT on `.onnx`; merged Loop graph hits the
+  catch, escalates — `[cache-format]` log fires, `.onnx` deleted,
+  `.use-ort` hint written, and the fall-through cache-write path
+  emits `.ort` *this same call* (so 2-run convergence, not 3).
+- Run 3+ (warm): all four HIT on their respective formats.
+
+Measured run 3 (steady-state, all-HIT):
+
+| graph | format | HIT time |
+|---|---|---|
+| speech_encoder | .onnx | 1117 ms |
+| embed_tokens | .onnx | 32 ms |
+| language_model | .onnx | 824 ms |
+| conditional_decoder_loop | .ort | 1776 ms |
+| **total** | | **3752 ms** |
+
+vs the PR #58 baseline of 4134 ms (where the merged Loop graph was
+cache=miss at ~2100 ms every run): **382 ms saved per warm load**,
+all four graphs genuinely cached.
+
+**Verdict: shipping.** The layered design keeps fast `.onnx` lazy-load
+for normal graphs and uses `.ort` only where it has to. The sentinel
+infrastructure built in PR #58 is still there as a third tier; it
+has not been observed to trigger and probably never will for our
+current graphs, but it's cheap defense-in-depth.

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -98,27 +98,45 @@ public static class OrtSessionBuilder
     /// Create an <see cref="InferenceSession"/> backed by a disk-cached
     /// post-optimization graph. First call loads <paramref name="modelPath"/>,
     /// runs graph optimization at <paramref name="optLevel"/>, and writes the
-    /// optimized graph next to the source as <c>{stem}.opt.{ep}.{ortver}.onnx</c>
-    /// (with a <c>.opt_data</c> sidecar for tensors above
-    /// <paramref name="externalInitializersMinBytes"/>). Subsequent calls find
-    /// the cached file, skip optimization (<c>ORT_DISABLE_ALL</c>), and load
-    /// directly — typically 5–10× faster for large graphs.
+    /// optimized graph next to the source. Subsequent calls find the cached
+    /// file, skip optimization (<c>ORT_DISABLE_ALL</c>), and load directly —
+    /// typically 5–10× faster for large graphs.
     ///
-    /// Cache key embeds EP, ORT version, and source-file mtime+size, so source
-    /// changes or ORT upgrades automatically invalidate. Stale optimized files
-    /// are NOT auto-cleaned — callers can `rm <stem>.opt.*` to reset.
+    /// <b>Layered cache format.</b> Three states per cache key, advanced by
+    /// observed round-trip behavior:
+    /// <list type="number">
+    ///   <item><description><b>.onnx</b> (primary). Fast: ORT can lazy-load
+    ///     weights from a <c>_data</c> external-initializer sidecar. Works
+    ///     for almost every graph.</description></item>
+    ///   <item><description><b>.ort</b> (fallback, marked by a
+    ///     <c>.use-ort</c> hint file). Used when the <c>.onnx</c> writer
+    ///     mishandles the graph — currently any graph containing a Loop
+    ///     subgraph (issue #56 — the <c>.onnx</c> serializer duplicates
+    ///     body-scope initializers into the outer scope). The <c>.ort</c>
+    ///     binary writer encodes subgraphs faithfully and round-trips at
+    ///     every opt level, but embeds all initializers inline so loads
+    ///     are slower for large graphs. Only used when needed.</description></item>
+    ///   <item><description><b>No cache</b> (last resort, marked by a
+    ///     <c>.cache-disabled</c> sentinel). Used when even <c>.ort</c>
+    ///     can't round-trip. Stops the broken write→fail→delete cycle.
+    ///     Has not been observed in practice but the path exists as
+    ///     defense-in-depth.</description></item>
+    /// </list>
+    ///
+    /// Convergence costs one extra cache miss per state transition: a
+    /// Loop-bearing graph takes 2 runs to reach a steady-state cache hit
+    /// (run 1: write .onnx → run 2: .onnx reload fails, escalate to .ort
+    /// hint, write .ort in the same call → run 3+: .ort cache HIT).
+    /// Most graphs stay on the .onnx path forever.
+    ///
+    /// Cache key (in the path stem) embeds EP, ORT version, and source-file
+    /// mtime+size, so source changes or ORT upgrades automatically invalidate
+    /// everything including hints and sentinels. Stale files are NOT
+    /// auto-cleaned — callers can `rm &lt;stem&gt;.opt.*` to reset.
     ///
     /// Set <c>VERNACULA_ORT_NO_CACHE=1</c> to bypass the cache entirely
     /// (forces a fresh full-optimization load every time; useful when debugging
     /// graph-level surprises).
-    ///
-    /// If a cache write+read round-trip fails (issue #56 — ORT can't reload
-    /// optimized graphs that contain Loop subgraphs), the failed cache file
-    /// is deleted and a small sentinel <c>{cachePath}.cache-disabled</c> is
-    /// written next to it. Future calls see the sentinel and skip caching
-    /// entirely (no write, no disk churn, no doomed re-load attempt) until
-    /// the source or ORT version changes — which moves the cache key and
-    /// the sentinel path along with it.
     /// </summary>
     public static InferenceSession CreateCachedSession(
         string modelPath,
@@ -143,32 +161,33 @@ public static class OrtSessionBuilder
             throw new FileNotFoundException($"Model file not found: {modelPath}");
 
         bool bypassCache = Environment.GetEnvironmentVariable("VERNACULA_ORT_NO_CACHE") == "1";
-        string cachePath = bypassCache ? "" : ComputeCachePath(modelPath, ep, optLevel);
-        string cacheDataPath = cachePath + "_data";
-        // Sentinel file written next to the cache when a write/read round-trip
-        // is known to fail for this model (issue #56 — ORT's serialization of
-        // optimized graphs with Loop subgraphs duplicates body-scope
-        // initializers into the outer scope, producing a graph that won't
-        // re-load). When present, we skip caching entirely: no write, no
-        // disk churn (~720 MB per run for the merged Loop graph), no
-        // doomed re-load attempt. The sentinel sits at
-        // cachePath+".cache-disabled", so the same source-mtime+EP+ORT-version
-        // hash that keys the cache also auto-invalidates the sentinel — a
-        // source edit or ORT upgrade will trigger a fresh cache attempt.
-        string cacheDisabledPath = bypassCache ? "" : cachePath + ".cache-disabled";
-        bool cacheDisabledForThisModel = !bypassCache && File.Exists(cacheDisabledPath);
+        string cacheBase = bypassCache ? "" : ComputeCacheBasePath(modelPath, ep, optLevel);
+        // All cache-key-derived paths. The five files form a small state
+        // machine; the per-key disposition is encoded by which marker
+        // (if any) exists alongside the actual cache file(s).
+        string cachePathOnnx = cacheBase + ".onnx";   // primary cache (with _data sidecar)
+        string cacheDataPath = cachePathOnnx + "_data";
+        string cachePathOrt = cacheBase + ".ort";     // fallback for Loop-bearing graphs
+        string useOrtHintPath = cacheBase + ".use-ort";       // ".onnx round-trip failed, escalate to .ort"
+        string cacheDisabledPath = cacheBase + ".cache-disabled"; // "both formats failed, skip caching"
 
-        if (cacheDisabledForThisModel)
+        bool cacheDisabled = !bypassCache && File.Exists(cacheDisabledPath);
+        bool useOrtFormat = !bypassCache && !cacheDisabled && File.Exists(useOrtHintPath);
+
+        if (cacheDisabled)
         {
             // Defensive cleanup: if a previous catch-block's File.Delete
             // silently failed (file locked, EACCES, etc.) we'd be leaking
-            // ~720 MB per affected model. Retry the deletes now that we know
-            // the cache is permanently disabled for this key.
-            try { if (File.Exists(cachePath)) File.Delete(cachePath); } catch { /* best-effort */ }
+            // hundreds of MB per affected model. Retry the deletes now that
+            // we know the cache is permanently disabled for this key.
+            try { if (File.Exists(cachePathOnnx)) File.Delete(cachePathOnnx); } catch { /* best-effort */ }
             try { if (File.Exists(cacheDataPath)) File.Delete(cacheDataPath); } catch { /* best-effort */ }
+            try { if (File.Exists(cachePathOrt))  File.Delete(cachePathOrt);  } catch { /* best-effort */ }
         }
 
-        if (!bypassCache && !cacheDisabledForThisModel && File.Exists(cachePath))
+        string activeCachePath = useOrtFormat ? cachePathOrt : cachePathOnnx;
+
+        if (!bypassCache && !cacheDisabled && File.Exists(activeCachePath))
         {
             // Cache hit: load pre-optimized graph with optimization DISABLED
             // (the graph is already optimized; re-running passes is wasted work
@@ -176,48 +195,72 @@ public static class OrtSessionBuilder
             var hitOpts = Create(ep, GraphOptimizationLevel.ORT_DISABLE_ALL, enableProfiling: false, out _);
             try
             {
-                var session = new InferenceSession(cachePath, hitOpts);
+                var session = new InferenceSession(activeCachePath, hitOpts);
                 cacheHit = true;
                 return session;
             }
             catch
             {
-                // Cache file is corrupt or incompatible — fall through to a
-                // fresh load. Drop the bad file AND write a sentinel so the
-                // next run skips the doomed write+read cycle entirely.
-                // One-time log so the silent transition is visible (every
-                // subsequent run still prints cache=miss; only this catch
-                // marks the point caching was turned off for this key).
-                Console.WriteLine(
-                    $"[cache-disabled] {Path.GetFileName(cachePath)}: " +
-                    "ORT round-trip failed, disabling cache for this model (see issue #56).");
                 hitOpts.Dispose();
-                try { File.Delete(cachePath); } catch { /* best-effort */ }
-                try { File.Delete(cacheDataPath); } catch { /* best-effort */ }
-                try { File.WriteAllText(cacheDisabledPath, ""); } catch { /* best-effort */ }
-                cacheDisabledForThisModel = true;
+                if (useOrtFormat)
+                {
+                    // .ort fallback also can't round-trip. Disable caching
+                    // for this key entirely. Logged once (not per-load) so
+                    // the silent transition is visible.
+                    Console.WriteLine(
+                        $"[cache-disabled] {Path.GetFileName(cachePathOrt)}: " +
+                        ".ort fallback ALSO failed to round-trip; disabling cache for this model (see issue #56).");
+                    try { File.Delete(cachePathOrt); } catch { /* best-effort */ }
+                    try { File.WriteAllText(cacheDisabledPath, ""); } catch { /* best-effort */ }
+                    cacheDisabled = true;
+                }
+                else
+                {
+                    // .onnx round-trip failed; escalate to .ort fallback.
+                    // useOrtFormat=true makes the fall-through cache-write
+                    // path emit .ort this run — so by the end of *this* call
+                    // the .ort file is on disk, and the very next call sees
+                    // a cache HIT instead of having to repeat the cycle.
+                    Console.WriteLine(
+                        $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
+                        ".onnx round-trip failed (likely a Loop-subgraph graph); switching to .ort for this model (see issue #56).");
+                    try { File.Delete(cachePathOnnx); } catch { /* best-effort */ }
+                    try { File.Delete(cacheDataPath); } catch { /* best-effort */ }
+                    try { File.WriteAllText(useOrtHintPath, ""); } catch { /* best-effort */ }
+                    useOrtFormat = true;
+                }
             }
         }
 
         // Cache miss (or bypass, or this-model-disabled): load source,
         // optimize, optionally save the result for next time.
         var opts = Create(ep, optLevel, enableProfiling: false, out _);
-        if (!bypassCache && !cacheDisabledForThisModel)
+        if (!bypassCache && !cacheDisabled)
         {
-            opts.OptimizedModelFilePath = cachePath;
-            // For >2GB graphs, force the optimized weights to an external-data
-            // sidecar; otherwise the serializer hits protobuf's 2GB limit.
-            opts.AddSessionConfigEntry(
-                "session.optimized_model_external_initializers_file_name",
-                Path.GetFileName(cacheDataPath));
-            opts.AddSessionConfigEntry(
-                "session.optimized_model_external_initializers_min_size_in_bytes",
-                externalInitializersMinBytes.ToString());
+            opts.OptimizedModelFilePath = useOrtFormat ? cachePathOrt : cachePathOnnx;
+            if (useOrtFormat)
+            {
+                // .ort embeds all initializers inline; no _data sidecar.
+                opts.AddSessionConfigEntry("session.save_model_format", "ORT");
+            }
+            else
+            {
+                // For >2GB graphs, force the optimized weights to an external-data
+                // sidecar; otherwise the serializer hits protobuf's 2GB limit.
+                opts.AddSessionConfigEntry(
+                    "session.optimized_model_external_initializers_file_name",
+                    Path.GetFileName(cacheDataPath));
+                opts.AddSessionConfigEntry(
+                    "session.optimized_model_external_initializers_min_size_in_bytes",
+                    externalInitializersMinBytes.ToString());
+            }
         }
         return new InferenceSession(modelPath, opts);
     }
 
-    private static string ComputeCachePath(
+    // Returns the cache-key path STEM (no extension). Caller appends
+    // ".onnx" / ".ort" / ".use-ort" / ".cache-disabled" as needed.
+    private static string ComputeCacheBasePath(
         string modelPath, ExecutionProvider ep, GraphOptimizationLevel optLevel)
     {
         var fi = new FileInfo(modelPath);
@@ -236,6 +279,6 @@ public static class OrtSessionBuilder
         var hashHex = Convert.ToHexString(hash).ToLowerInvariant();
         var dir = fi.DirectoryName ?? ".";
         var stem = Path.GetFileNameWithoutExtension(modelPath);
-        return Path.Combine(dir, $"{stem}.opt.{epTag}.{hashHex}.onnx");
+        return Path.Combine(dir, $"{stem}.opt.{epTag}.{hashHex}");
     }
 }


### PR DESCRIPTION
## Summary

PR #58 papered over issue #56 with a sentinel that stops the disk churn. This PR is the real fix: the merged `conditional_decoder_loop.onnx` now actually caches.

Layered state machine per cache key:
1. **`.onnx` primary** — fast lazy-load via `_data` external-initializer sidecars. Default for every graph.
2. **`.ort` fallback** — selected (via a `.use-ort` zero-byte hint file) after a `.onnx` round-trip failure. Slower per load because the binary writer embeds everything inline, but it actually round-trips Loop subgraphs.
3. **No cache** — selected (via `.cache-disabled` sentinel from PR #58) only if `.ort` *also* fails. Untested in practice; defense-in-depth.

Most graphs stay on `.onnx` forever. Loop-bearing graphs converge in 2 runs (cold → write `.onnx` → warm `.onnx` reload fails, escalate to `.ort` in the same call → warm HIT on `.ort` next run).

## Why not always `.ort`?

Tried it (Run 2 in the investigation doc). Net +1.7 s per warm load because `.ort` embeds initializers inline and ORT loses the lazy-load path. The 2 GB language model went 875 ms → 2275 ms. Layering keeps the fast path for graphs that don't need the fallback.

## Investigation log

Full detail in `docs/ort_loop_cache_investigation.md`. Headline findings:
- Probe across all opt levels × {`.onnx`, `.ort`}: `.onnx` writer fails to round-trip Loop subgraphs at *every* opt level (including `DISABLE_ALL`), so the bug is in the serializer itself, not any optimization pass.
- Source merged graph is byte-clean (zero duplicate initializer names at any scope). The `Duplicate initializer 'const_transpose_optimizer_token_NN'` warnings ORT prints are about names ORT itself creates during its transpose-folding pass. They're noise; they're not the round-trip cause.

## Verification

`ChatterboxSmoke` end-to-end (RTX 3090, CUDA EP, ORT 1.24.4):

| graph | PR #58 baseline | this PR |
|---|---|---|
| speech_encoder | 1129 ms HIT | 1117 ms HIT |
| embed_tokens | 32 ms HIT | 32 ms HIT |
| language_model | 875 ms HIT | 824 ms HIT |
| conditional_decoder_loop | 2098 ms MISS | **1776 ms HIT** |
| **total** | **4134 ms** | **3752 ms** |

**382 ms saved per warm load**, and all four graphs now genuinely cache HIT.

## Test plan

- [x] Cold cache: all four sessions write `.onnx`
- [x] First warm: 3 graphs HIT on `.onnx`; merged Loop graph hits the catch, `[cache-format]` log fires, escalates to `.ort` written in the same call
- [x] Second warm: all four cache HIT (3 on `.onnx`, 1 on `.ort`)
- [x] Disk layout: 3 graphs have `{base}.onnx + {base}.onnx_data`; Loop graph has `{base}.ort + {base}.use-ort` (no orphans)
- [ ] `.ort` round-trip failure path (sentinel escalation) — no graph currently triggers it; tested manually by planting bad `.ort` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)