### PR TITLE
Chatterbox Stage 1 #3: Markdown → speakable text + source-range index

### DIFF
--- a/Vernacula.slnx
+++ b/Vernacula.slnx
@@ -27,4 +27,7 @@
   <Project Path="tests/AsrBackendCoverage/AsrBackendCoverage.csproj">
     <Platform Project="x64" />
   </Project>
+  <Project Path="tests/Chatterbox.Tests/Chatterbox.Tests.csproj">
+    <Platform Project="x64" />
+  </Project>
 </Solution>

--- a/src/Chatterbox.Base/Chatterbox.Base.csproj
+++ b/src/Chatterbox.Base/Chatterbox.Base.csproj
@@ -29,6 +29,13 @@
     <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 
+  <!-- Markdig: markdown AST for MarkdownTextExtractor. Matches the version
+       Vernacula.Avalonia is already on so two copies don't end up in a
+       composite app (cf. Markdown.Avalonia → Markdig). -->
+  <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.34.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <!-- Shared ORT plumbing: OrtSessionBuilder, ExecutionProvider enum, etc. -->
     <ProjectReference Include="..\Vernacula.Base\Vernacula.Base.csproj">

--- a/src/Chatterbox.Base/Markdown/MarkdownTextExtractor.cs
+++ b/src/Chatterbox.Base/Markdown/MarkdownTextExtractor.cs
@@ -11,11 +11,17 @@ namespace Chatterbox.Base.Markdown;
 /// came from. The Source* fields are character offsets into the original
 /// markdown string (the same units the file was read in).
 ///
-/// Synthetic whitespace (paragraph separators, sentence-terminator periods
+/// <para><see cref="OutputLength"/> and <see cref="SourceLength"/> may differ:
+/// inline code's source range covers the backticks (<c>`foo()`</c>, length 7)
+/// while the output omits them (<c>foo()</c>, length 5). Consumers should
+/// not assume the two slices are equal-length, only that the output
+/// substring is a *subsequence* of the source substring.</para>
+///
+/// <para>Synthetic whitespace (paragraph separators, sentence-terminator periods
 /// the extractor appends to headings) does NOT get an entry — those bytes
 /// exist in <see cref="MarkdownExtractionResult.Text"/> but map to nothing
 /// in the source. Word-highlighting downstream walks the ranges in order
-/// and accepts that some output offsets fall in the gaps.
+/// and accepts that some output offsets fall in the gaps.</para>
 /// </summary>
 public sealed record TextRange(int OutputStart, int OutputLength, int SourceStart, int SourceLength);
 
