### PR TITLE
Chatterbox perf Run 10: merged-batched vocoder (Path B)

### DIFF
--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -1368,3 +1368,69 @@ Two scenarios where the per-call advantage would translate:
 
 Neither is testable on the 3090 directly. The Path B graph and
 metadata flag are in place if/when that hardware shows up.
+
+### Run 10 sidebar — Memcpy elimination, dead-end investigation
+
+Followed up on the "57 body Memcpys block CUDA Graph capture" angle
+from the Run 10 conclusion. **Conclusion: dead-end. CUDA Graph
+cannot run on this merged graph at all, regardless of Memcpys.**
+
+What we tried:
+
+1. **`session.disable_cpu_ep_fallback=1`**. With CPU EP removed,
+   session load failed: "This session contains graph nodes that are
+   assigned to the default CPU EP, but fallback to CPU EP has been
+   explicitly disabled by the user." Some ops (notably `mel2wav__/STFT`)
+   have no CUDA kernel at all — the fallback isn't just heuristic,
+   it's mandatory.
+
+2. **`onnxslim` re-pass on the merged graph**. Outer 1681 → 1677
+   nodes, body 3015 → 3007 nodes. Per-call timing unchanged (B=4
+   stays at ~2000 ms). The 57 body Memcpys aren't redundant —
+   they're real data shuffles for shape-derived computations.
+
+3. **ORT-transformers `optimize_model(model_type=...)` attention
+   fusion** on `cfm_estimator.onnx`. Tried `unet`, `mmdit`, `clip`,
+   `vae`, `sam2`, `conformer`, `bart`. The U-net pattern reduced
+   2988 → 2557 nodes (`LayerNormalization` fused to
+   `SkipLayerNormalization`), but the shape-pattern op count
+   (Shape/Gather/Unsqueeze/Slice/Sqrt/Div/Cast) was unchanged at
+   643 across every variant, and **no `Attention` / `MultiHeadAttention`
+   nodes were produced**. cfm_estimator's attention is a custom
+   conv-like layout that none of ORT's fusion targets recognize.
+
+4. **`enable_cuda_graph=1` provider option**, the actual reason
+   CUDA Graph was on the table. Session refused to load:
+
+   ```
+   This session cannot use the graph capture feature as requested
+   by the user as the model has control flow nodes which can't be
+   supported by CUDAExecutionProvider
+   ```
+
+   The merged graph's `Loop` op is the blocker, not the Memcpys.
+   The earlier "including unable to run CUDA graph" Memcpy warning
+   was a red herring for this graph — CUDA Graph wasn't on the
+   table regardless.
+
+### What this means
+
+The projected upside from eliminating the Memcpys (~50-100 ms/call
+from CUDA Graph capture) was based on a misread of the warning.
+With CUDA Graph fundamentally unavailable on a Loop-bearing
+session, the Memcpy elimination would yield only the per-call
+launch overhead saving — microseconds, not milliseconds.
+
+To make Memcpy elimination actually pay off on this graph, we'd
+need EITHER:
+
+- Manually rewrite cfm_estimator's attention export to match an
+  ORT-fusion pattern (real upstream change to the export pipeline,
+  multi-day work).
+- Unroll the CFM Loop into 10 sequential function calls (lose the
+  GPU-side Loop, gain CUDA Graph eligibility — but lose the very
+  thing that makes the merged graph faster than split).
+
+Neither has a payoff that justifies the work for this branch. Path B
+ships as documented: ~1% wall win, ~1.1 GB VRAM savings, simpler
+single-vocoder-path architecture.

--- a/docs/chatterbox_perf_investigation.md
+++ b/docs/chatterbox_perf_investigation.md
@@ -1208,3 +1208,163 @@ substantially larger projects than Runs 1-9 were.
 - `/tmp/cb_fp16io*.wav` — audio outputs (parity confirmed)
 - `quantize_lm.py --no-keep-io-types` — produces the true-fp16 graph
 - `AcousticLM._lmFp16` + 6 helpers — dtype-aware IoBinding, ready for any future fp16/bf16 LM variant without further C# changes
