### PR TITLE
Chatterbox.CLI: one-shot synth front-end on Chatterbox.Base

### DIFF
--- a/Vernacula.slnx
+++ b/Vernacula.slnx
@@ -12,6 +12,9 @@
   <Project Path="src/Chatterbox.Base/Chatterbox.Base.csproj">
     <Platform Project="x64" />
   </Project>
+  <Project Path="src/Chatterbox.CLI/Chatterbox.CLI.csproj">
+    <Platform Project="x64" />
+  </Project>
   <Project Path="src/Vernacula.CLI/Vernacula.CLI.csproj">
     <Platform Project="x64" />
   </Project>

--- a/src/Chatterbox.CLI/Chatterbox.CLI.csproj
+++ b/src/Chatterbox.CLI/Chatterbox.CLI.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <Platforms>x64</Platforms>
+    <RootNamespace>Chatterbox.CLI</RootNamespace>
+    <AssemblyName>chatterbox</AssemblyName>
+
+    <!--
+      Select execution provider at build time, matching Vernacula.CLI:
+        dotnet build -c Release -p:EP=Cuda       (default)
+        dotnet build -c Release -p:EP=DirectML
+        dotnet build -c Release -p:EP=Cpu
+    -->
+    <EP Condition="'$(EP)' == ''">Cuda</EP>
+    <DefineConstants Condition="'$(EP)' == 'DirectML'">$(DefineConstants);DIRECTML</DefineConstants>
+    <DefineConstants Condition="'$(EP)' == 'Cpu'">$(DefineConstants);CPU</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EP)' == 'Cuda'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(EP)' == 'DirectML'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.21.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(EP)' == 'Cpu'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NAudio" Version="2.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chatterbox.Base\Chatterbox.Base.csproj">
+      <SetConfiguration>EP=$(EP)</SetConfiguration>
+    </ProjectReference>
+    <ProjectReference Include="..\Vernacula.Base\Vernacula.Base.csproj">
+      <SetConfiguration>EP=$(EP)</SetConfiguration>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/src/Chatterbox.CLI/Program.cs
+++ b/src/Chatterbox.CLI/Program.cs
@@ -12,6 +12,7 @@
 // See README.md for full flag reference.
 
 using System.Diagnostics;
+using System.Globalization;
 using Chatterbox.Base;
 using NAudio.Wave;
 using Vernacula.Base.Models;
@@ -24,48 +25,75 @@ string? outPath       = null;
 string? text          = null;
 string? textFile      = null;
 string? tokenizerJson = null;
-string  ep            = "cuda";
+string  ep            = "auto";
 bool    verbose       = false;
 bool?   useIoBinding  = null;
 float   exaggeration  = ChatterboxConstants.DefaultExaggeration;
 int     maxSteps      = ChatterboxConstants.DefaultMaxLmSteps;
 
