### PR TITLE
Chatterbox Stage 1 #8: long-form CLI via ChunkedSynthesizer + paragraph chunker

### DIFF
--- a/src/Chatterbox.Base/Markdown/ParagraphChunker.cs
+++ b/src/Chatterbox.Base/Markdown/ParagraphChunker.cs
@@ -1,0 +1,113 @@
+using System.Text.RegularExpressions;
+
+namespace Chatterbox.Base.Markdown;
+
+/// <summary>
+/// Splits speakable text into chunks at paragraph boundaries for the
+/// long-form synthesis path (Stage 1 #8).
+///
+/// Pairs with <see cref="MarkdownTextExtractor"/> — the extractor emits
+/// <c>\n\n</c> between paragraphs precisely so this chunker has a clean
+/// boundary. List items separated by single <c>\n</c> stay grouped with
+/// their surrounding paragraph (a bulleted list is one chunk, not N).
+///
+/// The chunker doesn't know about tokens — it works on character count
+/// against a coarse heuristic upper bound. The real per-chunk limit
+/// comes from <see cref="AcousticLM"/>'s <c>maxSteps</c> (256 default,
+/// ~10 s of audio). A typical paragraph fits comfortably; a very long
+/// single paragraph that exceeds <see cref="MaxCharsPerChunk"/> gets
+/// split on sentence boundaries as a fallback.
+/// </summary>
+public static class ParagraphChunker
+{
+    /// <summary>
+    /// Default upper bound on chunk size in characters. Sized so a
+    /// typical paragraph at this length tokenizes well below the LM's
+    /// 256-step rollout cap (rough rule: 1 LM step ≈ 4-6 source chars
+    /// of English prose at the default exaggeration). 600 chars is
+    /// well inside that with margin.
+    /// </summary>
+    public const int MaxCharsPerChunk = 600;
+
+    /// <summary>
+    /// Don't bother chunking text shorter than this — single-shot
+    /// synthesis is cheaper than the pipeline orchestration overhead
+    /// for trivial inputs.
+    /// </summary>
+    public const int MinCharsForChunking = 200;
+
+    // \n followed by optional whitespace + \n, repeated. Catches both
+    // \n\n and \n  \n (extractor only emits \n\n, but defensive).
+    private static readonly Regex ParagraphSplit = new(@"\n[ \t]*\n+", RegexOptions.Compiled);
+
+    // Sentence-end split for the over-long-paragraph fallback. Looks for
+    // .!? followed by whitespace; conservative (won't split on
+    // abbreviations like "Dr." since we'd need full sentence tokenization
+    // for that — acceptable for the fallback case).
+    private static readonly Regex SentenceSplit = new(@"(?<=[.!?])\s+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Split <paramref name="text"/> into chunks at paragraph boundaries.
+    /// Returns the input as a single chunk if it has no paragraph breaks
+    /// or is shorter than <see cref="MinCharsForChunking"/>.
+    /// </summary>
+    /// <param name="maxCharsPerChunk">Per-chunk cap. Paragraphs longer than
+    /// this are sub-split on sentence boundaries.</param>
+    public static List<string> Chunk(string text, int maxCharsPerChunk = MaxCharsPerChunk)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return new List<string>();
+
+        var trimmed = text.Trim();
+        if (trimmed.Length < MinCharsForChunking)
+            return new List<string> { trimmed };
+
+        var paragraphs = ParagraphSplit.Split(trimmed)
+            .Select(p => p.Trim())
+            .Where(p => p.Length > 0)
+            .ToList();
+        if (paragraphs.Count == 0)
+            return new List<string>();
+
+        var chunks = new List<string>();
+        foreach (var p in paragraphs)
+        {
+            if (p.Length <= maxCharsPerChunk)
+            {
+                chunks.Add(p);
+            }
+            else
+            {
+                // Over-long paragraph: split on sentence boundaries, then
+                // greedily pack sentences into ≤maxCharsPerChunk chunks.
+                // A single sentence longer than the cap stays as its own
+                // chunk (we don't split mid-sentence; the LM's maxSteps
+                // will truncate the audio if it really is too long).
+                foreach (var sub in PackSentences(p, maxCharsPerChunk))
+                    chunks.Add(sub);
+            }
+        }
+        return chunks;
+    }
+
+    private static IEnumerable<string> PackSentences(string paragraph, int maxChars)
+    {
+        var sentences = SentenceSplit.Split(paragraph);
+        var buffer = new System.Text.StringBuilder();
+        foreach (var s in sentences)
+        {
+            var sent = s.Trim();
+            if (sent.Length == 0) continue;
+            // +1 for the space we'll insert between sentences in the buffer.
+            int projected = buffer.Length == 0 ? sent.Length : buffer.Length + 1 + sent.Length;
+            if (projected > maxChars && buffer.Length > 0)
+            {
+                yield return buffer.ToString();
+                buffer.Clear();
+            }
+            if (buffer.Length > 0) buffer.Append(' ');
+            buffer.Append(sent);
+        }
+        if (buffer.Length > 0) yield return buffer.ToString();
+    }
+}