+
+## Run 10 — 2026-05-16 23:30 — Path B: merged-batched vocoder
+
+Following the Run 6 sidebar — the merged `conditional_decoder_loop.onnx`
+graph baked CFG-doubling at trace time and rejects B>1. PR #66 worked
+around this by falling back to the split-graph orchestration at B>1
+(measured Run 6c at +3-5% wall when LM was batched; net 8-chunk wall
+went from 6.4 s → 6.1 s). Useful but small.
+
+The merged graph's real advantage over split is the GPU-side CFM Loop
+— 10 CFM iterations stay on the device; split round-trips through
+host between every iter. Path B rewrites the merge script so the
+merged graph accepts B>1, then we get the GPU-side Loop *with*
+batching. Projected from Run 6c: per-chunk voc could drop from
+~514 ms (split B=8) to ~150-200 ms (merged-batched B=8).
+
+### What's hardcoded for B=1 in the current merge script
+
+After reading `scripts/_export_utils/merge_cond_decoder_loop.py`:
+
+| Site | Spec | Status at B>1 |
+|---|---|---|
+| outer CFG-doubling for mu / spks / cond | `Concat([x, ZerosLike(x)], axis=0)` via `Shape`+`ConstantOfShape` | already dynamic ✓ |
+| outer mask CFG-doubling | `Concat([mel_mask, mel_mask], axis=0)` | already dynamic ✓ |
+| body `cfm__x_in` | `Concat([x_carried, x_carried], axis=0)` | already dynamic ✓ |
+| **body `cfm__t_in`** | `Concat([t_now_1d, t_now_1d], axis=0)` → fixed `(2,)` | **broken — needs `(2B,)`** |
+| **body input shape decl** | `x_carried: [1, MEL_BINS, "T_mel"]` | **broken — needs `["batch_size", MEL_BINS, "T_mel"]`** |
+| **body output shape decl** | `x_new: [1, MEL_BINS, "T_mel"]` | **broken — same** |
+| **z (Loop v_initial)** | flow_encoder emits `z` at fixed `[1, M, T]` due to the pinned-rand_noise patch (Run 6c sidebar) | **broken — need Expand(z, mu_shape) before Loop** |
+
+Three real fixes. The rest of the merge script already handles B>1
+correctly because the original author used `Shape`+`ConstantOfShape`
+instead of literal-2 leading dims (which is good defensive ONNX
+authoring that's now paying off).
+
+### Plan
+
+1. Patch `merge_cond_decoder_loop.py`: t_in via `Tile`, body shape
+   decls dynamic, z replication via `Expand(z, mu_shape)`.
+2. Re-export `conditional_decoder_loop.onnx`.
+3. Re-run `--bench-batched-voc B=4` probe to confirm B>1 acceptance.
+4. Update `Vocoder.SynthesizeBatch` so it prefers the merged graph
+   when it accepts B>1 (detect via session metadata or just try; the
+   split-graph fallback stays as a safety net for older bundles).
+5. Bench `--pipelined --lm-batch 4` vs Run 7c's 7.1 s headline.
+
+### Implementation
+
+Three fixes to `merge_cond_decoder_loop.py`:
+
+1. **`cfm__t_in` dynamic sizing**. Old code: `Concat([t_now_1d, t_now_1d])`
+   producing fixed `(2,)`. New code: read `B` from `Shape(x_carried)[0]`,
+   compute `[2B]`, `Tile(t_now_1d, [2B])` → shape `(2B,)`. At B=1
+   produces the same `(2,)` as before (parity preserved).
+2. **Body input/output shape decls**. `[1, MEL_BINS, "T_mel"]` →
+   `["batch_size", MEL_BINS, "T_mel"]` on `x_carried` and `x_new`.
+3. **`z` replication outside the Loop**. `flow_encoder.onnx` emits z
+   at fixed `[1, MelBins, T_mel]` (pinned-rand_noise patch, Run 6c).
+   Added `Expand(z, mu_shape)` so the Loop's `v_initial` matches B.
+   At B=1, Expand is a no-op identity.
+
+The outer graph's CFG-doubling (mu, mask, spks, cond) already used
+`Shape`+`ConstantOfShape` for dynamic zeros — no changes needed
+there. Run 6's author had already done that piece defensively.
+
+Plus a `metadata_props["supports_batched"] = "true"` flag on the
+exported model so `Vocoder.cs` can detect Path B graphs vs older
+fixed-B bundles.
+
+C# side, `Vocoder` constructor reads the metadata. When
+`_mergedSupportsBatched`:
+- Don't load the split graphs (saves ~1.1 GB VRAM, the whole point
+  of Path B in Run 6c sidebar).
+- `SynthesizeBatch` routes to a new `RunMergedBatched` that packs all
+  B chunks into one merged-graph `.Run`.
+
+Older bundles without the metadata flag still work: they fall
+through to the split-graph orchestration as before.
+
+### Parity (B=1, new vs old merged graph, seeded random inputs)
+
+```
+max abs diff: 3.39e-05
+mean abs diff: 4.57e-08
+old shape=(1, 144000)   new shape=(1, 144000)
+```
+
+Within ORT non-determinism floor. End-to-end Chatterbox synthesis
+through the new graph at B=1 produces 174 LM steps, 6.92 s audio —
+bit-equivalent to Run 1's baseline.
+
+### Perf (8 chunks, RTX 3090, CUDA, with `--io-binding`)
+
+| Config | chunks-wall | voc/chunk |
+|---|---|---|
+| Run 7c: split-batched, pipelined groups (B=4) | 7.1 s | ~540 ms (first), 503 (steady) |
+| **Run 10: merged-batched, pipelined groups (B=4)** | **7.0 s** | **~557 ms (first), 497 (steady)** |
+| Run 10: merged-batched, lm-batch=4 + voc-batch=4 (no pipelining) | 7.4 s | 524 (first), 498 (steady) |
+| Standalone vocoder probe B=4 (no LM contention) | n/a | **553 ms/batch-elem** |
+
+Marginal 1% wall reduction (7.1 → 7.0 s). The dramatic Path B
+projection in Run 6c ("voc/chunk ~150-200 ms at B=8") didn't
+materialize: the batched CFM kernel costs scale almost linearly
+with B at both split and merged paths, so per-batch-elem voc time
+stays at ~500 ms regardless of which graph we use.
+
+### Why the per-call advantage didn't translate
+
+The standalone Python probe (no .NET, no IoBinding) showed
+merged-batched B=4 at 1775 ms = ~444 ms/elem vs split-batched
+~540 ms/elem — a real 18% kernel-level win. But in the end-to-end
+.NET pipeline:
+
+- ORT inserted 3 outer + 57 body Memcpy nodes on the CUDA EP. The
+  warning text explicitly notes "may have negative impact on
+  performance (including unable to run CUDA graph)". The body's
+  per-iter Memcpys cost ~50-100 ms each — close to the per-CFM-iter
+  budget itself.
+- Under pipelined-groups, the wall is `max(LM-share, voc-share)`
+  per group plus an LM-only first group and a voc-only tail.
+  Vocoder isn't on the critical path most of the time; saving
+  ~40 ms of voc-per-chunk hides behind the LM contention spike
+  (`LM-share` inflates from 421 → 821 ms in group 2 due to SM
+  contention with concurrent voc).
+
+So the bottleneck moved from "vocoder graph cost" (where Path B
+would help) to "LM SM contention" (where it doesn't).
+
+### What we actually got
+
+| Benefit | Measured | Value |
+|---|---|---|
+| Wall reduction | −1% (7.1 → 7.0 s) | Marginal |
+| VRAM savings | −1.1 GB (split graphs no longer loaded when merged is batched-capable) | Real on 24 GB cards |
+| Code path simplification | `Vocoder.SynthesizeBatch` is single-path for capable bundles; orchestration in ONNX, not C# | Real |
+| Backward compatibility | Old bundles without metadata fall through to split orchestration | Preserved |
+
+Net assessment: Path B is **worth landing** for the VRAM saving and
+architectural simplification, even though the wall-perf win is
+small on this hardware. On a memory-constrained box (or future
+quantized-LM bundles where the LM also wants more VRAM headroom),
+the 1.1 GB matters more.
+
+### Where else could the merged-batched advantage land?
+
+Two scenarios where the per-call advantage would translate:
+
+1. **No pipelining contention**: a single-stream invocation
+   (`--lm-batch 4` without `--pipelined`) sees voc-share 524 ms
+   merged vs 540 ms split (first call, no contention) — a tighter
+   3% win. With more aggressive batching (B=8+), the absolute saving
+   grows linearly but stays in single-digit percent.
+
+2. **Beefier GPU (H100, RTX 4090)** where SM contention isn't the
+   bottleneck. The kernel-level 18% merged-vs-split advantage from
+   the Python probe should show up as actual wall reduction when the
+   LM and vocoder can truly run in parallel without contention.
+
+Neither is testable on the 3090 directly. The Path B graph and
+metadata flag are in place if/when that hardware shows up.

--- a/scripts/_export_utils/merge_cond_decoder_loop.py
+++ b/scripts/_export_utils/merge_cond_decoder_loop.py
@@ -202,10 +202,24 @@ def build_loop_body(
     # Opset 13+ Unsqueeze: axes as a 1-D tensor input. Build via Constant + Unsqueeze.
     pre_nodes.extend(_make_unsqueeze_with_axes(
         "t_now", "t_now_1d", axes=[0], const_node_name="t_now_1d_axes"))
+    # Compute dynamic 2*B from x_carried's leading dim so cfm__t_in is (2B,)
+    # at B>1 (cfm_estimator wants one t per CFG-doubled row). At B=1 this
+    # produces (2,) — same as the prior Concat-by-2 — preserving B=1 parity.
     pre_nodes.extend([
-        # t_now_1d is (1,); concat with itself to get (2,) for cfm__t_in.
-        helper.make_node("Concat", ["t_now_1d", "t_now_1d"], ["cfm__t_in"], axis=0),
-        # x_in = Concat([x_carried, x_carried], axis=0) → (2, 80, T_mel)
+        helper.make_node("Shape", ["x_carried"], ["x_carried_shape"]),
+        # x_b_dim is a length-1 1-D tensor = [B].
+        make_const_node("two_b_starts", np.array([0], dtype=np.int64)),
+        make_const_node("two_b_ends",   np.array([1], dtype=np.int64)),
+        make_const_node("two_b_axes",   np.array([0], dtype=np.int64)),
+        helper.make_node("Slice",
+                         ["x_carried_shape", "two_b_starts", "two_b_ends", "two_b_axes"],
+                         ["x_b_dim"]),
+        make_const_node("two_const", np.array([2], dtype=np.int64)),
+        # two_b is [2B] as a length-1 1-D tensor — Tile's repeats spec.
+        helper.make_node("Mul", ["x_b_dim", "two_const"], ["two_b"]),
+        # cfm__t_in = Tile(t_now_1d, [2B]) → shape (2B,).
+        helper.make_node("Tile", ["t_now_1d", "two_b"], ["cfm__t_in"]),
+        # x_in = Concat([x_carried, x_carried], axis=0) → [2B, 80, T_mel]
         helper.make_node("Concat", ["x_carried", "x_carried"], ["cfm__x_in"], axis=0),
         # Wire outer-scope inputs directly via Identity (keeps the graph
         # explicit; ORT will optimize away).
@@ -257,16 +271,20 @@ def build_loop_body(
 
     # Body inputs (signature): iter_num, cond_in, x_carried.
     # Body outputs: cond_out, x_new.
+    # Leading dim is dynamic "batch_size" — Run 10 makes the whole graph
+    # B>1-capable. cfm__t_in is dynamically sized to (2B,) via Tile in
+    # pre_nodes; everything else (x_in, mu_in_pair, etc.) was already
+    # constructed via axis-0 Concat that scales with B.
     body_inputs = [
         helper.make_tensor_value_info("iter_num", TensorProto.INT64, []),
         helper.make_tensor_value_info("cond_in", TensorProto.BOOL, []),
         helper.make_tensor_value_info("x_carried", TensorProto.FLOAT,
-                                       [1, MEL_BINS, "T_mel"]),
+                                       ["batch_size", MEL_BINS, "T_mel"]),
     ]
     body_outputs = [
         helper.make_tensor_value_info("cond_out", TensorProto.BOOL, []),
         helper.make_tensor_value_info("x_new", TensorProto.FLOAT,
-                                       [1, MEL_BINS, "T_mel"]),
+                                       ["batch_size", MEL_BINS, "T_mel"]),
     ]
     body = helper.make_graph(
         body_nodes, "cfm_loop_body",
@@ -375,10 +393,21 @@ def merge(flow_enc_path: Path, cfm_est_path: Path, mel2wav_path: Path,
     )
     outer_inits.extend(cfm_initializers_outer)
 
-    # Loop op: trip=10, cond=True, v_initial=[z], outputs x_final.
+    # flow_encoder's `z` output stays at [1, MelBins, T_mel] regardless of
+    # the input batch B — the export's pinned-rand_noise patch (Run 11 of
+    # docs/chatterbox_investigation.md, for parity-test reproducibility)
+    # makes the graph treat z as effectively constant. At B>1 the body
+    # needs x_carried at [B, MelBins, T_mel], so we Expand z to mu's shape
+    # before feeding it as the Loop's v_initial. At B=1 Expand([1,...], [1,...])
+    # is a no-op pass-through, preserving prior parity.
+    pre_loop_nodes.append(
+        helper.make_node("Expand", ["z", "mu_shape"], ["z_b"]),
+    )
+
+    # Loop op: trip=10, cond=True, v_initial=[z_b], outputs x_final.
     loop_node = helper.make_node(
         "Loop",
-        inputs=["trip_count_const", "loop_cond_init", "z"],
+        inputs=["trip_count_const", "loop_cond_init", "z_b"],
         outputs=["x_final"],
         body=body,
     )
@@ -424,6 +453,12 @@ def merge(flow_enc_path: Path, cfm_est_path: Path, mel2wav_path: Path,
         opset_imports=[helper.make_opsetid("", opset)],
         producer_name="vernacula.merge_cond_decoder_loop",
     )
+    # Signal to Vocoder.cs that this graph accepts B>1 (Path B / Run 10).
+    # Older bundles without this metadata get routed to the split-graph
+    # fallback in SynthesizeBatch instead.
+    meta = model.metadata_props.add()
+    meta.key = "supports_batched"
+    meta.value = "true"
     # Pin IR version to match the input sub-graphs (IR 8 ships from
     # torch.onnx.export on opset 18). onnx 1.18 otherwise defaults to IR
     # 13, which ORT < 1.24 can't load.

--- a/src/Chatterbox.Base/Vocoder.cs
+++ b/src/Chatterbox.Base/Vocoder.cs
@@ -39,14 +39,23 @@ public sealed class Vocoder : IDisposable
     public VocoderMode Mode { get; }
 
     /// <summary>
-    /// True iff all three split graphs (flow_encoder, cfm_estimator,
-    /// mel2wav) are loaded. Always true in <see cref="VocoderMode.Split"/>;
-    /// also true in <see cref="VocoderMode.Merged"/> when the split
-    /// artifacts are present on disk (so <see cref="SynthesizeBatch"/>
-    /// can fall back to them). False in monolithic mode or when split
-    /// artifacts are missing.
+    /// True when <see cref="SynthesizeBatch"/> has a working path at B&gt;1
+    /// — either the merged graph carries the Path B (Run 10) metadata flag
+    /// <c>supports_batched=true</c>, or all three split graphs are loaded
+    /// as a fallback. False in monolithic mode or when neither route is
+    /// available.
     /// </summary>
-    public bool SupportsBatched => _flowEnc is not null && _cfmEst is not null && _m2w is not null;
+    public bool SupportsBatched => _mergedSupportsBatched
+                                || (_flowEnc is not null && _cfmEst is not null && _m2w is not null);
+
+    /// <summary>
+    /// True when the loaded merged graph was exported with Path B fixes
+    /// (Run 10) and accepts B&gt;1 via dynamic CFG-doubling. Detected from
+    /// the model's <c>supports_batched</c> metadata prop. Older bundles
+    /// without this prop fall through to the split-graph path in
+    /// <see cref="SynthesizeBatch"/>.
+    /// </summary>
+    private readonly bool _mergedSupportsBatched;
 
     /// <summary>Auto-detect the available cond-decoder layout in <paramref name="onnxDir"/> and load.</summary>
     /// <param name="onLoad">Optional callback fired once per session loaded
@@ -63,12 +72,18 @@ public sealed class Vocoder : IDisposable
         {
             Mode = VocoderMode.Merged;
             _merged = SessionLoader.LoadAndReport(Path.Combine(onnxDir, "conditional_decoder_loop.onnx"), ep, onLoad);
-            // ALSO load split graphs when present so SynthesizeBatch can
-            // fall back to them: the merged graph baked CFG-doubling at
-            // trace time and rejects B>1 (Run 6a in
-            // docs/chatterbox_perf_investigation.md), but the split
-            // cfm_estimator accepts B>2 (CFG-doubled) cleanly.
-            if (splitAvail)
+            // Run 10 / Path B: merge_cond_decoder_loop.py now stamps a
+            // `supports_batched=true` metadata prop when the graph supports
+            // B>1. Older bundles don't carry it and fall back to split.
+            _mergedSupportsBatched =
+                _merged.ModelMetadata.CustomMetadataMap.TryGetValue("supports_batched", out var sb)
+                && string.Equals(sb, "true", StringComparison.OrdinalIgnoreCase);
+            // Load split graphs as a fallback for B>1 when the merged graph
+            // doesn't support it. Skipping when merged is already
+            // batched-capable saves the ~1.1 GB VRAM the split graphs cost
+            // (per Run 6c sidebar) — that was the whole reason Path B was
+            // worth doing.
+            if (splitAvail && !_mergedSupportsBatched)
             {
                 _flowEnc = SessionLoader.LoadAndReport(Path.Combine(onnxDir, "flow_encoder.onnx"), ep, onLoad);
                 _cfmEst = SessionLoader.LoadAndReport(Path.Combine(onnxDir, "cfm_estimator.onnx"), ep, onLoad);
@@ -114,6 +129,59 @@ public sealed class Vocoder : IDisposable
             NamedOnnxValue.CreateFromTensor("speaker_features", spkFeatT),
         ]);
         return loopOut.First().AsTensor<float>().ToArray();
+    }
+
+    /// <summary>
+    /// Run 10 / Path B: one merged-graph call at B>1. The graph's outer
+    /// CFG-doubling, body t_in Tile, and Loop's v_initial Expand were
+    /// rewritten in <c>merge_cond_decoder_loop.py</c> to scale with B,
+    /// so a single .Run produces B waveforms in input order. Avoids the
+    /// host-roundtrip per CFM iter that bottlenecks the split path.
+    /// </summary>
+    private float[][] RunMergedBatched(
+        IReadOnlyList<long[]> speechTokensPerChunk,
+        DenseTensor<float> speakerEmbeddings,
+        DenseTensor<float> speakerFeatures,
+        int B, int tTok)
+    {
+        // Pack speech_tokens [B, tTok].
+        var speechTokensB = new long[B * tTok];
+        for (int b = 0; b < B; b++)
+            Array.Copy(speechTokensPerChunk[b], 0, speechTokensB, b * tTok, tTok);
+
+        // Replicate speaker_embeddings + speaker_features across B (one voice).
+        var spkEmbArr = speakerEmbeddings.ToArray();
+        int spkDim = speakerEmbeddings.Dimensions[1];
+        var spkEmbB = new float[B * spkDim];
+        for (int b = 0; b < B; b++) Array.Copy(spkEmbArr, 0, spkEmbB, b * spkDim, spkDim);
+
+        var spkFeatArr = speakerFeatures.ToArray();
+        int spkFeatLen = spkFeatArr.Length;
+        var spkFeatB = new float[B * spkFeatLen];
+        for (int b = 0; b < B; b++) Array.Copy(spkFeatArr, 0, spkFeatB, b * spkFeatLen, spkFeatLen);
+
+        var spkFeatDims = speakerFeatures.Dimensions.ToArray();
+
+        using var loopOut = _merged!.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("speech_tokens",
+                new DenseTensor<long>(speechTokensB, new[] { B, tTok })),
+            NamedOnnxValue.CreateFromTensor("speaker_embeddings",
+                new DenseTensor<float>(spkEmbB, new[] { B, spkDim })),
+            NamedOnnxValue.CreateFromTensor("speaker_features",
+                new DenseTensor<float>(spkFeatB, new[] { B, spkFeatDims[1], spkFeatDims[2] })),
+        });
+        var wavTensor = loopOut.First().AsTensor<float>();
+        var wavDims = wavTensor.Dimensions.ToArray();
+        int nSamples = wavDims[1];
+        var wavFlat = wavTensor.ToArray();
+        var perChunk = new float[B][];
+        for (int b = 0; b < B; b++)
+        {
+            perChunk[b] = new float[nSamples];
+            Array.Copy(wavFlat, b * nSamples, perChunk[b], 0, nSamples);
+        }
+        return perChunk;
     }
 
     private float[] RunMonolithic(DenseTensor<long> speechTokT, DenseTensor<float> spkEmbT, DenseTensor<float> spkFeatT)
@@ -273,6 +341,14 @@ public sealed class Vocoder : IDisposable
                 throw new ArgumentException(
                     $"All speech_tokens chunks must have the same length (MVP); got {speechTokensPerChunk[b].Length} vs {tTok} at index {b}.");
         }