-for (int i = 0; i < args.Length; i++)
+// Bounds-checked value reader. Caller passes the flag name so the error
+// mentions which arg was missing its value. Args are parsed via a manual
+// loop because the codebase convention (see Vernacula.CLI) is to avoid
+// the System.CommandLine dependency.
+string Next(string flag, int i)
 {
-    switch (args[i])
+    if (i + 1 >= args.Length)
+        throw new ArgumentException($"{flag} requires a value");
+    return args[i + 1];
+}
+
+try
+{
+    for (int i = 0; i < args.Length; i++)
     {
-        case "--onnx-dir":       onnxDir       = args[++i]; break;
-        case "--voice":          voicePath     = args[++i]; break;
-        case "--out":            outPath       = args[++i]; break;
-        case "--text":           text          = args[++i]; break;
-        case "--text-file":      textFile      = args[++i]; break;
-        case "--tokenizer-json": tokenizerJson = args[++i]; break;
-        case "--ep":             ep            = args[++i].ToLowerInvariant(); break;
-        case "--verbose" or "-v": verbose      = true; break;
-        case "--io-binding":     useIoBinding  = true; break;
-        case "--no-io-binding":  useIoBinding  = false; break;
-        case "--exaggeration":
-            if (!float.TryParse(args[++i], out exaggeration))
-            {
-                Console.Error.WriteLine("--exaggeration expects a float (default 0.5).");
+        switch (args[i])
+        {
+            case "--onnx-dir":       onnxDir       = Next("--onnx-dir", i);       i++; break;
+            case "--voice":          voicePath     = Next("--voice", i);          i++; break;
+            case "--out":            outPath       = Next("--out", i);            i++; break;
+            case "--text":           text          = Next("--text", i);           i++; break;
+            case "--text-file":      textFile      = Next("--text-file", i);      i++; break;
+            case "--tokenizer-json": tokenizerJson = Next("--tokenizer-json", i); i++; break;
+            case "--ep":             ep            = Next("--ep", i).ToLowerInvariant(); i++; break;
+            case "--verbose" or "-v": verbose      = true; break;
+            case "--io-binding":     useIoBinding  = true; break;
+            case "--no-io-binding":  useIoBinding  = false; break;
+            case "--exaggeration":
+                // InvariantCulture: a German-locale machine would otherwise
+                // reject "0.5" and require "0,5" — opposite of what CLI
+                // users will type. Same applies to --max-steps below.
+                if (!float.TryParse(Next("--exaggeration", i),
+                        NumberStyles.Float, CultureInfo.InvariantCulture, out exaggeration))
+                {
+                    Console.Error.WriteLine("--exaggeration expects a float (default 0.5).");
+                    return 2;
+                }
+                i++;
+                break;
+            case "--max-steps":
+                if (!int.TryParse(Next("--max-steps", i),
+                        NumberStyles.Integer, CultureInfo.InvariantCulture, out maxSteps)
+                    || maxSteps < 1)
+                {
+                    Console.Error.WriteLine("--max-steps expects a positive integer (default 256).");
+                    return 2;
+                }
+                i++;
+                break;
+            case "--help" or "-h":
+                PrintUsage();
+                return 0;
+            default:
+                Console.Error.WriteLine($"Unknown arg: {args[i]}");
+                PrintUsage();
                 return 2;
-            }
-            break;
-        case "--max-steps":
-            if (!int.TryParse(args[++i], out maxSteps) || maxSteps < 1)
-            {
-                Console.Error.WriteLine("--max-steps expects a positive integer (default 256).");
-                return 2;
-            }
-            break;
-        case "--help" or "-h":
-            PrintUsage();
-            return 0;
-        default:
-            Console.Error.WriteLine($"Unknown arg: {args[i]}");
-            PrintUsage();
-            return 2;
+        }
     }
+}
+catch (ArgumentException ex)
+{
+    Console.Error.WriteLine(ex.Message);
+    return 2;
 }
 
 // ── Validate ───────────────────────────────────────────────────────────────────
@@ -87,10 +115,22 @@ if (text is not null && textFile is not null)
     Console.Error.WriteLine("--text and --text-file are mutually exclusive.");
     return 2;
 }
-if (ep is not ("cpu" or "cuda"))
+// Map --ep to ExecutionProvider. Distinct from --ep cuda is --ep auto:
+// `cuda` requires the CUDA EP to be available (throws if not); `auto`
+// silently falls back from CUDA to DirectML when CUDA isn't available
+// — the right call on heterogeneous Windows boxes. The csproj also
+// supports DirectML builds (`-p:EP=DirectML`); `--ep directml` makes
+// that wiring reachable at runtime.
+ExecutionProvider epEnum;
+switch (ep)
 {
-    Console.Error.WriteLine($"Unknown EP: {ep}. Choose cpu or cuda.");
-    return 2;
+    case "auto":     epEnum = ExecutionProvider.Auto;     break;
+    case "cuda":     epEnum = ExecutionProvider.Cuda;     break;
+    case "cpu":      epEnum = ExecutionProvider.Cpu;      break;
+    case "directml": epEnum = ExecutionProvider.DirectML; break;
+    default:
+        Console.Error.WriteLine($"Unknown EP: {ep}. Choose cpu, cuda, directml, or auto.");
+        return 2;
 }
 
 onnxDir   = ExpandHome(onnxDir);