--- a/src/Chatterbox.Base/Markdown/ParagraphChunker.cs
+++ b/src/Chatterbox.Base/Markdown/ParagraphChunker.cs
@@ -36,9 +36,12 @@ public static class ParagraphChunker
     /// </summary>
     public const int MinCharsForChunking = 200;
 
-    // \n followed by optional whitespace + \n, repeated. Catches both
-    // \n\n and \n  \n (extractor only emits \n\n, but defensive).
-    private static readonly Regex ParagraphSplit = new(@"\n[ \t]*\n+", RegexOptions.Compiled);
+    // \r?\n followed by optional whitespace + \r?\n, repeated. Handles
+    // both Unix (\n\n) and Windows (\r\n\r\n) line endings.
+    // MarkdownTextExtractor only emits \n\n, but --text and other input
+    // sources can carry CRLF — the chunker shouldn't silently fail on
+    // Windows-line-ended input.
+    private static readonly Regex ParagraphSplit = new(@"\r?\n[ \t\r]*\n+", RegexOptions.Compiled);
 
     // Sentence-end split for the over-long-paragraph fallback. Looks for
     // .!? followed by whitespace; conservative (won't split on

--- a/src/Chatterbox.CLI/Program.cs
+++ b/src/Chatterbox.CLI/Program.cs
@@ -30,7 +30,12 @@ string  ep            = "auto";
 bool    verbose       = false;
 bool?   useIoBinding  = null;
 float   exaggeration  = ChatterboxConstants.DefaultExaggeration;
-int     maxSteps      = ChatterboxConstants.DefaultMaxLmSteps;
+// CLI default is intentionally higher than ChatterboxConstants.DefaultMaxLmSteps
+// (256). The constant is the smoke/bench reference; the CLI sees long-form
+// markdown where typical paragraph chunks run 300-500 LM steps and would
+// silently truncate at 256. 1024 is a comfortable cap that natural STOP_SPEECH
+// reaches first on real prose; users can lower it if they want hard limits.
+int     maxSteps      = 1024;
 
 // Bounds-checked value reader. Caller passes the flag name so the error
 // mentions which arg was missing its value. Args are parsed via a manual
@@ -76,7 +81,7 @@ try
                         NumberStyles.Integer, CultureInfo.InvariantCulture, out maxSteps)
                     || maxSteps < 1)
                 {
-                    Console.Error.WriteLine("--max-steps expects a positive integer (default 256).");
+                    Console.Error.WriteLine("--max-steps expects a positive integer (default 1024).");
                     return 2;
                 }
                 i++;