@@ -42,7 +48,11 @@ public sealed record MarkdownExtractionResult(string Text, IReadOnlyList<TextRan
 /// <item>Block quotes — text only, the <c>&gt;</c> markup is dropped.</item>
 /// <item>Inline code / bold / italic / strike — markup stripped, content kept.</item>
 /// <item>Links — emit the link text, drop the URL.</item>
-/// <item>Fenced code blocks, tables, images, HTML, horizontal rules,
+/// <item>Inline HTML — tags (<c>&lt;span&gt;</c>, <c>&lt;/span&gt;</c>) dropped,
+///       but text nodes between tags survive as ordinary literals (Markdig
+///       parses them as <c>LiteralInline</c> not <c>HtmlInline</c>). Block
+///       HTML is filtered at block level.</item>
+/// <item>Fenced code blocks, tables, images, horizontal rules,
 ///       footnotes — <b>skipped entirely.</b></item>
 /// </list>
 ///
@@ -223,12 +233,12 @@ public sealed class MarkdownTextExtractor
                 EmitInlines(emph);
                 break;
 
-            case LineBreakInline lb:
-                // Hard line break → space (soft line breaks usually parse the
-                // same way; both are intra-paragraph whitespace for TTS).
+            case LineBreakInline:
+                // Both hard and soft line breaks → space. TTS doesn't
+                // distinguish; both are intra-paragraph whitespace.
                 // Don't emit if the previous char is already whitespace.
                 if (_sb.Length > 0 && !char.IsWhiteSpace(_sb[^1]))
-                    _sb.Append(lb.IsHard ? ' ' : ' ');
+                    _sb.Append(' ');
                 break;
 
             case HtmlInline:

--- a/src/Chatterbox.Base/Markdown/MarkdownTextExtractor.cs
+++ b/src/Chatterbox.Base/Markdown/MarkdownTextExtractor.cs
@@ -1,0 +1,249 @@
+using System.Text;
+using Markdig;
+using Markdig.Parsers;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+
+namespace Chatterbox.Base.Markdown;
+
+/// <summary>
+/// One contiguous span of extracted output text and the source range it
+/// came from. The Source* fields are character offsets into the original
+/// markdown string (the same units the file was read in).
+///
+/// Synthetic whitespace (paragraph separators, sentence-terminator periods
+/// the extractor appends to headings) does NOT get an entry — those bytes
+/// exist in <see cref="MarkdownExtractionResult.Text"/> but map to nothing
+/// in the source. Word-highlighting downstream walks the ranges in order
+/// and accepts that some output offsets fall in the gaps.
+/// </summary>
+public sealed record TextRange(int OutputStart, int OutputLength, int SourceStart, int SourceLength);
+
+/// <summary>
+/// Output of <see cref="MarkdownTextExtractor.Extract"/>: the speakable
+/// text and a parallel index of source positions. Index is sorted by
+/// OutputStart and non-overlapping; gaps correspond to synthetic
+/// whitespace the extractor inserted.
+/// </summary>
+public sealed record MarkdownExtractionResult(string Text, IReadOnlyList<TextRange> Ranges);
+
+/// <summary>
+/// Markdown → speakable plain text, preserving a source-range index for
+/// downstream forced alignment (Stage 1 step 9). Walks Markdig's AST and
+/// emits text-bearing inlines while dropping markup. The defaults match
+/// the user-confirmed decisions captured in PR <see href="https://github.com/christopherthompson81/vernacula/pull/68"/>:
+///
+/// <list type="bullet">
+/// <item>Headings — emit text, append a period if it doesn't already end
+///       in terminal punctuation (so the TTS pauses correctly).</item>
+/// <item>Paragraphs — text with a double newline between (TTS interprets
+///       as a longer pause).</item>
+/// <item>List items — one per line, no enumeration prefix.</item>
+/// <item>Block quotes — text only, the <c>&gt;</c> markup is dropped.</item>
+/// <item>Inline code / bold / italic / strike — markup stripped, content kept.</item>
+/// <item>Links — emit the link text, drop the URL.</item>
+/// <item>Fenced code blocks, tables, images, HTML, horizontal rules,
+///       footnotes — <b>skipped entirely.</b></item>
+/// </list>
+///
+/// Pure-CPU, no ORT dependency. Lives in Chatterbox.Base so both the CLI
+/// and the eventual Avalonia app share it. Not thread-safe per-instance
+/// because the extractor object holds a builder + ranges list; the
+/// static <see cref="Extract(string)"/> facade creates a fresh instance
+/// per call so concurrent callers are fine.
+/// </summary>
+public sealed class MarkdownTextExtractor
+{
+    private readonly StringBuilder _sb = new();
+    private readonly List<TextRange> _ranges = new();
+
+    // Pipeline is shared across extractions — Markdig pipelines are
+    // thread-safe to call concurrently per their docs. Built with the
+    // "advanced" extension set so tables/footnotes parse into typed
+    // blocks (and then get skipped at walk time) instead of leaking
+    // their syntax through as literal text.
+    private static readonly MarkdownPipeline Pipeline =
+        new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
+    private MarkdownTextExtractor() { }
+
+    /// <summary>Extract speakable text + source-range index from markdown.</summary>
+    public static MarkdownExtractionResult Extract(string markdown)
+    {
+        var extractor = new MarkdownTextExtractor();
+        return extractor.Run(markdown);
+    }
+
+    private MarkdownExtractionResult Run(string markdown)
+    {
+        var doc = MarkdownParser.Parse(markdown, Pipeline);
+        bool first = true;
+        foreach (var block in doc)
+        {
+            if (TryEmitBlock(block, ref first))
+                first = false;
+        }
+        // Trim trailing whitespace the block-separator logic may have appended.
+        while (_sb.Length > 0 && char.IsWhiteSpace(_sb[^1])) _sb.Length--;
+        return new MarkdownExtractionResult(_sb.ToString(), _ranges);
+    }
+
+    // Returns true if the block actually produced any output (so callers
+    // can suppress the leading block separator for the first non-empty block).
+    private bool TryEmitBlock(Block block, ref bool first)
+    {
+        switch (block)
+        {
+            case HeadingBlock heading:
+                EmitBlockSeparator(first);
+                int beforeHeading = _sb.Length;
+                EmitInlines(heading.Inline);
+                AppendTerminalPeriod(beforeHeading);
+                return _sb.Length > beforeHeading;
+
+            case ParagraphBlock para:
+                EmitBlockSeparator(first);
+                int beforePara = _sb.Length;
+                EmitInlines(para.Inline);
+                return _sb.Length > beforePara;
+
+            case QuoteBlock quote:
+                // Block quote: walk children with the same separator rules.
+                bool emittedAny = false;
+                bool innerFirst = first;
+                foreach (var child in quote)
+                {
+                    if (TryEmitBlock(child, ref innerFirst))
+                    {
+                        emittedAny = true;
+                        innerFirst = false;
+                    }
+                }
+                if (emittedAny) first = false;
+                return emittedAny;
+
+            case ListBlock list:
+                EmitBlockSeparator(first);
+                int beforeList = _sb.Length;
+                foreach (var item in list)
+                {
+                    if (item is not ListItemBlock listItem) continue;
+                    int beforeItem = _sb.Length;
+                    // Each item: walk its children blocks (typically a single
+                    // ParagraphBlock). Use a newline-only separator between
+                    // items so the TTS gets a short pause, not the longer
+                    // paragraph break.
+                    bool itemFirst = true;
+                    foreach (var child in listItem)
+                    {
+                        if (TryEmitBlock(child, ref itemFirst))
+                            itemFirst = false;
+                    }
+                    // Newline between items (after the last item we strip
+                    // trailing whitespace at the document level).
+                    if (_sb.Length > beforeItem) _sb.Append('\n');
+                }
+                return _sb.Length > beforeList;
+
+            // Skipped block kinds: fenced code, tables, HTML, thematic break,
+            // footnote group, link reference definitions, and anything else
+            // not enumerated above. The "return false" tells the caller this
+            // block didn't move the cursor.
+            default:
+                return false;
+        }
+    }
+
+    private void EmitBlockSeparator(bool first)
+    {
+        if (first) return;
+        // Paragraph-style separator: blank line. The TTS doesn't actually
+        // pause on whitespace, but downstream chunking (Stage 1 step 8)
+        // uses blank lines as natural chunk boundaries.
+        _sb.Append("\n\n");
+    }
+
+    private void AppendTerminalPeriod(int blockStart)
+    {
+        if (_sb.Length == blockStart) return;
+        char last = _sb[^1];
+        if (last == '.' || last == '!' || last == '?' || last == ':' || last == ';') return;
+        _sb.Append('.');
+    }
+
+    private void EmitInlines(ContainerInline? container)
+    {
+        if (container is null) return;
+        foreach (var inline in container)
+            EmitInline(inline);
+    }
+
+    private void EmitInline(Inline inline)
+    {
+        switch (inline)
+        {
+            case LiteralInline lit:
+                // Literal text: copy the slice verbatim AND record a range
+                // entry pointing back to the source span.
+                var slice = lit.Content;
+                if (slice.Length <= 0) return;
+                int srcStart = slice.Start;
+                int srcLen = slice.End - slice.Start + 1;
+                int outStart = _sb.Length;
+                _sb.Append(slice.AsSpan());
+                _ranges.Add(new TextRange(outStart, srcLen, srcStart, srcLen));
+                break;
+
+            case CodeInline code:
+                // `inline code` → emit the text, drop the backticks.
+                if (string.IsNullOrEmpty(code.Content)) return;
+                int codeOutStart = _sb.Length;
+                _sb.Append(code.Content);
+                // Source span includes the backticks; the inner content
+                // starts after the leading backticks. Markdig's Span
+                // points at the full delimited extent, so record the
+                // full delim range — close-enough for forced alignment
+                // which works at word granularity.
+                _ranges.Add(new TextRange(codeOutStart, code.Content.Length,
+                    code.Span.Start, code.Span.End - code.Span.Start + 1));
+                break;
+
+            case LinkInline link when !link.IsImage:
+                // [text](url) → emit just the text, drop the URL.
+                EmitInlines(link);
+                break;
+
+            // Image is a LinkInline with IsImage=true; skip entirely (no alt
+            // text in the speech stream).
+            case LinkInline { IsImage: true }:
+                break;
+
+            case EmphasisInline emph:
+                // *italic* / **bold** / ~~strike~~ → markup stripped, walk children.
+                EmitInlines(emph);
+                break;
+
+            case LineBreakInline lb:
+                // Hard line break → space (soft line breaks usually parse the
+                // same way; both are intra-paragraph whitespace for TTS).
+                // Don't emit if the previous char is already whitespace.
+                if (_sb.Length > 0 && !char.IsWhiteSpace(_sb[^1]))
+                    _sb.Append(lb.IsHard ? ' ' : ' ');
+                break;
+
+            case HtmlInline:
+                // Inline HTML — skip. Block HTML is filtered out at block level.
+                break;
+
+            case ContainerInline container:
+                // Any other container (e.g. AutolinkInline with children) — walk.
+                EmitInlines(container);
+                break;
+
+            // Unhandled inlines (TaskList, Math, etc. from advanced extensions):
+            // skip silently. Logging them would be noisy on real documents.
+            default:
+                break;
+        }
+    }
+}

--- a/src/Chatterbox.CLI/Program.cs
+++ b/src/Chatterbox.CLI/Program.cs
@@ -14,6 +14,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using Chatterbox.Base;
+using Chatterbox.Base.Markdown;
 using NAudio.Wave;
 using Vernacula.Base.Models;
 
@@ -156,12 +157,34 @@ if (textFile is not null && !File.Exists(textFile))
 }
 
 // ── Read text source ──────────────────────────────────────────────────────────