@@ -143,7 +183,6 @@ if (tokenizerPath is null)
 // ── Load + synthesize ─────────────────────────────────────────────────────────
 
 var totalSw = Stopwatch.StartNew();
-var epEnum = ep == "cuda" ? ExecutionProvider.Auto : ExecutionProvider.Cpu;
 
 SessionLoadObserver? onLoad = verbose
     ? e => Console.WriteLine(
@@ -152,9 +191,18 @@ SessionLoadObserver? onLoad = verbose
     : null;
 
 if (verbose) Console.WriteLine($"Loading ONNX bundle from {onnxDir} (ep={ep}) ...");
+var loadSw = Stopwatch.StartNew();
 using var pipeline = new ChatterboxPipeline(onnxDir, epEnum, tokenizerPath, onLoad);
-if (verbose) Console.WriteLine($"  vocoder mode: {pipeline.Vocoder.Mode}");
+loadSw.Stop();
+if (verbose)
+{
+    Console.WriteLine($"  vocoder mode: {pipeline.Vocoder.Mode}");
+    Console.WriteLine($"Loaded sessions in {loadSw.ElapsedMilliseconds} ms total  (requested-ep={ep})");
+}
 
+// pipeline.Tokenizer is non-null here: we resolved `tokenizerPath` above
+// and would have exited 1 if no tokenizer.json was findable, so the
+// pipeline's auto-locate fallback never fires.
 var tokenIds = pipeline.Tokenizer!.WrapForLm(textToSpeak);
 if (verbose)
 {
@@ -217,12 +265,21 @@ static void PrintUsage()
 
         Optional:
           --out <wav>              Output WAV path. Default: chatterbox_out.wav
-          --ep cpu | cuda          Execution provider. Default: cuda.
+          --ep <name>              Execution provider, one of:
+                                     auto      — CUDA, fall back to DirectML (default)
+                                     cuda      — CUDA only, fail if unavailable
+                                     directml  — DirectML only, fail if unavailable
+                                     cpu       — CPU only
+                                   The csproj's `-p:EP=...` build flag must include
+                                   the runtime you ask for here (cuda needs OnnxRuntime.Gpu,
+                                   directml needs OnnxRuntime.DirectML).
           --tokenizer-json <path>  Path to chatterbox tokenizer.json. Default:
                                    auto-locate from the HF hub cache.
           --io-binding /           Force GPU-resident KV-cache chaining for the LM.
-          --no-io-binding          Default: auto-detect based on the effective EP.
+          --no-io-binding          Default: auto-detect from the effective EP.
           --exaggeration <float>   Conditioning scalar passed to embed_tokens. Default: 0.5.
+                                   Typical range 0.0 – 1.0; out-of-range values are
+                                   accepted but produce increasingly unusual audio.
           --max-steps <int>        Cap on LM rollout length. Default: 256.
           --verbose / -v           Print per-stage timing and cache info.
           --help / -h              Show this message.

--- a/src/Chatterbox.CLI/Program.cs
+++ b/src/Chatterbox.CLI/Program.cs
@@ -1,0 +1,230 @@
+// Chatterbox TTS CLI.
+//
+// Thin command-line front end over Chatterbox.Base. Loads the ONNX
+// bundle once per invocation, synthesizes one utterance, writes a
+// 24 kHz mono float32 WAV. Designed for the one-shot case; chunked
+// synthesis and continuous-reader modes will land in a follow-up.
+//
+// Usage:
+//   chatterbox --onnx-dir <dir> --voice <wav> --text "..." --out <wav>
+//   chatterbox --onnx-dir <dir> --voice <wav> --text-file in.md --out <wav>
+//
+// See README.md for full flag reference.
+
+using System.Diagnostics;
+using Chatterbox.Base;
+using NAudio.Wave;
+using Vernacula.Base.Models;
+
+// ── Argument parsing ──────────────────────────────────────────────────────────
+
+string? onnxDir       = null;
+string? voicePath     = null;
+string? outPath       = null;
+string? text          = null;
+string? textFile      = null;
+string? tokenizerJson = null;
+string  ep            = "cuda";
+bool    verbose       = false;
+bool?   useIoBinding  = null;
+float   exaggeration  = ChatterboxConstants.DefaultExaggeration;
+int     maxSteps      = ChatterboxConstants.DefaultMaxLmSteps;
+
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--onnx-dir":       onnxDir       = args[++i]; break;
+        case "--voice":          voicePath     = args[++i]; break;
+        case "--out":            outPath       = args[++i]; break;
+        case "--text":           text          = args[++i]; break;
+        case "--text-file":      textFile      = args[++i]; break;
+        case "--tokenizer-json": tokenizerJson = args[++i]; break;
+        case "--ep":             ep            = args[++i].ToLowerInvariant(); break;
+        case "--verbose" or "-v": verbose      = true; break;
+        case "--io-binding":     useIoBinding  = true; break;
+        case "--no-io-binding":  useIoBinding  = false; break;
+        case "--exaggeration":
+            if (!float.TryParse(args[++i], out exaggeration))
+            {
+                Console.Error.WriteLine("--exaggeration expects a float (default 0.5).");
+                return 2;
+            }
+            break;
+        case "--max-steps":
+            if (!int.TryParse(args[++i], out maxSteps) || maxSteps < 1)
+            {
+                Console.Error.WriteLine("--max-steps expects a positive integer (default 256).");
+                return 2;
+            }
+            break;
+        case "--help" or "-h":
+            PrintUsage();
+            return 0;
+        default:
+            Console.Error.WriteLine($"Unknown arg: {args[i]}");
+            PrintUsage();
+            return 2;
+    }
+}
+
+// ── Validate ───────────────────────────────────────────────────────────────────
+
+if (onnxDir is null || voicePath is null)
+{
+    Console.Error.WriteLine("Missing required: --onnx-dir <dir> --voice <wav>");
+    PrintUsage();
+    return 2;
+}
+if (text is null && textFile is null)
+{
+    Console.Error.WriteLine("Provide one of: --text \"...\"  or  --text-file <path>");
+    PrintUsage();
+    return 2;
+}
+if (text is not null && textFile is not null)
+{
+    Console.Error.WriteLine("--text and --text-file are mutually exclusive.");
+    return 2;
+}
+if (ep is not ("cpu" or "cuda"))
+{
+    Console.Error.WriteLine($"Unknown EP: {ep}. Choose cpu or cuda.");
+    return 2;
+}
+
+onnxDir   = ExpandHome(onnxDir);
+voicePath = ExpandHome(voicePath);
+outPath   = ExpandHome(outPath ?? "chatterbox_out.wav");
+if (textFile is not null) textFile = ExpandHome(textFile);
+if (tokenizerJson is not null) tokenizerJson = ExpandHome(tokenizerJson);
+
+if (!Directory.Exists(onnxDir))
+{
+    Console.Error.WriteLine($"--onnx-dir not found: {onnxDir}");
+    return 1;
+}
+if (!File.Exists(voicePath))
+{
+    Console.Error.WriteLine($"--voice not found: {voicePath}");
+    return 1;
+}
+if (textFile is not null && !File.Exists(textFile))
+{
+    Console.Error.WriteLine($"--text-file not found: {textFile}");
+    return 1;
+}
+
+// ── Read text source ──────────────────────────────────────────────────────────
+// --text-file is currently passed through as plain text. Markdown
+// parsing (Stage 1 step 4) will land in a follow-up so a `.md` source
+// has heading/list/emphasis markers stripped before synthesis. Today,
+// any markdown punctuation appears verbatim in the output.
+
+string textToSpeak = text ?? File.ReadAllText(textFile!);
+if (string.IsNullOrWhiteSpace(textToSpeak))
+{
+    Console.Error.WriteLine("Text is empty (after reading --text-file).");
+    return 1;
+}
+
+// ── Resolve tokenizer ─────────────────────────────────────────────────────────
+
+var tokenizerPath = tokenizerJson ?? ChatterboxPipeline.LocateCachedTokenizerJson();
+if (tokenizerPath is null)
+{
+    Console.Error.WriteLine(
+        "No tokenizer.json found. Pass --tokenizer-json <path>, or download via:");
+    Console.Error.WriteLine(
+        "  huggingface-cli download ResembleAI/chatterbox tokenizer.json");
+    return 1;
+}
+
+// ── Load + synthesize ─────────────────────────────────────────────────────────
+
+var totalSw = Stopwatch.StartNew();
+var epEnum = ep == "cuda" ? ExecutionProvider.Auto : ExecutionProvider.Cpu;
+
+SessionLoadObserver? onLoad = verbose
+    ? e => Console.WriteLine(
+        $"  {e.FileName}: {e.ElapsedMs} ms  cache={(e.CacheHit ? "HIT" : "miss")}  "
+        + $"ep={(e.UsedCuda ? "cuda" : "cpu/dml")}  src={e.SourceSizeBytes / 1e6:F0} MB")
+    : null;
+
+if (verbose) Console.WriteLine($"Loading ONNX bundle from {onnxDir} (ep={ep}) ...");
+using var pipeline = new ChatterboxPipeline(onnxDir, epEnum, tokenizerPath, onLoad);
+if (verbose) Console.WriteLine($"  vocoder mode: {pipeline.Vocoder.Mode}");
+
+var tokenIds = pipeline.Tokenizer!.WrapForLm(textToSpeak);
+if (verbose)
+{
+    var preview = textToSpeak.Length > 60 ? textToSpeak[..60] + "..." : textToSpeak;
+    Console.WriteLine($"Tokenized \"{preview.Replace("\n", " ")}\" → {tokenIds.Length} tokens");
+}
+
+var synthSw = Stopwatch.StartNew();
+var spk = pipeline.Embedder.Embed(voicePath);
+if (verbose) Console.WriteLine(
+    $"speech_encoder: cond_emb=({string.Join(",", spk.CondEmb.Dimensions.ToArray())})  "
+    + $"audio_tokens=(1,{spk.AudioTokens.Length})");
+
+var lmResult = pipeline.Lm.Generate(spk.CondEmb, tokenIds,
+    useIoBinding: useIoBinding,
+    exaggeration: exaggeration,
+    maxSteps: maxSteps);
+if (verbose) Console.WriteLine(
+    $"LM: {lmResult.Steps} steps, generated {lmResult.RawGeneratedTokens.Count - 1} tokens");
+
+var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
+var samples = pipeline.Vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+synthSw.Stop();
+
+// ── Write WAV ─────────────────────────────────────────────────────────────────
+
+var fmt = WaveFormat.CreateIeeeFloatWaveFormat(ChatterboxConstants.S3GenSr, 1);
+using (var writer = new WaveFileWriter(outPath, fmt))
+{
+    writer.WriteSamples(samples, 0, samples.Length);
+}
+totalSw.Stop();
+
+float audioSeconds = samples.Length / (float)ChatterboxConstants.S3GenSr;
+Console.WriteLine(
+    $"Synthesized {audioSeconds:F2}s of audio → {outPath} "
+    + $"({totalSw.ElapsedMilliseconds / 1000.0:F1}s total, "
+    + $"{synthSw.ElapsedMilliseconds / 1000.0:F1}s synth)");
+return 0;
+
+
+static string ExpandHome(string path)
+    => path.StartsWith("~/")
+        ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), path[2..])
+        : path;
+
+static void PrintUsage()
+{
+    Console.Error.WriteLine("""
+        Usage: chatterbox --onnx-dir <dir> --voice <wav> (--text "..." | --text-file <path>) [options]
+
+        Required:
+          --onnx-dir <dir>         Directory containing the Chatterbox ONNX bundle
+                                   (speech_encoder, embed_tokens, language_model,
+                                    + one of the cond-decoder layouts).
+          --voice <wav>            Reference voice clip. Any sample rate / channels.
+          --text "..."   OR        Text to synthesize. Mutually exclusive with --text-file.
+          --text-file <path>       Read text from a file. Currently passed through as
+                                   plain text (markdown stripping is a follow-up).
+
+        Optional:
+          --out <wav>              Output WAV path. Default: chatterbox_out.wav
+          --ep cpu | cuda          Execution provider. Default: cuda.
+          --tokenizer-json <path>  Path to chatterbox tokenizer.json. Default:
+                                   auto-locate from the HF hub cache.
+          --io-binding /           Force GPU-resident KV-cache chaining for the LM.
+          --no-io-binding          Default: auto-detect based on the effective EP.
+          --exaggeration <float>   Conditioning scalar passed to embed_tokens. Default: 0.5.
+          --max-steps <int>        Cap on LM rollout length. Default: 256.
+          --verbose / -v           Print per-stage timing and cache info.
+          --help / -h              Show this message.
+        """);
+}