+
+        // Run 10: merged-graph batched path keeps the CFM solve on-device
+        // for all B chunks at once (no host roundtrip per CFM iter, which
+        // is what kept split-batched at ~514 ms/chunk in Run 6c). Routed
+        // here when the merged graph carries the supports_batched=true
+        // metadata flag stamped by merge_cond_decoder_loop.py.
+        if (_mergedSupportsBatched)
+            return RunMergedBatched(speechTokensPerChunk, speakerEmbeddings, speakerFeatures, B, tTok);
 
         const int MelBins = ChatterboxConstants.MelBins;
         const int PromptLen = ChatterboxConstants.PromptLen;

--- a/src/Chatterbox.Base/Vocoder.cs
+++ b/src/Chatterbox.Base/Vocoder.cs
@@ -297,18 +297,21 @@ public sealed class Vocoder : IDisposable
     /// shared speaker_embeddings, one shared speaker_features. Returns
     /// B waveforms in input order.
     ///
-    /// Always uses the SPLIT 3-graph path even when
-    /// <see cref="Mode"/> == <see cref="VocoderMode.Merged"/>, because
-    /// the merged conditional_decoder_loop.onnx baked CFG-doubling at
-    /// trace time and rejects B>1 (cfm_body Concat expects dim 2). The
-    /// split <c>cfm_estimator.onnx</c> accepts B>2 (CFG-doubled batch)
-    /// cleanly — see <c>docs/chatterbox_perf_investigation.md</c>
-    /// Run 6a for the probe data.
+    /// Dispatches on the loaded bundle's capabilities:
+    ///   - merged graph carrying <c>supports_batched=true</c> metadata
+    ///     (Path B / Run 10) → single merged-graph call at B&gt;1 via
+    ///     <see cref="RunMergedBatched"/>; split graphs aren't loaded
+    ///     and ~1.1 GB VRAM is saved.
+    ///   - older merged graph (no metadata flag) + split graphs present
+    ///     → C# orchestrated CFM solve loop on the split 3-graph path.
+    /// See <c>docs/chatterbox_perf_investigation.md</c> Run 6/10 for
+    /// the rationale + perf numbers.
     ///
