### PR TITLE
Chatterbox long-form perf: pipelined batched groups (Runs 1-9)

### DIFF
--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -190,3 +190,87 @@ Other angle worth a one-day probe before Stage 2: explicit
 to `RunWithBinding`; the LM and vocoder on different priority streams
 might let CUDA's scheduler interleave them less destructively. Cheap
 to try.
+
+
+## Run 3 — 2026-05-17 19:30 — Batched-LM feasibility probe
+
+Goal: confirm the LM ONNX honors B>1 at runtime (its `dynamic_axes`
+in `export_chatterbox_to_onnx.py:625-633` declare `batch_size` on
+every input/output, but we've never exercised it), then measure the
+amortization factor `wall(B=N) / wall(B=1)` — anything below N means
+batching wins.
+
+New `--bench-batched-lm B` flag in `ChatterboxSmoke` bypasses voice +
+vocoder; loads only `embed_tokens + language_model`, replicates the
+same prompt across the B dimension (Ezreal sentence, S=82), runs
+prefill + 10 autoregressive steps, reports per-step ms.
+
+```
+=== B=1 ===  step iter avg: 14.0 ms/call  (14.0 ms/batch-elem)
+=== B=2 ===  step iter avg: 21.8 ms/call  (10.9 ms/batch-elem)
+=== B=4 ===  step iter avg: 31.3 ms/call  ( 7.8 ms/batch-elem)
+```
+
+Prefill (S=82) numbers:
+
+| B | wall | per-batch-elem |
+|---|---|---|
+| 1 | 31 ms | 31 ms |
+| 2 | 43 ms | 21.5 ms |
+| 4 | 69 ms | 17.3 ms |
+
+### Amortization
+
+Amortization factor = `wall(B=N) / wall(B=1)`. Theoretical perfect = 1.0
+(infinite parallelism); theoretical worst = N (no amortization).
+
+| Stage | wall ratio | % of theoretical wall savings captured |
+|---|---|---|
+| Prefill B=2 | 1.39× | 61% |
+| Step iter B=2 | 1.56× | 44% |
+| Prefill B=4 | 2.22× | 59% |
+| Step iter B=4 | 2.24× | 59% |
+
+We're capturing 44–61% of the theoretical batching wall savings. The
+gap is exactly the bandwidth-bound story: at fp32, each step reads
+the full 2 GB of LM weights through PCIe regardless of how many batch
+elements share them. Batching amortizes kernel launch overhead but
+not the weight read.
+
+### Implication for long-form throughput
+
+Currently (serial B=1): per chunk = LM 1.25 s + vocoder 0.55 s = 1.80 s.
+With B=4 batched LM (assuming the per-step ratio holds at full
+rollout): LM 1.25 × 2.24/4 = 0.70 s per chunk, vocoder still 0.55 s
+serial (or also batched). 4-chunk wall:
+
+| | Serial today | B=4 batched LM | Reduction |
+|---|---|---|---|
+| LM | 4 × 1.25 = 5.00 s | 1 × 2.80 s | 44% |
+| Vocoder | 4 × 0.55 = 2.20 s | 4 × 0.55 = 2.20 s (unchanged) | 0% |
+| Total | 7.20 s | 5.00 s | **31%** |
+
+**31% wall reduction projected** at fp32 — vs the ~7% pipelining
+yielded. The gap to "theoretical perfect batching" (which would give
+~58%) is bandwidth, not compute.
+
+### And this is the lever fp16 unlocks
+
+The amortization factor is bandwidth-ceiling-limited. Halving the LM
+weight size with fp16 quantization (Stage 3 in the original analysis)
+halves the bandwidth ceiling — at which point the B=4 amortization
+should drop from 2.24× toward something like 1.3–1.5×, putting
+batched throughput into the 2–3× per-chunk territory.
+
+So the batched-LM work today is architectural: build the C# plumbing
++ orchestration so fp16 lands into a ready-shaped infrastructure
+later. The fp32 throughput win is real (31%) but not the headline —
+the headline is the structure.
+
+### Next step in this PR series
+
+Implement `AcousticLM.GenerateBatch` (same-length inputs MVP, run to
+shared max_steps; per-element early stop is Phase 2). Then a Run 4
+that measures full end-to-end batched rollout, including the
+realistic STOP_SPEECH-driven variable length per element (which will
+cost some efficiency vs the probe's uniform-length steady state).

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -809,3 +809,100 @@ further dedup-style export optimization will move the needle at
 fp32.** fp16 quantization remains the right next lever for the
 weight-bandwidth ceiling; merged-graph batching (Path B from the
 previous sidebar) remains low priority for the same reason.
+
+
+## Run 7 — 2026-05-17 22:00 — Pipelined batched groups
+
+`ChunkedSynthesizer.Synthesize` gains a `groupSize` parameter. When >1,
+dispatches to new `SynthesizeInGroups` (Channel-based producer/consumer
+pattern, same shape as the chunk-at-a-time path from Run 2, but at
+the group level). ChatterboxSmoke's `--pipelined` + `--lm-batch B`
+combination now routes through this path.
+
+### Measurements (all RTX 3090, CUDA, warm cache)
+
+| Config | Chunks | Groups | Chunks-wall | vs non-pipelined equivalent |
+|---|---|---|---|---|
+| **Run 7c** lm-batch=4 + pipelined | 8 | 2 | **7.5 s** | vs Run 6c lm-batch=4+voc-batch=4: 7.7 s (−0.2 s, −3%) |
+| **Run 7a** lm-batch=8 + pipelined | 16 | 2 | **11.6 s** | vs serial-batched extrapolation 12.6 s (−1.0 s, −8%) |
+| **Run 7b** lm-batch=4 + pipelined | 16 | 4 | **14.3 s** | vs serial-batched 16.5 s (−2.2 s, −13%) |
+
+### Why the win is small
+
+Same contention story as Run 2. The chunk timings show it directly —
+for Run 7a (2 groups of B=8):
+
+```
+chunk 1/16 (group 1): LM-share 245 ms, voc-share 540 ms
+chunk 8/16 (group 1): LM-share 245 ms, voc-share 540 ms
+chunk 9/16 (group 2): LM-share 704 ms, voc-share 503 ms  ← +2.9× LM!
+chunk 16/16 (group 2): LM-share 704 ms, voc-share 503 ms
+```
+
+Group 1's batched LM runs alone (no overlap) at 245 ms/chunk. Group
+2's batched LM runs concurrent with group 1's vocoder, slows to
+704 ms/chunk due to shared SM/bandwidth contention. The vocoder
+itself is only slightly affected (540 → 503 ms — actually faster
+since it's running in isolation toward the end).
+
+Decomposed wall for Run 7a:
+- LM1: 245 × 8 = 1960 ms (alone)
+- max(LM2 contended, voc1): max(5632, 4320) = 5632 ms
+- voc2 (alone): 503 × 8 = 4024 ms
+- Total: 11,616 ms ✓ matches measured 11.6 s
+
+The LM2 inflation (1960 → 5632 ms) cancels most of the overlap
+benefit. We save vocoder time but spend it back on slower LM.
+
+### Better at smaller batch sizes
+
+Run 7b (lm-batch=4 → 4 groups) gets a larger % reduction (13%) than
+Run 7a (lm-batch=8 → 2 groups, 8% reduction). More groups means more
+overlap opportunities, even with contention. But the absolute wall
+is worse (14.3 vs 11.6 s) because group=8 has higher batched LM
+throughput per chunk.
+
+### Cumulative perf summary (8 chunks, RTX 3090, CUDA)
+
+| Run | Lever | Chunks-wall | vs Run 1 |
+|---|---|---|---|
+| Run 1 | Serial baseline (IoBinding) | 14.7 s | — |
+| Run 2 | + LM/Vocoder pipelining (B=1) | 13.7 s | −7% |
+| Run 5 | Batched IoBinding LM (B=4) | 7.8 s | −47% |
+| Run 5 | Batched IoBinding LM (B=8) | 6.4 s | −57% |
+| Run 6 | + Batched vocoder (B=4) | 7.7 s | −48% |
+| Run 6 | + Batched vocoder (B=8) | 6.1 s | −59% |
+| **Run 7c** | **+ Pipelined groups (B=4)** | **7.5 s** | **−49%** |
+
+At 16 chunks (more pipelining headroom): Run 7a at 11.6 s vs baseline
+extrapolated 29.4 s = **−60% wall reduction.**
+
+### Architectural state at end of Run 7
+
+C# pipeline now has every fp32 perf lever in place:
+
+- **Serial / one-shot**: `AcousticLM.Generate` + `Vocoder.Synthesize`
+- **Pipelined one-shot**: `ChunkedSynthesizer.Synthesize(groupSize=1)`
+- **Batched**: `AcousticLM.GenerateBatch` + `Vocoder.SynthesizeBatch`
+- **Pipelined batched groups (long-form audiobook target)**:
+  `ChunkedSynthesizer.Synthesize(groupSize=B)`
+
+ChatterboxSmoke exposes all four via `--bench-chunks`, `--pipelined`,
+`--lm-batch`, `--voc-batch`. Future fp16 quantization plugs into
+these surfaces without architectural change.
+
+### Where the headroom is now
+
+Roughly speaking:
+
+| Lever | Remaining headroom (fp32) | Notes |
+|---|---|---|
+| Pipelining contention | 10-20% | Run 2/7 contention is GPU SM + DRAM bandwidth. CUDA stream priority hints might recover some. |
+| Vocoder Path B (merged-batched) | 3-5% | Detailed in Run 6 sidebar. Half-day fix; defer. |
+| Duplicate-node removal | 0% | Per Run 6 sidebar 2 — already done. |
+| fp16 LM quantization | **2-4×** projected | Halves weight bandwidth ceiling. Separate workstream. |
+| Custom attention fusion | 5-10% | 310 Transposes in the body could fuse with a custom kernel. Real work. |
+
+The single biggest remaining lever is fp16. Everything we've built
+in Runs 1-7 plugs into it; the perf iteration is at a natural
+pause point.

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -274,3 +274,121 @@ shared max_steps; per-element early stop is Phase 2). Then a Run 4
 that measures full end-to-end batched rollout, including the
 realistic STOP_SPEECH-driven variable length per element (which will
 cost some efficiency vs the probe's uniform-length steady state).
+
+
+## Run 4 — 2026-05-17 19:55 — End-to-end batched LM rollout (8 chunks, B=4)
+
+`AcousticLM.GenerateBatch` (same-length MVP, basic Run path, no
+IoBinding) wired through ChatterboxSmoke as `--lm-batch B`. Runs
+benchChunks chunks in `ceil(benchChunks/B)` groups; each group is one
+`GenerateBatch` plus B serial vocoder calls.
+
+```
+=== --bench-chunks 8 --lm-batch 4 ===
+    batch LM call: 13451 ms total for B=4   (group 1)
+    batch LM call: 12891 ms total for B=4   (group 2)
+Bench: 8 chunks (lm-batch=4), LM avg 3292 ms, voc avg 558 ms,
+  per-chunk-sum-avg 3850 ms, chunks-wall 30.8s [total wall 35.2s]
+```
+
+### Surprise vs Run 3's projection
+
+Run 3 predicted 31% wall reduction at B=4. Reality at B=4 in the full
+rollout is **worse than serial-IoBinding** in absolute terms:
+
+| Config | LM per chunk | Chunks-wall (8) |
+|---|---|---|
+| Serial B=1 + IoBinding (Run 1 baseline) | 1284 ms | 14.7 s |
+| Batched B=4 + basic Run (this Run 4) | 3292 ms ("share") | 30.8 s |
+
+**Batched is 2.4× SLOWER than serial-IoBinding in absolute time.** The
+per-step LM time at B=4 in the full 174-step rollout is ~75 ms vs the
+probe's 7.8 ms/batch-elem — what gives?
+
+### Apples-to-apples: basic Run for both
+
+The IoBinding path keeps KV-cache outputs GPU-resident; the basic Run
+path host-roundtrips them every step. At step 174 the past_kv per layer
+is `[B=4, 16, 255, 64]` × 4 bytes × 60 (30 layers × K+V) = ~250 MB
+**copied out of GPU memory per step**. The probe only ran 10 steps;
+the full rollout amplifies the host-roundtrip cost.
+
+Re-running serial with `--no-io-binding` for the fair comparison:
+
+```
+=== --bench-chunks 8 --no-io-binding ===
+  chunk 1/8: LM 5400 ms (174 steps), voc 715 ms, audio 6.92s
+  ...
+Bench: 8 chunks (serial), LM avg 5219 ms, voc avg 557 ms,
+  per-chunk-sum-avg 5776 ms, chunks-wall 46.2s
+```
+
+Now we can compare like-for-like:
+
+| Mode (basic Run for both) | LM per chunk | Chunks-wall (8) | vs serial |
+|---|---|---|---|
+| Serial B=1 basic | 5219 ms | 46.2 s | (baseline) |
+| Batched B=4 basic | 3292 ms ("share") | 30.8 s | **−33%** |
+
+The 33% wall reduction matches Run 3's projection. Batching works
+exactly as the probe said it would. Just not at IoBinding's absolute
+level.
+
+### The real ceiling: IoBinding × batching, both
+
+The two perf wins are independent and stack:
+
+- IoBinding (Run 1 vs basic): 5219 → 1284 ms/chunk = **4.1× LM speedup**
+- Batching (basic B=1 vs B=4): 5219 → 3292 ms/chunk = **1.6× LM speedup**
+
+Combined ceiling (assuming the per-step amortization factor of 2.24×
+from Run 3 holds when KV stays GPU-resident):
+  Serial IoBinding 1284 ms/chunk
+  → Batched IoBinding B=4: 1284 × (2.24/4) ≈ 720 ms/chunk
+  → ~44% LM reduction per chunk vs serial-IoBinding
+  → ~30-35% wall reduction (vocoder share stays constant)
+
+That's the architectural ceiling at fp32. Real IoBinding-for-batch
+work is non-trivial:
+
+- `RunLmLoopIoBinding` hardcodes shape `[1, KvHeads, T_kv, HeadDim]`
+  for the per-layer KV bindings. Needs parameterization on B.
+- Per-element argmax extracts a row from `[B, S, vocab]` GPU memory;
+  cheaper if we move argmax to GPU (separate op) or accept one
+  `[B, vocab]` last-row CPU copy per step.
+- Empty initial KV tensors `[B, KvHeads, 0, HeadDim]` need batch-
+  aware allocation.
+
+None of these are blocking; just plumbing work.
+
+### What's shipping in this PR
+
+The `GenerateBatch` MVP itself — even at basic-Run cost — is the
+**architectural commit**:
+
+- `AcousticLM.GenerateBatch(condEmbs, textTokenIdsPerChunk, ...)`
+  returns `BatchedAcousticLmResult` (per-element results + actual
+  steps run).
+- Same-length input constraint (Phase 1); STOP_SPEECH triggers
+  per-element done tracking but the inner loop still steps in
+  lockstep until ALL done or maxSteps. Per-element batch shrinking
+  is a follow-up.
+- Basic Run path, no IoBinding (Phase 1).
+
+The fp32 throughput is lateral vs serial-IoBinding (slower, in fact),
+but the C# shape is now in place for two compounding wins to land
+into:
+
+1. IoBinding-for-batch (estimated 30-35% wall reduction at fp32)
+2. fp16 LM quantization (halves bandwidth ceiling — combined with
+   batched IoBinding, expected 50-60% wall reduction territory)
+
+Neither of these requires re-touching `AcousticLM`'s public surface.
+
+### Honest framing
+
+Pure throughput today: shipping the batched path WITHOUT IoBinding
+would be a regression vs serial-IoBinding. Ship it behind the
+`--lm-batch` flag (opt-in benchmark/measurement only) until IoBinding-
+for-batch lands. The API surface (`GenerateBatch` and
+`BatchedAcousticLmResult`) is the durable contract.

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -392,3 +392,110 @@ would be a regression vs serial-IoBinding. Ship it behind the
 `--lm-batch` flag (opt-in benchmark/measurement only) until IoBinding-
 for-batch lands. The API surface (`GenerateBatch` and
 `BatchedAcousticLmResult`) is the durable contract.
+
+
+## Run 5 — 2026-05-17 20:15 — IoBinding-for-batch: the architecture pays off
+
+Generalized the IoBinding LM-loop path to accept B>1 by parameterizing
+the per-layer KV bindings on the leading batch dim. New
+`RunBatchedLmLoopIoBinding` is a sibling to the single-batch
+`RunLmLoopIoBinding`, sharing the same OrtValue-chaining pattern. The
+public `GenerateBatch` gains `useIoBinding` (auto-detected from
+`_effectiveCuda`, matching `Generate`); it dispatches between the
+basic and IoBinding loop bodies.
+
+Common helpers extracted (`ArgmaxBatchedLastRow`, `AllDone`,
+`EmbedBatch`, `GrowBatchedMask`) so both loop bodies share the
+correctness-critical bits.
+
+### Batch scaling (8 chunks per run, RTX 3090, CUDA, warm cache)
+
+| Config | LM ms/chunk | LM call wall | Chunks-wall | Total wall | Reduction vs serial-IoB |
+|---|---|---|---|---|---|
+| Serial IoBinding (Run 1) | 1284 | n/a | 14.7 s | 19.3 s | (baseline) |
+| Batched IoB **B=2** | 748 | 1670→1444 ms/group | 10.5 s | 14.9 s | **−29%** |
+| Batched IoB **B=4** | 409 | 1783→1494 ms/group | 7.8 s | 12.4 s | **−47%** |
+| Batched IoB **B=8** | 236 | 1894 ms (1 group) | 6.4 s | 10.8 s | **−57%** |
+| Batched IoB **B=16** (16 chunks) | 152 | 2447 ms (1 group) | 11.2 s | 15.7 s | n/a (different N) |
+
+Amortization (one batched LM call vs B× serial calls):
+
+| B | LM ms/chunk | × B | / single (1284) | Effective LM throughput vs serial |
+|---|---|---|---|---|
+| 1 | 1284 | 1284 | 1.00× | 1.0× |
+| 2 | 748 | 1496 | 1.17× | 1.72× |
+| 4 | 409 | 1636 | 1.27× | 3.14× |
+| 8 | 236 | 1888 | 1.47× | 5.44× |
+| 16 | 152 | 2432 | 1.89× | 8.45× |
+
+### Why this is so much better than Run 3's projection
+
+Run 3's probe predicted 31% chunks-wall reduction at B=4. Reality
+delivered **47%**. The probe undershot because it included KV-extract
+overhead in its step timing (basic Run path); with IoBinding keeping
+KV GPU-resident, the per-step amortization is much cleaner.
+
+The Run 4 finding ("batched-basic is slower than serial-IoBinding")
+isn't wrong — it's just the wrong-combination measurement. IoBinding
+and batching are independent multipliers and stack better than either
+alone.
+
+### Vocoder is now the bottleneck
+
+At B≥8 the vocoder dominates the per-chunk wall:
+
+| | LM ms/chunk | Voc ms/chunk |
+|---|---|---|
+| B=4 | 409 | 560 |
+| B=8 | 236 | 559 |
+| B=16 | 152 | 549 |
+
+At B=4 the LM is still 73% of per-chunk time; at B=8 the vocoder is
+70% of per-chunk time; at B=16 the vocoder is 78%.
+
+What this means for the next iteration:
+
+1. **Vocoder batching probe**: does the merged `conditional_decoder_loop.onnx`
+   accept B>1? The export's dynamic_axes for that graph DO declare
+   `batch_size` on inputs/outputs, but we've never exercised it
+   (vocoder is single-batch in `Vocoder.cs`).
+2. **Or vocoder pipelining**: bring back Run 2's LM/Vocoder overlap
+   pattern, applied across batches. Vocoder for batch N runs in
+   parallel with LM for batch N+1.
+
+Either lifts the chunk-wall further. Without one of them, going past
+B=8 doesn't help much in this run (B=8 chunks-wall is 6.4s; B=16 with
+16 chunks is 11.2s — but that's more chunks total, normalized to
+chunks-wall/chunk it's only marginally different: 0.80 s/chunk vs
+0.70 s/chunk).
+
+### Memory floor
+
+KV cache at B=16, step 174, fp32:
+  B × KvHeads × T_kv × HeadDim × 4 bytes × 60 (layers × K+V)
+  = 16 × 16 × 255 × 64 × 4 × 60 = 1.0 GB
+
+Plus 2 GB LM weights. 3090 has 24 GB. Plenty of headroom; could
+explore B=32 or even B=64 to push the LM further before memory bites.
+
+But — and this is the user's framing — pushing batched LM higher at
+fp32 still hits the bandwidth ceiling. fp16 halves both the weight
+read AND the KV cache, allowing both bigger batches and faster
+per-step (the 2.24× amortization at B=4 should drop to ~1.3× and
+chunks-wall should fall to a smaller multiple). The architectural
+work in Run 5 is what fp16 plugs into.
+
+### Net delivered in this iteration
+
+| Run | Lever | Wall reduction vs Run 1 |
+|---|---|---|
+| Run 1 | (serial-IoBinding baseline) | (baseline) |
+| Run 2 | LM/Voc pipelining | −7% (lateral) |
+| Run 3 | (probe only) | (probe only) |
+| Run 4 | Batched basic-Run | NEGATIVE (architectural commit) |
+| **Run 5** | **Batched IoBinding B=4** | **−36% (total wall), −47% (chunks-wall)** |
+| **Run 5** | **Batched IoBinding B=8** | **−44% (total wall), −57% (chunks-wall)** |
+
+Run 5 is the headline. Per the user's framing it's also where the
+fp16 lever will land — the C# shape is in place; the inference
+quality story changes when weights halve.

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -1059,3 +1059,152 @@ is at least a B=1-mode win to bank.
 - `/tmp/cb_dyn5/language_model.{fp16,int4,int8}.opt.cuda.*.onnx{,_data}` — baked optimized graphs
 - `/tmp/cb_diag_{fp32,fp16,int4,int8}/cs_tokens.bin` — per-variant token streams for parity diffs
 - `/tmp/cb_{fp32,fp16,int4,int8}_*.wav` — audio outputs (subjective listening check)
+
+## Run 9 — 2026-05-16 22:48 — True-fp16 KV cache (boundary-Cast hypothesis test)
+
+Run 8a left a clean hypothesis: fp16's slight regression came from
+boundary Casts on the 60 past_kv ports (30 layers × {key, value} ×
+{in, out}). The fix was supposed to be true-fp16 I/O — drop
+`keep_io_types`, allocate fp16 zero-tensors in C# IoBinding, let
+the KV cache live as fp16 end-to-end. Projected: 30-50% LM
+throughput win across all batch sizes.
+
+### What we built
+
+**Quantization side**: `quantize_lm.py` gained `--no-keep-io-types`
+producing `language_model.fp16io.onnx` with fp16 `inputs_embeds`,
+`past_key_values.*`, `present.*`, and `logits` (attention_mask
+stays int64).
+
+**C# side**: `AcousticLM` became dtype-aware:
+
+- New `_lmFp16` field detected at construction from
+  `_lm.InputMetadata["inputs_embeds"].ElementDataType`.
+- Six new helpers: `MakeEmbedsOrtValue`, `MakeEmptyPastKvOrtValue`,
+  `LogitsToFloatArray`, `MakeEmbedsNamedValue`,
+  `MakePastKvNamedValue`, `PresentToFloatArray`/`PresentDims`.
+- All four rollout loops (B=1 / B>1 × IoBinding / basic) thread the
+  fp16 dtype through inputs_embeds + past_kv binding and the logits
+  readback. Scratch arrays kept alive past `RunWithBinding` via
+  explicit `GC.KeepAlive`.
+- Pattern adapted from `VibeVoiceAsr.cs::_kvCacheIsFloat32`, which
+  already handles the same fp16/fp32-KV switch for its decoder.
+
+### Parity (single-chunk, --io-binding)
+
+fp32 baseline vs true-fp16 LM:
+
+| Metric | fp32 | fp16io |
+|---|---|---|
+| step0 argmax (pre-penalty) | 1708 | 1708 ✓ |
+| step1 argmax (pre-penalty) | 1736 | 1736 ✓ |
+| step0 first 10 logits | (reference) | bit-identical to Run 8a fp16 row, fp32 within 1 ULP |
+| Total LM steps | 174 | 174 ✓ |
+| Audio output length | 6.92 s | 6.92 s ✓ |
+
+Identical to Run 8a's parity story — the dtype-aware C# binding
+produces the same tokens as the keep_io_types=True version, just
+without the boundary Casts. **The architecture is correct.**
+
+### Perf (RTX 3090, CUDA, warm ORT bake)
+
+| Path | fp32 | fp16io | Δ |
+|---|---|---|---|
+| Single-chunk B=1 | 1491 ms (8.6 ms/step) | 1713 ms (9.8 ms/step) | **+15% slower** |
+| Pipelined B=1 (8 chunks) | 13.6 s wall | 13.9 s wall | +2% slower |
+| Batched B=4 (8 chunks) | 7.7 s wall, 403 ms LM/chunk | 7.9 s wall, 427 ms LM/chunk | +6% slower |
+
+**Same 5-15% regression we saw in Run 8a, despite the boundary
+Casts being gone.** The hypothesis that boundary Casts were the
+problem was wrong.
+
+### What actually happened
+
+I diffed the ORT-baked optimized graphs side-by-side. The fp32 and
+fp16io graphs after ORT's CUDA optimization are **structurally
+identical**:
+
+```
+fp32-opt:    2260 nodes, 272 MatMul, 35 Cast (all to fp16), 61 SimplifiedLayerNormalization, ...
+fp16io-opt:  2260 nodes, 272 MatMul, 35 Cast (all to fp16), 61 SimplifiedLayerNormalization, ...
+```
+
+ORT applied the same fusions to both. The 35 fp16-target Casts in
+**both** graphs say ORT is internally casting fp32 intermediates
+to fp16 in 35 places — meaning even the "fp32" baseline does a fair
+amount of fp16 compute. The MatMul kernels selected at this dim
+(B=1 T=1, 1024 hidden, 64 head_dim) appear not to use Tensor
+Cores at all — they're running cuBLAS SGEMM in fp32 in both cases,
+just with different load patterns.
+
+The slight regression in fp16io is the cost of:
+- C# fp32→fp16 conversion on inputs_embeds (1024 floats/step)
+- Cast nodes ORT inserts at fp16 input → fp32 compute boundary
+- fp16 logits readback then host fp32 conversion (8194 floats/step)
+
+None of these are big individually, but together they slightly
+outweigh whatever bandwidth advantage true-fp16 KV gives.
+
+### Why ORT isn't picking fp16 Tensor Core kernels here
+
+Best guess (haven't verified with verbose kernel logs):
+- LLM hidden 1024 / head_dim 64 may be below cuBLAS's heuristic
+  threshold for switching to wmma/mma kernels
+- B=1 single-token decode is memory-bound; the kernel choice would
+  benefit from fp16 weights but not fp16 activations
+- ORT's SimplifiedLayerNormalization fusion may force fp32 LN
+  internals (the 35 fp16-target Casts)
+
+The "30-50%" projection was wishful — based on what fp16 *should*
+deliver on Ampere for transformer LMs at scale, not what ORT
+actually delivers on a 30-layer / 1024-hidden Llama-style backbone
+at B=1.
+
+### Where this leaves the perf
+
+Same place Run 7c left it. The best long-form path is still:
+
+```
+fp32 + lm-batch=4 + pipelined groups → 7.5-7.7 s for 8 chunks (−49%)
+```
+
+| Run | Best 8-chunk wall | vs Run 1 |
+|---|---|---|
+| Run 1 | 14.7 s | — |
+| Run 7c | 7.5 s | −49% |
+| Run 8 int4 (pipelined B=1) | 12.2 s | −17% |
+| Run 9 fp16io (batched B=4) | 7.9 s | −46% |
+
+**Net Run 9: zero perf win, architecturally cleaner code.** The C#
+fp16/fp32 dtype-aware machinery is in place — if any future LM
+variant comes with a kernel set that *does* benefit from fp16, we
+just point `--lm-path` at it and the dtype-aware binding handles
+the rest.
+
+### Where the remaining levers actually are
+
+The quantization sweep + fp16 IoBinding work covers ORT-native
+quantization for this LM. Things on the table that haven't been
+tried:
+
+| Lever | Hypothesis | Cost | Risk of finding zero again |
+|---|---|---|---|
+| BFloat16 KV cache | bf16 has fp32 range so fewer LN-internals Casts; some ORT kernels are bf16-only-tuned | Same as Run 9 (just regenerate the model + rerun) | Medium — same kernel-selection ceiling may apply |
+| ORT TransformerOptimizer's `optimize_by_fusion` with `model_type=gpt2` | Forces explicit MultiHeadAttention / Attention fusion nodes that ORT *does* have fp16 kernels for | Half-day; needs to verify the Llama-derived export matches the gpt2 patterns | Medium — Chatterbox isn't exact gpt2 |
+| Onnxruntime-genai conversion | Different runtime that builds attention as a single op; known-fast fp16 kernels | Day+; involves swapping ORT for ORT-GenAI in C# binding | Low if it works at all; high if Chatterbox export doesn't fit GenAI's contract |
+| Vocoder fp16 + Path B (merged-batched) | Vocoder is currently 50%+ of long-form wall in some configs; same fp16 + Run-6 deferred work | Day+ | Medium |
+| Custom MultiHeadAttention CUDA kernel | The 310 Transposes in the merged body could fuse with a real attention kernel | Week+ | Low payoff probability without dedicated profiling |
+
+The clearest signal: **off-the-shelf ORT quantization has been
+exhausted for this graph on this hardware.** Further LM perf needs
+either a different runtime (GenAI), a different graph (re-export
+with fused-attention op type hints), or custom kernel work — all
+substantially larger projects than Runs 1-9 were.
+
+### Artifacts
+
+- `/tmp/cb_dyn5/language_model.fp16io.onnx{,_data}` — 1.0 GB true-fp16 LM
+- `/tmp/cb_diag_fp16io/cs_tokens.bin` — token stream for parity diff
+- `/tmp/cb_fp16io*.wav` — audio outputs (parity confirmed)
+- `quantize_lm.py --no-keep-io-types` — produces the true-fp16 graph
+- `AcousticLM._lmFp16` + 6 helpers — dtype-aware IoBinding, ready for any future fp16/bf16 LM variant without further C# changes

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -499,3 +499,130 @@ work in Run 5 is what fp16 plugs into.
 Run 5 is the headline. Per the user's framing it's also where the
 fp16 lever will land — the C# shape is in place; the inference
 quality story changes when weights halve.
+
+
+## Run 6 — 2026-05-17 21:30 — Vocoder batching: split-graph fallback
+
+After Run 5 made vocoder the new bottleneck, probe whether the
+merged `conditional_decoder_loop.onnx` accepts B>1.
+
+### Run 6a — Probe results
+
+```
+Merged conditional_decoder_loop.onnx:
+  B=1: 843 ms  (works, single-Run on GPU-side Loop)
+  B=2: FAIL  cfm__/estimator/Concat_2: dim 4 vs expected 2
+  B=4: FAIL  ...dim 8 vs expected 2
+  B=8: FAIL  ...dim 16 vs expected 2
+
+Split graphs (flow_encoder + cfm_estimator + mel2wav):
+  flow_encoder B=2: 24 ms
+  flow_encoder B=4: 38 ms
+  cfm_estimator B=4 (CFG-doubled=8): 173 ms (single step; full CFM = 10 steps)
+  mel2wav B=2: 318 ms
+  mel2wav B=4: 436 ms
+```
+
+The merged graph baked CFG-doubling at trace time — the inner Loop
+body's Concat ops have hardcoded dim 2 from the trace. The split
+graphs accept B>1 cleanly because their `dynamic_axes` were never
+collapsed by a trace-time fold.
+
+**Two paths forward** (decided to go with A; B is a future cleanup):
+
+- **Path A (no export changes)**: use split-graph orchestration in C#
+  for B>1 vocoder. Trade GPU-side Loop efficiency for C#-orchestrated
+  B>1 batching.
+- **Path B (real export refinement)**: rewrite
+  `scripts/_export_utils/merge_cond_decoder_loop.py` to make
+  CFG-doubling dynamic on input batch. Maybe a day's work +
+  parity re-verification. Unlocks single-Run batched-merged vocoder.
+
+### Run 6b — `Vocoder.SynthesizeBatch`
+
+New method always uses the split orchestration path (B>1 requires
+split graphs anyway). Constructor change: when `Mode == Merged`,
+also load split graphs if present so `SynthesizeBatch` has them.
+Added `Vocoder.SupportsBatched` property to surface the capability.
+
+VRAM cost (answering the question explicitly): loading both merged
+and split graphs doubles the cond-decoder weight residency. On disk:
+~576 MB merged + ~500-600 MB split = ~1.1 GB additional. The 3090
+with 24 GB has headroom; a 12 GB card with the 2 GB LM resident
+would be tighter. If it bites, gate the split-load on a
+`loadSplitForBatch` constructor flag.
+
+One real bug surfaced: `flow_encoder.onnx`'s `z` output stays at
+`[1, MelBins, T_mel]` even when input batch is B>1. The pinned
+`rand_noise` patch we added in Run 11 of
+`docs/chatterbox_investigation.md` for parity reproducibility made
+`z` look graph-constant to ORT. Fix in `SynthesizeBatch`: detect
+B=1 output and replicate B times in C#. Per-batch-element noise is
+intentionally identical (same seed); if we ever want per-element
+noise variation, that's a separate export-patch change.
+
+### Run 6c — End-to-end batched LM + batched vocoder
+
+```
+=== --bench-chunks 8 --lm-batch 4 --voc-batch 4 ===
+Bench: 8 chunks (lm-batch=4+voc-batch=4), LM avg 425 ms,
+  voc avg 541 ms, per-chunk-sum-avg 966 ms,
+  chunks-wall 7.7s [total wall 13.4s]
+
+=== --bench-chunks 8 --lm-batch 8 --voc-batch 8 ===
+Bench: 8 chunks (lm-batch=8+voc-batch=8), LM avg 242 ms,
+  voc avg 514 ms, per-chunk-sum-avg 756 ms,
+  chunks-wall 6.1s [total wall 11.8s]
+```
+
+Headline comparison:
+
+| Config | LM ms/chunk | Voc ms/chunk | Chunks-wall | vs serial baseline |
+|---|---|---|---|---|
+| Serial IoBinding (Run 1) | 1284 | 557 (merged) | 14.7 s | (baseline) |
+| Run 5: lm-batch=4 | 409 | 560 (merged) | 7.8 s | −47% |
+| Run 5: lm-batch=8 | 236 | 559 (merged) | 6.4 s | −57% |
+| Run 6c: lm-batch=4 + voc-batch=4 | 425 | 541 (split) | 7.7 s | −48% |
+| Run 6c: lm-batch=8 + voc-batch=8 | 242 | 514 (split) | 6.1 s | −59% |
+
+Vocoder batching saves **3-5% additional wall** when LM is already
+batched. Less than hoped — the C#-orchestrated CFM solve adds 10
+host-roundtrips per chunk (one per CFM step) that the merged
+graph's GPU-side Loop avoided. So the per-chunk voc-share goes
+from 557 (merged, no contention) → 514 (split B=8) = 8% reduction,
+not the 30-40% the per-call probe suggested at face value.
+
+### What this tells us about Path B (export refinement)
+
+Path B isn't a free 3× win — even the split-graph batching at B=8
+amortizes only modestly. The MERGED graph's superiority is the
+GPU-side CFM Loop, not the batch dimension. Path B would let us
+keep that GPU-side Loop while ALSO supporting B>1 — the combination
+is what would actually pay off. Estimated win for Path B at B=8:
+voc/chunk would be ~150-200 ms (rough projection from "what if
+GPU-side Loop's amortization at B=8 looked like the merged graph's
+B=1 timing × (B=8 amortization factor of ~1.5)").
+
+So Path B is worth doing eventually, but not urgent. Logging it as
+a follow-up issue.
+
+### Architectural state at end of Run 6
+
+The C# pipeline now supports B>1 end-to-end. Both `AcousticLM` and
+`Vocoder` have `*Batch` methods with consistent same-length-MVP
+constraints. ChatterboxSmoke exposes `--lm-batch` and `--voc-batch`
+flags. fp16 quantization (when it arrives) plugs into this surface
+without further architectural changes.
+
+Cumulative wins:
+
+| Run | What | Chunks-wall (8) | vs Run 1 |
+|---|---|---|---|
+| Run 1 | Serial baseline | 14.7 s | (baseline) |
+| Run 5 | + Batched IoBinding LM (B=8) | 6.4 s | −57% |
+| Run 6 | + Batched split vocoder (B=8) | 6.1 s | −59% |
+
+Run 7 (vocoder pipelining: LM(group N+1) overlapped with voc(N)) is
+the next iteration target. The contention story should be friendlier
+now than in Run 2 — at lm-batch=8 the LM is small enough (242 ms)
+that overlapping the 514 ms voc shouldn't starve it.

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -1,0 +1,192 @@
+# Chatterbox long-form perf investigation
+
+Per `chatterbox.scratch.md` Stage 1, the eventual app synthesizes
+long-form markdown — many paragraph-sized chunks per CLI invocation,
+not the one-shot we ship today. The optimization surface for that goal
+differs from the one-shot's: per-chunk costs dominate while load time
+amortizes to nothing.
+
+The opening analysis (see PR-comment thread on #64) projected the
+following ladder of attack:
+
+| Stage | Strategy | Expected wall reduction for a 5-min audiobook |
+|---|---|---|
+| Today | Serial chunks | baseline |
+| 1 | LM/vocoder pipelined per chunk | ~25% |
+| 2 | LM-batched B=4 | ~70% |
+| 3 | + LM fp16 quantization | ~85% |
+
+This investigation tackles them in order. Stage 1 first because it's
+the smallest code change (one new orchestrator class in
+`Chatterbox.Base`) with no risk surface — neither the export nor any
+existing pipeline math changes.
+
+Test methodology: drive synthesis via a throw-away C# probe that
+constructs one `ChatterboxPipeline`, embeds the voice once, then
+synthesizes N text chunks. Measure wall time end-to-end and per-stage
+where instrumentation allows. The same chunk text is used N times so
+the LM rollout length is identical across runs — isolates the
+pipelining lever from any chunking-strategy variability.
+
+Test bed: RTX 3090, ORT 1.24.4, CUDA EP, ChatterboxSmoke's standard
+voice (`/home/chris/Downloads/VCTK_p303.wav`), pre-resampled to 24
+kHz off-line (see issue #53 / Run 12 in
+`docs/chatterbox_investigation.md` for why this matters).
+
+## Run 1 — 2026-05-17 18:35 — Baseline: serial chunks
+
+ChatterboxSmoke gains a `--bench-chunks N` flag that reuses one
+pipeline + one speaker embedding across N serial chunk synthesizes
+(same text each time so the LM rollout length is identical and
+inter-run noise is minimal).
+
+```
+$ dotnet run --project tests/ChatterboxSmoke -- \
+    --onnx-dir /tmp/cb_dyn5 --voice /home/chris/Downloads/VCTK_p303.wav \
+    --bench-chunks 8 --ep cuda
+
+Loaded sessions in 3847 ms total  (requested=cuda, effective=cuda)
+Loaded voice /home/chris/Downloads/VCTK_p303.wav: 312936 samples (13.04s)  [15 ms]
+  chunk 1/8: LM 1485 ms (174 steps), voc 710 ms, audio 6.92s
+  chunk 2/8: LM 1234 ms (174 steps), voc 534 ms, audio 6.92s
+  chunk 3/8: LM 1299 ms (174 steps), voc 535 ms, audio 6.92s
+  chunk 4/8: LM 1248 ms (174 steps), voc 535 ms, audio 6.92s
+  chunk 5/8: LM 1245 ms (174 steps), voc 535 ms, audio 6.92s
+  chunk 6/8: LM 1240 ms (174 steps), voc 535 ms, audio 6.92s
+  chunk 7/8: LM 1252 ms (174 steps), voc 534 ms, audio 6.92s
+  chunk 8/8: LM 1266 ms (174 steps), voc 537 ms, audio 6.92s
+Bench: 8 chunks (serial), LM avg 1284 ms, voc avg 557 ms,
+  per-chunk avg 1840 ms, chunks-total 14.7s [total wall 19.3s]
+```
+
+Per-chunk numbers (steady-state, dropping chunk 1 as warmup):
+
+| | value |
+|---|---|
+| LM | 1252 ms avg (174 steps × 7.2 ms/step) |
+| Vocoder | 535 ms |
+| Per-chunk total | 1787 ms |
+| Audio produced | 6.92 s |
+| **Real-time factor** | **0.26** (vs the opening analysis's 0.35 projection — better than expected) |
+| LM share of per-chunk | 70% |
+
+8-chunk wall breakdown: 3.85 s session load + 0.7 s voice/embed +
+14.7 s chunk-total = 19.3 s.
+
+### Pipelined target (theoretical)
+
+With LM(N+1) running concurrent with vocoder(N) on the GPU, the
+critical path becomes max(LM, voc) per chunk plus a vocoder tail:
+
+```
+t_pipelined = LM_1 + Σ max(LM_n, voc_{n-1}) + voc_N
+            = LM × N + voc_N             (since LM > voc here)
+            = 8 × 1284 + 557
+            = 10829 ms
+```
+
+Predicted wall: 4.55 s warmup + 10.83 s chunks = **15.4 s**, a
+**20% wall reduction** over the 19.3 s baseline (26% reduction on
+the chunk-total alone). Vocoder cost essentially disappears inside
+the LM time.
+
+If voc were larger than LM (longer chunks → fewer LM steps → less
+benefit; OR shorter chunks where the vocoder constant dominates →
+more benefit), the savings would shift. For our typical chunk size
+the LM is comfortably the bottleneck.
+
+## Run 2 — 2026-05-17 18:50 — Pipelined LM/vocoder: real measurement
+
+New `Chatterbox.Base.ChunkedSynthesizer` runs the LM on a producer
+`Task.Run` thread, vocoder on the main thread, with a bounded
+`Channel<(idx, speechTokens, lmMs, lmSteps)>` of capacity 1 between
+them. Different `InferenceSession` objects → no per-session locking
+needed (verified earlier in the SessionLoadObserver discussion).
+
+```
+$ dotnet run --project tests/ChatterboxSmoke -- \
+    --onnx-dir /tmp/cb_dyn5 --voice /home/chris/Downloads/VCTK_p303.wav \
+    --bench-chunks 8 --pipelined --ep cuda
+
+  chunk 1/8: LM 1520 ms (174 steps), voc 779 ms, audio 6.92s
+  chunk 2/8: LM 1668 ms (174 steps), voc 589 ms, audio 6.92s
+  chunk 3/8: LM 1681 ms (174 steps), voc 590 ms, audio 6.92s
+  chunk 4/8: LM 1662 ms (174 steps), voc 592 ms, audio 6.92s
+  chunk 5/8: LM 1669 ms (174 steps), voc 591 ms, audio 6.92s
+  chunk 6/8: LM 1654 ms (174 steps), voc 592 ms, audio 6.92s
+  chunk 7/8: LM 1670 ms (174 steps), voc 591 ms, audio 6.92s
+  chunk 8/8: LM 1662 ms (174 steps), voc 536 ms, audio 6.92s
+Bench: 8 chunks (pipelined), LM avg 1648 ms, voc avg 608 ms,
+  per-chunk-sum-avg 2256 ms, chunks-wall 13.7s [total wall 18.2s]
+```
+
+### Versus Run 1 baseline
+
+| Metric | Serial (Run 1) | Pipelined (Run 2) | Delta |
+|---|---|---|---|
+| LM avg | 1284 ms | 1648 ms | **+364 ms (+28% slower)** |
+| Vocoder avg | 557 ms | 608 ms | +51 ms (+9% slower) |
+| Per-chunk sum | 1840 ms | 2256 ms | +416 ms (+23% slower) |
+| Chunks-wall (8 chunks) | 14.7 s | **13.7 s** | **−1.0 s (−7%)** |
+| Total wall | 19.3 s | 18.2 s | −1.1 s (−6%) |
+
+**This is much less than the 25-26% theoretical reduction.** Per-call
+operations are 9–28% slower because LM and vocoder now contend for
+GPU resources. The pipelining still nets a positive wall delta — but
+only ~1/3 of what the no-contention model predicted.
+
+### Why per-call slows down
+
+The LM (memory-bandwidth-bound, 2 GB of weights streaming through PCIe
+per step) and the vocoder (compute-heavy, FFT-like ops on the SMs)
+share one CUDA context. Concurrent kernel launches go onto separate
+streams, but at the hardware level they contend for:
+
+- **Memory bandwidth**: LM step is dominated by KV-cache reads + matmul
+  weight reads. Vocoder's STFT/conv ops also pull weights. Adding the
+  two together pushes the 3090's ~900 GB/s DRAM bandwidth into
+  contention.
+- **SM occupancy**: large matmuls (LM) and convolutions (vocoder) both
+  want most of the SMs. Co-resident kernels get fewer SMs each.
+
+The result: the LM time grows by ~28% (its weight reads are now
+sharing bandwidth with the vocoder's outputs); the vocoder time grows
+by ~9% (it was already lighter and proportionally less affected).
+
+### Should we ship Run 2's implementation?
+
+Two reasons in favor, both real:
+
+1. **GUI responsiveness**: in the eventual Avalonia app, the LM
+   thread no longer blocks the UI thread. Even a 7% throughput win
+   pays off as a much-larger perceived-latency win when the user
+   sees the first chunk's audio start playing while the second
+   chunk's LM is still rolling.
+2. **Net wall is positive**: 6–7% reduction is real, not lost in noise
+   (8 chunks × repeatable per-chunk numbers).
+
+One reason against:
+
+- **The throughput ceiling is unaffected**: contention means we
+  can't stack this with future optimizations cleanly. Stage 2
+  (batched LM) and Stage 3 (fp16) would have to redo their own
+  contention modeling — the batched LM occupies the GPU more fully,
+  making vocoder overlap *even worse* than what we measured.
+
+### Conclusion + next step
+
+Ship the pipelining for the GUI-responsiveness reason; the throughput
+delta is honest signal (small but real). DON'T treat Run 2's pattern
+as the load-bearing perf strategy.
+
+The real next probe should be **batched LM (Stage 2)** — where the
+export already supports `B>1` dynamic axes (verified above), and the
+expected payoff is 2-3× LM throughput. Pipelining a batched-LM with
+serial vocoder may give the cleanest combined win because each LM
+call now does more work per GPU-context-acquisition.
+
+Other angle worth a one-day probe before Stage 2: explicit
+`OrtCUDAStream` priority hints. ORT supports passing a stream handle
+to `RunWithBinding`; the LM and vocoder on different priority streams
+might let CUDA's scheduler interleave them less destructively. Cheap
+to try.

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -626,3 +626,186 @@ Run 7 (vocoder pipelining: LM(group N+1) overlapped with voc(N)) is
 the next iteration target. The contention story should be friendlier
 now than in Run 2 — at lm-batch=8 the LM is small enough (242 ms)
 that overlapping the 514 ms voc shouldn't starve it.
+
+
+## Run 6 sidebar — Vocoder export investigation
+
+Question (from the user, mid-Run-7): is Path B (rewriting the merge
+script to support batched-merged) worth doing? Or is there no real
+headroom to recover even if we fix it?
+
+### What's hardcoded in the merge script
+
+`scripts/_export_utils/merge_cond_decoder_loop.py` was written
+assuming B=1 input. Three places hardcode the CFG-doubling shape:
+
+1. **Body input/output shape**: lines 260-269 declare
+   `x_carried [1, MEL_BINS, "T_mel"]` and `x_new [1, MEL_BINS, "T_mel"]`.
+   For batched, these need `["batch_size", MEL_BINS, "T_mel"]`.
+
+2. **t_in construction inside the body**: line 207 does
+   `Concat([t_now_1d, t_now_1d], axis=0)` producing shape `(2,)`.
+   At B>1 input, cfm_estimator expects `t_in` shape `(2*B,)` to
+   match the CFG-doubled batch. The Concat needs to become a
+   `Tile(t_now_1d, [2*B])` where 2*B is computed dynamically from
+   the runtime x_carried shape:
+   ```
+   shape = Shape(x_carried)                # (3,) int64
+   batch = Slice(shape, [0], [1], [0])     # (1,) = [B]
+   two_b = Mul(batch, [2])                 # (1,) = [2*B]
+   t_in  = Tile(t_now_1d, two_b)           # (2*B,)
+   ```
+
+3. **x_in CFG-double**: line 209 `Concat([x_carried, x_carried], axis=0)`
+   correctly produces (2*B, ...) at any B (axis-0 concat scales) — no
+   change needed.
+
+The outer-scope CFG-doublers (lines 344-376) for mu/cond/spks/mask
+all use `ConstantOfShape(Shape(mu))` etc. which IS already dynamic
+on B — no change needed there.
+
+**Net change for Path B**: 4 nodes need replacement (the 2 fixed
+`[1, ...]` shape declarations + the t_in Tile-with-dynamic-2B). Half a
+day plus parity re-verification.
+
+### Headroom estimate
+
+What would batched-merged actually deliver vs batched-split?
+
+| | Measured | Source |
+|---|---|---|
+| Merged B=1 per chunk | 843 ms | Run 6a probe |
+| Split B=4 per chunk | 551 ms | Run 6a probe (38+1730+436)/4 |
+| Split B=8 per chunk | 514 ms | Run 6c measured |
+| **Hypothetical merged B=4** | **~500 ms** | flow 38 + 10 CFM in GPU Loop ~1500 + m2w 436 / 4 |
+| **Hypothetical merged B=8** | **~480 ms** | similar arithmetic at B=8 |
+
+The savings vs split come from removing the 10 host-roundtrips
+(allocating CFG-doubled arrays in C# per CFM step). Each roundtrip
+is maybe 1-3 ms of C# allocation + ORT call setup. For B=8: 10 × ~3
+ms = ~30 ms saved per chunk-group, spread across 8 chunks = ~4 ms/chunk.
+
+**Headroom for Path B at fp32**: roughly **5-8% of vocoder time**, or
+**~3-5% of total wall time** at our current best configuration
+(Run 6c: 6.1 s for 8 chunks at lm-batch=8 + voc-batch=8).
+
+In absolute terms: maybe shave 200-300 ms off the 6.1 s wall. Real
+but small.
+
+### Why the headroom is small at fp32
+
+The vocoder is dominated by the actual CFM compute (8 attention
+blocks × 10 Euler steps), not the orchestration overhead. The
+"10 host-roundtrips" overhead the split path adds is small relative
+to the per-step kernel time. Whether the Loop runs on GPU or C#
+orchestrates it, the same 10 cfm_estimator computations happen.
+
+### When Path B would matter more
+
+- **fp16 quantization**: vocoder weights halve, per-step CFM time
+  drops. The 30 ms of orchestration overhead becomes proportionally
+  bigger. Maybe 10-15% headroom recovery at that point.
+- **Streaming-within-chunk**: a merged-batched graph keeps the CFM
+  solve as one Run, which is a cleaner unit for streaming
+  pre-emption / interruption (the C#-orchestrated split path needs
+  to interleave per-step checks).
+- **Code surface reduction**: SynthesizeBatch is ~150 LOC of CFG
+  orchestration in C# that Path B would let us delete in favor of
+  one ORT Run call.
+
+### Decision
+
+**Don't do Path B now.** Estimated 3-5% wall reduction at fp32 doesn't
+justify the merge-script surgery + parity re-verification. The user
+called this correctly — there's some headroom but not much, and
+fp16 is the lever that would make it meaningful.
+
+Logged as a follow-up in [issue TODO] alongside the fp16 quantization
+work; the two should land together since the latter unlocks the
+former's payoff.
+
+### What this means for Run 7
+
+Vocoder pipelining (Run 7, in progress) is still worth doing — it's
+orthogonal to merged-vs-split and gives parallelism across groups.
+The contention story from Run 2 is friendlier now (LM at lm-batch=8
+is only 242 ms; voc is 514 ms — voc dominates, so overlapping with
+LM is mostly free for the LM's perspective).
+
+
+## Run 6 sidebar 2 — Duplicate-node hunt (user-prompted)
+
+Question (from the user): is the export still carrying redundant
+nodes we haven't eliminated? The Phase 1 70K→7K cfm_estimator win
+came from killing the 10× CFM unroll — are there leftover patterns?
+
+### Value-duplicate initializers
+
+Hashed every initializer in the merged graph and grouped by
+(shape, dtype, raw-data-hash):
+
+```
+Total initializers:     1545
+Unique value-hashes:    1521
+Value-duplicate groups: 15
+Total waste:            220 bytes (in 575 MB of initializer data)
+```
+
+Every duplicate is a tiny shape-arithmetic constant (shape `(1,)` or
+`()`, used in trace-time Shape→Gather chains). **0% headroom** here.
+
+### onnxslim pass on the merged graph
+
+Noticed the merged graph never gets the slim treatment — the export
+runs `slim_and_externalize` BEFORE the merge step. Ran onnxslim
+manually on the produced merged graph:
+
+```
+Outer nodes: 1680 → 1676  (−4)
+Body nodes:  3008 → 3004  (−4)
+File size:   548 MB → 548 MB
+```
+
+**−8 nodes out of 4688** (the 4 Identity nodes the merge script adds
+at the body boundary plus 4 in outer scope, probably). Negligible
+perf impact; not worth wiring an extra slim pass into the export.
+
+### Node-count audit by graph
+
+| Graph | Nodes | Notes |
+|---|---|---|
+| cfm_estimator standalone | 2988 | per-step, post-Phase-1 |
+| Merged body | 3008 | cfm_estimator + 20 boundary ops |
+| Merged outer | 1680 | flow_encoder (863) + mel2wav (802) + 15 outer-CFG ops |
+| flow_encoder | 863 | dynamic-shape post-Run-10 |
+| mel2wav | 802 | scatter_add ISTFT (Run 3 fix) |
+
+The merge script added ~35 nodes total to the union of the three
+slimmed sub-graphs. That's a clean stitch.
+
+### Op-type top-5 in the merged body
+
+```
+MatMul:               448  (attention + FFN; load-bearing)
+Add:                  421
+Mul:                  323
+Transpose:            310  (attention head reshapes; could in principle be fused)
+Reshape:              226
+```
+
+The 310 Transposes are the only "huh" — that's a lot. They're mostly
+attention-block head-dim reshapes baked in by upstream's
+`AttnProcessor → MinimalAttnProcessor` swap and the diffusers
+`BasicTransformerBlock` layout. Fusing them would require a custom
+attention kernel (TensorRT, ORT custom op) — significant work for
+probably <5% gain on attention compute. Not the next lever.
+
+### Conclusion
+
+The export pipeline already eliminated the heavy redundancy. What
+remains is essentially compute-bound (matmul + attention) and
+memory-bandwidth-bound (weight reads), not redundant work. **No
+further dedup-style export optimization will move the needle at
+fp32.** fp16 quantization remains the right next lever for the
+weight-bandwidth ceiling; merged-graph batching (Path B from the
+previous sidebar) remains low priority for the same reason.

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -906,3 +906,156 @@ Roughly speaking:
 The single biggest remaining lever is fp16. Everything we've built
 in Runs 1-7 plugs into it; the perf iteration is at a natural
 pause point.
+
+## Run 8 — 2026-05-16 22:35 — LM quantization sweep (fp16 / int8-dynamic / int4)
+
+User asked: "sweep through the LM down to int4." Goal: cash in the
+fp16 lever called out at the end of Run 7 (projected 2-4× LM
+throughput), and survey the broader ORT quantization toolbox while
+the rest of the pipeline sits at a natural pause point.
+
+### Strategies tried
+
+| Strategy | Tool | Where it lives in the codebase |
+|---|---|---|
+| fp16 (keep_io_types=True) | `onnxruntime.transformers.float16.convert_float_to_float16` | `scripts/_export_utils/quantize_lm.py --mode fp16` |
+| int8 dynamic (W8A8) | `onnxruntime.quantization.quantize_dynamic` | `--mode int8` |
+| int4 RTN MatMulNBits (W4A16, accuracy_level=4) | `onnxruntime.quantization.matmul_nbits_quantizer.MatMulNBitsQuantizer` | `--mode int4` |
+
+ChatterboxSmoke got a `--lm-path <path>` flag so an alternate
+`language_model.*.onnx` can be loaded without rebuilding the bundle.
+
+Strategies surveyed but not run this round: AWQ / GPTQ (need a small
+calibration set; deferred unless RTN int4 quality fails the listening
+test); static W8A8 with calibration (same — int8 dynamic failed so
+hard that static probably won't fix the kernel-selection issue, which
+turned out to be the real problem).
+
+### Disk footprint
+
+| Variant | language_model.onnx + sidecar | vs fp32 |
+|---|---|---|
+| fp32 (original) | 1.9 GB + 600 MB ≈ 2.5 GB | 1.0× |
+| fp16 | 0.8 MB + 1024 MB ≈ 1.0 GB | 0.4× |
+| int4 | 0.9 MB + 320 MB ≈ 320 MB | 0.13× |
+| int8 | 3.4 MB + 512 MB ≈ 515 MB | 0.21× |
+
+### Parity vs fp32 (single-chunk, --io-binding, Ezreal sentence)
+
+| Variant | step0 argmax | step1 argmax | Total steps | Audio length | Tokens diverge at |
+|---|---|---|---|---|---|
+| fp32 | 1708 | 1736 | 174 | 6.92 s | — (reference) |
+| fp16 | 1708 ✓ | 1736 ✓ | 174 ✓ | 6.92 s ✓ | byte 1017 (~token 127) — drift accumulates but stays in-distribution |
+| int4 | 1708 ✓ | 1736 ✓ | 176 | 7.00 s | very early, but argmax pattern preserved |
+| int8 | 6453 ✗ | 5186 ✗ | 93 (early STOP) | 3.68 s ✗ | step 0 — quality collapse |
+
+int8 dynamic is unusable. The other two preserve the speaker timbre
+and content end-to-end on listening (informal check; subjective).
+
+### Perf (RTX 3090, CUDA, warm ORT bake cache)
+
+Single-chunk (B=1), `--io-binding`, 174-176 LM steps:
+
+| Variant | LM total ms | ms/step | vs fp32 |
+|---|---|---|---|
+| fp32 | 1627 | 9.4 | — |
+| fp16 | 1822 | 10.5 | +12% slower |
+| int4 | 1432 | 8.1 | **−14% (faster)** |
+| int8 | 3009 | 32.4 | +245% (CPU fallback, useless) |
+
+Pipelined 8-chunk (groupSize=1):
+
+| Variant | chunks-wall | vs fp32 |
+|---|---|---|
+| fp32 | 13.6 s | — |
+| int4 | 12.2 s | **−10%** |
+
+Batched 8-chunk (`--lm-batch 4`):
+
+| Variant | chunks-wall | LM ms/chunk | vs fp32 |
+|---|---|---|---|
+| fp32 | 7.7 s | 403 | — |
+| fp16 | 8.1 s | 444 | +5% slower |
+| int4 | 10.5 s | 745 | +36% slower |
+
+### What we learned
+
+**fp16 with `keep_io_types=True` is a slight regression, not a win.**
+
+The conversion adds 251 fp16-target Casts and 61 fp32-target Casts —
+net +122 Cast nodes vs the fp32 graph (4919 → 5041 total). The
+critical-path damage: the LM exposes 30 layers × 2 (key + value) past_kv
+inputs, all declared fp32 by the export contract. With `keep_io_types=True`
+the converter wraps each in an input-side Cast (fp32 → fp16) and an
+output-side Cast (fp16 → fp32). With IoBinding chaining KV across 174
+steps, that's ~120 Casts/step on the hot path. Whatever compute we save
+in the layer body, we spend back at the I/O boundary.
+
+The fix is true fp16 KV cache (`keep_io_types=False` or a custom
+include-set that excludes only `inputs_embeds`/`attention_mask`/`logits`).
+That requires the C# IoBinding code to allocate fp16 zero-tensors
+for the initial empty past_kv inputs and accept fp16 logits/KV out
+— a one-day workstream we deferred.
+
+**int8 dynamic (W8A8) hits a CPU fallback on CUDA EP for this LM.**
+
+3.4× slower at the kernel level, plus quality collapse (step-0
+argmax 6453 vs reference 1708). The combo says ORT isn't fusing the
+QuantizeLinear/MatMulInteger into a tensor-core kernel for our op
+pattern — it's running int8 MatMul on CPU. The quality regression
+is the additional per-tensor activation-scale issue you'd see even
+on the working CUDA path. Static W8A8 wouldn't fix the kernel issue.
+**Mark int8 dynamic dead for this graph.**
+
+**int4 RTN MatMulNBits wins at B=1, loses at B>1.**
+
+The `MatMulNBits` operator has a CUDA kernel optimized for the LLM
+decoding case (B=1, T=1, weight-bound). At that operating point we
+saw 14% per-step speedup. But the kernel doesn't have an efficient
+batched path — `--lm-batch 4` runs 1.85× slower than fp32-B=4
+(745 vs 403 ms/chunk). MatMulNBits dequantizes weights per call;
+batching amortizes weight bandwidth in the fp32 path but the
+dequant cost in the int4 path doesn't share across batch elements.
+
+### Where this leaves long-form synthesis
+
+The Run 7 best (fp32 + `--lm-batch 4` + pipelined groups) is still
+the wall-clock champion at **7.7 s for 8 chunks**:
+
+| Run | Best path | 8-chunk chunks-wall | vs Run 1 |
+|---|---|---|---|
+| Run 1 | Serial IoBinding (fp32, B=1) | 14.7 s | — |
+| Run 5/6 | Batched LM+voc (fp32, B=8) | 6.1 s | −58% |
+| Run 7c | + Pipelined groups (fp32, B=4) | 7.5 s | −49% |
+| **Run 8 int4** | **Pipelined B=1 (int4)** | **12.2 s** | **−17%** |
+| Run 8 fp16 | Pipelined B=4 (fp16) | 8.1 s | −45% |
+| Run 8 int8 | — | — | unusable |
+
+int4 at pipelined B=1 is the best Run 8 result but it's much worse
+than fp32 batched. **None of the off-the-shelf quantization
+strategies improved long-form-batched throughput.**
+
+### Where headroom actually lives, post-sweep
+
+| Lever | Projected win | Notes |
+|---|---|---|
+| True fp16 KV cache (keep_io_types=False + C# fp16 IoBinding) | 30-50% | The natural fp16 win we missed because of boundary Casts. Half-day to a day of C# IoBinding work in AcousticLM. |
+| MatMulNBits with B>1-friendly kernel | unknown | Would need a custom ORT op or upstream PR. Not a 1-week project. |
+| int4 batched via AWQ/GPTQ + custom kernels | uncertain | Real LLM-stack territory; probably not the right cost for this perf budget. |
+| Vocoder Path B (merged-batched) | 3-5% | Still on the deferral list. |
+| Custom attention fusion | 5-10% | 310 Transposes in the body could fuse with a custom kernel. Real work. |
+
+The natural next step (if the user wants to keep pushing) is true
+fp16 KV cache. The natural pause point is honestly here: we've
+covered every off-the-shelf ORT quantization mode for this LM,
+documented the quality + kernel-coverage caveats, and the int4 path
+is at least a B=1-mode win to bank.
+
+### Artifacts on disk (left intact for follow-up runs)
+
+- `/tmp/cb_dyn5/language_model.fp16.onnx{,_data}` — 1.0 GB total
+- `/tmp/cb_dyn5/language_model.int4.onnx{,_data}` — 320 MB total
+- `/tmp/cb_dyn5/language_model.int8.onnx{,.data}` — 515 MB total (unusable; keep for forensics)
+- `/tmp/cb_dyn5/language_model.{fp16,int4,int8}.opt.cuda.*.onnx{,_data}` — baked optimized graphs
+- `/tmp/cb_diag_{fp32,fp16,int4,int8}/cs_tokens.bin` — per-variant token streams for parity diffs
+- `/tmp/cb_{fp32,fp16,int4,int8}_*.wav` — audio outputs (subjective listening check)

--- a/scripts/_export_utils/quantize_lm.py
+++ b/scripts/_export_utils/quantize_lm.py
@@ -91,6 +91,9 @@ def quantize_int8_dynamic(input_path: Path, output_path: Path) -> None:
     # by default; safer to copy the source into a temp location first.
     from onnxruntime.quantization import QuantType, quantize_dynamic
 
+    print("[int8] WARNING: Run 8b in docs/chatterbox_perf_investigation.md "
+          "found int8 dynamic falls back to CPU on CUDA EP for this LM — "
+          "3.4× slower and quality collapse at step 0. Continuing anyway.")
     print(f"[int8] dynamic-quantizing {input_path} -> {output_path} ...")
     t0 = time.time()
     quantize_dynamic(

--- a/scripts/_export_utils/quantize_lm.py
+++ b/scripts/_export_utils/quantize_lm.py
@@ -40,7 +40,7 @@ import time
 from pathlib import Path
 
 
-def quantize_fp16(input_path: Path, output_path: Path) -> None:
+def quantize_fp16(input_path: Path, output_path: Path, keep_io_types: bool = True) -> None:
     # keep_io_types=True leaves graph inputs/outputs as fp32; ORT inserts
     # Cast nodes at the boundary so the C# binding doesn't need to change.
     # disable_shape_infer=True bypasses a known crash on graphs with
@@ -56,11 +56,11 @@ def quantize_fp16(input_path: Path, output_path: Path) -> None:
 
     print(f"[fp16] loading {input_path} (with external data) ...")
     model = onnx.load(str(input_path), load_external_data=True)
-    print("[fp16] converting fp32 → fp16 (keep_io_types=True) ...")
+    print(f"[fp16] converting fp32 → fp16 (keep_io_types={keep_io_types}) ...")
     t0 = time.time()
     model_fp16 = convert_float_to_float16(
         model,
-        keep_io_types=True,
+        keep_io_types=keep_io_types,
         disable_shape_infer=True,
     )
     print(f"[fp16] convert done in {time.time() - t0:.1f}s; saving ...")
@@ -154,6 +154,12 @@ def main() -> int:
     ap.add_argument("--output", required=True, type=Path, help="Destination quantized .onnx")
     ap.add_argument("--mode", required=True, choices=["fp16", "int8", "int4"])
     ap.add_argument("--block-size", type=int, default=32, help="int4 RTN block size (default 32)")
+    ap.add_argument(
+        "--no-keep-io-types",
+        action="store_true",
+        help="[fp16 only] Convert I/O tensors to fp16 too (true fp16, no boundary Casts). "
+             "Caller must feed fp16 inputs and decode fp16 outputs.",
+    )
     args = ap.parse_args()
 
     if not args.input.exists():
@@ -167,7 +173,7 @@ def main() -> int:
         sidecar.unlink()
 
     if args.mode == "fp16":
-        quantize_fp16(args.input, args.output)
+        quantize_fp16(args.input, args.output, keep_io_types=not args.no_keep_io_types)
     elif args.mode == "int8":
         quantize_int8_dynamic(args.input, args.output)
     elif args.mode == "int4":

--- a/scripts/_export_utils/quantize_lm.py
+++ b/scripts/_export_utils/quantize_lm.py
@@ -1,0 +1,188 @@
+"""Quantize an exported LM ONNX graph for the Run 8 perf sweep.
+
+Operates on a single .onnx file (with sibling external-data file if
+present) and writes a new .onnx + .onnx_data sibling pair. Sized for
+the Chatterbox language_model.onnx (~2 GB external-data fp32), but the
+modes are generic — any KV-cache-style LM export with MatMul-heavy
+attention blocks should respond similarly.
+
+Three modes:
+
+  fp16  — onnxconverter_common.float16.convert_float_to_float16
+          (keep_io_types=True so the C# binding still feeds fp32).
+          Halves weight bytes; gates open the GPU's fp16 MMA pipes.
+          Lowest accuracy risk for transformer LMs.
+
+  int8  — onnxruntime.quantization.quantize_dynamic (W8A8 dynamic).
+          Quarter weight bytes vs fp32; needs no calibration data.
+          Higher risk than fp16, especially for residual streams.
+
+  int4  — onnxruntime.quantization.matmul_nbits_quantizer
+          .MatMulNBitsQuantizer with RTN (round-to-nearest) config.
+          ~1/8 weight bytes vs fp32; LLM-standard for inference.
+          accuracy_level=4 = int8 activations during MatMul.
+
+Mode-specific limitations are documented inline at each handler.
+
+Invocation (from repo root, with the chatterbox export venv active):
+
+    .venv-chatterbox-export/bin/python scripts/_export_utils/quantize_lm.py \\
+        --input /tmp/cb_dyn5/language_model.onnx \\
+        --output /tmp/cb_dyn5/language_model.fp16.onnx \\
+        --mode fp16
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+
+def quantize_fp16(input_path: Path, output_path: Path) -> None:
+    # keep_io_types=True leaves graph inputs/outputs as fp32; ORT inserts
+    # Cast nodes at the boundary so the C# binding doesn't need to change.
+    # disable_shape_infer=True bypasses a known crash on graphs with
+    # large external-data initializers — shape inference walks the whole
+    # weight tensor and runs out of stack on the 30-layer KV graph.
+    # ORT's transformers fp16 converter (vs onnxconverter_common's) handles
+    # transformer LMs robustly: it does proper type unification at Add/Mul
+    # boundaries (LayerNorm internals were tripping the onnxconverter_common
+    # 1.16.0 path with a "Type Error: T bound to different types" failure
+    # at /layers.0/input_layernorm/Add on this graph).
+    import onnx
+    from onnxruntime.transformers.float16 import convert_float_to_float16
+
+    print(f"[fp16] loading {input_path} (with external data) ...")
+    model = onnx.load(str(input_path), load_external_data=True)
+    print("[fp16] converting fp32 → fp16 (keep_io_types=True) ...")
+    t0 = time.time()
+    model_fp16 = convert_float_to_float16(
+        model,
+        keep_io_types=True,
+        disable_shape_infer=True,
+    )
+    print(f"[fp16] convert done in {time.time() - t0:.1f}s; saving ...")
+    # Save with external data — the fp16 weights are still ~1 GB, well
+    # above the 2 GB protobuf cap, and saving inline would silently
+    # truncate. Use the sibling .onnx_data convention the export script
+    # already established.
+    data_name = output_path.name + "_data"
+    onnx.save_model(
+        model_fp16,
+        str(output_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=data_name,
+        size_threshold=1024,
+        convert_attribute=False,
+    )
+    print(f"[fp16] wrote {output_path} (+ {data_name})")
+
+
+def quantize_int8_dynamic(input_path: Path, output_path: Path) -> None:
+    # Dynamic quantization picks per-tensor activation scales at runtime
+    # from observed min/max — no calibration set needed. Quantizes weights
+    # to int8 statically; quantizes activations to int8 dynamically each
+    # call. Cheapest path to "is int8 viable for this LM at all?".
+    #
+    # ORT's quantize_dynamic mutates external-data references in place
+    # by default; safer to copy the source into a temp location first.
+    from onnxruntime.quantization import QuantType, quantize_dynamic
+
+    print(f"[int8] dynamic-quantizing {input_path} -> {output_path} ...")
+    t0 = time.time()
+    quantize_dynamic(
+        model_input=str(input_path),
+        model_output=str(output_path),
+        weight_type=QuantType.QInt8,
+        # MatMul + Gather (the embedding lookup) cover the heavy weights.
+        # Attention.RotaryEmbedding and norm ops stay fp32, which is fine
+        # — they're cheap.
+        op_types_to_quantize=["MatMul", "Gather"],
+        per_channel=True,
+        reduce_range=False,
+        use_external_data_format=True,
+    )
+    print(f"[int8] done in {time.time() - t0:.1f}s")
+
+
+def quantize_int4(input_path: Path, output_path: Path, block_size: int = 32) -> None:
+    # RTN (round-to-nearest) weight-only 4-bit MatMul quantization.
+    # accuracy_level=4 = "int8 activations during the int4 MatMul"
+    # (vs 0=fp32, 1=fp16, 2=bf16, 3=int4 activations). int8 acts give
+    # ~all the speedup with ~no accuracy regression on attention LLMs.
+    # block_size=32 is the LLM default; smaller = more granular scales
+    # = better quality at slight compression cost.
+    import onnx
+    from onnxruntime.quantization.matmul_nbits_quantizer import (
+        MatMulNBitsQuantizer,
+        RTNWeightOnlyQuantConfig,
+    )
+
+    print(f"[int4] loading {input_path} ...")
+    model = onnx.load(str(input_path), load_external_data=True)
+    print(f"[int4] running MatMulNBitsQuantizer (RTN, block_size={block_size}) ...")
+    t0 = time.time()
+    cfg = RTNWeightOnlyQuantConfig()
+    q = MatMulNBitsQuantizer(
+        model=model,
+        block_size=block_size,
+        is_symmetric=True,  # symmetric = simpler kernels, slightly worse quality
+        accuracy_level=4,
+        algo_config=cfg,
+    )
+    q.process()
+    print(f"[int4] done in {time.time() - t0:.1f}s; saving ...")
+    data_name = output_path.name + "_data"
+    onnx.save_model(
+        q.model.model,
+        str(output_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=data_name,
+        size_threshold=1024,
+        convert_attribute=False,
+    )
+    print(f"[int4] wrote {output_path} (+ {data_name})")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--input", required=True, type=Path, help="Source language_model.onnx")
+    ap.add_argument("--output", required=True, type=Path, help="Destination quantized .onnx")
+    ap.add_argument("--mode", required=True, choices=["fp16", "int8", "int4"])
+    ap.add_argument("--block-size", type=int, default=32, help="int4 RTN block size (default 32)")
+    args = ap.parse_args()
+
+    if not args.input.exists():
+        print(f"ERROR: input not found: {args.input}", file=sys.stderr)
+        return 1
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    # Wipe any stale sidecar from a previous run; otherwise onnx.save_model
+    # may concatenate to it.
+    sidecar = args.output.with_name(args.output.name + "_data")
+    if sidecar.exists():
+        sidecar.unlink()
+
+    if args.mode == "fp16":
+        quantize_fp16(args.input, args.output)
+    elif args.mode == "int8":
+        quantize_int8_dynamic(args.input, args.output)
+    elif args.mode == "int4":
+        quantize_int4(args.input, args.output, block_size=args.block_size)
+    else:
+        print(f"ERROR: unknown mode {args.mode}", file=sys.stderr)
+        return 1
+
+    # Report size.
+    out_sz = args.output.stat().st_size
+    side_sz = sidecar.stat().st_size if sidecar.exists() else 0
+    print(f"[size] {args.output.name}: {out_sz / 1e6:.1f} MB"
+          + (f"  (+ {sidecar.name}: {side_sz / 1e6:.1f} MB)" if side_sz else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Chatterbox.Base/AcousticLM.cs
+++ b/src/Chatterbox.Base/AcousticLM.cs
@@ -162,19 +162,28 @@ public sealed class AcousticLM : IDisposable
     ///     waste their slot in subsequent steps. This is the simplest
     ///     correct implementation; per-element batch shrinking is a
     ///     follow-up if it bites.
-    ///   - Always uses the basic Run path (no IoBinding). IoBinding
-    ///     for B>1 is a separate perf increment.
+    ///   - Always uses the basic Run path (no IoBinding) at B&gt;1 until
+    ///     <paramref name="useIoBinding"/> is wired to the batched
+    ///     IoBinding loop. See <c>RunBatchedLmLoopIoBinding</c>.
     /// </summary>
+    /// <param name="useIoBinding">
+    /// Null (default) → auto-detect from the LM session's effective EP,
+    /// matching <see cref="Generate"/>'s rule (IoBinding when CUDA-backed).
+    /// </param>
     public BatchedAcousticLmResult GenerateBatch(
         IReadOnlyList<DenseTensor<float>> condEmbs,
         IReadOnlyList<long[]> textTokenIdsPerChunk,
+        bool? useIoBinding = null,
         float exaggeration = ChatterboxConstants.DefaultExaggeration,
         int maxSteps = ChatterboxConstants.DefaultMaxLmSteps,
         float repetitionPenalty = ChatterboxConstants.DefaultRepetitionPenalty)
     {
-        const int LlmLayers = ChatterboxConstants.LlmLayers;
-        const int LlmKvHeads = ChatterboxConstants.LlmKvHeads;
-        const int LlmHeadDim = ChatterboxConstants.LlmHeadDim;
+        bool resolvedIoBinding = useIoBinding ?? _effectiveCuda;
+        if (resolvedIoBinding && !_effectiveCuda)
+            throw new InvalidOperationException(
+                "GenerateBatch(useIoBinding=true) requires the LM session to be CUDA-backed.");
+
+        // Layer/head dims used only inside the dispatched loop bodies.
         const int LlmHidden = ChatterboxConstants.LlmHidden;
 
         int B = condEmbs.Count;
@@ -236,7 +245,38 @@ public sealed class AcousticLM : IDisposable
             doneAt[b] = -1;
         }
 
-        // ── attention_mask + past_kv (batched) ──
+        // ── Dispatch to the per-step rollout loop ─────────────────────
+        int actualSteps = resolvedIoBinding
+            ? RunBatchedLmLoopIoBinding(B, sTotal, inputsEmbeds, perTokens, doneAt, maxSteps, repetitionPenalty, exaggeration)
+            : RunBatchedLmLoopBasic(B, sTotal, inputsEmbeds, perTokens, doneAt, maxSteps, repetitionPenalty, exaggeration);
+
+        var perResults = new AcousticLmResult[B];
+        for (int b = 0; b < B; b++)
+            perResults[b] = new AcousticLmResult(perTokens[b], doneAt[b] >= 0 ? doneAt[b] + 1 : actualSteps);
+        return new BatchedAcousticLmResult(perResults, actualSteps);
+    }
+
+    /// <summary>
+    /// Batched LM rollout, basic Run path. Each step re-creates 2 + 60
+    /// NamedOnnxValue inputs (embeds, mask, 30 layers × {key,value}) and
+    /// host-roundtrips all KV outputs via <c>.ToArray()</c>. At full
+    /// 174-step rollout with B=4, this is roughly 3.2× slower than the
+    /// IoBinding sibling — see <c>docs/chatterbox_perf_investigation.md</c>
+    /// Runs 4 and 5 for the side-by-side numbers.
+    ///
+    /// Kept for CPU EP and as the verbatim semantic anchor for the
+    /// IoBinding path's correctness (both paths must produce
+    /// bit-identical token streams; verified via parity probe).
+    /// </summary>
+    private int RunBatchedLmLoopBasic(int B, int sTotal, float[] inputsEmbeds,
+        List<long>[] perTokens, int[] doneAt, int maxSteps,
+        float repetitionPenalty, float exaggeration)
+    {
+        const int LlmLayers = ChatterboxConstants.LlmLayers;
+        const int LlmKvHeads = ChatterboxConstants.LlmKvHeads;
+        const int LlmHeadDim = ChatterboxConstants.LlmHeadDim;
+        const int LlmHidden = ChatterboxConstants.LlmHidden;
+
         var attentionMask = new long[B * sTotal];
         Array.Fill(attentionMask, 1);
         var pastKv = new float[LlmLayers * 2][];
@@ -247,7 +287,6 @@ public sealed class AcousticLM : IDisposable
         for (int step = 0; step < maxSteps; step++)
         {
             actualSteps = step + 1;
-
             int seqLen = step == 0 ? sTotal : 1;
             var embedT = new DenseTensor<float>(inputsEmbeds, new[] { B, seqLen, LlmHidden });
             var attnMaskPerB = attentionMask.Length / B;
@@ -270,35 +309,13 @@ public sealed class AcousticLM : IDisposable
             var logits = outList[0].AsTensor<float>();
             int vocab = logits.Dimensions[2];
             var logitsArr = logits.ToArray();
-
-            // Per-element argmax on the last row's logits.
             int outSeqLen = logits.Dimensions[1];
-            int lastRowOffsetInLogits = (outSeqLen - 1) * vocab;
-            var nextTokensFlat = new long[B];
-            for (int b = 0; b < B; b++)
-            {
-                int rowStart = b * outSeqLen * vocab + lastRowOffsetInLogits;
-                var rowLogits = new float[vocab];
-                Array.Copy(logitsArr, rowStart, rowLogits, 0, vocab);
-                if (doneAt[b] < 0)
-                {
-                    foreach (var t in perTokens[b])
-                        if (rowLogits[t] > 0) rowLogits[t] /= repetitionPenalty;
-                }
-                nextTokensFlat[b] = Argmax(rowLogits);
-                if (doneAt[b] < 0)
-                {
-                    perTokens[b].Add(nextTokensFlat[b]);
-                    if (nextTokensFlat[b] == ChatterboxConstants.StopSpeechToken) doneAt[b] = step;
-                }
-            }
 
-            // Check all-done.
-            bool allDone = true;
-            for (int b = 0; b < B; b++) if (doneAt[b] < 0) { allDone = false; break; }
-            if (allDone) break;
+            var nextTokensFlat = ArgmaxBatchedLastRow(logitsArr, B, outSeqLen, vocab,
+                perTokens, doneAt, repetitionPenalty, step);
 
-            // Embed next tokens (B tokens at position step+1) for the next iteration.
+            if (AllDone(doneAt, B)) break;
+
             inputsEmbeds = EmbedBatch(nextTokensFlat, step + 1, exaggeration);
             attentionMask = GrowBatchedMask(attentionMask, B, 1);
             for (int layer = 0; layer < LlmLayers; layer++)
@@ -308,11 +325,172 @@ public sealed class AcousticLM : IDisposable
             }
             pastKvShape = outList[1].AsTensor<float>().Dimensions.ToArray();
         }
+        return actualSteps;
+    }
 
-        var perResults = new AcousticLmResult[B];
+    /// <summary>
+    /// Batched LM rollout, IoBinding path. Keeps the per-layer KV-cache
+    /// outputs GPU-resident between steps via direct <see cref="OrtValue"/>
+    /// chaining instead of host-roundtripping ~250 MB per step (at B=4
+    /// step 174). Same shape contract as the single-batch IoBinding
+    /// path in <see cref="RunLmLoopIoBinding"/>, generalized on the
+    /// leading batch dim.
+    ///
+    /// CUDA-only: hardcodes <c>OrtMemType.Default</c> on
+    /// <c>OrtMemoryInfo("Cuda")</c> for the KV bindings, same as the
+    /// single-batch path. Callers should auto-detect via the
+    /// <c>_effectiveCuda</c> flag on the LM session.
+    /// </summary>
+    private int RunBatchedLmLoopIoBinding(int B, int sTotal, float[] inputsEmbeds,
+        List<long>[] perTokens, int[] doneAt, int maxSteps,
+        float repetitionPenalty, float exaggeration)
+    {
+        const int LlmLayers = ChatterboxConstants.LlmLayers;
+        const int LlmKvHeads = ChatterboxConstants.LlmKvHeads;
+        const int LlmHeadDim = ChatterboxConstants.LlmHeadDim;
+        const int LlmHidden = ChatterboxConstants.LlmHidden;
+
+        using var cudaMemInfo = new OrtMemoryInfo("Cuda", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var cpuMemInfo = new OrtMemoryInfo("Cpu", OrtAllocatorType.ArenaAllocator, 0, OrtMemType.Default);
+        using var runOpts = new RunOptions();
+
+        var attentionMask = new long[B * sTotal];
+        Array.Fill(attentionMask, 1);
+
+        // Prefill: empty past_kv shaped [B, KvHeads, 0, HeadDim].
+        var emptyPastValues = new List<OrtValue>(LlmLayers * 2);
+        for (int i = 0; i < LlmLayers * 2; i++)
+            emptyPastValues.Add(OrtValue.CreateTensorValueFromMemory(
+                Array.Empty<float>(), new long[] { B, LlmKvHeads, 0L, LlmHeadDim }));
+
+        IDisposableReadOnlyCollection<OrtValue> prefillOutputs;
+        {
+            using var prefillEmbeds = OrtValue.CreateTensorValueFromMemory(
+                inputsEmbeds, new long[] { B, sTotal, LlmHidden });
+            using var prefillMask = OrtValue.CreateTensorValueFromMemory(
+                attentionMask, new long[] { B, sTotal });
+            using var binding = _lm.CreateIoBinding();
+            binding.BindInput("inputs_embeds", prefillEmbeds);
+            binding.BindInput("attention_mask", prefillMask);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                binding.BindInput($"past_key_values.{layer}.key", emptyPastValues[2 * layer]);
+                binding.BindInput($"past_key_values.{layer}.value", emptyPastValues[2 * layer + 1]);
+            }
+            binding.BindOutputToDevice("logits", cpuMemInfo);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                binding.BindOutputToDevice($"present.{layer}.key", cudaMemInfo);
+                binding.BindOutputToDevice($"present.{layer}.value", cudaMemInfo);
+            }
+            _lm.RunWithBinding(runOpts, binding);
+            prefillOutputs = binding.GetOutputValues();
+        }
+        foreach (var v in emptyPastValues) v.Dispose();
+
+        int vocab = (int)prefillOutputs[0].GetTensorTypeAndShape().Shape[2];
+        int outSeqLenPrefill = (int)prefillOutputs[0].GetTensorTypeAndShape().Shape[1];  // == sTotal
+        var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
+        // prefill logits live in CPU memory (we bound to cpuMemInfo); extract row -1 per batch.
+        var prefillLogitsArr = prefillLogitsSpan.ToArray();
+        var nextTokensFlat = ArgmaxBatchedLastRow(prefillLogitsArr, B, outSeqLenPrefill, vocab,
+            perTokens, doneAt, repetitionPenalty, 0);
+        if (AllDone(doneAt, B))
+        {
+            prefillOutputs.Dispose();
+            return 1;
+        }
+
+        // Step 1+: chain prev KV outputs as next KV inputs.
+        inputsEmbeds = EmbedBatch(nextTokensFlat, 1, exaggeration);
+        attentionMask = GrowBatchedMask(attentionMask, B, 1);
+
+        IDisposableReadOnlyCollection<OrtValue> prevStep = prefillOutputs;
+        int actualSteps = 1;
+        for (int step = 1; step < maxSteps; step++)
+        {
+            using var stepEmbeds = OrtValue.CreateTensorValueFromMemory(
+                inputsEmbeds, new long[] { B, 1L, LlmHidden });
+            using var stepMask = OrtValue.CreateTensorValueFromMemory(
+                attentionMask, new long[] { B, attentionMask.Length / B });
+            using var binding = _lm.CreateIoBinding();
+            binding.BindInput("inputs_embeds", stepEmbeds);
+            binding.BindInput("attention_mask", stepMask);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                binding.BindInput($"past_key_values.{layer}.key", prevStep[1 + 2 * layer]);
+                binding.BindInput($"past_key_values.{layer}.value", prevStep[1 + 2 * layer + 1]);
+            }
+            binding.BindOutputToDevice("logits", cpuMemInfo);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                binding.BindOutputToDevice($"present.{layer}.key", cudaMemInfo);
+                binding.BindOutputToDevice($"present.{layer}.value", cudaMemInfo);
+            }
+            _lm.RunWithBinding(runOpts, binding);
+            var curStep = binding.GetOutputValues();
+
+            // Safe to dispose prevStep here even though `binding` holds
+            // BindInput references — RunWithBinding has completed and ORT
+            // only reads input OrtValues during the Run call, not after.
+            // Same pattern as RunLmLoopIoBinding.
+            prevStep.Dispose();
+            prevStep = curStep;
+
+            // Step logits are [B, 1, vocab]; extract last (only) row per batch.
+            var stepLogitsSpan = curStep[0].GetTensorDataAsSpan<float>();
+            var stepLogitsArr = stepLogitsSpan.ToArray();
+            nextTokensFlat = ArgmaxBatchedLastRow(stepLogitsArr, B, 1, vocab,
+                perTokens, doneAt, repetitionPenalty, step);
+            actualSteps = step + 1;
+
+            if (AllDone(doneAt, B)) break;
+
+            inputsEmbeds = EmbedBatch(nextTokensFlat, step + 1, exaggeration);
+            attentionMask = GrowBatchedMask(attentionMask, B, 1);
+        }
+        prevStep.Dispose();
+        return actualSteps;
+    }
+
+    /// <summary>
+    /// Per-element argmax on the last-row logits, applying upstream's
+    /// repetition penalty to already-generated tokens. Mutates
+    /// <paramref name="perTokens"/> (appends each element's next token)
+    /// and <paramref name="doneAt"/> (records the step that element
+    /// emitted STOP_SPEECH, or leaves -1 if not yet done).
+    /// </summary>
+    private static long[] ArgmaxBatchedLastRow(
+        float[] logitsArr, int B, int outSeqLen, int vocab,
+        List<long>[] perTokens, int[] doneAt,
+        float repetitionPenalty, int step)
+    {
+        var nextTokensFlat = new long[B];
+        int lastRowOffsetInLogits = (outSeqLen - 1) * vocab;
         for (int b = 0; b < B; b++)
-            perResults[b] = new AcousticLmResult(perTokens[b], doneAt[b] >= 0 ? doneAt[b] + 1 : actualSteps);
-        return new BatchedAcousticLmResult(perResults, actualSteps);
+        {
+            int rowStart = b * outSeqLen * vocab + lastRowOffsetInLogits;
+            var rowLogits = new float[vocab];
+            Array.Copy(logitsArr, rowStart, rowLogits, 0, vocab);
+            if (doneAt[b] < 0)
+            {
+                foreach (var t in perTokens[b])
+                    if (rowLogits[t] > 0) rowLogits[t] /= repetitionPenalty;
+            }
+            nextTokensFlat[b] = Argmax(rowLogits);
+            if (doneAt[b] < 0)
+            {
+                perTokens[b].Add(nextTokensFlat[b]);
+                if (nextTokensFlat[b] == ChatterboxConstants.StopSpeechToken) doneAt[b] = step;
+            }
+        }
+        return nextTokensFlat;
+    }
+
+    private static bool AllDone(int[] doneAt, int B)
+    {
+        for (int b = 0; b < B; b++) if (doneAt[b] < 0) return false;
+        return true;
     }
 
     /// <summary>Batched single-token embed for the autoregressive loop.</summary>

--- a/src/Chatterbox.Base/AcousticLM.cs
+++ b/src/Chatterbox.Base/AcousticLM.cs
@@ -572,7 +572,7 @@ public sealed class AcousticLM : IDisposable
         IDisposableReadOnlyCollection<OrtValue> prefillOutputs;
         {
             using var prefillEmbeds = MakeEmbedsOrtValue(
-                inputsEmbeds, [1L, sTotal, LlmHidden], out _);
+                inputsEmbeds, [1L, sTotal, LlmHidden], out var prefillEmbedsScratch);
             using var prefillMask = OrtValue.CreateTensorValueFromMemory(
                 attentionMask, [1L, sTotal]);
             using var binding = _lm.CreateIoBinding();
@@ -591,6 +591,7 @@ public sealed class AcousticLM : IDisposable
             }
             _lm.RunWithBinding(runOpts, binding);
             prefillOutputs = binding.GetOutputValues();
+            GC.KeepAlive(prefillEmbedsScratch);
         }
         foreach (var v in emptyPastValues) v.Dispose();
 

--- a/src/Chatterbox.Base/AcousticLM.cs
+++ b/src/Chatterbox.Base/AcousticLM.cs
@@ -136,6 +136,219 @@ public sealed class AcousticLM : IDisposable
     }
 
     /// <summary>
+    /// Result of <see cref="GenerateBatch"/>: per-element rollouts in
+    /// input order, plus the wall-clock steps actually run (the inner
+    /// loop runs until all elements emit STOP or maxSteps is hit, so
+    /// individual elements may have completed earlier).
+    /// </summary>
+    public sealed record BatchedAcousticLmResult(
+        IReadOnlyList<AcousticLmResult> PerChunkResults,
+        int Steps);
+
+    /// <summary>
+    /// Generate B chunks concurrently through a single batched LM
+    /// rollout. Reaps the amortization benefit measured in Run 3 of
+    /// <c>docs/chatterbox_perf_investigation.md</c> — at B=4 on fp32,
+    /// per-batch-element step time drops from 14.0 ms (B=1) to 7.8 ms,
+    /// translating to ~31% wall reduction per chunk in long-form synth.
+    ///
+    /// MVP constraints (Phase 1 — Phase 2 will relax both):
+    ///   - All elements must share the same text-prompt length and
+    ///     the same cond_emb sequence length. Caller pads in advance
+    ///     if needed (chunk the text uniformly to keep this honest).
+    ///   - Inner loop runs until ALL elements have emitted STOP_SPEECH
+    ///     or maxSteps is hit; doesn't shrink the active batch as
+    ///     elements complete early. Elements that finished early
+    ///     waste their slot in subsequent steps. This is the simplest
+    ///     correct implementation; per-element batch shrinking is a
+    ///     follow-up if it bites.
+    ///   - Always uses the basic Run path (no IoBinding). IoBinding
+    ///     for B>1 is a separate perf increment.
+    /// </summary>
+    public BatchedAcousticLmResult GenerateBatch(
+        IReadOnlyList<DenseTensor<float>> condEmbs,
+        IReadOnlyList<long[]> textTokenIdsPerChunk,
+        float exaggeration = ChatterboxConstants.DefaultExaggeration,
+        int maxSteps = ChatterboxConstants.DefaultMaxLmSteps,
+        float repetitionPenalty = ChatterboxConstants.DefaultRepetitionPenalty)
+    {
+        const int LlmLayers = ChatterboxConstants.LlmLayers;
+        const int LlmKvHeads = ChatterboxConstants.LlmKvHeads;
+        const int LlmHeadDim = ChatterboxConstants.LlmHeadDim;
+        const int LlmHidden = ChatterboxConstants.LlmHidden;
+
+        int B = condEmbs.Count;
+        if (B == 0 || textTokenIdsPerChunk.Count != B)
+            throw new ArgumentException(
+                $"condEmbs ({B}) and textTokenIdsPerChunk ({textTokenIdsPerChunk.Count}) must be same non-zero length.");
+
+        int sText = textTokenIdsPerChunk[0].Length;
+        int sCond = condEmbs[0].Dimensions[1];
+        for (int b = 0; b < B; b++)
+        {
+            if (textTokenIdsPerChunk[b].Length != sText)
+                throw new ArgumentException(
+                    $"All chunks must have same text-prompt length (MVP); got {textTokenIdsPerChunk[b].Length} vs {sText} at index {b}.");
+            if (condEmbs[b].Dimensions[1] != sCond)
+                throw new ArgumentException(
+                    $"All cond_embs must have same sequence dim (MVP); got {condEmbs[b].Dimensions[1]} vs {sCond} at index {b}.");
+        }
+
+        // ── B-batched text embeddings via a single embed_tokens call ──
+        var idsB = new long[B * sText];
+        var posB = new long[B * sText];
+        for (int b = 0; b < B; b++)
+        {
+            Array.Copy(textTokenIdsPerChunk[b], 0, idsB, b * sText, sText);
+            for (int i = 0; i < sText; i++)
+                posB[b * sText + i] = textTokenIdsPerChunk[b][i] >= ChatterboxConstants.StartSpeechToken ? 0 : i - 1;
+        }
+        var exagB = new float[B];
+        Array.Fill(exagB, exaggeration);
+        using var embOut = _embed.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(idsB, new[] { B, sText })),
+            NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(posB, new[] { B, sText })),
+            NamedOnnxValue.CreateFromTensor("exaggeration", new DenseTensor<float>(exagB, new[] { B })),
+        });
+        var textEmbB = embOut.First().AsTensor<float>().ToArray();  // [B, sText, LlmHidden]
+
+        // ── Build inputs_embeds[B, sTotal, hidden] = concat(cond_emb[b], text_emb[b]) per row ──
+        int sTotal = sCond + sText;
+        var inputsEmbeds = new float[B * sTotal * LlmHidden];
+        for (int b = 0; b < B; b++)
+        {
+            var condArr = condEmbs[b].ToArray();
+            // cond row: copy sCond × hidden floats from condArr to inputsEmbeds[b, 0:sCond, :]
+            Array.Copy(condArr, 0, inputsEmbeds, b * sTotal * LlmHidden, sCond * LlmHidden);
+            // text row: copy sText × hidden floats from textEmbB[b, :, :] to inputsEmbeds[b, sCond:, :]
+            Array.Copy(textEmbB, b * sText * LlmHidden,
+                       inputsEmbeds, b * sTotal * LlmHidden + sCond * LlmHidden,
+                       sText * LlmHidden);
+        }
+
+        // ── State per element ──
+        var perTokens = new List<long>[B];
+        var doneAt = new int[B];
+        for (int b = 0; b < B; b++)
+        {
+            perTokens[b] = new List<long> { ChatterboxConstants.StartSpeechToken };
+            doneAt[b] = -1;
+        }
+
+        // ── attention_mask + past_kv (batched) ──
+        var attentionMask = new long[B * sTotal];
+        Array.Fill(attentionMask, 1);
+        var pastKv = new float[LlmLayers * 2][];
+        var pastKvShape = new int[] { B, LlmKvHeads, 0, LlmHeadDim };
+        for (int k = 0; k < pastKv.Length; k++) pastKv[k] = [];
+
+        int actualSteps = 0;
+        for (int step = 0; step < maxSteps; step++)
+        {
+            actualSteps = step + 1;
+
+            int seqLen = step == 0 ? sTotal : 1;
+            var embedT = new DenseTensor<float>(inputsEmbeds, new[] { B, seqLen, LlmHidden });
+            var attnMaskPerB = attentionMask.Length / B;
+            var maskT = new DenseTensor<long>(attentionMask, new[] { B, attnMaskPerB });
+
+            var inputs = new List<NamedOnnxValue>(2 + 2 * LlmLayers)
+            {
+                NamedOnnxValue.CreateFromTensor("inputs_embeds", embedT),
+                NamedOnnxValue.CreateFromTensor("attention_mask", maskT),
+            };
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                inputs.Add(NamedOnnxValue.CreateFromTensor(
+                    $"past_key_values.{layer}.key", new DenseTensor<float>(pastKv[2 * layer], pastKvShape)));
+                inputs.Add(NamedOnnxValue.CreateFromTensor(
+                    $"past_key_values.{layer}.value", new DenseTensor<float>(pastKv[2 * layer + 1], pastKvShape)));
+            }
+            using var output = _lm.Run(inputs);
+            var outList = output.ToList();
+            var logits = outList[0].AsTensor<float>();
+            int vocab = logits.Dimensions[2];
+            var logitsArr = logits.ToArray();
+
+            // Per-element argmax on the last row's logits.
+            int outSeqLen = logits.Dimensions[1];
+            int lastRowOffsetInLogits = (outSeqLen - 1) * vocab;
+            var nextTokensFlat = new long[B];
+            for (int b = 0; b < B; b++)
+            {
+                int rowStart = b * outSeqLen * vocab + lastRowOffsetInLogits;
+                var rowLogits = new float[vocab];
+                Array.Copy(logitsArr, rowStart, rowLogits, 0, vocab);
+                if (doneAt[b] < 0)
+                {
+                    foreach (var t in perTokens[b])
+                        if (rowLogits[t] > 0) rowLogits[t] /= repetitionPenalty;
+                }
+                nextTokensFlat[b] = Argmax(rowLogits);
+                if (doneAt[b] < 0)
+                {
+                    perTokens[b].Add(nextTokensFlat[b]);
+                    if (nextTokensFlat[b] == ChatterboxConstants.StopSpeechToken) doneAt[b] = step;
+                }
+            }
+
+            // Check all-done.
+            bool allDone = true;
+            for (int b = 0; b < B; b++) if (doneAt[b] < 0) { allDone = false; break; }
+            if (allDone) break;
+
+            // Embed next tokens (B tokens at position step+1) for the next iteration.
+            inputsEmbeds = EmbedBatch(nextTokensFlat, step + 1, exaggeration);
+            attentionMask = GrowBatchedMask(attentionMask, B, 1);
+            for (int layer = 0; layer < LlmLayers; layer++)
+            {
+                pastKv[2 * layer] = outList[1 + 2 * layer].AsTensor<float>().ToArray();
+                pastKv[2 * layer + 1] = outList[1 + 2 * layer + 1].AsTensor<float>().ToArray();
+            }
+            pastKvShape = outList[1].AsTensor<float>().Dimensions.ToArray();
+        }
+
+        var perResults = new AcousticLmResult[B];
+        for (int b = 0; b < B; b++)
+            perResults[b] = new AcousticLmResult(perTokens[b], doneAt[b] >= 0 ? doneAt[b] + 1 : actualSteps);
+        return new BatchedAcousticLmResult(perResults, actualSteps);
+    }
+
+    /// <summary>Batched single-token embed for the autoregressive loop.</summary>
+    private float[] EmbedBatch(long[] tokensB, int position, float exaggeration)
+    {
+        int B = tokensB.Length;
+        var idsB = new long[B];
+        Array.Copy(tokensB, idsB, B);
+        var posB = new long[B];
+        Array.Fill(posB, position);
+        var exagB = new float[B];
+        Array.Fill(exagB, exaggeration);
+        using var o = _embed.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(idsB, new[] { B, 1 })),
+            NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(posB, new[] { B, 1 })),
+            NamedOnnxValue.CreateFromTensor("exaggeration", new DenseTensor<float>(exagB, new[] { B })),
+        });
+        return o.First().AsTensor<float>().ToArray();
+    }
+
+    /// <summary>Grow each batch element's attention mask by `growBy` trailing 1s.</summary>
+    private static long[] GrowBatchedMask(long[] mask, int batch, int growBy)
+    {
+        int oldPerB = mask.Length / batch;
+        int newPerB = oldPerB + growBy;
+        var grown = new long[batch * newPerB];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Copy(mask, b * oldPerB, grown, b * newPerB, oldPerB);
+            for (int i = oldPerB; i < newPerB; i++) grown[b * newPerB + i] = 1;
+        }
+        return grown;
+    }
+
+    /// <summary>
     /// LM autoregressive loop, IoBinding path. KV-cache outputs are kept
     /// CUDA-resident between steps via direct OrtValue chaining instead
     /// of host-roundtripping every layer's K/V each step. ~3.5× faster

--- a/src/Chatterbox.Base/AcousticLM.cs
+++ b/src/Chatterbox.Base/AcousticLM.cs
@@ -60,6 +60,15 @@ public sealed class AcousticLM : IDisposable
     /// reports false (and won't try the CUDA-only IoBinding path).
     /// </summary>
     private readonly bool _effectiveCuda;
+    /// <summary>
+    /// True when the loaded LM graph expects fp16 <c>inputs_embeds</c> /
+    /// <c>past_key_values.*</c> and emits fp16 <c>logits</c> / <c>present.*</c>.
+    /// Detected from session input metadata at construction time. Drives
+    /// the dtype-aware OrtValue/NamedOnnxValue construction in all four
+    /// rollout paths (single+batched × IoBinding+Basic). Run 9 result:
+    /// true-fp16 KV cache eliminates the boundary Casts that hurt Run 8a.
+    /// </summary>
+    private readonly bool _lmFp16;
 
     /// <summary>Load both graphs from disk.</summary>
     /// <param name="onLoad">Optional callback fired once per session (embed_tokens, then language_model).</param>
@@ -71,7 +80,12 @@ public sealed class AcousticLM : IDisposable
         // IoBinding actually fires); embed_tokens uses plain Run regardless.
         _lm = SessionLoader.LoadAndReport(languageModelPath, ep, onLoad, out var lmUsedCuda);
         _effectiveCuda = lmUsedCuda;
+        _lmFp16 = _lm.InputMetadata.TryGetValue("inputs_embeds", out var iemd)
+                  && iemd.ElementDataType == TensorElementType.Float16;
     }
+
+    /// <summary>True when the LM expects fp16 floats (KV cache + inputs_embeds + logits).</summary>
+    public bool LmIsFloat16 => _lmFp16;
 
     /// <summary>
     /// Run the LM autoregressively. Returns generated tokens including the
@@ -288,28 +302,28 @@ public sealed class AcousticLM : IDisposable
         {
             actualSteps = step + 1;
             int seqLen = step == 0 ? sTotal : 1;
-            var embedT = new DenseTensor<float>(inputsEmbeds, new[] { B, seqLen, LlmHidden });
             var attnMaskPerB = attentionMask.Length / B;
             var maskT = new DenseTensor<long>(attentionMask, new[] { B, attnMaskPerB });
 
             var inputs = new List<NamedOnnxValue>(2 + 2 * LlmLayers)
             {
-                NamedOnnxValue.CreateFromTensor("inputs_embeds", embedT),
+                MakeEmbedsNamedValue(inputsEmbeds, new[] { B, seqLen, LlmHidden }),
                 NamedOnnxValue.CreateFromTensor("attention_mask", maskT),
             };
             for (int layer = 0; layer < LlmLayers; layer++)
             {
-                inputs.Add(NamedOnnxValue.CreateFromTensor(
-                    $"past_key_values.{layer}.key", new DenseTensor<float>(pastKv[2 * layer], pastKvShape)));
-                inputs.Add(NamedOnnxValue.CreateFromTensor(
-                    $"past_key_values.{layer}.value", new DenseTensor<float>(pastKv[2 * layer + 1], pastKvShape)));
+                inputs.Add(MakePastKvNamedValue($"past_key_values.{layer}.key",
+                    pastKv[2 * layer], pastKvShape));
+                inputs.Add(MakePastKvNamedValue($"past_key_values.{layer}.value",
+                    pastKv[2 * layer + 1], pastKvShape));
             }
             using var output = _lm.Run(inputs);
             var outList = output.ToList();
-            var logits = outList[0].AsTensor<float>();
-            int vocab = logits.Dimensions[2];
-            var logitsArr = logits.ToArray();
-            int outSeqLen = logits.Dimensions[1];
+            // Logits → fp32 array via dtype-aware reader.
+            var logitsArr = PresentToFloatArray(outList[0]);
+            var logitsDims = PresentDims(outList[0]);
+            int vocab = logitsDims[2];
+            int outSeqLen = logitsDims[1];
 
             var nextTokensFlat = ArgmaxBatchedLastRow(logitsArr, B, outSeqLen, vocab,
                 perTokens, doneAt, repetitionPenalty, step);
@@ -320,10 +334,10 @@ public sealed class AcousticLM : IDisposable
             attentionMask = GrowBatchedMask(attentionMask, B, 1);
             for (int layer = 0; layer < LlmLayers; layer++)
             {
-                pastKv[2 * layer] = outList[1 + 2 * layer].AsTensor<float>().ToArray();
-                pastKv[2 * layer + 1] = outList[1 + 2 * layer + 1].AsTensor<float>().ToArray();
+                pastKv[2 * layer] = PresentToFloatArray(outList[1 + 2 * layer]);
+                pastKv[2 * layer + 1] = PresentToFloatArray(outList[1 + 2 * layer + 1]);
             }
-            pastKvShape = outList[1].AsTensor<float>().Dimensions.ToArray();
+            pastKvShape = PresentDims(outList[1]);
         }
         return actualSteps;
     }
@@ -357,16 +371,15 @@ public sealed class AcousticLM : IDisposable
         var attentionMask = new long[B * sTotal];
         Array.Fill(attentionMask, 1);
 
-        // Prefill: empty past_kv shaped [B, KvHeads, 0, HeadDim].
+        // Prefill: empty past_kv shaped [B, KvHeads, 0, HeadDim] (dtype-aware).
         var emptyPastValues = new List<OrtValue>(LlmLayers * 2);
         for (int i = 0; i < LlmLayers * 2; i++)
-            emptyPastValues.Add(OrtValue.CreateTensorValueFromMemory(
-                Array.Empty<float>(), new long[] { B, LlmKvHeads, 0L, LlmHeadDim }));
+            emptyPastValues.Add(MakeEmptyPastKvOrtValue(new long[] { B, LlmKvHeads, 0L, LlmHeadDim }));
 
         IDisposableReadOnlyCollection<OrtValue> prefillOutputs;
         {
-            using var prefillEmbeds = OrtValue.CreateTensorValueFromMemory(
-                inputsEmbeds, new long[] { B, sTotal, LlmHidden });
+            using var prefillEmbeds = MakeEmbedsOrtValue(
+                inputsEmbeds, new long[] { B, sTotal, LlmHidden }, out var prefillEmbedsScratch);
             using var prefillMask = OrtValue.CreateTensorValueFromMemory(
                 attentionMask, new long[] { B, sTotal });
             using var binding = _lm.CreateIoBinding();
@@ -385,14 +398,14 @@ public sealed class AcousticLM : IDisposable
             }
             _lm.RunWithBinding(runOpts, binding);
             prefillOutputs = binding.GetOutputValues();
+            GC.KeepAlive(prefillEmbedsScratch);
         }
         foreach (var v in emptyPastValues) v.Dispose();
 
         int vocab = (int)prefillOutputs[0].GetTensorTypeAndShape().Shape[2];
         int outSeqLenPrefill = (int)prefillOutputs[0].GetTensorTypeAndShape().Shape[1];  // == sTotal
-        var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
-        // prefill logits live in CPU memory (we bound to cpuMemInfo); extract row -1 per batch.
-        var prefillLogitsArr = prefillLogitsSpan.ToArray();
+        // Logits → fp32 array (dtype-aware). CPU-bound, full B*sTotal*vocab slab.
+        var prefillLogitsArr = LogitsToFloatArray(prefillOutputs[0]);
         var nextTokensFlat = ArgmaxBatchedLastRow(prefillLogitsArr, B, outSeqLenPrefill, vocab,
             perTokens, doneAt, repetitionPenalty, 0);
         if (AllDone(doneAt, B))
@@ -409,8 +422,8 @@ public sealed class AcousticLM : IDisposable
         int actualSteps = 1;
         for (int step = 1; step < maxSteps; step++)
         {
-            using var stepEmbeds = OrtValue.CreateTensorValueFromMemory(
-                inputsEmbeds, new long[] { B, 1L, LlmHidden });
+            using var stepEmbeds = MakeEmbedsOrtValue(
+                inputsEmbeds, new long[] { B, 1L, LlmHidden }, out var stepEmbedsScratch);
             using var stepMask = OrtValue.CreateTensorValueFromMemory(
                 attentionMask, new long[] { B, attentionMask.Length / B });
             using var binding = _lm.CreateIoBinding();
@@ -429,6 +442,7 @@ public sealed class AcousticLM : IDisposable
             }
             _lm.RunWithBinding(runOpts, binding);
             var curStep = binding.GetOutputValues();
+            GC.KeepAlive(stepEmbedsScratch);
 
             // Safe to dispose prevStep here even though `binding` holds
             // BindInput references — RunWithBinding has completed and ORT
@@ -437,9 +451,9 @@ public sealed class AcousticLM : IDisposable
             prevStep.Dispose();
             prevStep = curStep;
 
-            // Step logits are [B, 1, vocab]; extract last (only) row per batch.
-            var stepLogitsSpan = curStep[0].GetTensorDataAsSpan<float>();
-            var stepLogitsArr = stepLogitsSpan.ToArray();
+            // Step logits are [B, 1, vocab] (fp16 or fp32). LogitsToFloatArray
+            // returns fp32 floats either way for downstream argmax math.
+            var stepLogitsArr = LogitsToFloatArray(curStep[0]);
             nextTokensFlat = ArgmaxBatchedLastRow(stepLogitsArr, B, 1, vocab,
                 perTokens, doneAt, repetitionPenalty, step);
             actualSteps = step + 1;
@@ -550,16 +564,15 @@ public sealed class AcousticLM : IDisposable
         Array.Fill(attentionMask, 1);
         var generateTokens = new List<long> { ChatterboxConstants.StartSpeechToken };
 
-        // Prefill (step 0): empty past_kv.
+        // Prefill (step 0): empty past_kv (fp16 or fp32 depending on LM dtype).
         var emptyPastValues = new List<OrtValue>(LlmLayers * 2);
         for (int i = 0; i < LlmLayers * 2; i++)
-            emptyPastValues.Add(OrtValue.CreateTensorValueFromMemory(
-                Array.Empty<float>(), [1L, LlmKvHeads, 0L, LlmHeadDim]));
+            emptyPastValues.Add(MakeEmptyPastKvOrtValue([1L, LlmKvHeads, 0L, LlmHeadDim]));
 
         IDisposableReadOnlyCollection<OrtValue> prefillOutputs;
         {
-            using var prefillEmbeds = OrtValue.CreateTensorValueFromMemory(
-                inputsEmbeds, [1L, sTotal, LlmHidden]);
+            using var prefillEmbeds = MakeEmbedsOrtValue(
+                inputsEmbeds, [1L, sTotal, LlmHidden], out _);
             using var prefillMask = OrtValue.CreateTensorValueFromMemory(
                 attentionMask, [1L, sTotal]);
             using var binding = _lm.CreateIoBinding();
@@ -583,8 +596,10 @@ public sealed class AcousticLM : IDisposable
 
         // Read vocab from tensor metadata (robust against future batch>1).
         int vocab = (int)prefillOutputs[0].GetTensorTypeAndShape().Shape[2];
-        var prefillLogitsSpan = prefillOutputs[0].GetTensorDataAsSpan<float>();
-        var lastLogits = prefillLogitsSpan.Slice((sTotal - 1) * vocab, vocab).ToArray();
+        // Logits → float[] via dtype-aware reader. Slice last row for argmax.
+        var prefillLogitsAll = LogitsToFloatArray(prefillOutputs[0]);
+        var lastLogits = new float[vocab];
+        Array.Copy(prefillLogitsAll, (sTotal - 1) * vocab, lastLogits, 0, vocab);
         MaybeDumpStep(diagDir, 0, lastLogits, inputsEmbeds, attentionMask);
         foreach (var t in generateTokens)
             if (lastLogits[t] > 0) lastLogits[t] /= repetitionPenalty;
@@ -603,8 +618,10 @@ public sealed class AcousticLM : IDisposable
         int actualSteps = 1;
         for (int step = 1; step < maxSteps; step++)
         {
-            using var stepEmbeds = OrtValue.CreateTensorValueFromMemory(
-                inputsEmbeds, [1L, 1L, LlmHidden]);
+            // fp16 path: stepEmbedsScratch must stay alive until RunWithBinding
+            // completes (OrtValue holds an unmanaged pointer into it).
+            using var stepEmbeds = MakeEmbedsOrtValue(
+                inputsEmbeds, [1L, 1L, LlmHidden], out var stepEmbedsScratch);
             using var stepMask = OrtValue.CreateTensorValueFromMemory(
                 attentionMask, [1L, attentionMask.Length]);
             using var binding = _lm.CreateIoBinding();
@@ -623,6 +640,12 @@ public sealed class AcousticLM : IDisposable
             }
             _lm.RunWithBinding(runOpts, binding);
             var curStep = binding.GetOutputValues();
+            // Keep the GC honest: scratch buffer must outlive Run. The using
+            // on stepEmbeds disposes after this scope, by which point
+            // stepEmbedsScratch is also unreachable — that's the correct
+            // ordering. The explicit reference here forbids the JIT from
+            // eliding it before RunWithBinding returns.
+            GC.KeepAlive(stepEmbedsScratch);
 
             // Safe to dispose prevStep here even though `binding` (which holds
             // BindInput references to prevStep's OrtValues) is still alive:
@@ -631,8 +654,9 @@ public sealed class AcousticLM : IDisposable
             prevStep.Dispose();
             prevStep = curStep;
 
-            var stepLogitsSpan = curStep[0].GetTensorDataAsSpan<float>();
-            lastLogits = stepLogitsSpan[..vocab].ToArray();
+            // Step logits = [1, 1, vocab]; vocab-length tail is the only row.
+            var stepLogitsAll = LogitsToFloatArray(curStep[0]);
+            lastLogits = stepLogitsAll[..vocab];
             MaybeDumpStep(diagDir, step, lastLogits, inputsEmbeds, attentionMask);
             foreach (var t in generateTokens)
                 if (lastLogits[t] > 0) lastLogits[t] /= repetitionPenalty;
@@ -676,30 +700,27 @@ public sealed class AcousticLM : IDisposable
         for (int step = 0; step < maxSteps; step++)
         {
             int seqLen = step == 0 ? sTotal : 1;
-            var embedT = new DenseTensor<float>(inputsEmbeds, [1, seqLen, LlmHidden]);
 
             var inputs = new List<NamedOnnxValue>(2 + 2 * LlmLayers)
             {
-                NamedOnnxValue.CreateFromTensor("inputs_embeds", embedT),
+                MakeEmbedsNamedValue(inputsEmbeds, [1, seqLen, LlmHidden]),
                 NamedOnnxValue.CreateFromTensor("attention_mask",
                     new DenseTensor<long>(attentionMask.ToArray(), [1, attentionMask.Length])),
             };
             for (int layer = 0; layer < LlmLayers; layer++)
             {
-                inputs.Add(NamedOnnxValue.CreateFromTensor(
-                    $"past_key_values.{layer}.key",
-                    new DenseTensor<float>(pastKv[2 * layer], pastKvShape)));
-                inputs.Add(NamedOnnxValue.CreateFromTensor(
-                    $"past_key_values.{layer}.value",
-                    new DenseTensor<float>(pastKv[2 * layer + 1], pastKvShape)));
+                inputs.Add(MakePastKvNamedValue($"past_key_values.{layer}.key",
+                    pastKv[2 * layer], pastKvShape));
+                inputs.Add(MakePastKvNamedValue($"past_key_values.{layer}.value",
+                    pastKv[2 * layer + 1], pastKvShape));
             }
             using var output = _lm.Run(inputs);
             var outList = output.ToList();
-            var logits = outList[0].AsTensor<float>();
-            int vocab = logits.Dimensions[2];
+            var logitsArr = PresentToFloatArray(outList[0]);
+            var logitsDims = PresentDims(outList[0]);
+            int vocab = logitsDims[2];
             var lastLogits = new float[vocab];
-            int logitsOffset = (logits.Dimensions[1] - 1) * vocab;
-            var logitsArr = logits.ToArray();
+            int logitsOffset = (logitsDims[1] - 1) * vocab;
             Array.Copy(logitsArr, logitsOffset, lastLogits, 0, vocab);
             MaybeDumpStep(diagDir, step, lastLogits, inputsEmbeds, attentionMask, pastKv, pastKvShape);
 
@@ -713,10 +734,10 @@ public sealed class AcousticLM : IDisposable
             attentionMask = Grow(attentionMask, 1);
             for (int layer = 0; layer < LlmLayers; layer++)
             {
-                pastKv[2 * layer] = outList[1 + 2 * layer].AsTensor<float>().ToArray();
-                pastKv[2 * layer + 1] = outList[1 + 2 * layer + 1].AsTensor<float>().ToArray();
+                pastKv[2 * layer] = PresentToFloatArray(outList[1 + 2 * layer]);
+                pastKv[2 * layer + 1] = PresentToFloatArray(outList[1 + 2 * layer + 1]);
             }
-            pastKvShape = outList[1].AsTensor<float>().Dimensions.ToArray();
+            pastKvShape = PresentDims(outList[1]);
             actualSteps = step + 1;
         }
         return new AcousticLmResult(generateTokens, actualSteps);
@@ -794,6 +815,107 @@ public sealed class AcousticLM : IDisposable
                 MemoryMarshal.AsBytes<float>(pastKv[1]).ToArray());
         }
     }
+
+    // ── Float / Float16 helpers for true-fp16 LM (Run 9) ───────────────────
+    // When `_lmFp16` is true the LM expects fp16 inputs_embeds / past_kv and
+    // emits fp16 logits / present.*. embed_tokens still produces fp32, so the
+    // conversion happens at the BindInput/output boundary. attention_mask is
+    // int64 in both worlds (untouched).
+
+    /// <summary>Pack fp16-or-fp32 LM <c>inputs_embeds</c> from a CPU fp32 source.
+    /// Caller must dispose the returned OrtValue AND keep the returned buffer
+    /// alive until <c>RunWithBinding</c> completes (CreateTensorValueFromMemory
+    /// doesn't copy). For fp16 we allocate a fresh Float16[] scratch and
+    /// hand it back via <paramref name="fp16Scratch"/>; for fp32 the caller's
+    /// <paramref name="src"/> buffer is used directly and <paramref name="fp16Scratch"/>
+    /// is null.</summary>
+    private OrtValue MakeEmbedsOrtValue(float[] src, long[] shape, out Float16[]? fp16Scratch)
+    {
+        if (_lmFp16)
+        {
+            var dst = new Float16[src.Length];
+            for (int i = 0; i < src.Length; i++) dst[i] = (Float16)src[i];
+            fp16Scratch = dst;
+            return OrtValue.CreateTensorValueFromMemory(dst, shape);
+        }
+        fp16Scratch = null;
+        return OrtValue.CreateTensorValueFromMemory(src, shape);
+    }
+
+    /// <summary>Make an empty (zero-length sequence dim) past_kv tensor of
+    /// the LM's expected dtype. Used only at prefill — subsequent steps
+    /// chain real OrtValues from prior output.</summary>
+    private OrtValue MakeEmptyPastKvOrtValue(long[] shape)
+        => _lmFp16
+            ? OrtValue.CreateTensorValueFromMemory(Array.Empty<Float16>(), shape)
+            : OrtValue.CreateTensorValueFromMemory(Array.Empty<float>(), shape);
+
+    /// <summary>Read logits (CPU-bound output) as a fresh float[]. Always
+    /// returns fp32 floats for the argmax + repetition-penalty math, even
+    /// when the LM emitted fp16.</summary>
+    private float[] LogitsToFloatArray(OrtValue logits)
+    {
+        if (_lmFp16)
+        {
+            var span = logits.GetTensorDataAsSpan<Float16>();
+            var arr = new float[span.Length];
+            for (int i = 0; i < span.Length; i++) arr[i] = (float)span[i];
+            return arr;
+        }
+        return logits.GetTensorDataAsSpan<float>().ToArray();
+    }
+
+    /// <summary>Build a NamedOnnxValue carrying inputs_embeds at the LM's
+    /// expected dtype. Used by the basic-Run paths (RunLmLoopBasic and
+    /// RunBatchedLmLoopBasic).</summary>
+    private NamedOnnxValue MakeEmbedsNamedValue(float[] src, int[] shape)
+    {
+        if (_lmFp16)
+        {
+            var dst = new Float16[src.Length];
+            for (int i = 0; i < src.Length; i++) dst[i] = (Float16)src[i];
+            return NamedOnnxValue.CreateFromTensor("inputs_embeds",
+                new DenseTensor<Float16>(dst, shape));
+        }
+        return NamedOnnxValue.CreateFromTensor("inputs_embeds",
+            new DenseTensor<float>(src, shape));
+    }
+
+    /// <summary>Build a NamedOnnxValue carrying one past_kv slot at the
+    /// LM's expected dtype, given a fp32 CPU buffer (the basic path's
+    /// internal representation).</summary>
+    private NamedOnnxValue MakePastKvNamedValue(string name, float[] src, int[] shape)
+    {
+        if (_lmFp16)
+        {
+            var dst = new Float16[src.Length];
+            for (int i = 0; i < src.Length; i++) dst[i] = (Float16)src[i];
+            return NamedOnnxValue.CreateFromTensor(name, new DenseTensor<Float16>(dst, shape));
+        }
+        return NamedOnnxValue.CreateFromTensor(name, new DenseTensor<float>(src, shape));
+    }
+
+    /// <summary>Extract a present.* output to a CPU fp32 float[] for the
+    /// basic-Run paths, regardless of fp16/fp32 LM. (IoBinding paths chain
+    /// OrtValues directly and never visit this helper.)</summary>
+    private float[] PresentToFloatArray(DisposableNamedOnnxValue v)
+    {
+        if (_lmFp16)
+        {
+            var t = v.AsTensor<Float16>().ToArray();
+            var arr = new float[t.Length];
+            for (int i = 0; i < t.Length; i++) arr[i] = (float)t[i];
+            return arr;
+        }
+        return v.AsTensor<float>().ToArray();
+    }
+
+    /// <summary>Read the present.* output shape from a basic-Run output
+    /// in a dtype-agnostic way (only the metadata is needed; values are
+    /// already extracted via <see cref="PresentToFloatArray"/>).</summary>
+    private int[] PresentDims(DisposableNamedOnnxValue v)
+        => _lmFp16 ? v.AsTensor<Float16>().Dimensions.ToArray()
+                   : v.AsTensor<float>().Dimensions.ToArray();
 
     public void Dispose()
     {

--- a/src/Chatterbox.Base/AcousticLM.cs
+++ b/src/Chatterbox.Base/AcousticLM.cs
@@ -67,6 +67,13 @@ public sealed class AcousticLM : IDisposable
     /// the dtype-aware OrtValue/NamedOnnxValue construction in all four
     /// rollout paths (single+batched × IoBinding+Basic). Run 9 result:
     /// true-fp16 KV cache eliminates the boundary Casts that hurt Run 8a.
+    ///
+    /// Invariant: <c>embed_tokens.onnx</c> is assumed to stay fp32 (only
+    /// the LM is quantized by quantize_lm.py). <see cref="EmbedOne"/> and
+    /// <see cref="EmbedBatch"/> read its output via
+    /// <c>.AsTensor&lt;float&gt;().ToArray()</c>; an fp16 embed graph would
+    /// throw an unhelpful type error there. If we ever quantize embeds too,
+    /// both helpers need the same dtype-aware treatment as the LM.
     /// </summary>
     private readonly bool _lmFp16;
 
@@ -237,14 +244,19 @@ public sealed class AcousticLM : IDisposable
         var textEmbB = embOut.First().AsTensor<float>().ToArray();  // [B, sText, LlmHidden]
 
         // ── Build inputs_embeds[B, sTotal, hidden] = concat(cond_emb[b], text_emb[b]) per row ──
+        // Long-form audiobook case: all B chunks share the same speaker, so
+        // condEmbs[0..B] reference the same tensor (cf. ChunkedSynthesizer.SynthesizeInGroups).
+        // ToArray()-once when so, otherwise per-element.
         int sTotal = sCond + sText;
         var inputsEmbeds = new float[B * sTotal * LlmHidden];
+        bool sharedCondEmb = true;
+        for (int b = 1; b < B; b++)
+            if (!ReferenceEquals(condEmbs[b], condEmbs[0])) { sharedCondEmb = false; break; }
+        float[]? sharedCondArr = sharedCondEmb ? condEmbs[0].ToArray() : null;
         for (int b = 0; b < B; b++)
         {
-            var condArr = condEmbs[b].ToArray();
-            // cond row: copy sCond × hidden floats from condArr to inputsEmbeds[b, 0:sCond, :]
+            var condArr = sharedCondArr ?? condEmbs[b].ToArray();
             Array.Copy(condArr, 0, inputsEmbeds, b * sTotal * LlmHidden, sCond * LlmHidden);
-            // text row: copy sText × hidden floats from textEmbB[b, :, :] to inputsEmbeds[b, sCond:, :]
             Array.Copy(textEmbB, b * sText * LlmHidden,
                        inputsEmbeds, b * sTotal * LlmHidden + sCond * LlmHidden,
                        sText * LlmHidden);

--- a/src/Chatterbox.Base/ChunkedSynthesizer.cs
+++ b/src/Chatterbox.Base/ChunkedSynthesizer.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace Chatterbox.Base;
+
+/// <summary>
+/// Per-chunk timing record for callers that want to log + investigate.
+/// All durations are wall-clock at the producer/consumer thread that
+/// produced them — under pipelined execution, voc starts *while* the
+/// next chunk's LM is running, so summing the columns OVER-counts
+/// total wall time. Use <see cref="ChunkSynthesisResult.TotalWallMs"/>
+/// for the actual end-to-end number.
+/// </summary>
+/// <param name="ChunkIndex">0-based index in input order.</param>
+/// <param name="LmMs">LM rollout wall-clock for this chunk.</param>
+/// <param name="LmSteps">Number of autoregressive steps the LM took before STOP_SPEECH (or maxSteps cap).</param>
+/// <param name="VocoderMs">Vocoder wall-clock for this chunk.</param>
+/// <param name="AudioSamples">Length of the chunk's waveform in samples (24 kHz mono).</param>
+public sealed record ChunkTiming(int ChunkIndex, long LmMs, int LmSteps, long VocoderMs, int AudioSamples);
+
+/// <summary>
+/// Output of <see cref="ChunkedSynthesizer.Synthesize"/>: waveforms in
+/// input order, plus per-chunk timings and a true end-to-end wall.
+/// </summary>
+public sealed record ChunkSynthesisResult(
+    IReadOnlyList<float[]> Waveforms,
+    IReadOnlyList<ChunkTiming> ChunkTimings,
+    long TotalWallMs);
+
+/// <summary>
+/// Long-form chunk synthesizer that overlaps LM rollout for chunk N+1
+/// with vocoder synthesis for chunk N. Constructed over an existing
+/// <see cref="ChatterboxPipeline"/>; uses its <see cref="AcousticLM"/>
+/// and <see cref="Vocoder"/> sessions directly.
+///
+/// Concurrency model: one producer task running LM rollouts in input
+/// order, one consumer task running the vocoder. A bounded
+/// <see cref="Channel{T}"/> hands the LM's <c>speech_tokens</c> output
+/// to the vocoder; bound is intentionally small so memory doesn't
+/// balloon if the vocoder is faster than the LM (it never is for our
+/// chunk sizes, but defensive).
+///
+/// Safety: LM and Vocoder own different ORT <c>InferenceSession</c>
+/// objects. ORT sessions are not internally synchronized for concurrent
+/// <c>Run()</c> calls on the SAME session, but DIFFERENT sessions can
+/// run on different threads concurrently — that's exactly the
+/// configuration here. The shared <see cref="SpeakerEmbedding"/> is
+/// effectively read-only after construction (CPU arrays; no internal
+/// state mutated by either consumer).
+/// </summary>
+public sealed class ChunkedSynthesizer
+{
+    private readonly AcousticLM _lm;
+    private readonly Vocoder _vocoder;
+
+    /// <summary>Construct over already-loaded LM + Vocoder sessions.
+    /// Caller retains ownership; ChunkedSynthesizer doesn't dispose them.</summary>
+    public ChunkedSynthesizer(AcousticLM lm, Vocoder vocoder)
+    {
+        _lm = lm;
+        _vocoder = vocoder;
+    }
+
+    /// <summary>Convenience overload — pulls the LM + Vocoder from a pipeline.</summary>
+    public ChunkedSynthesizer(ChatterboxPipeline pipeline)
+        : this(pipeline.Lm, pipeline.Vocoder) { }
+
+    /// <summary>
+    /// Synthesize each <paramref name="textTokenIdsPerChunk"/> entry
+    /// in order. The same <paramref name="speaker"/> is used for every
+    /// chunk (synthesizing N chunks in one voice is the long-form
+    /// audiobook case). Returns waveforms in input order.
+    /// </summary>
+    /// <param name="useIoBinding">
+    /// Forwarded to <see cref="AcousticLM.Generate"/>; null = auto-detect
+    /// from the LM session's effective EP.
+    /// </param>
+    public ChunkSynthesisResult Synthesize(
+        SpeakerEmbedding speaker,
+        IReadOnlyList<long[]> textTokenIdsPerChunk,
+        bool? useIoBinding = null,
+        float exaggeration = ChatterboxConstants.DefaultExaggeration,
+        int maxSteps = ChatterboxConstants.DefaultMaxLmSteps)
+    {
+        int n = textTokenIdsPerChunk.Count;
+        if (n == 0)
+            return new ChunkSynthesisResult(Array.Empty<float[]>(), Array.Empty<ChunkTiming>(), 0);
+
+        // Bounded channel between LM and vocoder. Bound=1 because the
+        // vocoder is faster than the LM for typical chunks; the LM is
+        // the critical path, so having more buffered LM outputs in
+        // flight wouldn't help (vocoder is never starved) and would
+        // just waste memory (each speech_tokens[] is ~few KB but adds up).
+        var channel = Channel.CreateBounded<(int idx, long[] speechTokens, long lmMs, int lmSteps)>(
+            new BoundedChannelOptions(1)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = true,
+            });
+
+        var waveforms = new float[n][];
+        var timings = new ChunkTiming[n];
+        var totalSw = Stopwatch.StartNew();
+
+        // ── Producer: LM ─────────────────────────────────────────────
+        var lmTask = Task.Run(() =>
+        {
+            try
+            {
+                for (int i = 0; i < n; i++)
+                {
+                    var sw = Stopwatch.StartNew();
+                    var lm = _lm.Generate(
+                        speaker.CondEmb, textTokenIdsPerChunk[i],
+                        useIoBinding: useIoBinding,
+                        exaggeration: exaggeration,
+                        maxSteps: maxSteps);
+                    sw.Stop();
+                    var speechTokens = lm.BuildSpeechTokens(speaker.AudioTokens);
+                    // Block if the vocoder hasn't drained the previous one yet.
+                    channel.Writer.WriteAsync((i, speechTokens, sw.ElapsedMilliseconds, lm.Steps))
+                                  .AsTask().GetAwaiter().GetResult();
+                }
+            }
+            finally
+            {
+                channel.Writer.Complete();
+            }
+        });
+
+        // ── Consumer: Vocoder ─────────────────────────────────────────
+        // Runs on the current thread. Each iteration may block waiting
+        // for the next LM output, but the LM is on another thread, so
+        // we're not stalling its work.
+        foreach (var (idx, speechTokens, lmMs, lmSteps) in
+                 channel.Reader.ReadAllAsync().ToBlockingEnumerable())
+        {
+            var sw = Stopwatch.StartNew();
+            var wav = _vocoder.Synthesize(
+                speechTokens, speaker.SpeakerEmbeddings, speaker.SpeakerFeatures);
+            sw.Stop();
+            waveforms[idx] = wav;
+            timings[idx] = new ChunkTiming(idx, lmMs, lmSteps, sw.ElapsedMilliseconds, wav.Length);
+        }
+
+        // Surface any LM exception that the channel.Complete() hid.
+        lmTask.GetAwaiter().GetResult();
+        totalSw.Stop();
+
+        return new ChunkSynthesisResult(waveforms, timings, totalSw.ElapsedMilliseconds);
+    }
+}

--- a/src/Chatterbox.Base/ChunkedSynthesizer.cs
+++ b/src/Chatterbox.Base/ChunkedSynthesizer.cs
@@ -116,6 +116,14 @@ public sealed class ChunkedSynthesizer
         var timings = new ChunkTiming[n];
         var totalSw = Stopwatch.StartNew();
 
+        // Cancellation-on-consumer-failure: bound=1 means a vocoder throw
+        // would otherwise leave the LM blocked forever on WriteAsync, and
+        // the post-loop `lmTask.GetAwaiter().GetResult()` would deadlock.
+        // The token unblocks WriteAsync with an OperationCanceledException
+        // which the producer's finally still translates into a normal
+        // channel.Complete().
+        using var cts = new CancellationTokenSource();
+
         // ── Producer: LM ─────────────────────────────────────────────
         var lmTask = Task.Run(() =>
         {
@@ -132,7 +140,7 @@ public sealed class ChunkedSynthesizer
                     sw.Stop();
                     var speechTokens = lm.BuildSpeechTokens(speaker.AudioTokens);
                     // Block if the vocoder hasn't drained the previous one yet.
-                    channel.Writer.WriteAsync((i, speechTokens, sw.ElapsedMilliseconds, lm.Steps))
+                    channel.Writer.WriteAsync((i, speechTokens, sw.ElapsedMilliseconds, lm.Steps), cts.Token)
                                   .AsTask().GetAwaiter().GetResult();
                 }
             }
@@ -146,15 +154,23 @@ public sealed class ChunkedSynthesizer
         // Runs on the current thread. Each iteration may block waiting
         // for the next LM output, but the LM is on another thread, so
         // we're not stalling its work.
-        foreach (var (idx, speechTokens, lmMs, lmSteps) in
-                 channel.Reader.ReadAllAsync().ToBlockingEnumerable())
+        try
         {
-            var sw = Stopwatch.StartNew();
-            var wav = _vocoder.Synthesize(
-                speechTokens, speaker.SpeakerEmbeddings, speaker.SpeakerFeatures);
-            sw.Stop();
-            waveforms[idx] = wav;
-            timings[idx] = new ChunkTiming(idx, lmMs, lmSteps, sw.ElapsedMilliseconds, wav.Length);
+            foreach (var (idx, speechTokens, lmMs, lmSteps) in
+                     channel.Reader.ReadAllAsync().ToBlockingEnumerable())
+            {
+                var sw = Stopwatch.StartNew();
+                var wav = _vocoder.Synthesize(
+                    speechTokens, speaker.SpeakerEmbeddings, speaker.SpeakerFeatures);
+                sw.Stop();
+                waveforms[idx] = wav;
+                timings[idx] = new ChunkTiming(idx, lmMs, lmSteps, sw.ElapsedMilliseconds, wav.Length);
+            }
+        }
+        catch
+        {
+            cts.Cancel();
+            throw;
         }
 
         // Surface any LM exception that the channel.Complete() hid.
@@ -196,6 +212,10 @@ public sealed class ChunkedSynthesizer
         var timings = new ChunkTiming[n];
         var totalSw = Stopwatch.StartNew();
 
+        // See the sibling Synthesize() for the rationale — vocoder throw
+        // would otherwise deadlock the bounded-channel producer.
+        using var cts = new CancellationTokenSource();
+
         var lmTask = Task.Run(() =>
         {
             try
@@ -226,7 +246,7 @@ public sealed class ChunkedSynthesizer
                         speechTokensPerB[b] = batched.PerChunkResults[b].BuildSpeechTokens(speaker.AudioTokens);
                         lmStepsPerB[b] = batched.PerChunkResults[b].Steps;
                     }
-                    channel.Writer.WriteAsync((produced, speechTokensPerB, sw.ElapsedMilliseconds, lmStepsPerB))
+                    channel.Writer.WriteAsync((produced, speechTokensPerB, sw.ElapsedMilliseconds, lmStepsPerB), cts.Token)
                                   .AsTask().GetAwaiter().GetResult();
                     produced += B;
                 }
@@ -237,26 +257,34 @@ public sealed class ChunkedSynthesizer
             }
         });
 
-        foreach (var (groupStartIdx, speechTokensPerB, lmMs, lmSteps) in
-                 channel.Reader.ReadAllAsync().ToBlockingEnumerable())
+        try
         {
-            int B = speechTokensPerB.Length;
-            var sw = Stopwatch.StartNew();
-            var groupWavs = _vocoder.SynthesizeBatch(
-                speechTokensPerB, speaker.SpeakerEmbeddings, speaker.SpeakerFeatures);
-            sw.Stop();
-            long vocMs = sw.ElapsedMilliseconds;
-            for (int b = 0; b < B; b++)
+            foreach (var (groupStartIdx, speechTokensPerB, lmMs, lmSteps) in
+                     channel.Reader.ReadAllAsync().ToBlockingEnumerable())
             {
-                int idx = groupStartIdx + b;
-                waveforms[idx] = groupWavs[b];
-                // Both LM and voc were batched — report the per-batch-elem
-                // shares (group wall / B). This lets the summary compute
-                // "per-chunk LM" and "per-chunk voc" symmetrically with
-                // the serial path.
-                timings[idx] = new ChunkTiming(
-                    idx, lmMs / B, lmSteps[b], vocMs / B, groupWavs[b].Length);
+                int B = speechTokensPerB.Length;
+                var sw = Stopwatch.StartNew();
+                var groupWavs = _vocoder.SynthesizeBatch(
+                    speechTokensPerB, speaker.SpeakerEmbeddings, speaker.SpeakerFeatures);
+                sw.Stop();
+                long vocMs = sw.ElapsedMilliseconds;
+                for (int b = 0; b < B; b++)
+                {
+                    int idx = groupStartIdx + b;
+                    waveforms[idx] = groupWavs[b];
+                    // Both LM and voc were batched — report the per-batch-elem
+                    // shares (group wall / B). This lets the summary compute
+                    // "per-chunk LM" and "per-chunk voc" symmetrically with
+                    // the serial path.
+                    timings[idx] = new ChunkTiming(
+                        idx, lmMs / B, lmSteps[b], vocMs / B, groupWavs[b].Length);
+                }
             }
+        }
+        catch
+        {
+            cts.Cancel();
+            throw;
         }
 
         lmTask.GetAwaiter().GetResult();

--- a/src/Chatterbox.Base/ChunkedSynthesizer.cs
+++ b/src/Chatterbox.Base/ChunkedSynthesizer.cs
@@ -75,13 +75,26 @@ public sealed class ChunkedSynthesizer
     /// Forwarded to <see cref="AcousticLM.Generate"/>; null = auto-detect
     /// from the LM session's effective EP.
     /// </param>
+    /// <param name="groupSize">
+    /// Chunks per batched LM/vocoder call. 1 (default) = chunk-at-a-time
+    /// with LM/voc per-chunk overlap (the Run 2 mode). >1 = batched-LM
+    /// + batched-voc per group, with pipelining across groups (the Run 7
+    /// mode). At groupSize&gt;1 all chunks must share the same prompt
+    /// length (MVP — same constraint as <see cref="AcousticLM.GenerateBatch"/>).
+    /// </param>
     public ChunkSynthesisResult Synthesize(
         SpeakerEmbedding speaker,
         IReadOnlyList<long[]> textTokenIdsPerChunk,
         bool? useIoBinding = null,
         float exaggeration = ChatterboxConstants.DefaultExaggeration,
-        int maxSteps = ChatterboxConstants.DefaultMaxLmSteps)
+        int maxSteps = ChatterboxConstants.DefaultMaxLmSteps,
+        int groupSize = 1)
     {
+        if (groupSize < 1)
+            throw new ArgumentException("groupSize must be >= 1.", nameof(groupSize));
+        if (groupSize > 1)
+            return SynthesizeInGroups(speaker, textTokenIdsPerChunk, groupSize, useIoBinding, exaggeration, maxSteps);
+
         int n = textTokenIdsPerChunk.Count;
         if (n == 0)
             return new ChunkSynthesisResult(Array.Empty<float[]>(), Array.Empty<ChunkTiming>(), 0);
@@ -148,6 +161,106 @@ public sealed class ChunkedSynthesizer
         lmTask.GetAwaiter().GetResult();
         totalSw.Stop();
 
+        return new ChunkSynthesisResult(waveforms, timings, totalSw.ElapsedMilliseconds);
+    }
+
+    /// <summary>
+    /// Run 7 pipelined-batched path. Producer LM-batches chunks in groups
+    /// of <paramref name="groupSize"/> via <see cref="AcousticLM.GenerateBatch"/>;
+    /// consumer voc-batches via <see cref="Vocoder.SynthesizeBatch"/>.
+    /// Channel between them carries per-group bundles, so vocoder for
+    /// group N runs concurrent with LM for group N+1. Critical path is
+    /// max(LM, voc) per group plus a vocoder tail.
+    /// </summary>
+    private ChunkSynthesisResult SynthesizeInGroups(
+        SpeakerEmbedding speaker,
+        IReadOnlyList<long[]> textTokenIdsPerChunk,
+        int groupSize,
+        bool? useIoBinding,
+        float exaggeration,
+        int maxSteps)
+    {
+        int n = textTokenIdsPerChunk.Count;
+        if (n == 0)
+            return new ChunkSynthesisResult(Array.Empty<float[]>(), Array.Empty<ChunkTiming>(), 0);
+
+        var channel = Channel.CreateBounded<(int groupStartIdx, long[][] speechTokensPerB, long lmMs, int[] lmSteps)>(
+            new BoundedChannelOptions(1)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = true,
+            });
+
+        var waveforms = new float[n][];
+        var timings = new ChunkTiming[n];
+        var totalSw = Stopwatch.StartNew();
+
+        var lmTask = Task.Run(() =>
+        {
+            try
+            {
+                int produced = 0;
+                while (produced < n)
+                {
+                    int B = Math.Min(groupSize, n - produced);
+                    var condEmbs = new Microsoft.ML.OnnxRuntime.Tensors.DenseTensor<float>[B];
+                    var tokensPerB = new long[B][];
+                    for (int b = 0; b < B; b++)
+                    {
+                        condEmbs[b] = speaker.CondEmb;
+                        tokensPerB[b] = textTokenIdsPerChunk[produced + b];
+                    }
+                    var sw = Stopwatch.StartNew();
+                    var batched = _lm.GenerateBatch(
+                        condEmbs, tokensPerB,
+                        useIoBinding: useIoBinding,
+                        exaggeration: exaggeration,
+                        maxSteps: maxSteps);
+                    sw.Stop();
+
+                    var speechTokensPerB = new long[B][];
+                    var lmStepsPerB = new int[B];
+                    for (int b = 0; b < B; b++)
+                    {
+                        speechTokensPerB[b] = batched.PerChunkResults[b].BuildSpeechTokens(speaker.AudioTokens);
+                        lmStepsPerB[b] = batched.PerChunkResults[b].Steps;
+                    }
+                    channel.Writer.WriteAsync((produced, speechTokensPerB, sw.ElapsedMilliseconds, lmStepsPerB))
+                                  .AsTask().GetAwaiter().GetResult();
+                    produced += B;
+                }
+            }
+            finally
+            {
+                channel.Writer.Complete();
+            }
+        });
+
+        foreach (var (groupStartIdx, speechTokensPerB, lmMs, lmSteps) in
+                 channel.Reader.ReadAllAsync().ToBlockingEnumerable())
+        {
+            int B = speechTokensPerB.Length;
+            var sw = Stopwatch.StartNew();
+            var groupWavs = _vocoder.SynthesizeBatch(
+                speechTokensPerB, speaker.SpeakerEmbeddings, speaker.SpeakerFeatures);
+            sw.Stop();
+            long vocMs = sw.ElapsedMilliseconds;
+            for (int b = 0; b < B; b++)
+            {
+                int idx = groupStartIdx + b;
+                waveforms[idx] = groupWavs[b];
+                // Both LM and voc were batched — report the per-batch-elem
+                // shares (group wall / B). This lets the summary compute
+                // "per-chunk LM" and "per-chunk voc" symmetrically with
+                // the serial path.
+                timings[idx] = new ChunkTiming(
+                    idx, lmMs / B, lmSteps[b], vocMs / B, groupWavs[b].Length);
+            }
+        }
+
+        lmTask.GetAwaiter().GetResult();
+        totalSw.Stop();
         return new ChunkSynthesisResult(waveforms, timings, totalSw.ElapsedMilliseconds);
     }
 }

--- a/src/Chatterbox.Base/Vocoder.cs
+++ b/src/Chatterbox.Base/Vocoder.cs
@@ -38,9 +38,20 @@ public sealed class Vocoder : IDisposable
 
     public VocoderMode Mode { get; }
 
+    /// <summary>
+    /// True iff all three split graphs (flow_encoder, cfm_estimator,
+    /// mel2wav) are loaded. Always true in <see cref="VocoderMode.Split"/>;
+    /// also true in <see cref="VocoderMode.Merged"/> when the split
+    /// artifacts are present on disk (so <see cref="SynthesizeBatch"/>
+    /// can fall back to them). False in monolithic mode or when split
+    /// artifacts are missing.
+    /// </summary>
+    public bool SupportsBatched => _flowEnc is not null && _cfmEst is not null && _m2w is not null;
+
     /// <summary>Auto-detect the available cond-decoder layout in <paramref name="onnxDir"/> and load.</summary>
     /// <param name="onLoad">Optional callback fired once per session loaded
-    /// (1× for Merged/Monolithic, 3× for Split).</param>
+    /// (1× for Merged-only or Monolithic; 3× for Split-only; 4× for
+    /// Merged + split fallback available).</param>
     public Vocoder(string onnxDir, ExecutionProvider ep, SessionLoadObserver? onLoad = null)
     {
         bool mergedAvail = File.Exists(Path.Combine(onnxDir, "conditional_decoder_loop.onnx"));
@@ -52,6 +63,17 @@ public sealed class Vocoder : IDisposable
         {
             Mode = VocoderMode.Merged;
             _merged = SessionLoader.LoadAndReport(Path.Combine(onnxDir, "conditional_decoder_loop.onnx"), ep, onLoad);
+            // ALSO load split graphs when present so SynthesizeBatch can
+            // fall back to them: the merged graph baked CFG-doubling at
+            // trace time and rejects B>1 (Run 6a in
+            // docs/chatterbox_perf_investigation.md), but the split
+            // cfm_estimator accepts B>2 (CFG-doubled) cleanly.
+            if (splitAvail)
+            {
+                _flowEnc = SessionLoader.LoadAndReport(Path.Combine(onnxDir, "flow_encoder.onnx"), ep, onLoad);
+                _cfmEst = SessionLoader.LoadAndReport(Path.Combine(onnxDir, "cfm_estimator.onnx"), ep, onLoad);
+                _m2w = SessionLoader.LoadAndReport(Path.Combine(onnxDir, "mel2wav.onnx"), ep, onLoad);
+            }
         }
         else if (splitAvail)
         {
@@ -198,6 +220,229 @@ public sealed class Vocoder : IDisposable
         var r = new float[a.Length + b.Length];
         Array.Copy(a, 0, r, 0, a.Length);
         Array.Copy(b, 0, r, a.Length, b.Length);
+        return r;
+    }
+
+    /// <summary>
+    /// Batched vocoder synthesis. Inputs: B parallel chunks each with
+    /// its own speech_tokens (same length per chunk for the MVP), one
+    /// shared speaker_embeddings, one shared speaker_features. Returns
+    /// B waveforms in input order.
+    ///
+    /// Always uses the SPLIT 3-graph path even when
+    /// <see cref="Mode"/> == <see cref="VocoderMode.Merged"/>, because
+    /// the merged conditional_decoder_loop.onnx baked CFG-doubling at
+    /// trace time and rejects B>1 (cfm_body Concat expects dim 2). The
+    /// split <c>cfm_estimator.onnx</c> accepts B>2 (CFG-doubled batch)
+    /// cleanly — see <c>docs/chatterbox_perf_investigation.md</c>
+    /// Run 6a for the probe data.
+    ///
+    /// Throws if <see cref="SupportsBatched"/> is false (no split
+    /// artifacts in the model directory). Caller's recourse: re-export
+    /// with <c>--split-cond-decoder</c> (or <c>--merge-cond-decoder</c>
+    /// which implies it).
+    ///
+    /// MVP constraint: all <paramref name="speechTokensPerChunk"/>
+    /// entries must have the same length. Phase 2 will accept ragged
+    /// inputs (pad + mask).
+    /// </summary>
+    public float[][] SynthesizeBatch(
+        IReadOnlyList<long[]> speechTokensPerChunk,
+        DenseTensor<float> speakerEmbeddings,
+        DenseTensor<float> speakerFeatures)
+    {
+        if (!SupportsBatched)
+            throw new InvalidOperationException(
+                "Batched vocoder synthesis requires the split cond-decoder graphs "
+                + "(flow_encoder, cfm_estimator, mel2wav) which were not found in "
+                + "the model directory. Re-export with --split-cond-decoder.");
+
+        int B = speechTokensPerChunk.Count;
+        if (B == 0) return Array.Empty<float[]>();
+        if (B == 1)
+        {
+            // Trivial case — defer to the well-tested merged or split path.
+            var wav = Synthesize(speechTokensPerChunk[0], speakerEmbeddings, speakerFeatures);
+            return new[] { wav };
+        }
+
+        int tTok = speechTokensPerChunk[0].Length;
+        for (int b = 0; b < B; b++)
+        {
+            if (speechTokensPerChunk[b].Length != tTok)
+                throw new ArgumentException(
+                    $"All speech_tokens chunks must have the same length (MVP); got {speechTokensPerChunk[b].Length} vs {tTok} at index {b}.");
+        }
+
+        const int MelBins = ChatterboxConstants.MelBins;
+        const int PromptLen = ChatterboxConstants.PromptLen;
+        const int CfmSteps = ChatterboxConstants.CfmSteps;
+        const float CfgRate = ChatterboxConstants.CfgRate;
+
+        // Build B-batched flow_encoder inputs.
+        var speechTokensB = new long[B * tTok];
+        for (int b = 0; b < B; b++)
+            Array.Copy(speechTokensPerChunk[b], 0, speechTokensB, b * tTok, tTok);
+
+        var spkEmbArr = speakerEmbeddings.ToArray();
+        var spkFeatArr = speakerFeatures.ToArray();
+        // Replicate speaker_embeddings and speaker_features across B
+        // (one voice, many chunks).
+        int spkDim = speakerEmbeddings.Dimensions[1];
+        var spkEmbB = new float[B * spkDim];
+        for (int b = 0; b < B; b++) Array.Copy(spkEmbArr, 0, spkEmbB, b * spkDim, spkDim);
+
+        int spkFeatLen = spkFeatArr.Length;
+        var spkFeatB = new float[B * spkFeatLen];
+        for (int b = 0; b < B; b++) Array.Copy(spkFeatArr, 0, spkFeatB, b * spkFeatLen, spkFeatLen);
+
+        // 1) flow_encoder at B
+        using var encOut = _flowEnc!.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("speech_tokens", new DenseTensor<long>(speechTokensB, new[] { B, tTok })),
+            NamedOnnxValue.CreateFromTensor("speaker_embeddings",
+                new DenseTensor<float>(spkEmbB, new[] { B, spkDim })),
+            NamedOnnxValue.CreateFromTensor("speaker_features",
+                new DenseTensor<float>(spkFeatB, speakerFeatures.Dimensions.ToArray() is var d
+                    ? new[] { B, d[1], d[2] } : throw new InvalidOperationException("speaker_features must be rank-3"))),
+        });
+        var encList = encOut.ToList();
+        var muT = encList[0].AsTensor<float>();
+        int tMel = muT.Dimensions[2];
+
+        float[] mu = muT.ToArray();             // [B, MelBins, tMel]
+        float[] mask = encList[1].AsTensor<float>().ToArray();  // [B, 1, tMel]
+        float[] embed = encList[2].AsTensor<float>().ToArray(); // [B, MelBins]
+        float[] cond = encList[3].AsTensor<float>().ToArray();  // [B, MelBins, tMel]
+        float[] xRaw = encList[4].AsTensor<float>().ToArray();  // expected [B, MelBins, tMel]
+        // flow_encoder's `z` output is the CFM initial state. Run 6c
+        // discovered that the export's pinned-rand_noise patch (added in
+        // Run 11 of docs/chatterbox_investigation.md for parity-test
+        // reproducibility) makes z appear constant from the graph's
+        // perspective, so ORT emits it at [1, MelBins, tMel] regardless
+        // of input batch. We detect that case and replicate to
+        // [B, MelBins, tMel] manually. Per-batch-element noise is
+        // intentionally identical here (same initial seed across the
+        // batch); if we ever want per-element noise variation, that's a
+        // separate change to the export-side patch.
+        int perBatchElemSize = MelBins * tMel;
+        float[] x;
+        if (xRaw.Length == perBatchElemSize)
+        {
+            x = new float[B * perBatchElemSize];
+            for (int b = 0; b < B; b++) Array.Copy(xRaw, 0, x, b * perBatchElemSize, perBatchElemSize);
+        }
+        else if (xRaw.Length == B * perBatchElemSize)
+        {
+            x = xRaw;
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"flow_encoder.onnx z output had unexpected length {xRaw.Length}; expected {perBatchElemSize} (B=1, will replicate) or {B * perBatchElemSize}.");
+        }
+
+        // 2) CFM solve loop. CFG-doubled along batch → [2*B, ...].
+        var tSpan = new float[CfmSteps + 1];
+        for (int i = 0; i <= CfmSteps; i++)
+        {
+            float linear = i / (float)CfmSteps;
+            tSpan[i] = 1.0f - MathF.Cos(linear * 0.5f * MathF.PI);
+        }
+        float t = tSpan[0];
+        float dt = tSpan[1] - tSpan[0];
+
+        int cfgB = 2 * B;
+        int muSize = MelBins * tMel;          // per-batch-elem
+        int maskSize = tMel;
+        int embedSize = MelBins;
+        int condSize = MelBins * tMel;
+
+        for (int step = 1; step <= CfmSteps; step++)
+        {
+            // Build CFG-doubled inputs: first B rows = cond, next B rows = uncond (zeros for mu/cond/spks).
+            var xIn = ReplicateCfg(x, B, muSize);              // [2B, MelBins, tMel]; both halves = x (mask gets x too in upstream conv)
+            var maskIn = ReplicateCfg(mask, B, maskSize);      // [2B, 1, tMel]; both halves = mask
+            var muIn = CfgZeroSecondHalf(mu, B, muSize);       // [2B, MelBins, tMel]; second half zeros
+            var condIn = CfgZeroSecondHalf(cond, B, condSize); // [2B, MelBins, tMel]; second half zeros
+            var spksIn = CfgZeroSecondHalf(embed, B, embedSize); // [2B, MelBins]; second half zeros
+            var tIn = new float[cfgB];
+            Array.Fill(tIn, t);
+
+            using var estOut = _cfmEst!.Run(new[]
+            {
+                NamedOnnxValue.CreateFromTensor("x_in",    new DenseTensor<float>(xIn,    new[] { cfgB, MelBins, tMel })),
+                NamedOnnxValue.CreateFromTensor("mask_in", new DenseTensor<float>(maskIn, new[] { cfgB, 1, tMel })),
+                NamedOnnxValue.CreateFromTensor("mu_in",   new DenseTensor<float>(muIn,   new[] { cfgB, MelBins, tMel })),
+                NamedOnnxValue.CreateFromTensor("t_in",    new DenseTensor<float>(tIn,    new[] { cfgB })),
+                NamedOnnxValue.CreateFromTensor("spks_in", new DenseTensor<float>(spksIn, new[] { cfgB, MelBins })),
+                NamedOnnxValue.CreateFromTensor("cond_in", new DenseTensor<float>(condIn, new[] { cfgB, MelBins, tMel })),
+            });
+            var dphi = estOut.First().AsTensor<float>().ToArray();  // [2B, MelBins, tMel]
+            int perBatchElem = muSize;
+            float a = 1.0f + CfgRate;
+            // CFG combine + Euler step, per batch element.
+            for (int b = 0; b < B; b++)
+            {
+                int condOff = b * perBatchElem;
+                int uncondOff = (B + b) * perBatchElem;
+                for (int i = 0; i < perBatchElem; i++)
+                {
+                    float c = dphi[condOff + i];
+                    float u = dphi[uncondOff + i];
+                    x[condOff + i] = x[condOff + i] + dt * (a * c - CfgRate * u);
+                }
+            }
+            t = tSpan[step];
+            if (step < CfmSteps) dt = tSpan[step + 1] - t;
+        }
+
+        // 3) Trim mel per batch element: drop first PromptLen frames along last dim.
+        int tTrim = tMel - PromptLen;
+        var feat = new float[B * MelBins * tTrim];
+        for (int b = 0; b < B; b++)
+        {
+            int srcBaseB = b * MelBins * tMel;
+            int dstBaseB = b * MelBins * tTrim;
+            for (int c = 0; c < MelBins; c++)
+            {
+                Array.Copy(x, srcBaseB + c * tMel + PromptLen,
+                           feat, dstBaseB + c * tTrim, tTrim);
+            }
+        }
+
+        // 4) mel2wav at B → [B, num_samples]
+        using var m2wOut = _m2w!.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("mel", new DenseTensor<float>(feat, new[] { B, MelBins, tTrim })),
+        });
+        var wavTensor = m2wOut.First().AsTensor<float>();
+        int numSamples = wavTensor.Dimensions[1];
+        var wavFlat = wavTensor.ToArray();
+        var perChunkWavs = new float[B][];
+        for (int b = 0; b < B; b++)
+        {
+            perChunkWavs[b] = new float[numSamples];
+            Array.Copy(wavFlat, b * numSamples, perChunkWavs[b], 0, numSamples);
+        }
+        return perChunkWavs;
+    }
+
+    /// <summary>Stack `x` (length B*elemSize) on top of itself → 2B rows.</summary>
+    private static float[] ReplicateCfg(float[] x, int B, int elemSize)
+    {
+        var r = new float[2 * B * elemSize];
+        Array.Copy(x, 0, r, 0, B * elemSize);
+        Array.Copy(x, 0, r, B * elemSize, B * elemSize);
+        return r;
+    }
+
+    /// <summary>Stack `x` (length B*elemSize) on top of `B*elemSize` zeros → cond + uncond CFG pair.</summary>
+    private static float[] CfgZeroSecondHalf(float[] x, int B, int elemSize)
+    {
+        var r = new float[2 * B * elemSize];
+        Array.Copy(x, 0, r, 0, B * elemSize);
+        // second half stays default zero
         return r;
     }
 

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -52,6 +52,7 @@ internal static class Program
         bool useIoBinding = true;
         string? text = null;
         string? tokenizerJson = null;
+        string? lmPath = null;  // --lm-path: override path to language_model*.onnx (Run 8 quantization sweep)
         int benchChunks = 1;
         bool pipelined = false;
         int benchBatchedLm = 0;  // 0 = disabled; >0 = run probe with B=this
@@ -71,6 +72,7 @@ internal static class Program
                 case "--no-io-binding":  useIoBinding = false; break;
                 case "--text":           text = args[++i]; break;
                 case "--tokenizer-json": tokenizerJson = args[++i]; break;
+                case "--lm-path":        lmPath = args[++i]; break;
                 case "--bench-chunks":
                     // Loop the post-load synthesis N times. The pipeline
                     // (sessions, voice embedding, tokenization) is set up
@@ -222,9 +224,16 @@ internal static class Program
         var totalLoadSw = Stopwatch.StartNew();
         using var embedder = new SpeakerEmbedder(
             Path.Combine(onnxDir, "speech_encoder.onnx"), epEnum, OnSessionLoad);
+        // --lm-path: when set, load the LM graph from an arbitrary path
+        // (e.g. /tmp/cb_dyn5/language_model.fp16.onnx) instead of the
+        // bundle default. Lets the Run 8 quantization sweep swap LMs
+        // without rebuilding the whole bundle dir.
+        var lmGraphPath = lmPath is not null ? ExpandHome(lmPath) : Path.Combine(onnxDir, "language_model.onnx");
+        if (lmPath is not null)
+            Console.WriteLine($"  [lm-path override] {lmGraphPath}");
         using var lm = new AcousticLM(
             Path.Combine(onnxDir, "embed_tokens.onnx"),
-            Path.Combine(onnxDir, "language_model.onnx"),
+            lmGraphPath,
             epEnum, OnSessionLoad);
         using var vocoder = new Vocoder(onnxDir, epEnum, OnSessionLoad);
         totalLoadSw.Stop();

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -87,7 +87,9 @@ internal static class Program
                     // Use ChunkedSynthesizer (LM and Vocoder concurrent on
                     // separate threads, one chunk apart). Only meaningful
                     // with --bench-chunks N for N>1; for N=1 collapses to
-                    // a serial single-chunk call.
+                    // a serial single-chunk call. When --lm-batch B is
+                    // also set, the pipelining happens at the group level
+                    // (batched LM(N+1) overlapped with batched voc(N)).
                     pipelined = true;
                     break;
                 case "--lm-batch":

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -50,6 +50,8 @@ internal static class Program
         bool useIoBinding = true;
         string? text = null;
         string? tokenizerJson = null;
+        int benchChunks = 1;
+        bool pipelined = false;
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
@@ -63,6 +65,25 @@ internal static class Program
                 case "--no-io-binding":  useIoBinding = false; break;
                 case "--text":           text = args[++i]; break;
                 case "--tokenizer-json": tokenizerJson = args[++i]; break;
+                case "--bench-chunks":
+                    // Loop the post-load synthesis N times. The pipeline
+                    // (sessions, voice embedding, tokenization) is set up
+                    // once; each iteration reruns LM + vocoder on the same
+                    // text. Use this to measure per-chunk steady-state cost
+                    // amortized over warmup — drives the long-form perf work.
+                    if (!int.TryParse(args[++i], out benchChunks) || benchChunks < 1)
+                    {
+                        Console.Error.WriteLine("--bench-chunks expects a positive integer.");
+                        return 2;
+                    }
+                    break;
+                case "--pipelined":
+                    // Use ChunkedSynthesizer (LM and Vocoder concurrent on
+                    // separate threads, one chunk apart). Only meaningful
+                    // with --bench-chunks N for N>1; for N=1 collapses to
+                    // a serial single-chunk call.
+                    pipelined = true;
+                    break;
                 default:
                     Console.Error.WriteLine($"Unknown arg: {args[i]}");
                     return 2;
@@ -178,43 +199,118 @@ internal static class Program
                 + "Pass --text \"...\" for arbitrary input.");
         }
 
-        // ── LM rollout ─────────────────────────────────────────────────────
-        var lmSw = Stopwatch.StartNew();
-        var lmResult = lm.Generate(spk.CondEmb, inputIds,
-            useIoBinding: useIoBinding,
-            diagDir: diagDir);
-        lmSw.Stop();
-        Console.WriteLine($"LM ({(useIoBinding ? "io-binding" : "basic")}): {lmResult.Steps} steps, "
-            + $"generated {lmResult.RawGeneratedTokens.Count - 1} tokens "
-            + $"[{lmSw.ElapsedMilliseconds} ms, {lmSw.ElapsedMilliseconds / (double)lmResult.Steps:F1} ms/step]");
+        // ── Synthesis loop ─────────────────────────────────────────────────
+        // benchChunks=1 (default): single-chunk run, writes WAV and prints
+        // per-stage timing as before. benchChunks>1: same chunk N times.
+        // Two execution modes:
+        //   serial (default): LM and vocoder run sequentially per chunk
+        //   --pipelined: ChunkedSynthesizer overlaps LM(N+1) with voc(N)
+        // Drives the long-form perf measurements in
+        // docs/chatterbox_perf_investigation.md.
+        var chunkLmMs = new long[benchChunks];
+        var chunkVocMs = new long[benchChunks];
+        var chunkSteps = new int[benchChunks];
+        float[]? lastSamples = null;
+        long pipelinedChunkWallMs = 0;  // populated when --pipelined; serial branch uses sums below
 
-        if (diagDir is not null)
+        if (pipelined && benchChunks > 1)
         {
-            File.WriteAllBytes(Path.Combine(diagDir, "cs_tokens.bin"),
-                System.Runtime.InteropServices.MemoryMarshal.AsBytes<long>(
-                    lmResult.RawGeneratedTokens.ToArray()).ToArray());
-            Console.WriteLine($"[diag] wrote {diagDir}/cs_tokens.bin ({lmResult.RawGeneratedTokens.Count} tokens)");
+            var synth = new ChunkedSynthesizer(lm, vocoder);
+            var tokensPerChunk = Enumerable.Repeat(inputIds, benchChunks).ToArray();
+            var result = synth.Synthesize(spk, tokensPerChunk, useIoBinding: useIoBinding);
+            for (int chunk = 0; chunk < benchChunks; chunk++)
+            {
+                var t = result.ChunkTimings[chunk];
+                chunkLmMs[chunk] = t.LmMs;
+                chunkVocMs[chunk] = t.VocoderMs;
+                chunkSteps[chunk] = t.LmSteps;
+                lastSamples = result.Waveforms[chunk];
+                Console.WriteLine($"  chunk {chunk + 1}/{benchChunks}: "
+                    + $"LM {t.LmMs} ms ({t.LmSteps} steps), "
+                    + $"voc {t.VocoderMs} ms, "
+                    + $"audio {t.AudioSamples / (float)ChatterboxConstants.S3GenSr:F2}s");
+            }
+            pipelinedChunkWallMs = result.TotalWallMs;
+        }
+        else
+        {
+            for (int chunk = 0; chunk < benchChunks; chunk++)
+            {
+                var lmSw = Stopwatch.StartNew();
+                var lmResult = lm.Generate(spk.CondEmb, inputIds,
+                    useIoBinding: useIoBinding,
+                    diagDir: chunk == 0 ? diagDir : null);  // only diag the first chunk
+                lmSw.Stop();
+                chunkLmMs[chunk] = lmSw.ElapsedMilliseconds;
+                chunkSteps[chunk] = lmResult.Steps;
+
+                if (chunk == 0 && diagDir is not null)
+                {
+                    File.WriteAllBytes(Path.Combine(diagDir, "cs_tokens.bin"),
+                        System.Runtime.InteropServices.MemoryMarshal.AsBytes<long>(
+                            lmResult.RawGeneratedTokens.ToArray()).ToArray());
+                    Console.WriteLine($"[diag] wrote {diagDir}/cs_tokens.bin ({lmResult.RawGeneratedTokens.Count} tokens)");
+                }
+
+                var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
+                sw.Restart();
+                var samples = vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+                sw.Stop();
+                chunkVocMs[chunk] = sw.ElapsedMilliseconds;
+                lastSamples = samples;
+
+                if (benchChunks == 1)
+                {
+                    // Existing single-chunk verbose output.
+                    Console.WriteLine($"LM ({(useIoBinding ? "io-binding" : "basic")}): {lmResult.Steps} steps, "
+                        + $"generated {lmResult.RawGeneratedTokens.Count - 1} tokens "
+                        + $"[{chunkLmMs[chunk]} ms, {chunkLmMs[chunk] / (double)lmResult.Steps:F1} ms/step]");
+                    Console.WriteLine($"speech_tokens: shape=(1, {speechTokens.Length})  "
+                        + $"({spk.AudioTokens.Length} from voice + {speechTokens.Length - spk.AudioTokens.Length} from LM)");
+                    Console.WriteLine($"cond_decoder ({vocoder.Mode}): waveform=(1, {samples.Length}) "
+                        + $"→ {samples.Length / (float)ChatterboxConstants.S3GenSr:F2}s  [{chunkVocMs[chunk]} ms]");
+                }
+                else
+                {
+                    Console.WriteLine($"  chunk {chunk + 1}/{benchChunks}: "
+                        + $"LM {chunkLmMs[chunk]} ms ({chunkSteps[chunk]} steps), "
+                        + $"voc {chunkVocMs[chunk]} ms, "
+                        + $"audio {samples.Length / (float)ChatterboxConstants.S3GenSr:F2}s");
+                }
+            }
         }
 
-        // ── Build speech_tokens + vocoder ──────────────────────────────────
-        var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
-        Console.WriteLine($"speech_tokens: shape=(1, {speechTokens.Length})  "
-            + $"({spk.AudioTokens.Length} from voice + {speechTokens.Length - spk.AudioTokens.Length} from LM)");
-
-        sw.Restart();
-        var samples = vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
-        sw.Stop();
-        Console.WriteLine($"cond_decoder ({vocoder.Mode}): waveform=(1, {samples.Length}) "
-            + $"→ {samples.Length / (float)ChatterboxConstants.S3GenSr:F2}s  [{sw.ElapsedMilliseconds} ms]");
-
-        // ── Write WAV ──────────────────────────────────────────────────────
+        // ── Write last chunk's WAV (or only chunk in non-bench mode) ──────
         var fmt = WaveFormat.CreateIeeeFloatWaveFormat(ChatterboxConstants.S3GenSr, 1);
         using (var writer = new WaveFileWriter(outPath, fmt))
         {
-            writer.WriteSamples(samples, 0, samples.Length);
+            writer.WriteSamples(lastSamples!, 0, lastSamples!.Length);
         }
         totalSw.Stop();
-        Console.WriteLine($"Wrote {outPath}  [total {totalSw.ElapsedMilliseconds / 1000.0:F1}s]");
+
+        if (benchChunks > 1)
+        {
+            long lmSum = 0, vocSum = 0;
+            foreach (var v in chunkLmMs) lmSum += v;
+            foreach (var v in chunkVocMs) vocSum += v;
+            // For pipelined mode, "chunks-total" is the actual wall measured
+            // by ChunkedSynthesizer (not the sum, which over-counts because
+            // LM and vocoder overlap). For serial mode, sum and chunks-total
+            // are the same thing.
+            double chunksTotalSec = pipelined
+                ? pipelinedChunkWallMs / 1000.0
+                : (lmSum + vocSum) / 1000.0;
+            Console.WriteLine($"Bench: {benchChunks} chunks ({(pipelined ? "pipelined" : "serial")}), "
+                + $"LM avg {lmSum / (double)benchChunks:F0} ms, "
+                + $"voc avg {vocSum / (double)benchChunks:F0} ms, "
+                + $"per-chunk-sum-avg {(lmSum + vocSum) / (double)benchChunks:F0} ms, "
+                + $"chunks-wall {chunksTotalSec:F1}s "
+                + $"[total wall {totalSw.ElapsedMilliseconds / 1000.0:F1}s]");
+        }
+        else
+        {
+            Console.WriteLine($"Wrote {outPath}  [total {totalSw.ElapsedMilliseconds / 1000.0:F1}s]");
+        }
         return 0;
     }
 

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -55,6 +55,8 @@ internal static class Program
         int benchChunks = 1;
         bool pipelined = false;
         int benchBatchedLm = 0;  // 0 = disabled; >0 = run probe with B=this
+        int benchBatchedVoc = 0; // 0 = disabled; >0 = run vocoder-only probe at B=this
+        int vocBatch = 1;        // --voc-batch B: group bench-chunks vocoder calls similarly to --lm-batch
         int lmBatch = 1;  // --lm-batch B: group benchChunks into batched LM calls of size B
         for (int i = 0; i < args.Length; i++)
         {
@@ -113,6 +115,25 @@ internal static class Program
                         return 2;
                     }
                     break;
+                case "--bench-batched-voc":
+                    // Sister probe to --bench-batched-lm: does the merged
+                    // conditional_decoder_loop.onnx (or split / monolithic
+                    // fallback) accept B>1? Replicates one speaker+tokens
+                    // input across the B dimension, runs one Synthesize at
+                    // batch B, reports wall + per-batch-elem ms.
+                    if (!int.TryParse(args[++i], out benchBatchedVoc) || benchBatchedVoc < 1)
+                    {
+                        Console.Error.WriteLine("--bench-batched-voc expects a positive integer batch size.");
+                        return 2;
+                    }
+                    break;
+                case "--voc-batch":
+                    if (!int.TryParse(args[++i], out vocBatch) || vocBatch < 1)
+                    {
+                        Console.Error.WriteLine("--voc-batch expects a positive integer.");
+                        return 2;
+                    }
+                    break;
                 default:
                     Console.Error.WriteLine($"Unknown arg: {args[i]}");
                     return 2;
@@ -130,13 +151,15 @@ internal static class Program
                     + "Use --no-io-binding for full past_kv diag artifacts.");
             }
         }
-        // --bench-batched-lm skips voice + vocoder; only needs --onnx-dir.
+        // --bench-batched-{lm,voc} both skip voice loading; only need --onnx-dir.
         // Other modes need --voice. --out always has a default.
-        if (onnxDir is null || (voicePath is null && benchBatchedLm == 0))
+        bool isProbe = benchBatchedLm > 0 || benchBatchedVoc > 0;
+        if (onnxDir is null || (voicePath is null && !isProbe))
         {
             Console.Error.WriteLine(
                 "Usage: --onnx-dir <dir> --voice <wav> [--out <wav>] [--ep cpu|cuda]\n"
-                + "   or: --onnx-dir <dir> --bench-batched-lm <B>");
+                + "   or: --onnx-dir <dir> --bench-batched-lm <B>\n"
+                + "   or: --onnx-dir <dir> --bench-batched-voc <B>");
             return 2;
         }
         if (ep is not ("cpu" or "cuda"))
@@ -152,10 +175,14 @@ internal static class Program
         var sw = new Stopwatch();
         var epEnum = ep == "cuda" ? ExecutionProvider.Auto : ExecutionProvider.Cpu;
 
-        // ── Probe mode: --bench-batched-lm ────────────────────────────────
+        // ── Probe mode: --bench-batched-lm / --bench-batched-voc ────────────
         if (benchBatchedLm > 0)
         {
             return RunBatchedLmProbe(onnxDir, epEnum, benchBatchedLm);
+        }
+        if (benchBatchedVoc > 0)
+        {
+            return RunBatchedVocProbe(onnxDir, epEnum, benchBatchedVoc);
         }
 
         // ── Resolve tokenizer (needed only if --text was given) ───────────
@@ -271,24 +298,53 @@ internal static class Program
                 var batched = lm.GenerateBatch(condEmbs, tokensPerB);
                 batchLmSw.Stop();
 
+                // Build speech_tokens per element ahead of vocoder dispatch.
+                var speechTokensPerB = new long[B][];
+                for (int b = 0; b < B; b++)
+                    speechTokensPerB[b] = batched.PerChunkResults[b].BuildSpeechTokens(spk.AudioTokens);
+
+                // Vocoder dispatch: batched if vocBatch > 1, serial otherwise.
+                long batchVocMs = 0;
+                float[][] batchSamples;
+                if (vocBatch > 1)
+                {
+                    // MVP requires same-length speech_tokens; the test driver
+                    // replicates the same chunk so this holds. Real long-form
+                    // would need ragged-input support (Phase 2).
+                    var vocSw = Stopwatch.StartNew();
+                    batchSamples = vocoder.SynthesizeBatch(
+                        speechTokensPerB, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+                    vocSw.Stop();
+                    batchVocMs = vocSw.ElapsedMilliseconds;
+                }
+                else
+                {
+                    batchSamples = new float[B][];
+                    for (int b = 0; b < B; b++)
+                    {
+                        sw.Restart();
+                        batchSamples[b] = vocoder.Synthesize(
+                            speechTokensPerB[b], spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+                        sw.Stop();
+                        chunkVocMs[produced + b] = sw.ElapsedMilliseconds;
+                    }
+                }
+
                 for (int b = 0; b < B; b++)
                 {
                     var lmResult = batched.PerChunkResults[b];
-                    var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
-                    sw.Restart();
-                    var samples = vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
-                    sw.Stop();
                     int globalIdx = produced + b;
                     chunkLmMs[globalIdx] = batchLmSw.ElapsedMilliseconds / B;  // amortized share
-                    chunkVocMs[globalIdx] = sw.ElapsedMilliseconds;
+                    if (vocBatch > 1) chunkVocMs[globalIdx] = batchVocMs / B;  // amortized share
                     chunkSteps[globalIdx] = lmResult.Steps;
-                    lastSamples = samples;
+                    lastSamples = batchSamples[b];
                     Console.WriteLine($"  chunk {globalIdx + 1}/{benchChunks} [batch {(produced / lmBatch) + 1}, elem {b + 1}/{B}]: "
                         + $"LM-share {chunkLmMs[globalIdx]} ms, "
-                        + $"voc {chunkVocMs[globalIdx]} ms, "
-                        + $"audio {samples.Length / (float)ChatterboxConstants.S3GenSr:F2}s");
+                        + $"voc{(vocBatch > 1 ? "-share" : "")} {chunkVocMs[globalIdx]} ms, "
+                        + $"audio {batchSamples[b].Length / (float)ChatterboxConstants.S3GenSr:F2}s");
                 }
-                Console.WriteLine($"    batch LM call: {batchLmSw.ElapsedMilliseconds} ms total for B={B}");
+                Console.WriteLine($"    batch LM call: {batchLmSw.ElapsedMilliseconds} ms total for B={B}"
+                    + (vocBatch > 1 ? $"; batch voc call: {batchVocMs} ms total for B={B}" : ""));
                 produced += B;
             }
             batchWallSw.Stop();
@@ -385,7 +441,8 @@ internal static class Program
             double chunksTotalSec = (pipelined || lmBatch > 1)
                 ? pipelinedChunkWallMs / 1000.0
                 : (lmSum + vocSum) / 1000.0;
-            string mode = lmBatch > 1 ? $"lm-batch={lmBatch}"
+            string mode = lmBatch > 1
+                ? (vocBatch > 1 ? $"lm-batch={lmBatch}+voc-batch={vocBatch}" : $"lm-batch={lmBatch}")
                 : pipelined ? "pipelined"
                 : "serial";
             Console.WriteLine($"Bench: {benchChunks} chunks ({mode}), "
@@ -558,4 +615,213 @@ internal static class Program
         => "(" + string.Join(", ", dims) + ")";
     private static string DimsOf(System.ReadOnlySpan<int> dims)
         => "(" + string.Join(", ", dims.ToArray()) + ")";
+
+    /// <summary>
+    /// Sister to <see cref="RunBatchedLmProbe"/> — confirms whether the
+    /// merged conditional_decoder_loop.onnx (or split / monolithic
+    /// fallback) honors B>1 inputs. Uses random data at the right
+    /// shapes (we don't care about output quality here, only whether
+    /// the graph accepts the batched call and how the wall time scales).
+    ///
+    /// ALSO probes the split flow_encoder + cfm_estimator + mel2wav
+    /// graphs at the same B, since the merged graph has CFG-doubling
+    /// baked in (axis-0 trace at 2) which blocks B>1 there.
+    /// </summary>
+    private static int RunBatchedVocProbe(string onnxDir, ExecutionProvider ep, int batchSize)
+    {
+        // Reuse Vocoder's auto-detect to pick the layout we'd actually
+        // ship, then call its underlying merged session directly with a
+        // B-shaped input. The probe needs direct ORT access because
+        // Vocoder.Synthesize hardcodes batch=1 today (the SynthesizeBatch
+        // method is the thing we're motivating with this probe).
+        string mergedPath = Path.Combine(onnxDir, "conditional_decoder_loop.onnx");
+        if (!File.Exists(mergedPath))
+        {
+            Console.Error.WriteLine($"--bench-batched-voc requires the merged conditional_decoder_loop.onnx in --onnx-dir; not found at {mergedPath}");
+            return 1;
+        }
+
+        Console.WriteLine($"Batched-voc probe: B={batchSize}, ep={ep}");
+        var loadSw = Stopwatch.StartNew();
+        using var session = OrtSessionBuilder.CreateCachedSession(mergedPath, ep);
+        loadSw.Stop();
+        Console.WriteLine($"  loaded conditional_decoder_loop.onnx in {loadSw.ElapsedMilliseconds} ms");
+
+        // Synthetic inputs at the canonical shapes Vocoder.Synthesize uses.
+        // speech_tokens: [B, T_tok] of int64 in [0, SPEECH_VOCAB_SIZE);
+        //                we pick T_tok = 423 to match the Ezreal-sentence
+        //                speech_tokens length the bench produces (250
+        //                from voice + 173 from LM).
+        // speaker_embeddings: [B, 192] of float
+        // speaker_features:   [B, 500, 80] of float
+        const int TTok = 423;
+        const int SpeakerDim = 192;
+        const int PromptLen = ChatterboxConstants.PromptLen;
+        const int MelBins = ChatterboxConstants.MelBins;
+
+        var rng = new Random(0);
+        var speechTokensB = new long[batchSize * TTok];
+        for (int i = 0; i < speechTokensB.Length; i++)
+            speechTokensB[i] = rng.Next(0, 6561);  // SPEECH_BASE_VOCAB_SIZE
+        var spkEmbB = new float[batchSize * SpeakerDim];
+        for (int i = 0; i < spkEmbB.Length; i++) spkEmbB[i] = (float)(rng.NextDouble() * 2 - 1);
+        var spkFeatB = new float[batchSize * PromptLen * MelBins];
+        for (int i = 0; i < spkFeatB.Length; i++) spkFeatB[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var runSw = Stopwatch.StartNew();
+        try
+        {
+            using var output = session.Run(new[]
+            {
+                NamedOnnxValue.CreateFromTensor("speech_tokens",
+                    new DenseTensor<long>(speechTokensB, new[] { batchSize, TTok })),
+                NamedOnnxValue.CreateFromTensor("speaker_embeddings",
+                    new DenseTensor<float>(spkEmbB, new[] { batchSize, SpeakerDim })),
+                NamedOnnxValue.CreateFromTensor("speaker_features",
+                    new DenseTensor<float>(spkFeatB, new[] { batchSize, PromptLen, MelBins })),
+            });
+            runSw.Stop();
+            var wavTensor = output.First().AsTensor<float>();
+            int outBatch = wavTensor.Dimensions[0];
+            int outSamples = wavTensor.Dimensions[1];
+            double msPerElem = runSw.ElapsedMilliseconds / (double)batchSize;
+            Console.WriteLine($"  vocoder B={batchSize}: {runSw.ElapsedMilliseconds} ms wall  ({msPerElem:F1} ms/batch-elem  → output shape ({outBatch},{outSamples}))");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            runSw.Stop();
+            Console.Error.WriteLine($"  vocoder B={batchSize} FAILED after {runSw.ElapsedMilliseconds} ms: {ex.GetType().Name}: {ex.Message.Split('\n')[0]}");
+            // Fall through to the split-graph probe — that's where the
+            // hope is, since the merged graph baked the CFG-doubling
+            // hardcoded at trace time.
+        }
+
+        // ── Split-graph probe (flow_encoder + cfm_estimator + mel2wav) ──
+        return ProbeSplitVocoderAtBatch(onnxDir, ep, batchSize, speechTokensB, spkEmbB, spkFeatB,
+            TTok, SpeakerDim, PromptLen, MelBins);
+    }
+
+    private static int ProbeSplitVocoderAtBatch(string onnxDir, ExecutionProvider ep, int batchSize,
+        long[] speechTokensB, float[] spkEmbB, float[] spkFeatB,
+        int TTok, int SpeakerDim, int PromptLen, int MelBins)
+    {
+        string flowPath = Path.Combine(onnxDir, "flow_encoder.onnx");
+        string cfmPath = Path.Combine(onnxDir, "cfm_estimator.onnx");
+        string m2wPath = Path.Combine(onnxDir, "mel2wav.onnx");
+        if (!File.Exists(flowPath) || !File.Exists(cfmPath) || !File.Exists(m2wPath))
+        {
+            Console.Error.WriteLine($"  split vocoder graphs not in {onnxDir}; can't fall back to split probe.");
+            return 1;
+        }
+        Console.WriteLine($"  Probing split graphs at B={batchSize} ...");
+        using var flow = OrtSessionBuilder.CreateCachedSession(flowPath, ep);
+        using var cfm = OrtSessionBuilder.CreateCachedSession(cfmPath, ep);
+        using var m2w = OrtSessionBuilder.CreateCachedSession(m2wPath, ep);
+
+        // flow_encoder at B>1
+        var flowSw = Stopwatch.StartNew();
+        IDisposableReadOnlyCollection<DisposableNamedOnnxValue>? flowOut = null;
+        try
+        {
+            flowOut = flow.Run(new[]
+            {
+                NamedOnnxValue.CreateFromTensor("speech_tokens",
+                    new DenseTensor<long>(speechTokensB, new[] { batchSize, TTok })),
+                NamedOnnxValue.CreateFromTensor("speaker_embeddings",
+                    new DenseTensor<float>(spkEmbB, new[] { batchSize, SpeakerDim })),
+                NamedOnnxValue.CreateFromTensor("speaker_features",
+                    new DenseTensor<float>(spkFeatB, new[] { batchSize, PromptLen, MelBins })),
+            });
+            flowSw.Stop();
+            var muT = flowOut.ToList()[0].AsTensor<float>();
+            Console.WriteLine($"  flow_encoder B={batchSize}: {flowSw.ElapsedMilliseconds} ms  mu={DimsOf(muT.Dimensions)}");
+        }
+        catch (Exception ex)
+        {
+            flowSw.Stop();
+            Console.Error.WriteLine($"  flow_encoder B={batchSize} FAILED after {flowSw.ElapsedMilliseconds} ms: {ex.Message.Split('\n')[0]}");
+            return 1;
+        }
+
+        // cfm_estimator at B>2 (CFG-doubled): replicate flow outputs ×2 along batch
+        var encList = flowOut!.ToList();
+        var muArr = encList[0].AsTensor<float>().ToArray();
+        var maskArr = encList[1].AsTensor<float>().ToArray();
+        var embedArr = encList[2].AsTensor<float>().ToArray();
+        var condArr = encList[3].AsTensor<float>().ToArray();
+        var zArr = encList[4].AsTensor<float>().ToArray();
+        int tMel = encList[0].AsTensor<float>().Dimensions[2];
+
+        // CFG-doubled to [2*B, ...] per the C# split-vocoder convention.
+        int cfgB = 2 * batchSize;
+        var muIn = new float[cfgB * MelBins * tMel];
+        Array.Copy(muArr, 0, muIn, 0, muArr.Length);
+        // second half stays zeros (uncond)
+        var maskIn = new float[cfgB * 1 * tMel];
+        Array.Copy(maskArr, 0, maskIn, 0, maskArr.Length);
+        Array.Copy(maskArr, 0, maskIn, maskArr.Length, maskArr.Length);
+        var xIn = new float[cfgB * MelBins * tMel];
+        Array.Copy(zArr, 0, xIn, 0, zArr.Length);
+        Array.Copy(zArr, 0, xIn, zArr.Length, zArr.Length);
+        var spksIn = new float[cfgB * MelBins];
+        Array.Copy(embedArr, 0, spksIn, 0, embedArr.Length);
+        var condIn = new float[cfgB * MelBins * tMel];
+        Array.Copy(condArr, 0, condIn, 0, condArr.Length);
+        var tIn = new float[cfgB];
+        Array.Fill(tIn, 0.0f);
+
+        var cfmSw = Stopwatch.StartNew();
+        try
+        {
+            using var cfmOut = cfm.Run(new[]
+            {
+                NamedOnnxValue.CreateFromTensor("x_in",    new DenseTensor<float>(xIn,    new[] { cfgB, MelBins, tMel })),
+                NamedOnnxValue.CreateFromTensor("mask_in", new DenseTensor<float>(maskIn, new[] { cfgB, 1, tMel })),
+                NamedOnnxValue.CreateFromTensor("mu_in",   new DenseTensor<float>(muIn,   new[] { cfgB, MelBins, tMel })),
+                NamedOnnxValue.CreateFromTensor("t_in",    new DenseTensor<float>(tIn,    new[] { cfgB })),
+                NamedOnnxValue.CreateFromTensor("spks_in", new DenseTensor<float>(spksIn, new[] { cfgB, MelBins })),
+                NamedOnnxValue.CreateFromTensor("cond_in", new DenseTensor<float>(condIn, new[] { cfgB, MelBins, tMel })),
+            });
+            cfmSw.Stop();
+            var dphi = cfmOut.First().AsTensor<float>();
+            Console.WriteLine($"  cfm_estimator B={cfgB} (CFG-doubled): {cfmSw.ElapsedMilliseconds} ms  dphi={DimsOf(dphi.Dimensions)}");
+        }
+        catch (Exception ex)
+        {
+            cfmSw.Stop();
+            Console.Error.WriteLine($"  cfm_estimator B={cfgB} FAILED after {cfmSw.ElapsedMilliseconds} ms: {ex.Message.Split('\n')[0]}");
+            flowOut.Dispose();
+            return 1;
+        }
+
+        // mel2wav at B>1 — needs a mel of shape [B, 80, T_mel_trimmed]
+        int tTrim = tMel - PromptLen;
+        var melB = new float[batchSize * MelBins * tTrim];
+        // (random values; we only care about timing + crash-free)
+        var rng = new Random(0);
+        for (int i = 0; i < melB.Length; i++) melB[i] = (float)(rng.NextDouble() * 2 - 1);
+        var m2wSw = Stopwatch.StartNew();
+        try
+        {
+            using var m2wOut = m2w.Run(new[]
+            {
+                NamedOnnxValue.CreateFromTensor("mel",
+                    new DenseTensor<float>(melB, new[] { batchSize, MelBins, tTrim })),
+            });
+            m2wSw.Stop();
+            var wav = m2wOut.First().AsTensor<float>();
+            Console.WriteLine($"  mel2wav B={batchSize}: {m2wSw.ElapsedMilliseconds} ms  wav={DimsOf(wav.Dimensions)}");
+        }
+        catch (Exception ex)
+        {
+            m2wSw.Stop();
+            Console.Error.WriteLine($"  mel2wav B={batchSize} FAILED after {m2wSw.ElapsedMilliseconds} ms: {ex.Message.Split('\n')[0]}");
+            flowOut.Dispose();
+            return 1;
+        }
+
+        flowOut.Dispose();
+        return 0;
+    }
 }

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -15,6 +15,8 @@
 
 using System.Diagnostics;
 using Chatterbox.Base;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
 using Chatterbox.Base.AudioIo;
 using Chatterbox.Base.Tokenization;
 using NAudio.Wave;
@@ -52,6 +54,7 @@ internal static class Program
         string? tokenizerJson = null;
         int benchChunks = 1;
         bool pipelined = false;
+        int benchBatchedLm = 0;  // 0 = disabled; >0 = run probe with B=this
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
@@ -84,6 +87,20 @@ internal static class Program
                     // a serial single-chunk call.
                     pipelined = true;
                     break;
+                case "--bench-batched-lm":
+                    // Probe whether the LM ONNX accepts B>1 inputs at all
+                    // (its dynamic_axes say yes; this confirms ORT actually
+                    // honors it). Bypasses voice/tokenizer/vocoder — loads
+                    // only embed_tokens + language_model, runs a B-batch
+                    // prefill + a handful of step iterations, reports
+                    // per-step ms. Use to compute the amortization factor
+                    // vs serial B=1: lower than 1.0 means batching wins.
+                    if (!int.TryParse(args[++i], out benchBatchedLm) || benchBatchedLm < 1)
+                    {
+                        Console.Error.WriteLine("--bench-batched-lm expects a positive integer batch size.");
+                        return 2;
+                    }
+                    break;
                 default:
                     Console.Error.WriteLine($"Unknown arg: {args[i]}");
                     return 2;
@@ -101,10 +118,13 @@ internal static class Program
                     + "Use --no-io-binding for full past_kv diag artifacts.");
             }
         }
-        if (onnxDir is null || voicePath is null || outPath is null)
+        // --bench-batched-lm skips voice + vocoder; only needs --onnx-dir.
+        // Other modes need --voice. --out always has a default.
+        if (onnxDir is null || (voicePath is null && benchBatchedLm == 0))
         {
             Console.Error.WriteLine(
-                "Usage: --onnx-dir <dir> --voice <wav> [--out <wav>] [--ep cpu|cuda]");
+                "Usage: --onnx-dir <dir> --voice <wav> [--out <wav>] [--ep cpu|cuda]\n"
+                + "   or: --onnx-dir <dir> --bench-batched-lm <B>");
             return 2;
         }
         if (ep is not ("cpu" or "cuda"))
@@ -113,12 +133,18 @@ internal static class Program
             return 2;
         }
 
-        voicePath = ExpandHome(voicePath);
-        outPath = ExpandHome(outPath);
+        if (voicePath is not null) voicePath = ExpandHome(voicePath);
+        outPath = ExpandHome(outPath ?? "/tmp/chatterbox_out_cs.wav");
 
         var totalSw = Stopwatch.StartNew();
         var sw = new Stopwatch();
         var epEnum = ep == "cuda" ? ExecutionProvider.Auto : ExecutionProvider.Cpu;
+
+        // ── Probe mode: --bench-batched-lm ────────────────────────────────
+        if (benchBatchedLm > 0)
+        {
+            return RunBatchedLmProbe(onnxDir, epEnum, benchBatchedLm);
+        }
 
         // ── Resolve tokenizer (needed only if --text was given) ───────────
         EnTokenizer? tokenizer = null;
@@ -172,8 +198,10 @@ internal static class Program
         Console.WriteLine($"Loaded sessions in {totalLoadSw.ElapsedMilliseconds} ms total  (requested={ep}, effective={effectiveEp})");
 
         // ── Speaker embedding ──────────────────────────────────────────────
+        // voicePath is non-null here: the only path that allows it to be
+        // null is benchBatchedLm > 0, which returned above.
         sw.Restart();
-        var audio = VoicePromptLoader.Load(voicePath);
+        var audio = VoicePromptLoader.Load(voicePath!);
         sw.Stop();
         Console.WriteLine($"Loaded voice {voicePath}: {audio.Length} samples "
             + $"({audio.Length / (float)ChatterboxConstants.S3GenSr:F2}s)  [{sw.ElapsedMilliseconds} ms]");
@@ -318,4 +346,156 @@ internal static class Program
         => path.StartsWith("~/")
             ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), path[2..])
             : path;
+
+    /// <summary>
+    /// Bypasses voice/tokenizer/vocoder; loads only embed_tokens + language_model,
+    /// runs a single prefill at batch=B plus a handful of autoregressive step
+    /// iterations, reports per-step ms. Used to answer:
+    ///   1. Does ORT actually honor the LM ONNX's B>1 dynamic_axes? (yes/no)
+    ///   2. What is the amortization factor — wall(B=N) / wall(B=1)?
+    ///      Lower than 1.0 means batching wins; close to N means we're
+    ///      memory-bandwidth-bound and batching adds little.
+    ///
+    /// Same prompt is replicated across the B dimension to keep the prefill
+    /// length identical per batch element. Real per-element variable-length
+    /// prefill is a Stage-2-implementation concern, not a probe concern.
+    /// </summary>
+    private static int RunBatchedLmProbe(string onnxDir, ExecutionProvider ep, int batchSize)
+    {
+        const int StepIterations = 10;  // average across this many step calls
+
+        Console.WriteLine($"Batched-LM probe: B={batchSize}, ep={ep}");
+        var loadSw = Stopwatch.StartNew();
+        using var embed = OrtSessionBuilder.CreateCachedSession(
+            Path.Combine(onnxDir, "embed_tokens.onnx"), ep);
+        using var lm = OrtSessionBuilder.CreateCachedSession(
+            Path.Combine(onnxDir, "language_model.onnx"), ep);
+        loadSw.Stop();
+        Console.WriteLine($"  loaded embed_tokens + language_model in {loadSw.ElapsedMilliseconds} ms");
+
+        // Build B-batched input. Replicate FallbackInputIds (the Ezreal sentence
+        // wrapped with [EXAGGERATION, ..., START_SPEECH, START_SPEECH]) across B.
+        int sText = FallbackInputIds.Length;
+        var idsB = new long[batchSize * sText];
+        var posB = new long[batchSize * sText];
+        for (int b = 0; b < batchSize; b++)
+        {
+            Array.Copy(FallbackInputIds, 0, idsB, b * sText, sText);
+            for (int i = 0; i < sText; i++)
+                posB[b * sText + i] = FallbackInputIds[i] >= ChatterboxConstants.StartSpeechToken ? 0 : i - 1;
+        }
+        var exagB = new float[batchSize];
+        Array.Fill(exagB, ChatterboxConstants.DefaultExaggeration);
+
+        // embed_tokens at B, S (dynamic axes support it).
+        var embSw = Stopwatch.StartNew();
+        using var embOut = embed.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("input_ids", new DenseTensor<long>(idsB, new[] { batchSize, sText })),
+            NamedOnnxValue.CreateFromTensor("position_ids", new DenseTensor<long>(posB, new[] { batchSize, sText })),
+            NamedOnnxValue.CreateFromTensor("exaggeration", new DenseTensor<float>(exagB, new[] { batchSize })),
+        });
+        var textEmb = embOut.First().AsTensor<float>();
+        embSw.Stop();
+        Console.WriteLine($"  embed_tokens B={batchSize}: {embSw.ElapsedMilliseconds} ms  text_emb shape={DimsOf(textEmb.Dimensions)}");
+
+        // inputs_embeds = text_emb directly (no cond_emb prepend; this probe
+        // doesn't care about parity, only kernel timing). Shape: [B, S, 1024].
+        var inputsEmbeds = textEmb.ToArray();
+        int sTotal = sText;
+        int hidden = ChatterboxConstants.LlmHidden;
+
+        // ── Prefill ─────────────────────────────────────────────────────
+        var attentionMask = new long[batchSize * sTotal];
+        Array.Fill(attentionMask, 1);
+        var pastKv = new float[ChatterboxConstants.LlmLayers * 2][];
+        var pastKvShape = new int[] { batchSize, ChatterboxConstants.LlmKvHeads, 0, ChatterboxConstants.LlmHeadDim };
+        for (int k = 0; k < pastKv.Length; k++) pastKv[k] = [];
+
+        var prefillSw = Stopwatch.StartNew();
+        var prefillOut = RunLmOnce(lm, inputsEmbeds, batchSize, sTotal, attentionMask, pastKv, pastKvShape);
+        prefillSw.Stop();
+        var prefillList = prefillOut.ToList();
+        int vocab = prefillList[0].AsTensor<float>().Dimensions[2];
+        for (int layer = 0; layer < ChatterboxConstants.LlmLayers; layer++)
+        {
+            pastKv[2 * layer] = prefillList[1 + 2 * layer].AsTensor<float>().ToArray();
+            pastKv[2 * layer + 1] = prefillList[1 + 2 * layer + 1].AsTensor<float>().ToArray();
+        }
+        pastKvShape = prefillList[1].AsTensor<float>().Dimensions.ToArray();
+        prefillOut.Dispose();
+        Console.WriteLine($"  prefill B={batchSize} S={sTotal}: {prefillSw.ElapsedMilliseconds} ms  vocab={vocab}  past_kv per-layer shape={DimsOf(pastKvShape)}");
+
+        // ── StepIterations autoregressive steps (random input embeds, B,1,1024) ──
+        var stepMs = new long[StepIterations];
+        for (int step = 0; step < StepIterations; step++)
+        {
+            var stepEmbeds = new float[batchSize * 1 * hidden];
+            // Use deterministic dummy data; this probe measures cost, not output correctness.
+            for (int j = 0; j < stepEmbeds.Length; j++) stepEmbeds[j] = (j % 17) / 17.0f;
+
+            attentionMask = GrowBatchedMask(attentionMask, batchSize, 1);
+            var stepSw = Stopwatch.StartNew();
+            var stepOut = RunLmOnce(lm, stepEmbeds, batchSize, 1, attentionMask, pastKv, pastKvShape);
+            stepSw.Stop();
+            stepMs[step] = stepSw.ElapsedMilliseconds;
+
+            var stepList = stepOut.ToList();
+            for (int layer = 0; layer < ChatterboxConstants.LlmLayers; layer++)
+            {
+                pastKv[2 * layer] = stepList[1 + 2 * layer].AsTensor<float>().ToArray();
+                pastKv[2 * layer + 1] = stepList[1 + 2 * layer + 1].AsTensor<float>().ToArray();
+            }
+            pastKvShape = stepList[1].AsTensor<float>().Dimensions.ToArray();
+            stepOut.Dispose();
+        }
+
+        long stepSum = 0;
+        foreach (var ms in stepMs) stepSum += ms;
+        double stepAvgPerCall = stepSum / (double)StepIterations;
+        double stepAvgPerBatchElem = stepAvgPerCall / batchSize;
+        Console.WriteLine($"  step iter avg: {stepAvgPerCall:F1} ms/call  ({stepAvgPerBatchElem:F1} ms/batch-elem  → B={batchSize} amortization)");
+        return 0;
+    }
+
+    private static IDisposableReadOnlyCollection<DisposableNamedOnnxValue> RunLmOnce(
+        InferenceSession lm, float[] inputsEmbeds, int batch, int seqLen,
+        long[] attentionMask, float[][] pastKv, int[] pastKvShape)
+    {
+        const int LlmHidden = ChatterboxConstants.LlmHidden;
+        const int LlmLayers = ChatterboxConstants.LlmLayers;
+        var embedT = new DenseTensor<float>(inputsEmbeds, new[] { batch, seqLen, LlmHidden });
+        var maskT = new DenseTensor<long>(attentionMask, new[] { batch, attentionMask.Length / batch });
+        var inputs = new List<NamedOnnxValue>(2 + 2 * LlmLayers)
+        {
+            NamedOnnxValue.CreateFromTensor("inputs_embeds", embedT),
+            NamedOnnxValue.CreateFromTensor("attention_mask", maskT),
+        };
+        for (int layer = 0; layer < LlmLayers; layer++)
+        {
+            inputs.Add(NamedOnnxValue.CreateFromTensor(
+                $"past_key_values.{layer}.key", new DenseTensor<float>(pastKv[2 * layer], pastKvShape)));
+            inputs.Add(NamedOnnxValue.CreateFromTensor(
+                $"past_key_values.{layer}.value", new DenseTensor<float>(pastKv[2 * layer + 1], pastKvShape)));
+        }
+        return lm.Run(inputs);
+    }
+
+    private static long[] GrowBatchedMask(long[] mask, int batch, int growBy)
+    {
+        int oldPerB = mask.Length / batch;
+        int newPerB = oldPerB + growBy;
+        var grown = new long[batch * newPerB];
+        for (int b = 0; b < batch; b++)
+        {
+            Array.Copy(mask, b * oldPerB, grown, b * newPerB, oldPerB);
+            for (int i = oldPerB; i < newPerB; i++) grown[b * newPerB + i] = 1;
+        }
+        return grown;
+    }
+
+    private static string DimsOf(IReadOnlyList<int> dims)
+        => "(" + string.Join(", ", dims) + ")";
+    private static string DimsOf(System.ReadOnlySpan<int> dims)
+        => "(" + string.Join(", ", dims.ToArray()) + ")";
 }

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -55,6 +55,7 @@ internal static class Program
         int benchChunks = 1;
         bool pipelined = false;
         int benchBatchedLm = 0;  // 0 = disabled; >0 = run probe with B=this
+        int lmBatch = 1;  // --lm-batch B: group benchChunks into batched LM calls of size B
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
@@ -86,6 +87,17 @@ internal static class Program
                     // with --bench-chunks N for N>1; for N=1 collapses to
                     // a serial single-chunk call.
                     pipelined = true;
+                    break;
+                case "--lm-batch":
+                    // Group bench-chunks N into batched LM calls of size B.
+                    // Each group runs one GenerateBatch with B same-text prompts,
+                    // then B vocoder calls serially. With --bench-chunks 8
+                    // --lm-batch 4, that's 2 batched LM calls × 8 vocoder calls.
+                    if (!int.TryParse(args[++i], out lmBatch) || lmBatch < 1)
+                    {
+                        Console.Error.WriteLine("--lm-batch expects a positive integer.");
+                        return 2;
+                    }
                     break;
                 case "--bench-batched-lm":
                     // Probe whether the LM ONNX accepts B>1 inputs at all
@@ -241,7 +253,48 @@ internal static class Program
         float[]? lastSamples = null;
         long pipelinedChunkWallMs = 0;  // populated when --pipelined; serial branch uses sums below
 
-        if (pipelined && benchChunks > 1)
+        if (lmBatch > 1 && benchChunks > 1)
+        {
+            // Batched-LM mode. Group benchChunks into lmBatch-sized groups;
+            // each group: 1 batched GenerateBatch + B serial vocoder calls.
+            // Measures the per-chunk amortization established in Run 3 but
+            // end-to-end (real STOP_SPEECH-driven rollouts, full vocoder).
+            var batchWallSw = Stopwatch.StartNew();
+            int produced = 0;
+            while (produced < benchChunks)
+            {
+                int B = Math.Min(lmBatch, benchChunks - produced);
+                var condEmbs = Enumerable.Repeat(spk.CondEmb, B).ToArray();
+                var tokensPerB = Enumerable.Repeat(inputIds, B).ToArray();
+
+                var batchLmSw = Stopwatch.StartNew();
+                var batched = lm.GenerateBatch(condEmbs, tokensPerB);
+                batchLmSw.Stop();
+
+                for (int b = 0; b < B; b++)
+                {
+                    var lmResult = batched.PerChunkResults[b];
+                    var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
+                    sw.Restart();
+                    var samples = vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+                    sw.Stop();
+                    int globalIdx = produced + b;
+                    chunkLmMs[globalIdx] = batchLmSw.ElapsedMilliseconds / B;  // amortized share
+                    chunkVocMs[globalIdx] = sw.ElapsedMilliseconds;
+                    chunkSteps[globalIdx] = lmResult.Steps;
+                    lastSamples = samples;
+                    Console.WriteLine($"  chunk {globalIdx + 1}/{benchChunks} [batch {(produced / lmBatch) + 1}, elem {b + 1}/{B}]: "
+                        + $"LM-share {chunkLmMs[globalIdx]} ms, "
+                        + $"voc {chunkVocMs[globalIdx]} ms, "
+                        + $"audio {samples.Length / (float)ChatterboxConstants.S3GenSr:F2}s");
+                }
+                Console.WriteLine($"    batch LM call: {batchLmSw.ElapsedMilliseconds} ms total for B={B}");
+                produced += B;
+            }
+            batchWallSw.Stop();
+            pipelinedChunkWallMs = batchWallSw.ElapsedMilliseconds;  // reuse for the summary
+        }
+        else if (pipelined && benchChunks > 1)
         {
             var synth = new ChunkedSynthesizer(lm, vocoder);
             var tokensPerChunk = Enumerable.Repeat(inputIds, benchChunks).ToArray();
@@ -325,10 +378,17 @@ internal static class Program
             // by ChunkedSynthesizer (not the sum, which over-counts because
             // LM and vocoder overlap). For serial mode, sum and chunks-total
             // are the same thing.
-            double chunksTotalSec = pipelined
+            // For batched / pipelined modes, "chunks-wall" is the actual
+            // wall measured for the orchestrator (not the sum, which
+            // over-counts because of batching amortization or LM/voc
+            // overlap). For serial mode, sum and chunks-wall coincide.
+            double chunksTotalSec = (pipelined || lmBatch > 1)
                 ? pipelinedChunkWallMs / 1000.0
                 : (lmSum + vocSum) / 1000.0;
-            Console.WriteLine($"Bench: {benchChunks} chunks ({(pipelined ? "pipelined" : "serial")}), "
+            string mode = lmBatch > 1 ? $"lm-batch={lmBatch}"
+                : pipelined ? "pipelined"
+                : "serial";
+            Console.WriteLine($"Bench: {benchChunks} chunks ({mode}), "
                 + $"LM avg {lmSum / (double)benchChunks:F0} ms, "
                 + $"voc avg {vocSum / (double)benchChunks:F0} ms, "
                 + $"per-chunk-sum-avg {(lmSum + vocSum) / (double)benchChunks:F0} ms, "

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -155,6 +155,19 @@ internal static class Program
                     + "Use --no-io-binding for full past_kv diag artifacts.");
             }
         }
+        // --voc-batch is meaningful only under non-pipelined --lm-batch>1.
+        // Under --pipelined the group size is what drives voc batching (the
+        // group is the batching unit); --voc-batch alone with no --lm-batch
+        // falls through to the serial branch and is silently dropped.
+        if (vocBatch > 1 && (pipelined || lmBatch <= 1))
+        {
+            string why = pipelined
+                ? "under --pipelined the group size (--lm-batch) drives voc batching"
+                : "--voc-batch requires --lm-batch>1 — without batched LM there are no groups to batch the voc over";
+            Console.Error.WriteLine($"warning: --voc-batch {vocBatch} ignored: {why}.");
+            vocBatch = 1;
+        }
+
         // --bench-batched-{lm,voc} both skip voice loading; only need --onnx-dir.
         // Other modes need --voice. --out always has a default.
         bool isProbe = benchBatchedLm > 0 || benchBatchedVoc > 0;
@@ -512,6 +525,19 @@ internal static class Program
             Path.Combine(onnxDir, "language_model.onnx"), ep);
         loadSw.Stop();
         Console.WriteLine($"  loaded embed_tokens + language_model in {loadSw.ElapsedMilliseconds} ms");
+
+        // Probe is fp32-hardcoded (DenseTensor<float> for inputs_embeds + past_kv);
+        // an fp16 LM would throw ORT type-mismatch at the first BindInput with
+        // no useful message. Fail clearly instead.
+        if (lm.InputMetadata.TryGetValue("inputs_embeds", out var iemd)
+            && iemd.ElementDataType == TensorElementType.Float16)
+        {
+            Console.Error.WriteLine(
+                "--bench-batched-lm is fp32-hardcoded and the loaded LM expects fp16 inputs. "
+                + "Re-point the bundle's language_model.onnx at an fp32 export, or use the full "
+                + "synthesis path (--bench-chunks) which routes through AcousticLM's dtype-aware binding.");
+            return 2;
+        }
 
         // Build B-batched input. Replicate FallbackInputIds (the Ezreal sentence
         // wrapped with [EXAGGERATION, ..., START_SPEECH, START_SPEECH]) across B.

--- a/tests/ChatterboxSmoke/Program.cs
+++ b/tests/ChatterboxSmoke/Program.cs
@@ -282,12 +282,40 @@ internal static class Program
         float[]? lastSamples = null;
         long pipelinedChunkWallMs = 0;  // populated when --pipelined; serial branch uses sums below
 
-        if (lmBatch > 1 && benchChunks > 1)
+        if (pipelined && benchChunks > 1)
         {
-            // Batched-LM mode. Group benchChunks into lmBatch-sized groups;
-            // each group: 1 batched GenerateBatch + B serial vocoder calls.
-            // Measures the per-chunk amortization established in Run 3 but
-            // end-to-end (real STOP_SPEECH-driven rollouts, full vocoder).
+            // ChunkedSynthesizer mode. groupSize=lmBatch:
+            //   lmBatch=1: chunk-at-a-time LM/voc pipelining (Run 2)
+            //   lmBatch>1: per-group LM/voc batched + pipelined across
+            //              groups (Run 7). Voc-batch implicitly == lmBatch
+            //              in this mode (group is the batching unit).
+            var synth = new ChunkedSynthesizer(lm, vocoder);
+            var tokensPerChunk = Enumerable.Repeat(inputIds, benchChunks).ToArray();
+            var result = synth.Synthesize(
+                spk, tokensPerChunk,
+                useIoBinding: useIoBinding,
+                groupSize: lmBatch);
+            for (int chunk = 0; chunk < benchChunks; chunk++)
+            {
+                var t = result.ChunkTimings[chunk];
+                chunkLmMs[chunk] = t.LmMs;
+                chunkVocMs[chunk] = t.VocoderMs;
+                chunkSteps[chunk] = t.LmSteps;
+                lastSamples = result.Waveforms[chunk];
+                Console.WriteLine($"  chunk {chunk + 1}/{benchChunks}: "
+                    + $"LM-share {t.LmMs} ms ({t.LmSteps} steps), "
+                    + $"voc-share {t.VocoderMs} ms, "
+                    + $"audio {t.AudioSamples / (float)ChatterboxConstants.S3GenSr:F2}s");
+            }
+            pipelinedChunkWallMs = result.TotalWallMs;
+        }
+        else if (lmBatch > 1 && benchChunks > 1)
+        {
+            // Batched-LM mode (no pipelining). Group benchChunks into
+            // lmBatch-sized groups; each group: 1 batched GenerateBatch
+            // + B serial vocoder calls. Measures the per-chunk amortization
+            // established in Run 3 but end-to-end (real STOP_SPEECH-driven
+            // rollouts, full vocoder).
             var batchWallSw = Stopwatch.StartNew();
             int produced = 0;
             while (produced < benchChunks)
@@ -351,25 +379,6 @@ internal static class Program
             }
             batchWallSw.Stop();
             pipelinedChunkWallMs = batchWallSw.ElapsedMilliseconds;  // reuse for the summary
-        }
-        else if (pipelined && benchChunks > 1)
-        {
-            var synth = new ChunkedSynthesizer(lm, vocoder);
-            var tokensPerChunk = Enumerable.Repeat(inputIds, benchChunks).ToArray();
-            var result = synth.Synthesize(spk, tokensPerChunk, useIoBinding: useIoBinding);
-            for (int chunk = 0; chunk < benchChunks; chunk++)
-            {
-                var t = result.ChunkTimings[chunk];
-                chunkLmMs[chunk] = t.LmMs;
-                chunkVocMs[chunk] = t.VocoderMs;
-                chunkSteps[chunk] = t.LmSteps;
-                lastSamples = result.Waveforms[chunk];
-                Console.WriteLine($"  chunk {chunk + 1}/{benchChunks}: "
-                    + $"LM {t.LmMs} ms ({t.LmSteps} steps), "
-                    + $"voc {t.VocoderMs} ms, "
-                    + $"audio {t.AudioSamples / (float)ChatterboxConstants.S3GenSr:F2}s");
-            }
-            pipelinedChunkWallMs = result.TotalWallMs;
         }
         else
         {
@@ -443,10 +452,13 @@ internal static class Program
             double chunksTotalSec = (pipelined || lmBatch > 1)
                 ? pipelinedChunkWallMs / 1000.0
                 : (lmSum + vocSum) / 1000.0;
-            string mode = lmBatch > 1
-                ? (vocBatch > 1 ? $"lm-batch={lmBatch}+voc-batch={vocBatch}" : $"lm-batch={lmBatch}")
-                : pipelined ? "pipelined"
-                : "serial";
+            string mode;
+            if (pipelined && lmBatch > 1) mode = $"pipelined+group-batch={lmBatch}";
+            else if (pipelined) mode = "pipelined";
+            else if (lmBatch > 1) mode = vocBatch > 1
+                ? $"lm-batch={lmBatch}+voc-batch={vocBatch}"
+                : $"lm-batch={lmBatch}";
+            else mode = "serial";
             Console.WriteLine($"Bench: {benchChunks} chunks ({mode}), "
                 + $"LM avg {lmSum / (double)benchChunks:F0} ms, "
                 + $"voc avg {vocSum / (double)benchChunks:F0} ms, "


### PR DESCRIPTION
## Summary

Long-form-audiobook perf workstream for the Chatterbox TTS pipeline. Cumulative result on RTX 3090 / CUDA at 8 chunks:

| Path | chunks-wall | vs Run 1 baseline |
|---|---|---|
| Serial IoBinding (Run 1, baseline) | 14.7 s | — |
| **Pipelined batched groups (Run 7c)** | **7.1–7.7 s** | **−49%** |

The pipeline now exposes four orchestration modes — serial, pipelined (LM/voc overlap), batched (B>1 LM+voc per group), and pipelined batched groups (Run 7) — all selectable via `ChunkedSynthesizer.Synthesize(groupSize=N)` and the smoke driver flags `--bench-chunks`, `--pipelined`, `--lm-batch`, `--voc-batch`.

## What's in the branch

- **Runs 1-7**: cumulative perf work. Run 5 (batched IoBinding) is the biggest single win; Run 7 stacks pipelining on top.
- **Run 8**: LM quantization sweep (fp16/int8/int4). Honest finding: none improved long-form-batched throughput on this hardware. int4 RTN wins 14% at B=1 but loses at B=4 (kernel doesn't batch). int8 dynamic is a CPU-fallback trap with quality collapse — flagged at runtime in `quantize_lm.py`.
- **Run 9**: true-fp16 KV cache with C# dtype-aware IoBinding. Parity preserved (174 steps, argmax matches fp32, 6.92s output) but no perf win — ORT picks the same fp32 cuBLAS kernels for both at this dim. Architectural cleanup banked for future fp16-friendly LM variants.

## Files changed (~3100 LOC + investigation doc)

- `src/Chatterbox.Base/ChunkedSynthesizer.cs` (new) — Channel-based producer/consumer with two paths
- `src/Chatterbox.Base/AcousticLM.cs` — `GenerateBatch` + dtype-aware fp16/fp32 IoBinding helpers + batched IoBinding loop
- `src/Chatterbox.Base/Vocoder.cs` — `SynthesizeBatch` (split-graph fallback when merged graph rejects B>1)
- `tests/ChatterboxSmoke/Program.cs` — perf knobs + Run-3/Run-6 batched-probe modes
- `scripts/_export_utils/quantize_lm.py` (new) — fp16 / int8 / int4 LM quantization (Run 8/9)
- `docs/chatterbox_perf_investigation.md` (new, ~1200 lines) — chronological log of all 9 runs with raw findings and dead-ends

## Notes for reviewers

- **Hardware scope**: Measurements are RTX 3090 (Ampere consumer). Best batch sizes, pipelining contention factor, and quantization kernel selection are all hardware-specific. CPU/DirectML paths exist (basic Run loops) but weren't benched. IoBinding paths are CUDA-only by design (hardcoded `OrtMemoryInfo("Cuda")`).
- **Vocoder.SynthesizeBatch is split-graph-only** — the merged `conditional_decoder_loop.onnx` baked CFG-doubling at trace time and won't accept B>1. Throws a clear `InvalidOperationException` directing callers to re-export. Path B (rewriting the merge script) is detailed in Run 6 sidebar; deferred as small headroom (~3-5%).
- **Concurrency**: `ChunkedSynthesizer` uses bounded-channel producer/consumer. A pre-PR review caught a deadlock-on-vocoder-throw issue; fixed in d2d511b via CTS cancellation through the producer's WriteAsync. Both Synthesize paths now propagate exceptions cleanly.
- **No unit tests added** — perf branch driven by the smoke driver. Two cheap follow-ups worth doing: order-preservation invariant for ChunkedSynthesizer, and `LmIsFloat16` round-trip with an fp16 fixture.
- Run 8 and Run 9 are explicitly architectural-only commits — quantization didn't deliver perf. The branch lands the dtype-aware machinery so future LM variants with fp16-friendly kernels work via `--lm-path` without further C# changes.
- The investigation doc has a "Where the remaining levers actually are" section at the end of Run 9 listing the next workstreams (ORT-GenAI swap, fused-attention re-export, bf16 retry, vocoder Path B, custom CUDA kernel) and their expected costs.

## Test plan

- [ ] CI build green
- [ ] Spot-check single-chunk fp32 IoBinding output against pre-branch (token-level diff)
- [ ] `tests/ChatterboxSmoke --bench-chunks 8 --pipelined --lm-batch 4` produces 8 sensible WAVs in input order on a CUDA box
- [ ] `quantize_lm.py --mode fp16 --no-keep-io-types` produces a loadable model via `--lm-path` (dtype-aware path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)