--- a/src/Chatterbox.CLI/README.md
+++ b/src/Chatterbox.CLI/README.md
@@ -1,0 +1,88 @@
+# Chatterbox.CLI
+
+One-shot command-line front end over
+[`src/Chatterbox.Base/`](../Chatterbox.Base/). Synthesizes a single
+utterance and writes a 24 kHz mono float32 WAV.
+
+## Usage
+
+```bash
+# Inline text:
+dotnet run --project src/Chatterbox.CLI -- \
+    --onnx-dir /path/to/cb_dyn5 \
+    --voice ~/Downloads/voice_prompt.wav \
+    --text "Hello world. This is a fresh test sentence." \
+    --out /tmp/out.wav
+
+# Text from a file:
+dotnet run --project src/Chatterbox.CLI -- \
+    --onnx-dir /path/to/cb_dyn5 \
+    --voice ~/Downloads/voice_prompt.wav \
+    --text-file passage.txt \
+    --out /tmp/out.wav
+```
+
+Once `dotnet publish -c Release` is run, the binary is named `chatterbox`
+(see the `AssemblyName` in `Chatterbox.CLI.csproj`).
+
+## Required flags
+
+| Flag | Purpose |
+|---|---|
+| `--onnx-dir <dir>` | Directory containing the Chatterbox ONNX bundle produced by `scripts/chatterbox_export/export_chatterbox_to_onnx.py`. Must include `speech_encoder`, `embed_tokens`, `language_model`, and one of the cond-decoder layouts (merged Loop / split 3-graph / monolithic — auto-detected). |
+| `--voice <wav>` | Reference voice clip. Any sample rate / channel count; resampled to 24 kHz mono internally. |
+| `--text "..."` *or* `--text-file <path>` | Text to synthesize. Exactly one required. |
+
+## Optional flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--out <wav>` | `chatterbox_out.wav` | Output WAV path. |
+| `--ep cpu \| cuda` | `cuda` | Execution provider. CUDA requires `Microsoft.ML.OnnxRuntime.Gpu`; falls back to CPU at session load if CUDA is unavailable. |
+| `--tokenizer-json <path>` | auto-locate | Path to chatterbox `tokenizer.json`. Auto-located from `~/.cache/huggingface/hub/models--ResembleAI--chatterbox/snapshots/*/`. |
+| `--io-binding` / `--no-io-binding` | auto-detect from effective EP | Force or disable GPU-resident KV-cache chaining for the LM. |
+| `--exaggeration <float>` | `0.5` | Conditioning scalar passed to `embed_tokens`. |
+| `--max-steps <int>` | `256` | Cap on LM rollout length. |
+| `--verbose` / `-v` | off | Per-stage timing, cache state, effective-EP info per session. |
+
+## Exit codes
+
+- `0` — success
+- `1` — runtime error (e.g. missing input file, no tokenizer.json found)
+- `2` — bad arguments / usage error
+
+## Sample output
+
+Quiet (default):
+
+```
+Synthesized 6.92s of audio → /tmp/out.wav (7.0s total, 2.9s synth)
+```
+
+`--verbose`:
+
+```
+Loading ONNX bundle from /tmp/cb_dyn5 (ep=cuda) ...
+  speech_encoder.onnx: 1167 ms  cache=HIT  ep=cuda  src=1 MB
+  embed_tokens.onnx: 32 ms  cache=HIT  ep=cuda  src=0 MB
+  language_model.onnx: 860 ms  cache=HIT  ep=cuda  src=2048 MB
+  conditional_decoder_loop.onnx: 1791 ms  cache=HIT  ep=cuda  src=168 MB
+  vocoder mode: Merged
+Tokenized "Hello world. This is a fresh test sentence." → 14 tokens
+speech_encoder: cond_emb=(1,33,1024)  audio_tokens=(1,250)
+LM: 174 steps, generated 174 tokens
+Synthesized 6.92s of audio → /tmp/out.wav (7.0s total, 2.9s synth)
+```
+
+## What this does not do (yet)
+
+- **Markdown parsing.** `--text-file` reads the file as plain text; any
+  markdown punctuation (`#`, `**`, list markers) will appear in the
+  spoken output. Stripping markdown is Stage 1 step 4 in
+  `chatterbox.scratch.md`.
+- **Chunked synthesis / streaming.** The whole utterance is synthesized
+  before writing the WAV. Long passages will hit the `--max-steps` cap
+  and clip. Chunked synthesis and gapless concatenation are
+  Stage 1 step 5+.
+- **Forced alignment / word-level timestamps.** Not needed for the
+  one-shot CLI; will be added when the GUI needs the highlight track.