-    /// Throws if <see cref="SupportsBatched"/> is false (no split
-    /// artifacts in the model directory). Caller's recourse: re-export
-    /// with <c>--split-cond-decoder</c> (or <c>--merge-cond-decoder</c>
-    /// which implies it).
+    /// Throws if <see cref="SupportsBatched"/> is false (neither route
+    /// available). Caller's recourse: re-merge with
+    /// <c>scripts/_export_utils/merge_cond_decoder_loop.py</c> for the
+    /// Path B graph, or re-export with <c>--split-cond-decoder</c> to
+    /// get the split fallback.
     ///
     /// MVP constraint: all <paramref name="speechTokensPerChunk"/>
     /// entries must have the same length. Phase 2 will accept ragged
@@ -321,9 +324,10 @@ public sealed class Vocoder : IDisposable
     {
         if (!SupportsBatched)
             throw new InvalidOperationException(
-                "Batched vocoder synthesis requires the split cond-decoder graphs "
-                + "(flow_encoder, cfm_estimator, mel2wav) which were not found in "
-                + "the model directory. Re-export with --split-cond-decoder.");
+                "Batched vocoder synthesis requires either a Path B merged graph "
+                + "(conditional_decoder_loop.onnx exported via merge_cond_decoder_loop.py "
+                + "with supports_batched=true metadata) OR the split 3-graph set "
+                + "(flow_encoder, cfm_estimator, mel2wav). Neither was found.");
 
         int B = speechTokensPerChunk.Count;
         if (B == 0) return Array.Empty<float[]>();