-// --text-file is currently passed through as plain text. Markdown
-// parsing (Stage 1 step 4) will land in a follow-up so a `.md` source
-// has heading/list/emphasis markers stripped before synthesis. Today,
-// any markdown punctuation appears verbatim in the output.
+// --text-file routed through MarkdownTextExtractor when the file extension
+// is .md or .markdown (case-insensitive) so headings/lists/code/emphasis
+// markup gets stripped before tokenization. --text always treated as plain
+// text — callers passing a string usually want it spoken verbatim. The
+// extractor's behavior matrix and the source-range index (for downstream
+// forced alignment) are documented on the class itself.
 
-string textToSpeak = text ?? File.ReadAllText(textFile!);
+string textToSpeak;
+if (text is not null)
+{
+    textToSpeak = text;
+}
+else
+{
+    var raw = File.ReadAllText(textFile!);
+    var ext = Path.GetExtension(textFile!).ToLowerInvariant();
+    if (ext is ".md" or ".markdown")
+    {
+        var extracted = MarkdownTextExtractor.Extract(raw);
+        if (verbose)
+            Console.WriteLine($"Markdown extracted: {raw.Length} chars → {extracted.Text.Length} chars, {extracted.Ranges.Count} source-range entries");
+        textToSpeak = extracted.Text;
+    }
+    else
+    {
+        textToSpeak = raw;
+    }
+}
 if (string.IsNullOrWhiteSpace(textToSpeak))
 {
     Console.Error.WriteLine("Text is empty (after reading --text-file).");
@@ -260,8 +283,11 @@ static void PrintUsage()
                                     + one of the cond-decoder layouts).
           --voice <wav>            Reference voice clip. Any sample rate / channels.
           --text "..."   OR        Text to synthesize. Mutually exclusive with --text-file.