--- a/src/Chatterbox.CLI/README.md
+++ b/src/Chatterbox.CLI/README.md
@@ -38,10 +38,10 @@ Once `dotnet publish -c Release` is run, the binary is named `chatterbox`
 | Flag | Default | Purpose |
 |---|---|---|
 | `--out <wav>` | `chatterbox_out.wav` | Output WAV path. |
-| `--ep cpu \| cuda` | `cuda` | Execution provider. CUDA requires `Microsoft.ML.OnnxRuntime.Gpu`; falls back to CPU at session load if CUDA is unavailable. |
+| `--ep <name>` | `auto` | Execution provider — one of `auto` (CUDA → DirectML fallback), `cuda` (strict), `directml` (strict), or `cpu`. The csproj `-p:EP=...` build flag must include the runtime you ask for at runtime. |
 | `--tokenizer-json <path>` | auto-locate | Path to chatterbox `tokenizer.json`. Auto-located from `~/.cache/huggingface/hub/models--ResembleAI--chatterbox/snapshots/*/`. |
 | `--io-binding` / `--no-io-binding` | auto-detect from effective EP | Force or disable GPU-resident KV-cache chaining for the LM. |
-| `--exaggeration <float>` | `0.5` | Conditioning scalar passed to `embed_tokens`. |
+| `--exaggeration <float>` | `0.5` | Conditioning scalar passed to `embed_tokens`. Typical range 0.0–1.0; out-of-range values are accepted but produce increasingly unusual audio. |
 | `--max-steps <int>` | `256` | Cap on LM rollout length. |
 | `--verbose` / `-v` | off | Per-stage timing, cache state, effective-EP info per session. |
 