@@ -239,15 +244,70 @@ if (verbose) Console.WriteLine(
     $"speech_encoder: cond_emb=({string.Join(",", spk.CondEmb.Dimensions.ToArray())})  "
     + $"audio_tokens=(1,{spk.AudioTokens.Length})");
 
-var lmResult = pipeline.Lm.Generate(spk.CondEmb, tokenIds,
-    useIoBinding: useIoBinding,
-    exaggeration: exaggeration,
-    maxSteps: maxSteps);
-if (verbose) Console.WriteLine(
-    $"LM: {lmResult.Steps} steps, generated {lmResult.RawGeneratedTokens.Count - 1} tokens");
+// ── Chunking decision ────────────────────────────────────────────────────────
+// ParagraphChunker returns >1 chunks only when input is long enough AND has
+// paragraph breaks (\n\n). Short or single-paragraph inputs collapse to a
+// single chunk; we use the existing one-shot path to avoid orchestration
+// overhead for those.
+var chunks = ParagraphChunker.Chunk(textToSpeak);
+float[] samples;
+if (chunks.Count <= 1)
+{
+    // One-shot path (existing behavior).
+    var lmResult = pipeline.Lm.Generate(spk.CondEmb, tokenIds,
+        useIoBinding: useIoBinding,
+        exaggeration: exaggeration,
+        maxSteps: maxSteps);
+    if (verbose) Console.WriteLine(
+        $"LM: {lmResult.Steps} steps, generated {lmResult.RawGeneratedTokens.Count - 1} tokens");
 
-var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
-var samples = pipeline.Vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+    var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
+    samples = pipeline.Vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+}
+else
+{
+    // Long-form path: ChunkedSynthesizer pipelines LM(N+1) with voc(N) across
+    // chunk boundaries via a Channel<T> producer/consumer. groupSize=1 (no
+    // LM batching) because real paragraphs have different lengths; the
+    // batched mode requires same-length prompts. Pipelining alone still
+    // saves ~7% wall by overlapping vocoder with the next chunk's LM —
+    // see Run 2 in docs/chatterbox_perf_investigation.md.
+    if (verbose)
+        Console.WriteLine($"Chunked into {chunks.Count} paragraphs "
+            + $"(min/max char count: {chunks.Min(c => c.Length)}/{chunks.Max(c => c.Length)})");
+
+    var tokensPerChunk = chunks.Select(c => pipeline.Tokenizer!.WrapForLm(c)).ToArray();
+    var synth = new ChunkedSynthesizer(pipeline);
+    var result = synth.Synthesize(spk, tokensPerChunk,
+        useIoBinding: useIoBinding,
+        exaggeration: exaggeration,
+        maxSteps: maxSteps);
+
+    if (verbose)
+    {
+        for (int i = 0; i < result.ChunkTimings.Count; i++)
+        {
+            var t = result.ChunkTimings[i];
+            Console.WriteLine($"  chunk {i + 1}/{chunks.Count}: "
+                + $"LM {t.LmMs} ms ({t.LmSteps} steps), "
+                + $"voc {t.VocoderMs} ms, "
+                + $"audio {t.AudioSamples / (float)ChatterboxConstants.S3GenSr:F2}s");
+        }
+    }
+
+    // Concatenate per-chunk waveforms in input order. No fades / silence
+    // injection between chunks — paragraph boundaries already cue the TTS
+    // to taper naturally, and the LM's STOP_SPEECH emits a brief trailing
+    // silence per chunk.
+    int totalSamples = result.Waveforms.Sum(w => w.Length);
+    samples = new float[totalSamples];
+    int off = 0;
+    foreach (var w in result.Waveforms)
+    {
+        Array.Copy(w, 0, samples, off, w.Length);
+        off += w.Length;
+    }
+}
 synthSw.Stop();
 
 // ── Write WAV ─────────────────────────────────────────────────────────────────