-          --text-file <path>       Read text from a file. Currently passed through as
-                                   plain text (markdown stripping is a follow-up).
+          --text-file <path>       Read text from a file. Files with .md or .markdown
+                                   extensions are routed through the markdown extractor
+                                   (headings/lists/emphasis/links stripped; code blocks,
+                                   tables, images, HTML dropped entirely). Other extensions
+                                   are passed through as plain text.
 
         Optional:
           --out <wav>              Output WAV path. Default: chatterbox_out.wav

--- a/tests/Chatterbox.Tests/Chatterbox.Tests.csproj
+++ b/tests/Chatterbox.Tests/Chatterbox.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- CPU-only test host. Chatterbox.Base would otherwise pull
+         OnnxRuntime.Gpu through its default EP=Cuda property; override
+         here so the test process doesn't need CUDA at runtime
+         (MarkdownTextExtractor is pure CPU, but the project reference
+         still resolves the EP). -->
+    <Platforms>x64</Platforms>
+    <RootNamespace>Chatterbox.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit.v3" Version="1.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Chatterbox.Base\Chatterbox.Base.csproj">
+      <Private>true</Private>
+      <SetConfiguration>EP=Cpu</SetConfiguration>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Chatterbox.Tests/Chatterbox.Tests.csproj
+++ b/tests/Chatterbox.Tests/Chatterbox.Tests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit.v3" Version="1.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Chatterbox.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Chatterbox.Tests/MarkdownTextExtractorTests.cs
@@ -1,0 +1,266 @@
+using Chatterbox.Base.Markdown;
+using Xunit;
+
+namespace Chatterbox.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MarkdownTextExtractor"/>. The behavior
+/// matrix it locks down comes from the PR-confirmed defaults:
+/// headings/paragraphs/lists/quotes/emphasis/links → text only;
+/// fenced code blocks, tables, images, HTML, horizontal rules,
+/// footnotes → skipped entirely.
+///
+/// Each test asserts both the output text AND that source-range
+/// entries point back to a substring of the original markdown that
+/// actually contains the extracted text — that's the contract the
+/// forced-aligner downstream depends on.
+/// </summary>
+public class MarkdownTextExtractorTests
+{
+    // ── Headings ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Heading_emits_text_with_appended_period()
+    {
+        var r = MarkdownTextExtractor.Extract("# Hello World");
+        Assert.Equal("Hello World.", r.Text);
+    }
+
+    [Fact]
+    public void Heading_keeps_existing_terminal_punctuation()
+    {
+        var r = MarkdownTextExtractor.Extract("## Is it really?");
+        Assert.Equal("Is it really?", r.Text);
+    }
+
+    [Fact]
+    public void Heading_followed_by_paragraph_separates_with_blank_line()
+    {
+        var r = MarkdownTextExtractor.Extract("# Title\n\nBody text.");
+        Assert.Equal("Title.\n\nBody text.", r.Text);
+    }
+
+    // ── Paragraphs + line breaks ──────────────────────────────────────
+
+    [Fact]
+    public void Paragraph_emits_text_verbatim()
+    {
+        var r = MarkdownTextExtractor.Extract("Hello world, this is a test.");
+        Assert.Equal("Hello world, this is a test.", r.Text);
+    }
+
+    [Fact]
+    public void Two_paragraphs_separated_by_blank_line()
+    {
+        var r = MarkdownTextExtractor.Extract("First paragraph.\n\nSecond paragraph.");
+        Assert.Equal("First paragraph.\n\nSecond paragraph.", r.Text);
+    }
+
+    // ── Inline formatting (markup stripped, text kept) ────────────────
+
+    [Fact]
+    public void Bold_emphasis_strips_markup()
+    {
+        var r = MarkdownTextExtractor.Extract("This is **important** text.");
+        Assert.Equal("This is important text.", r.Text);
+    }
+
+    [Fact]
+    public void Italic_emphasis_strips_markup()
+    {
+        var r = MarkdownTextExtractor.Extract("An *emphasized* word.");
+        Assert.Equal("An emphasized word.", r.Text);
+    }
+
+    [Fact]
+    public void Inline_code_strips_backticks()
+    {
+        var r = MarkdownTextExtractor.Extract("Run `foo()` to start.");
+        Assert.Equal("Run foo() to start.", r.Text);
+    }
+
+    [Fact]
+    public void Link_emits_text_drops_url()
+    {
+        var r = MarkdownTextExtractor.Extract("See [the docs](https://example.com/long/url) for details.");
+        Assert.Equal("See the docs for details.", r.Text);
+    }
+
+    // ── Lists ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Bullet_list_emits_items_newline_separated()
+    {
+        var r = MarkdownTextExtractor.Extract("- apple\n- banana\n- cherry");
+        Assert.Equal("apple\nbanana\ncherry", r.Text);
+    }
+
+    [Fact]
+    public void Numbered_list_drops_enumeration_prefix()
+    {
+        var r = MarkdownTextExtractor.Extract("1. first\n2. second\n3. third");
+        Assert.Equal("first\nsecond\nthird", r.Text);
+    }
+
+    // ── Block quotes ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Block_quote_drops_marker_keeps_text()
+    {
+        var r = MarkdownTextExtractor.Extract("> quoted text here");
+        Assert.Equal("quoted text here", r.Text);
+    }
+
+    // ── Skipped constructs ────────────────────────────────────────────
+
+    [Fact]
+    public void Fenced_code_block_is_skipped_entirely()
+    {
+        var r = MarkdownTextExtractor.Extract("Before.\n\n```python\nprint('hi')\n```\n\nAfter.");
+        Assert.Equal("Before.\n\nAfter.", r.Text);
+    }
+
+    [Fact]
+    public void Image_is_skipped()
+    {
+        var r = MarkdownTextExtractor.Extract("Look: ![alt text](pic.png) at this.");
+        Assert.Equal("Look:  at this.", r.Text);
+    }
+
+    [Fact]
+    public void Table_is_skipped_entirely()
+    {
+        var md = "Intro.\n\n| col1 | col2 |\n|------|------|\n| a    | b    |\n\nOutro.";
+        var r = MarkdownTextExtractor.Extract(md);
+        Assert.Equal("Intro.\n\nOutro.", r.Text);
+    }
+
+    [Fact]
+    public void Horizontal_rule_is_skipped()
+    {
+        var r = MarkdownTextExtractor.Extract("Above.\n\n---\n\nBelow.");
+        Assert.Equal("Above.\n\nBelow.", r.Text);
+    }
+
+    [Fact]
+    public void Inline_html_is_skipped()
+    {
+        var r = MarkdownTextExtractor.Extract("Hello <span>tag</span> world.");
+        // Inline text inside HTML *element* leaks through Markdig as literal —
+        // we only filter the <span> open/close tokens. Locked in to make
+        // the behavior explicit; if this becomes a problem we can switch to
+        // a stricter HTML stripper.
+        Assert.Equal("Hello tag world.", r.Text);
+    }
+
+    // ── Source-range index ────────────────────────────────────────────
+
+    [Fact]
+    public void Plain_paragraph_range_points_back_to_source()
+    {
+        const string src = "Hello world.";
+        var r = MarkdownTextExtractor.Extract(src);
+        Assert.Single(r.Ranges);
+        var range = r.Ranges[0];
+        Assert.Equal(0, range.OutputStart);
+        Assert.Equal(12, range.OutputLength);
+        Assert.Equal(0, range.SourceStart);
+        Assert.Equal(src.Substring(range.SourceStart, range.SourceLength),
+                     r.Text.Substring(range.OutputStart, range.OutputLength));
+    }
+
+    [Fact]
+    public void Bold_inline_range_points_to_inner_text_only()
+    {
+        const string src = "A **bold** word.";
+        var r = MarkdownTextExtractor.Extract(src);
+        // Expect three text-bearing ranges: "A ", "bold", " word."
+        Assert.Equal("A bold word.", r.Text);
+        // Walk the ranges and verify each one's source slice contains the
+        // output substring it claims to represent.
+        foreach (var range in r.Ranges)
+        {
+            string outSlice = r.Text.Substring(range.OutputStart, range.OutputLength);
+            string srcSlice = src.Substring(range.SourceStart, range.SourceLength);
+            Assert.Contains(outSlice, srcSlice);
+        }
+    }
+
+    [Fact]
+    public void Heading_period_is_synthetic_no_range_for_it()
+    {
+        const string src = "# Title";
+        var r = MarkdownTextExtractor.Extract(src);
+        Assert.Equal("Title.", r.Text);
+        // The "." at position 5 is synthetic — no range entry should cover it.
+        // The single range entry covers "Title" at output [0..5].
+        Assert.Single(r.Ranges);
+        var range = r.Ranges[0];
+        Assert.Equal(0, range.OutputStart);
+        Assert.Equal(5, range.OutputLength);
+        Assert.Equal("Title", r.Text.Substring(range.OutputStart, range.OutputLength));
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Empty_input_produces_empty_output()
+    {
+        var r = MarkdownTextExtractor.Extract("");
+        Assert.Equal("", r.Text);
+        Assert.Empty(r.Ranges);
+    }
+
+    [Fact]
+    public void Whitespace_only_input_produces_empty_output()
+    {
+        var r = MarkdownTextExtractor.Extract("   \n\n   \n");
+        Assert.Equal("", r.Text);
+    }
+
+    [Fact]
+    public void Document_with_only_skipped_blocks_produces_empty_output()
+    {
+        var r = MarkdownTextExtractor.Extract("```\ncode only\n```\n\n---\n\n![img](p.png)");
+        Assert.Equal("", r.Text);
+    }
+
+    [Fact]
+    public void Real_world_doc_excerpt_round_trip()
+    {
+        // Sampled the kind of mixed-construct paragraph found in our own
+        // README files. Just check it doesn't crash and produces something
+        // sensible.
+        const string md = """
+            # Vernacula
+
+            **Vernacula** is a TTS tool. See the [README](README.md) for usage.
+
+            ## Features
+
+            - Long-form synthesis
+            - Voice cloning from a `reference.wav`
+            - Markdown input
+
+            > Note: GPU recommended.
+
+            ```bash
+            chatterbox --voice ref.wav --text-file in.md
+            ```
+
+            See the table below for benchmarks.
+
+            | Lever | Win |
+            |-------|-----|
+            | Batching | 50% |
+            """;
+        var r = MarkdownTextExtractor.Extract(md);
+        Assert.Contains("Vernacula", r.Text);
+        Assert.Contains("Long-form synthesis", r.Text);
+        Assert.Contains("Note: GPU recommended", r.Text);
+        Assert.DoesNotContain("chatterbox --voice", r.Text);  // code block dropped
+        Assert.DoesNotContain("Batching", r.Text);            // table dropped
+        Assert.DoesNotContain("README.md", r.Text);           // URL dropped, text kept
+        Assert.Contains("README", r.Text);
+    }
+}

--- a/tests/Chatterbox.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Chatterbox.Tests/MarkdownTextExtractorTests.cs
@@ -143,11 +143,13 @@ public class MarkdownTextExtractorTests
     }
 
     [Fact]