@@ -62,12 +62,13 @@ Synthesized 6.92s of audio → /tmp/out.wav (7.0s total, 2.9s synth)
 `--verbose`:
 
 ```
-Loading ONNX bundle from /tmp/cb_dyn5 (ep=cuda) ...
+Loading ONNX bundle from /tmp/cb_dyn5 (ep=auto) ...
   speech_encoder.onnx: 1167 ms  cache=HIT  ep=cuda  src=1 MB
   embed_tokens.onnx: 32 ms  cache=HIT  ep=cuda  src=0 MB
   language_model.onnx: 860 ms  cache=HIT  ep=cuda  src=2048 MB
   conditional_decoder_loop.onnx: 1791 ms  cache=HIT  ep=cuda  src=168 MB
   vocoder mode: Merged
+Loaded sessions in 3850 ms total  (requested-ep=auto)
 Tokenized "Hello world. This is a fresh test sentence." → 14 tokens
 speech_encoder: cond_emb=(1,33,1024)  audio_tokens=(1,250)
 LM: 174 steps, generated 174 tokens


### PR DESCRIPTION
## Summary

Stage 1 step 3 from `chatterbox.scratch.md`. Real CLI consuming the just-landed `Chatterbox.Base` library — closes the gap between the smoke test (fixed sentence, dev-only) and something a user could actually run.

```bash
chatterbox --onnx-dir /path/to/cb_dyn5 \
           --voice ~/Downloads/voice_prompt.wav \
           --text "Hello world. This is a fresh test." \
           --out /tmp/out.wav