@@ -260,10 +320,11 @@ using (var writer = new WaveFileWriter(outPath, fmt))
 totalSw.Stop();
 
 float audioSeconds = samples.Length / (float)ChatterboxConstants.S3GenSr;
+string chunkInfo = chunks.Count > 1 ? $", {chunks.Count} chunks" : "";
 Console.WriteLine(
     $"Synthesized {audioSeconds:F2}s of audio → {outPath} "
     + $"({totalSw.ElapsedMilliseconds / 1000.0:F1}s total, "
-    + $"{synthSw.ElapsedMilliseconds / 1000.0:F1}s synth)");
+    + $"{synthSw.ElapsedMilliseconds / 1000.0:F1}s synth{chunkInfo})");
 return 0;
 
 
@@ -306,7 +367,11 @@ static void PrintUsage()
           --exaggeration <float>   Conditioning scalar passed to embed_tokens. Default: 0.5.
                                    Typical range 0.0 – 1.0; out-of-range values are
                                    accepted but produce increasingly unusual audio.
-          --max-steps <int>        Cap on LM rollout length. Default: 256.
+          --max-steps <int>        Cap on LM rollout length. Default: 1024.
+                                   The LM naturally emits STOP_SPEECH at a paragraph's
+                                   end (usually 200-500 steps); this cap is a safety
+                                   net. Long-form markdown chunks need more headroom
+                                   than the smoke-bench default of 256.
           --verbose / -v           Print per-stage timing and cache info.
           --help / -h              Show this message.
         """);

--- a/src/Chatterbox.CLI/Program.cs
+++ b/src/Chatterbox.CLI/Program.cs
@@ -231,12 +231,6 @@ if (verbose)
 // pipeline.Tokenizer is non-null here: we resolved `tokenizerPath` above
 // and would have exited 1 if no tokenizer.json was findable, so the
 // pipeline's auto-locate fallback never fires.
-var tokenIds = pipeline.Tokenizer!.WrapForLm(textToSpeak);
-if (verbose)
-{
-    var preview = textToSpeak.Length > 60 ? textToSpeak[..60] + "..." : textToSpeak;
-    Console.WriteLine($"Tokenized \"{preview.Replace("\n", " ")}\" → {tokenIds.Length} tokens");
-}
 
 var synthSw = Stopwatch.StartNew();
 var spk = pipeline.Embedder.Embed(voicePath);
@@ -248,12 +242,19 @@ if (verbose) Console.WriteLine(
 // ParagraphChunker returns >1 chunks only when input is long enough AND has
 // paragraph breaks (\n\n). Short or single-paragraph inputs collapse to a
 // single chunk; we use the existing one-shot path to avoid orchestration
-// overhead for those.
+// overhead for those. Tokenization happens per-path (whole text once vs per
+// chunk) so we don't waste a tokenize-everything pass on the chunked path.
 var chunks = ParagraphChunker.Chunk(textToSpeak);
 float[] samples;
 if (chunks.Count <= 1)
 {
     // One-shot path (existing behavior).
+    var tokenIds = pipeline.Tokenizer!.WrapForLm(textToSpeak);
+    if (verbose)
+    {
+        var preview = textToSpeak.Length > 60 ? textToSpeak[..60] + "..." : textToSpeak;
+        Console.WriteLine($"Tokenized \"{preview.Replace("\n", " ")}\" → {tokenIds.Length} tokens");
+    }
     var lmResult = pipeline.Lm.Generate(spk.CondEmb, tokenIds,
         useIoBinding: useIoBinding,
         exaggeration: exaggeration,

--- a/tests/Chatterbox.Tests/ParagraphChunkerTests.cs
+++ b/tests/Chatterbox.Tests/ParagraphChunkerTests.cs
@@ -78,6 +78,29 @@ public class ParagraphChunkerTests
         foreach (var c in chunks)
             Assert.True(c.Length <= 600 || !c.Contains(". "),
                 $"chunk over 600 chars and containing splittable sentence boundary: '{c[..Math.Min(80, c.Length)]}...'");
+        // Loss-free invariant: joining the chunks with " " reconstructs the
+        // input (PackSentences only does .Trim() per sentence and rejoins
+        // with " ", so an input that was itself " "-joined round-trips).
+        Assert.Equal(sentences, string.Join(" ", chunks));
+    }
+
+    // ── Line-ending handling ──────────────────────────────────────────
+
+    [Fact]
+    public void CRLF_paragraph_breaks_are_recognized()
+    {
+        // Windows-line-ended input via --text or a CRLF-saved file should
+        // chunk the same as Unix line endings. Regression test for the
+        // ParagraphSplit regex.
+        var p1 = "First paragraph. " + new string('a', 200);
+        var p2 = "Second paragraph. " + new string('b', 200);
+        var unix = $"{p1}\n\n{p2}";
+        var crlf = $"{p1}\r\n\r\n{p2}";
+        var unixChunks = ParagraphChunker.Chunk(unix);
+        var crlfChunks = ParagraphChunker.Chunk(crlf);
+        Assert.Equal(2, unixChunks.Count);
+        Assert.Equal(2, crlfChunks.Count);
+        Assert.Equal(unixChunks, crlfChunks);
     }
 
     [Fact]

--- a/tests/Chatterbox.Tests/ParagraphChunkerTests.cs
+++ b/tests/Chatterbox.Tests/ParagraphChunkerTests.cs
@@ -1,0 +1,119 @@
+using Chatterbox.Base.Markdown;
+using Xunit;
+
+namespace Chatterbox.Tests;
+
+public class ParagraphChunkerTests
+{
+    [Fact]
+    public void Short_text_returns_single_chunk()
+    {
+        var chunks = ParagraphChunker.Chunk("Hello world.");
+        Assert.Single(chunks);
+        Assert.Equal("Hello world.", chunks[0]);
+    }
+
+    [Fact]
+    public void Empty_input_returns_empty_list()
+    {
+        Assert.Empty(ParagraphChunker.Chunk(""));
+        Assert.Empty(ParagraphChunker.Chunk("   \n\n   "));
+    }
+
+    [Fact]
+    public void Short_multi_paragraph_text_stays_single_chunk()
+    {
+        // Under MinCharsForChunking (200) → don't bother chunking even if
+        // there are paragraph breaks. Lets the existing one-shot path
+        // handle short multi-paragraph inputs without orchestration overhead.
+        var input = "Para one.\n\nPara two.";
+        var chunks = ParagraphChunker.Chunk(input);
+        Assert.Single(chunks);
+        Assert.Equal(input, chunks[0]);
+    }
+
+    [Fact]
+    public void Long_multi_paragraph_text_splits_per_paragraph()
+    {
+        // Two paragraphs, total > MinCharsForChunking, each ≤ MaxCharsPerChunk.
+        var p1 = new string('a', 150) + ".";  // 151 chars
+        var p2 = new string('b', 150) + ".";
+        var input = $"{p1}\n\n{p2}";
+        var chunks = ParagraphChunker.Chunk(input);
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal(p1, chunks[0]);
+        Assert.Equal(p2, chunks[1]);
+    }
+
+    [Fact]
+    public void Multiple_blank_lines_collapse_to_one_break()
+    {
+        var p1 = new string('a', 150) + ".";
+        var p2 = new string('b', 150) + ".";
+        var input = $"{p1}\n\n\n\n{p2}";
+        var chunks = ParagraphChunker.Chunk(input);
+        Assert.Equal(2, chunks.Count);
+    }
+
+    [Fact]
+    public void Single_paragraph_with_internal_newlines_stays_one_chunk()
+    {
+        // List items joined by single \n (extractor's list emission) — should
+        // NOT be split. Only \n\n is a chunk boundary.
+        var input = "Long paragraph that exceeds the threshold. " + new string('x', 200);
+        var chunks = ParagraphChunker.Chunk(input);
+        Assert.Single(chunks);
+    }
+
+    [Fact]
+    public void Over_long_paragraph_splits_on_sentence_boundaries()
+    {
+        // Paragraph > MaxCharsPerChunk (600) — should sub-split.
+        var sentences = string.Join(" ", Enumerable.Range(1, 20).Select(i =>
+            $"This is sentence number {i} with some filler text to bulk it out a bit."));
+        // sentences is ~1500 chars in one paragraph, no \n\n inside.
+        Assert.True(sentences.Length > 600);
+        var chunks = ParagraphChunker.Chunk(sentences);
+        Assert.True(chunks.Count > 1, $"expected multiple chunks for {sentences.Length} chars, got {chunks.Count}");
+        foreach (var c in chunks)
+            Assert.True(c.Length <= 600 || !c.Contains(". "),
+                $"chunk over 600 chars and containing splittable sentence boundary: '{c[..Math.Min(80, c.Length)]}...'");
+    }
+
+    [Fact]
+    public void Chunks_preserve_content_when_concatenated()
+    {
+        // For a paragraph-split case (no sub-sentence splits triggered), the
+        // chunks joined back with "\n\n" should reconstruct the input modulo
+        // trim. This is a loose round-trip invariant.
+        var p1 = "First paragraph. " + new string('a', 100);
+        var p2 = "Second paragraph. " + new string('b', 100);
+        var p3 = "Third paragraph. " + new string('c', 100);
+        var input = $"{p1}\n\n{p2}\n\n{p3}";
+        var chunks = ParagraphChunker.Chunk(input);
+        Assert.Equal(3, chunks.Count);
+        Assert.Equal(input, string.Join("\n\n", chunks));
+    }
+
+    [Fact]
+    public void Single_sentence_longer_than_cap_stays_one_chunk()
+    {
+        // No sentence terminator to split on; chunker doesn't mid-sentence-cut.
+        // LM's maxSteps will truncate the audio if this really is too long.
+        var oneSentence = "This is a single sentence with no terminator " + new string('x', 800);
+        var chunks = ParagraphChunker.Chunk(oneSentence);
+        Assert.Single(chunks);
+    }
+
+    [Fact]
+    public void Trims_whitespace_around_chunks()
+    {
+        var p1 = "First paragraph. " + new string('a', 200);
+        var p2 = "Second paragraph. " + new string('b', 200);
+        var input = $"   {p1}   \n\n   {p2}   ";
+        var chunks = ParagraphChunker.Chunk(input);
+        Assert.Equal(2, chunks.Count);
+        Assert.Equal(p1, chunks[0]);
+        Assert.Equal(p2, chunks[1]);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the existing `ChunkedSynthesizer` (Run 2's LM/voc pipelining) into the CLI so long-form markdown documents synthesize end-to-end in one invocation, with playback-ready WAV concatenation. Pairs naturally with PR #68's `MarkdownTextExtractor` (which already emits `\n\n` paragraph separators sized for exactly this).

## New: `ParagraphChunker`

`src/Chatterbox.Base/Markdown/ParagraphChunker.cs` — pure-CPU text splitter:

- Splits on `\n\n` (the extractor's paragraph boundary)
- Inputs shorter than `MinCharsForChunking` (200) or with no paragraph breaks → single chunk → existing one-shot path with zero orchestration overhead
- Paragraphs longer than `MaxCharsPerChunk` (600) fall back to sentence split, conservatively packed
- A single sentence longer than the cap passes through unchanged (no mid-sentence cuts)

10 new unit tests cover trim, multi-blank collapse, single-paragraph-stays-single, round-trip preservation, over-long sentence handling, and edge cases.

## CLI integration

`src/Chatterbox.CLI/Program.cs`:

- `ParagraphChunker.Chunk(textToSpeak)` decides which path
- `chunks.Count <= 1` → **existing one-shot synthesis** (preserves prior behavior for short inputs, no perf regression)
- `chunks.Count > 1` → **`ChunkedSynthesizer`** with `groupSize=1` (pipelined LM/voc concurrency, no LM batching since real paragraphs have different lengths)
- WAV concatenation: append per-chunk samples in input order. No fades — paragraph boundaries cue natural TTS taper and the LM emits trailing silence on `STOP_SPEECH`
- Verbose mode prints per-chunk `LM ms (steps), voc ms, audio s` so users can see how the chunking landed

### CLI default for `--max-steps` bumped 256 → 1024

The smoke/bench default of 256 was sized for the original Ezreal sentence test (174 LM steps). Real prose paragraphs run 300-500 steps and silently truncate at 256. **`ChatterboxConstants.DefaultMaxLmSteps` stays at 256 for bench-numbers continuity** — only the CLI's local default changes. Users who explicitly pass `--max-steps N` still get their value.

## End-to-end results (RTX 3090, CUDA, the multi-paragraph sample)

```
Markdown extracted: 1179 chars → 1175 chars, 6 source-range entries
Chunked into 6 paragraphs (min/max char count: 14/327)
  chunk 1/6: LM 279 ms (31 steps), voc 516 ms, audio 1.20s
  chunk 2/6: LM 3983 ms (451 steps), voc 1638 ms, audio 18.00s
  chunk 3/6: LM 4126 ms (401 steps), voc 1414 ms, audio 16.00s
  chunk 4/6: LM 775 ms (29 steps), voc 458 ms, audio 1.12s
  chunk 5/6: LM 4200 ms (479 steps), voc 1723 ms, audio 19.12s
  chunk 6/6: LM 3977 ms (374 steps), voc 1169 ms, audio 14.92s
Synthesized 70.36s of audio → /tmp/cb_long_final.wav (23.0s total, 19.2s synth, 6 chunks)
```

**70.36 s audio in 23.0 s wall = ~3.0× realtime** on the multi-paragraph prose sample. Chunks 1 and 4 are headings (short → fast); chunks 2/3/5/6 are body paragraphs (natural `STOP_SPEECH` 374-479 steps, well under the 1024 cap).

Short input through `--text "..."` still routes through the one-shot path (no `Chunked into N paragraphs` line in verbose output) — verified.

## Notes for reviewers

- The `groupSize=1` choice: real paragraphs have different token lengths, and `ChunkedSynthesizer`'s `groupSize>1` path requires same-length prompts (MVP constraint from Run 4). LM batching would still help if we padded but that's a follow-up, not blocking. Pipelining alone (groupSize=1) is what Run 2 measured at −7% wall vs serial.
- No fades / silence injection between chunks. The TTS already tapers; users wanting explicit pauses can edit the WAV post-hoc.
- `ChunkedSynthesizer` already handles failure propagation via the CTS pattern added in PR #66 (review-fix commit), so vocoder failures don't deadlock the producer.

## Stage 1 progress after this lands

| # | Item | Status |
|---|---|---|
| 1, 3, 4, 5, 6, 7 | Tokenizer, markdown extractor, embedder, LM, vocoder, CLI | ✅ |
| **8** | **Continuous reader / long-form CLI** | **✅ (this PR)** |
| 9 | Forced alignment (word timestamps) | Next |
| 10 | Avalonia app | Final |

## Test plan

- [ ] CI build green
- [ ] `dotnet test tests/Chatterbox.Tests/` produces 34/34 pass (24 markdown + 10 chunker)
- [ ] CLI on a multi-paragraph .md file produces continuous audio with no mid-paragraph truncation
- [ ] CLI on `--text "short string"` still uses the one-shot path (verify by absence of `Chunked into N` line in `--verbose`)
- [ ] `--max-steps 256` still works for users who want the old cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)