-    public void Inline_html_is_skipped()
+    public void Inline_html_tags_are_stripped_inner_text_kept()
     {
         var r = MarkdownTextExtractor.Extract("Hello <span>tag</span> world.");
-        // Inline text inside HTML *element* leaks through Markdig as literal —
-        // we only filter the <span> open/close tokens. Locked in to make
+        // Markdig parses this as Literal("Hello ") + HtmlInline("<span>") +
+        // Literal("tag") + HtmlInline("</span>") + Literal(" world."). We
+        // drop the HtmlInline nodes (open/close tokens) but the text nodes
+        // BETWEEN them are ordinary Literals and survive. Locked in to make
         // the behavior explicit; if this becomes a problem we can switch to
         // a stricter HTML stripper.
         Assert.Equal("Hello tag world.", r.Text);


### PR DESCRIPTION
## Summary

Fixes the existing CLI's silent .md-passthrough bug ([Program.cs line 159-162 before this PR](https://github.com/christopherthompson81/vernacula/blob/main/src/Chatterbox.CLI/Program.cs#L159-L162)) and lays foundation for forced-alignment-driven word highlighting (Stage 1 #9).

`MarkdownTextExtractor` in `Chatterbox.Base.Markdown` walks the Markdig AST and produces:
1. **Speakable text** with markup stripped
2. **A parallel source-range index** mapping each output character span back to its origin position in the markdown source — what the future Avalonia app will use to highlight the current word as TTS plays.

## Behavior matrix (per the PR-thread design decisions)

| Construct | Behavior |
|---|---|
| Headings | Emit text, append `.` if no terminal punctuation |
| Paragraphs | Text, double-newline between (becomes chunking boundary for #8) |
| Lists | Items newline-separated, no enumeration prefix |
| Block quotes | Text only, `>` marker dropped |
| Bold/italic/strike/inline-code | Markup stripped, content kept |
| Links | Emit link text, drop URL |
| Fenced code blocks, tables, images, HTML, horizontal rules, footnotes | **SKIPPED ENTIRELY** |

## CLI integration

`--text-file foo.md` (or `.markdown`) now routes through the extractor. `--text "..."` still treated as plain text — callers passing strings usually want them spoken verbatim. Other extensions pass through unchanged.

End-to-end smoke check against `/tmp/cb_dyn5` + a realistic .md sample with headings, lists, code blocks, quotes, links:
```
Markdown extracted: 442 chars → 326 chars, 12 source-range entries
Tokenized "Welcome to Vernacula.  Vernacula is a text-to-speech tool th..." → 216 tokens
Synthesized 10.24s of audio
```
Audio hits `maxSteps=256` because the extracted text is too long for one LM rollout — that's exactly the long-form-chunking gap Stage 1 #8 fills (the natural follow-up PR). The double-newline paragraph separators in the extractor output are sized for the chunker.

## Tests

New `tests/Chatterbox.Tests/` project (xunit.v3, CPU-only — `Chatterbox.Base` consumed at `EP=Cpu`). 24 tests covering:
- Each markdown construct (headings, paragraphs, lists, quotes, emphasis, code, links)
- Each skipped construct (fenced code, tables, images, HTML, horizontal rules)
- Source-range index invariants (`output_slice ⊆ source_slice`, synthetic chars have no range entry)
- Edge cases (empty input, whitespace-only, skipped-only)
- A realistic mixed-construct doc

All passing.

## Notes for reviewers

- New dep on Markdig 0.34.0 pinned to the same version `Vernacula.Avalonia` already uses (avoids two Markdig copies if the projects ever co-exist in one app).
- Test project added to `Vernacula.slnx` alongside the existing two xunit test projects.
- `MarkdownTextExtractor` is a sealed class with a static `Extract(string)` facade — instance-per-call so concurrent callers don't share state.
- The source-range index intentionally has GAPS at synthetic content (the appended `.` on headings, the `\n\n` between paragraphs). Forced-alignment downstream walks the ranges in order; gaps just mean "the spoken word at this output position didn't come from any specific source char."

## Test plan

- [ ] CI build green
- [ ] `dotnet test tests/Chatterbox.Tests/` produces 24/24 pass
- [ ] CLI `--text-file foo.md` produces sensible audio on a real markdown doc
- [ ] CLI `--text-file foo.txt` (non-markdown) still passes through verbatim
- [ ] CLI `--text "..."` still treats the string as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)