### PR DESCRIPTION
## Summary

Rewrites the merged vocoder graph (`conditional_decoder_loop.onnx`) to accept B>1, lets `Vocoder.SynthesizeBatch` use the merged graph directly instead of falling back to the split-graph orchestration.

**Net effect**: same wall time as the existing split-batched path on RTX 3090, with the split graphs no longer loaded → ~1.1 GB VRAM saved + a single vocoder code path for both B=1 and B>1.

## What changed

**`scripts/_export_utils/merge_cond_decoder_loop.py`** — three surgical edits to make the merged graph B-dynamic:

1. **Body's `cfm__t_in`**: was `Concat([t_now_1d, t_now_1d])` producing fixed `(2,)`; now reads `B` from `Shape(x_carried)[0]` and `Tile(t_now_1d, [2B])` producing `(2B,)`. cfm_estimator wants one t value per CFG-doubled row.
2. **Body input/output shape decls**: `[1, MEL_BINS, "T_mel"]` → `["batch_size", MEL_BINS, "T_mel"]` on `x_carried` and `x_new`.
3. **Loop's `v_initial` (`z`)**: `flow_encoder` emits `z` at fixed `[1, MelBins, T_mel]` due to its pinned-rand_noise patch (Run 6c). Added `Expand(z, mu_shape)` so the Loop body sees `[B, M, T]`. At B=1, Expand is identity → preserves prior parity.