```

## Project shape

Mirrors `Vernacula.CLI`:
- Top-level `Program.cs` (no namespace, no `Main` wrapper)
- Hand-rolled arg parser via `for`-loop + `switch`
- Build-time EP selection (`-p:EP=Cuda|DirectML|Cpu`)
- Int exit codes (`0` ok / `1` runtime / `2` usage)
- Assembly name `chatterbox` per scratch.md spec

New project at `src/Chatterbox.CLI/` (≈200 LOC). References `Chatterbox.Base` and `Vernacula.Base`. Added to `Vernacula.slnx`.

## Args

| | Required | Default |
|---|---|---|
| `--onnx-dir <dir>` | yes | — |
| `--voice <wav>` | yes | — |
| `--text "..."` / `--text-file <path>` | yes (exactly one) | — |
| `--out <wav>` | | `chatterbox_out.wav` |
| `--ep cpu \| cuda` | | `cuda` |
| `--tokenizer-json <path>` | | auto-locate from HF cache |
| `--io-binding` / `--no-io-binding` | | auto-detect from effective EP |
| `--exaggeration <float>` | | `0.5` |
| `--max-steps <int>` | | `256` |
| `--verbose` / `-v` | | off |
| `--help` / `-h` | | — |

## What this does not do (yet)

Called out in the README:

- **Markdown parsing.** `--text-file` is plain-text passthrough; markdown punctuation appears verbatim in output. Stage 1 step 4 in the roadmap is a follow-up.
- **Chunked synthesis / streaming.** Whole utterance synthesized before WAV write; long passages hit `--max-steps` cap. Stage 1 step 5+.
- **Forced alignment.** Not needed for one-shot CLI; added when the GUI needs the highlight track.

## Verification

End-to-end on the test machine (RTX 3090, CUDA EP, warm caches):

| Test | Result |
|---|---|
| Fresh text → fresh tokens (45 tokens vs Ezreal's 82) | ✓ 4.20 s audio output |
| Quiet mode (one-line summary) | ✓ `Synthesized 4.20s of audio → /tmp/out.wav (6.0s total, 2.1s synth)` |
| `--verbose` per-stage timing | ✓ uses the `SessionLoadObserver` from PR #61 |
| `--text-file <path>` | ✓ reads file as plain text, synthesizes |
| Missing `--voice` file | ✓ clean error, exit code 1 |
| `--help` | ✓ usage printed, exit 0 |
| Unknown flag | ✓ error + usage, exit 2 |

## Test plan

- [x] Build clean on CUDA EP
- [x] All flag combinations exercised above
- [x] Exit codes verified
- [ ] Published as a single-file binary (`dotnet publish -c Release`) — deferred to packaging work
- [ ] CPU EP path — untested live (the cold load on the 2 GB LM is slow; CLI logic doesn't differ from the smoke test which we already verified on CUDA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)