The outer graph's CFG-doubling for mu/mask/spks/cond was already defensively dynamic via `Shape`+`ConstantOfShape` — no changes needed there.

Exported model now carries `metadata_props["supports_batched"]="true"` so `Vocoder.cs` can detect Path B graphs.

**`src/Chatterbox.Base/Vocoder.cs`** — dtype-aware dispatch:

- Constructor reads the metadata flag. When set: skip loading the split graphs (the ~1.1 GB savings), expose `_mergedSupportsBatched`.
- `SynthesizeBatch` routes to a new `RunMergedBatched` (single merged-graph `.Run` at B>1) when the flag is set.
- Older bundles without the flag still fall through to the existing split orchestration. **Backward compatible.**

## Parity

B=1, seeded random inputs:
```
max abs diff: 3.39e-05
mean abs diff: 4.57e-08
```
Within ORT non-determinism floor. End-to-end Chatterbox at B=1 produces 174 LM steps, 6.92 s audio — bit-equivalent to baseline.

## Perf (8 chunks, RTX 3090, CUDA, `--pipelined --lm-batch 4`)

| Path | chunks-wall |
|---|---|
| Run 7c split-batched, pipelined groups | 7.1 s |
| **Run 10 merged-batched, pipelined groups** | **7.0 s** |

Marginal 1% wall reduction. The dramatic Path B projection in Run 6c (~150-200 ms voc/chunk) didn't materialize — on this hardware the LM SM contention spike (LM-share inflates 421 → 821 ms in group 2) hides the ~40 ms/chunk voc improvement merged offers over split.

## What didn't work (Memcpy investigation sidebar, second commit)

The 57 Memcpy nodes ORT inserts in the body subgraph caught my attention as a potential win. Four angles tried, all blocked:

| Approach | Result |
|---|---|
| `session.disable_cpu_ep_fallback=1` | Fails — `mel2wav__/STFT` has no CUDA kernel at all |
| `onnxslim` aggressive re-pass | −8 body nodes, zero perf change |
| ORT-transformers attention fusion (unet/mmdit/clip/vae/sam2/conformer/bart) | SkipLayerNormalization fuses; no Attention op produced — cfm_estimator's conv-attention matches none of ORT's fusion targets |
| `enable_cuda_graph=1` | Fails — \"this session cannot use the graph capture feature as the model has control flow nodes\" |

The `Loop` op blocks CUDA Graph capture independent of Memcpys. The Memcpy-warning's \"unable to run CUDA graph\" hint was a red herring on this graph. Documented as a dead-end sidebar in `docs/chatterbox_perf_investigation.md` so the next person doesn't re-chase it.

## Notes for reviewers

- **Backward compatibility**: Existing bundles without the `supports_batched` metadata flag continue to work via the split-graph fallback. No re-export required.
- **New bundles**: Anyone running `merge_cond_decoder_loop.py` after this PR gets the Path B graph automatically. The split graphs stay generated by `export_chatterbox_to_onnx.py --split-cond-decoder` so they're still usable if the merged path is bypassed.
- **No C# unit tests added** — same posture as PR #66. Smoke driver (`tests/ChatterboxSmoke`) covers end-to-end via `--bench-chunks N --pipelined --lm-batch B`.
- The Memcpy-sidebar findings are also a soft \"don't try CUDA Graph on this graph\" note for future perf work.

## Test plan

- [ ] CI build green
- [ ] `tests/ChatterboxSmoke --bench-chunks 8 --pipelined --lm-batch 4` produces 8 sensible WAVs against a re-exported bundle
- [ ] Single-chunk synthesis through B=1 produces audio bit-equivalent to baseline
- [ ] An older bundle (with the pre-Path-B `conditional_decoder_loop.onnx`) still works — falls through to split path

🤖 Generated with [Claude Code](https://claude.com/claude-code)