### PR TITLE
NeMo NFA CTC export script (issue #36 part 1)

### DIFF
--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -138,6 +138,11 @@ the wrapper modes (`wrapper` / `custom` / `dft`) behave identically. The
 script delegates via `from export_parakeet_nemo_to_onnx import
 export_preprocessor`.
 
+**Licensing**: the recommended NVIDIA checkpoints (`stt_en_fastconformer_*`,
+`stt_en_conformer_ctc_*`) are CC-BY-4.0 on HuggingFace. Vernacula doesn't
+redistribute them (users supply their own `.nemo`), but if you publish the
+exported ONNX bundle the attribution requirement carries through.
+
 ## Sortformer Export
 
 ```bash

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -126,11 +126,12 @@ Output bundle:
 
 | File | Purpose |
 |---|---|
-| `nemo128.onnx` | log-mel preprocessor (same shape as Parakeet's; reusable across both bundles — pass `--skip-preprocessor` if you already have it) |
-| `ctc-model.onnx` + `ctc-model.onnx.data` | encoder + CTC projection. In: features `[B, F, T]` + features_lens `[B]`. Out: log_probs `[B, T, V+1]` + log_probs_lens `[B]` (the trailing `+1` is the CTC blank) |
-| `vocab.txt` | sentencepiece vocab, one `token id` per line, plus the CTC blank token at id `len(vocab)` |
+| `nemo128.onnx` | log-mel preprocessor (same shape as Parakeet's; reusable across both bundles — pass `--skip-preprocessor` if you already have it). In: `waveforms [B, samples]` + `waveforms_lens [B]`. Out: `features [B, 80, T_feat]` + `features_lens [B]`. |
+| `ctc-model.onnx` (+ optional `.data` sidecar if weights spill out) | encoder + CTC projection. In: `audio_signal [B, 80, T_feat]` + `length [B]`. **Out: `logprobs [B, T_enc, V+1]`** — single output, log-softmax over vocab+blank. T_enc per batch elem = `ceil(features_lens[b] / encoder_subsampling)`; subsampling factor is in `export-report.json`. |
+| `vocab.txt` | sentencepiece vocab, one `token id` per line, plus the CTC blank token at id `len(vocab)` (so blank_id = V) |
+| `tokenizer.model` | sentencepiece model bytes (the byte→token encoding rules). Required by the C# Viterbi side to tokenize reference transcripts with the same encoding the CTC model was trained on. Extracted via the SP processor's `serialized_model_proto()`. |
 | `config.json` | export metadata + full NeMo `cfg` dump |
-| `export-report.json` | concise summary (what got exported, what failed, hybrid-switched flag) |
+| `export-report.json` | concise summary: hybrid-switched flag, `frame_shift_seconds`, `encoder_subsampling`, `sample_rate`, what got exported, any failure notes. The C# Viterbi reads `frame_shift_seconds * encoder_subsampling` to convert frame indices → wall-clock timestamps. |
 
 The preprocessor export reuses `export_parakeet_nemo_to_onnx.py`'s
 helpers — same NeMo `AudioToMelSpectrogramPreprocessor` underneath, so

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -10,6 +10,7 @@ It now covers both models in your pipeline:
 ## Files
 
 - `export_parakeet_nemo_to_onnx.py`: exports Parakeet `.nemo` to the split ONNX package used by Vernacula.
+- `export_nfa_ctc_to_onnx.py`: exports a NeMo CTC ASR `.nemo` (pure CTC or hybrid RNNT+CTC with the CTC head selected) to the ONNX bundle the C# Viterbi forced aligner consumes (issue #36 / Chatterbox Stage 1 #9).
 - `export_sortformer_nemo_to_onnx.py`: exports streaming Sortformer `.nemo` to the same six-input / three-output ONNX contract used by Vernacula's inference code.
 - `export_silero_vad_to_onnx.py`: exports Silero VAD to ONNX.
 - `benchmark_sortformer_rtf.py`: benchmarks Sortformer NeMo-vs-ONNX diarization RTF on CPU or CUDA.
@@ -98,6 +99,44 @@ Batching notes:
 - `nemo128.onnx` currently exports successfully on this toolchain, but in practice still behaves
   like a batch-1 preprocessor export. That means post-diarization encoder batching is available
   today, while full waveform-to-text batching still needs more export work.
+
+## NFA (CTC) Export
+
+NFA — NeMo Forced Aligner — is the algorithm that combines a CTC ASR
+model with a Viterbi DP pass to assign known text to audio frames. This
+script exports the model side; the Viterbi side is a follow-up C# PR
+(issue #36 / Chatterbox Stage 1 #9).
+
+```bash
+python scripts/nemo_export/export_nfa_ctc_to_onnx.py \
+  --nemo ~/models/stt_en_fastconformer_hybrid_large_pc.nemo \
+  --output-dir ~/models/nfa_ctc_onnx \
+  --opset 17
+```
+
+Recommended source checkpoints (any of these work):
+
+- `stt_en_fastconformer_hybrid_large_pc` — NFA's own quickstart default.
+  Hybrid RNNT+CTC; the export script switches decoding strategy to CTC
+  before invoking `model.export()` so only the CTC head ships.
+- `stt_en_fastconformer_ctc_large` — pure CTC, simpler export path.
+- `stt_en_conformer_ctc_large` — older / smaller.
+
+Output bundle:
+
+| File | Purpose |
+|---|---|
+| `nemo128.onnx` | log-mel preprocessor (same shape as Parakeet's; reusable across both bundles — pass `--skip-preprocessor` if you already have it) |
+| `ctc-model.onnx` + `ctc-model.onnx.data` | encoder + CTC projection. In: features `[B, F, T]` + features_lens `[B]`. Out: log_probs `[B, T, V+1]` + log_probs_lens `[B]` (the trailing `+1` is the CTC blank) |
+| `vocab.txt` | sentencepiece vocab, one `token id` per line, plus the CTC blank token at id `len(vocab)` |
+| `config.json` | export metadata + full NeMo `cfg` dump |
+| `export-report.json` | concise summary (what got exported, what failed, hybrid-switched flag) |
+
+The preprocessor export reuses `export_parakeet_nemo_to_onnx.py`'s
+helpers — same NeMo `AudioToMelSpectrogramPreprocessor` underneath, so
+the wrapper modes (`wrapper` / `custom` / `dft`) behave identically. The
+script delegates via `from export_parakeet_nemo_to_onnx import
+export_preprocessor`.
 
 ## Sortformer Export
 

--- a/scripts/nemo_export/export_nfa_ctc_to_onnx.py
+++ b/scripts/nemo_export/export_nfa_ctc_to_onnx.py
@@ -10,19 +10,29 @@ Output bundle (mirrors the Parakeet export's file layout where possible):
 
   - nemo128.onnx                — log-mel preprocessor (same op contract
                                   as the Parakeet bundle; reusable
-                                  across CTC and RNNT/TDT exports)
+                                  across CTC and RNNT/TDT exports).
   - ctc-model.onnx[.data]       — encoder + CTC projection in one
-                                  graph. Input: features [B, F, T]
-                                  + features_lens [B] from nemo128.
-                                  Output: log_probs [B, T, V+1] and
-                                  output_lens [B].
+                                  graph. Input: audio_signal [B, 80, T_feat]
+                                  + length [B] from nemo128.
+                                  Output: logprobs [B, T_enc, V+1]
+                                  (single output — T_enc per batch elem
+                                  is ceil(features_lens / encoder_subsampling),
+                                  computed by the C# Viterbi side from
+                                  the metadata this script writes).
   - vocab.txt                   — sentencepiece vocab, one (token, id)
                                   per line, plus the CTC blank token
                                   at id == len(vocab).
+  - tokenizer.model             — sentencepiece model bytes for the
+                                  C# Viterbi to encode reference
+                                  transcripts. vocab.txt alone is
+                                  insufficient (token strings without
+                                  byte→token encoding rules).
   - config.json                 — export metadata + full NeMo cfg dump
-                                  for reference
-  - export-report.json          — concise summary (what got exported,
-                                  what failed, what notes apply)
+                                  for reference.
+  - export-report.json          — concise summary including
+                                  frame_shift_seconds, encoder_subsampling,
+                                  hybrid-switched flag, and any
+                                  failure notes.
 
 Supported source models:
 
@@ -264,9 +274,21 @@ def export_ctc_graph(model: Any, output_dir: Path, opset: int) -> None:
 
     NeMo's `model.export()` for a CTC model writes one ONNX (and possibly
     a sidecar .data) containing the encoder followed by the CTC head's
-    linear projection + log-softmax. Inputs: (features [B, F, T],
-    features_lens [B]). Outputs: (log_probs [B, T, V+1], log_probs_lens [B])
-    — the trailing +1 in vocab dim is the CTC blank.
+    linear projection + log-softmax.
+
+    Verified contract for FastConformer hybrid CTC (NeMo 2.7.1):
+      Inputs:
+        audio_signal — float32 [B, F, T_feat]    (from nemo128.onnx)
+        length       — int64   [B]               (features_lens)
+      Outputs:
+        logprobs     — float32 [B, T_enc, V+1]   (log_softmax over vocab+blank)
+
+    T_enc relates to T_feat by the encoder's subsampling factor (8 for
+    FastConformer). The exported graph emits only logprobs, not a paired
+    logprobs_lens — the C# Viterbi side computes the valid length per
+    batch element as `ceil(features_lens[b] / encoder_subsampling)`,
+    reading encoder_subsampling from the export-report.json metadata
+    this script writes.
 
     The encoder for hybrid models is shared with the RNNT head; switching
     decoding strategy to 'ctc' before export should make NeMo only wire
@@ -433,36 +455,34 @@ def extract_frame_timing(model: Any) -> tuple[float | None, int | None]:
 
 
 def export_tokenizer_model(model: Any, output_dir: Path) -> bool:
-    """Copy the sentencepiece tokenizer model file alongside vocab.txt so
-    the C# Viterbi side can tokenize reference transcripts with the exact
-    same encoding the CTC model was trained on. vocab.txt alone is
-    insufficient — it lists tokens but not the byte→token encoding rules.
+    """Write the sentencepiece tokenizer model bytes as tokenizer.model
+    alongside vocab.txt. The C# Viterbi side needs the same encoder the
+    CTC model was trained on to tokenize reference transcripts — vocab.txt
+    lists tokens but not byte→token encoding rules.
 
-    Returns True if a tokenizer.model file was written."""
+    NeMo's SentencePieceTokenizer constructor takes a model_path but
+    doesn't preserve it on self (just loads into a SentencePieceProcessor
+    and discards). The reliable accessor is the inner SP processor's
+    serialized_model_proto() — returns the bytes that were loaded from
+    disk, identical to the original .model file.
+
+    Returns True if tokenizer.model was written."""
     tokenizer = getattr(model, "tokenizer", None)
     if tokenizer is None:
         return False
-    # NeMo's BPE tokenizer wraps a SentencePieceProcessor at .tokenizer
-    # and exposes the source .model path at one of these attrs depending
-    # on NeMo version.
-    candidates = []
-    for attr in ("tokenizer_model_path", "model_path", "vocab_path"):
-        path = getattr(tokenizer, attr, None)
-        if path:
-            candidates.append(Path(str(path)))
     inner = getattr(tokenizer, "tokenizer", None)
-    if inner is not None:
-        for attr in ("model_file", "model_path"):
-            path = getattr(inner, attr, None)
-            if path:
-                candidates.append(Path(str(path)))
-    for src in candidates:
-        if src.exists() and src.suffix == ".model":
-            dst = output_dir / "tokenizer.model"
-            cleanup_target(dst)
-            shutil.copyfile(str(src), str(dst))
-            return True
-    return False
+    if inner is None or not hasattr(inner, "serialized_model_proto"):
+        return False
+    try:
+        proto_bytes = inner.serialized_model_proto()
+    except Exception:
+        return False
+    if not proto_bytes:
+        return False
+    dst = output_dir / "tokenizer.model"
+    cleanup_target(dst)
+    dst.write_bytes(proto_bytes)
+    return True
 
 
 def write_config(model: Any, omega_conf: Any, output_dir: Path, metadata: ExportMetadata) -> None:

--- a/scripts/nemo_export/export_nfa_ctc_to_onnx.py
+++ b/scripts/nemo_export/export_nfa_ctc_to_onnx.py
@@ -1,0 +1,488 @@
+"""Export a NeMo CTC ASR .nemo checkpoint into the ONNX bundle the
+C# Viterbi forced aligner will consume (issue #36 / Stage 1 #9).
+
+This script is the export side of NeMo Forced Aligner (NFA): NFA itself
+is a CTC ASR model + Viterbi DP, and the model side is what we export
+here. Viterbi over the model's log-probs is a follow-up PR — runs in
+C# against this bundle's outputs.
+
+Output bundle (mirrors the Parakeet export's file layout where possible):
+
+  - nemo128.onnx                — log-mel preprocessor (same op contract
+                                  as the Parakeet bundle; reusable
+                                  across CTC and RNNT/TDT exports)
+  - ctc-model.onnx[.data]       — encoder + CTC projection in one
+                                  graph. Input: features [B, F, T]
+                                  + features_lens [B] from nemo128.
+                                  Output: log_probs [B, T, V+1] and
+                                  output_lens [B].
+  - vocab.txt                   — sentencepiece vocab, one (token, id)
+                                  per line, plus the CTC blank token
+                                  at id == len(vocab).
+  - config.json                 — export metadata + full NeMo cfg dump
+                                  for reference
+  - export-report.json          — concise summary (what got exported,
+                                  what failed, what notes apply)
+
+Supported source models:
+
+- Pure CTC checkpoints (`EncDecCTCModel`, `EncDecCTCModelBPE`).
+- Hybrid RNNT+CTC checkpoints (`EncDecHybridRNNTCTCModel`,
+  `EncDecHybridRNNTCTCBPEModel`) — the script switches the model's
+  decoding strategy to CTC before export so the exported graph only
+  carries the CTC head. Recommended default per NFA's own quickstart:
+  `stt_en_fastconformer_hybrid_large_pc` (CTC head used).
+
+Pattern intentionally matches `export_parakeet_nemo_to_onnx.py` so a
+single shared-helpers refactor can pull both scripts together when a
+third NeMo export consumer arrives. Some helpers duplicate the
+Parakeet script's bodies verbatim — keep them in sync until that
+refactor.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export a NeMo CTC ASR .nemo checkpoint into the ONNX bundle "
+            "used by Vernacula's forced-aligner (issue #36)."
+        )
+    )
+    parser.add_argument(
+        "--nemo",
+        required=True,
+        help=(
+            "Path to a local .nemo file. Recommended defaults: "
+            "stt_en_fastconformer_hybrid_large_pc (use CTC head — script handles "
+            "the switch); stt_en_fastconformer_ctc_large (pure CTC); "
+            "stt_en_conformer_ctc_large (older, smaller)."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory that will receive nemo128.onnx, ctc-model.onnx, vocab.txt, and config.json.",
+    )
+    parser.add_argument(
+        "--opset",
+        type=int,
+        default=17,
+        help="ONNX opset to request during export.",
+    )
+    parser.add_argument(
+        "--device",
+        choices=("auto", "cpu", "cuda"),
+        default="auto",
+        help="Device to use for model restore/export.",
+    )
+    parser.add_argument(
+        "--preprocessor-seconds",
+        type=float,
+        default=20.0,
+        help="Dummy waveform length used when exporting the preprocessor wrapper.",
+    )
+    parser.add_argument(
+        "--skip-preprocessor",
+        action="store_true",
+        help=(
+            "Skip nemo128.onnx export if you already have a compatible preprocessor bundle "
+            "(e.g. from the Parakeet export — the log-mel frontend is the same)."
+        ),
+    )
+    parser.add_argument(
+        "--preprocessor-opset",
+        type=int,
+        default=None,
+        help="Optional opset override for nemo128.onnx. Defaults to --opset.",
+    )
+    parser.add_argument(
+        "--preprocessor-mode",
+        choices=("wrapper", "custom", "dft"),
+        default="dft",
+        help=(
+            "How to build nemo128.onnx. 'wrapper' exports NeMo's preprocessor module "
+            "directly (often fails). 'custom' rebuilds it with explicit STFT. 'dft' uses "
+            "the Conv1d-DFT variant that tends to match NeMo's frame counts most reliably. "
+            "Defaults match the Parakeet export's preferred mode."
+        ),
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing files in --output-dir.",
+    )
+    return parser.parse_args()
+
+
+# ── Generic helpers (mirrors export_parakeet_nemo_to_onnx.py) ────────────────
+
+
+def import_dependencies() -> tuple[Any, Any, Any, Any]:
+    try:
+        import torch
+        from nemo.collections.asr.models import ASRModel
+        from omegaconf import OmegaConf
+    except Exception as exc:
+        raise SystemExit(
+            "Missing export dependencies. Create a Python 3.11/3.12 environment and "
+            "install the packages from scripts/nemo_export/requirements.txt.\n"
+            f"Original import error: {exc}"
+        ) from exc
+    return torch, ASRModel, OmegaConf, exc_to_string
+
+
+def exc_to_string(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+def resolve_device(torch: Any, requested: str) -> str:
+    if requested == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if requested == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("CUDA was requested but torch.cuda.is_available() is false.")
+    return requested
+
+
+def ensure_output_dir(path: Path, overwrite: bool) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if not overwrite:
+        collisions = [
+            name
+            for name in (
+                "nemo128.onnx",
+                "ctc-model.onnx",
+                "ctc-model.onnx.data",
+                "vocab.txt",
+                "config.json",
+                "export-report.json",
+            )
+            if (path / name).exists()
+        ]
+        if collisions:
+            raise SystemExit(
+                "Output directory already contains export targets. "
+                "Re-run with --overwrite to replace them.\n"
+                f"Existing files: {', '.join(collisions)}"
+            )
+
+
+def cleanup_target(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+
+
+def replace_file(src: Path, dst: Path) -> None:
+    cleanup_target(dst)
+    shutil.move(str(src), str(dst))
+
+
+def replace_if_present(src: Path, dst: Path) -> None:
+    if src.exists():
+        replace_file(src, dst)
+
+
+def consolidate_external_data(onnx_path: Path) -> None:
+    """Rewrite the ONNX so all initializers live in <onnx_path>.data.
+    NeMo's default export may scatter weights across multiple data files
+    depending on size; the C# consumer wants a single sidecar."""
+    import onnx
+
+    model = onnx.load(str(onnx_path), load_external_data=True)
+    data_target = onnx_path.with_suffix(onnx_path.suffix + ".data")
+    cleanup_target(data_target)
+    onnx.save_model(
+        model,
+        str(onnx_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=data_target.name,
+        size_threshold=1024,
+        convert_attribute=False,
+    )
+
+
+# ── Hybrid-vs-pure CTC handling ─────────────────────────────────────────────
+
+
+def switch_to_ctc_decoding_if_hybrid(model: Any) -> bool:
+    """If the loaded model is a hybrid RNNT+CTC checkpoint, switch its
+    decoding strategy to CTC so model.export() emits only the CTC head.
+    Returns True if a switch happened."""
+    model_class = type(model).__name__
+    is_hybrid = "Hybrid" in model_class
+    if not is_hybrid:
+        return False
+    # NeMo's hybrid models expose change_decoding_strategy(...) that gates
+    # which head is active. We need the CTC head for forced alignment.
+    if not hasattr(model, "change_decoding_strategy"):
+        raise RuntimeError(
+            f"Loaded model is hybrid ({model_class}) but doesn't expose "
+            "change_decoding_strategy. NeMo API changed?"
+        )
+    try:
+        model.change_decoding_strategy(decoder_type="ctc")
+    except TypeError:
+        # Older NeMo API used a positional or differently-named arg.
+        model.change_decoding_strategy("ctc")
+    return True
+
+
+# ── CTC encoder + head export ───────────────────────────────────────────────
+
+
+def export_ctc_graph(model: Any, output_dir: Path, opset: int) -> None:
+    """Export the encoder + CTC projection as a single ONNX.
+
+    NeMo's `model.export()` for a CTC model writes one ONNX (and possibly
+    a sidecar .data) containing the encoder followed by the CTC head's
+    linear projection + log-softmax. Inputs: (features [B, F, T],
+    features_lens [B]). Outputs: (log_probs [B, T, V+1], log_probs_lens [B])
+    — the trailing +1 in vocab dim is the CTC blank.
+
+    The encoder for hybrid models is shared with the RNNT head; switching
+    decoding strategy to 'ctc' before export should make NeMo only wire
+    the CTC head into the exported graph."""
+    export_stub = output_dir / "nfa_ctc.onnx"
+    cleanup_target(export_stub)
+
+    model.export(str(export_stub), onnx_opset_version=opset)
+
+    # NeMo may emit the file at the stub path directly, OR under a
+    # prefixed name like "encoder-nfa_ctc.onnx" for split exports. CTC
+    # models are usually single-graph (no split), but check both.
+    target = output_dir / "ctc-model.onnx"
+    if export_stub.exists():
+        # Single-file export: rename to the target name.
+        replace_file(export_stub, target)
+        replace_if_present(
+            output_dir / "nfa_ctc.onnx.data",
+            output_dir / "ctc-model.onnx.data",
+        )
+    else:
+        # Split export attempt (hybrid model didn't honor the strategy
+        # switch?). Try to find the encoder file.
+        encoder_src = output_dir / "encoder-nfa_ctc.onnx"
+        if encoder_src.exists():
+            raise RuntimeError(
+                "NeMo emitted a SPLIT export (encoder-nfa_ctc.onnx) instead of a single "
+                "CTC graph. This usually means the hybrid-model CTC switch didn't take. "
+                "Check the model's change_decoding_strategy support, or try a pure-CTC "
+                "checkpoint (e.g. stt_en_fastconformer_ctc_large)."
+            )
+        raise RuntimeError(
+            "NeMo export did not produce nfa_ctc.onnx or any recognized split artifact."
+        )
+
+    consolidate_external_data(target)
+
+
+# ── Preprocessor export (verbatim from export_parakeet_nemo_to_onnx) ────────
+#
+# The CTC and RNNT models share the same NeMo preprocessor (log-mel
+# frontend). Rather than re-write the preprocessor wrappers, we import
+# them from the Parakeet export module. The shared bits are at module
+# scope and don't have side effects.
+
+
+def export_preprocessor_via_parakeet(
+    model: Any,
+    torch: Any,
+    output_dir: Path,
+    opset: int,
+    dummy_seconds: float,
+    mode: str,
+) -> None:
+    """Delegate to the Parakeet export's preprocessor function, which
+    handles all three wrapper modes (wrapper/custom/dft) for any NeMo
+    AudioToMelSpectrogramPreprocessor."""
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parent))
+    from export_parakeet_nemo_to_onnx import export_preprocessor  # type: ignore[import-not-found]
+
+    export_preprocessor(
+        model,
+        torch,
+        output_dir,
+        opset,
+        dummy_seconds,
+        mode=mode,
+        dynamo=mode not in ("custom", "dft"),
+        optimize=mode not in ("custom", "dft"),
+        verify=False,
+        do_constant_folding=True,
+        dynamic_axes_enabled=True,
+    )
+
+
+# ── Vocab + config + report (mirrors Parakeet export) ───────────────────────
+
+
+def extract_vocab_entries(model: Any) -> list[tuple[int, str]]:
+    """Same logic as Parakeet's vocab extraction. CTC and RNN-T share
+    the tokenizer surface."""
+    vocab_by_id: dict[int, str] = {}
+
+    decoding_vocab = getattr(getattr(model, "decoding", None), "vocabulary", None)
+    if decoding_vocab:
+        for idx, token in enumerate(decoding_vocab):
+            vocab_by_id[idx] = str(token)
+
+    tokenizer = getattr(model, "tokenizer", None)
+    tokenizer_impl = getattr(tokenizer, "tokenizer", None)
+    if hasattr(tokenizer_impl, "get_vocab"):
+        raw_vocab = tokenizer_impl.get_vocab()
+        if isinstance(raw_vocab, dict):
+            for token, idx in raw_vocab.items():
+                normalized_idx = int(idx) - 1 if int(idx) > 0 else int(idx)
+                vocab_by_id[normalized_idx] = str(token)
+
+    if not vocab_by_id:
+        raise RuntimeError("Could not extract a tokenizer vocabulary from the NeMo model.")
+
+    return sorted(vocab_by_id.items(), key=lambda item: item[0])
+
+
+def write_vocab(model: Any, output_dir: Path) -> None:
+    entries = extract_vocab_entries(model)
+    blank_id = len(entries)
+    blank_token = "<blk>"
+    dst = output_dir / "vocab.txt"
+    with dst.open("w", encoding="utf-8", newline="\n") as handle:
+        for idx, token in entries:
+            handle.write(f"{token} {idx}\n")
+        if not any(token == blank_token for _, token in entries):
+            handle.write(f"{blank_token} {blank_id}\n")
+
+
+@dataclass
+class ExportMetadata:
+    nemo_file: str
+    nemo_model_class: str
+    nemo_model_name: str | None
+    hybrid_switched_to_ctc: bool
+    device: str
+    opset: int
+    sample_rate: int | None
+    preprocessor_exported: bool
+    notes: list[str]
+
+
+def write_config(model: Any, omega_conf: Any, output_dir: Path, metadata: ExportMetadata) -> None:
+    cfg = getattr(model, "cfg", None)
+    payload: dict[str, Any] = {"export": asdict(metadata)}
+    if cfg is not None:
+        try:
+            payload["nemo_cfg"] = omega_conf.to_container(cfg, resolve=True)
+        except Exception:
+            payload["nemo_cfg"] = str(cfg)
+    with (output_dir / "config.json").open("w", encoding="utf-8", newline="\n") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+def write_report(output_dir: Path, metadata: ExportMetadata) -> None:
+    with (output_dir / "export-report.json").open("w", encoding="utf-8", newline="\n") as handle:
+        json.dump(asdict(metadata), handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    args = parse_args()
+    nemo_path = Path(args.nemo).expanduser().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+
+    if not nemo_path.exists():
+        raise SystemExit(f".nemo file not found: {nemo_path}")
+
+    ensure_output_dir(output_dir, overwrite=args.overwrite)
+
+    torch, ASRModel, OmegaConf, format_exc = import_dependencies()
+    device = resolve_device(torch, args.device)
+
+    model = ASRModel.restore_from(str(nemo_path), map_location=device)
+    model.freeze()
+    model.eval()
+    model.to(device)
+
+    notes: list[str] = []
+    hybrid_switched = switch_to_ctc_decoding_if_hybrid(model)
+    if hybrid_switched:
+        notes.append(
+            f"Loaded {type(model).__name__} (hybrid); switched decoding to CTC "
+            "before export so the graph only carries the CTC head."
+        )
+
+    export_ctc_graph(model, output_dir, args.opset)
+
+    preprocessor_exported = False
+    if args.skip_preprocessor:
+        notes.append("Skipped preprocessor export because --skip-preprocessor was provided.")
+    else:
+        try:
+            export_preprocessor_via_parakeet(
+                model,
+                torch,
+                output_dir,
+                args.preprocessor_opset or args.opset,
+                args.preprocessor_seconds,
+                args.preprocessor_mode,
+            )
+            preprocessor_exported = True
+            notes.append(f"Preprocessor exported in mode={args.preprocessor_mode}.")
+        except Exception as exc:
+            notes.append(
+                "Preprocessor export failed. ctc-model.onnx is still usable if you bring your "
+                f"own preprocessor (e.g. from the Parakeet bundle). Failure: {format_exc(exc)}"
+            )
+
+    write_vocab(model, output_dir)
+
+    cfg_target = getattr(model, "cfg", None)
+    metadata = ExportMetadata(
+        nemo_file=str(nemo_path),
+        nemo_model_class=type(model).__name__,
+        nemo_model_name=getattr(cfg_target, "name", None) if cfg_target is not None else None,
+        hybrid_switched_to_ctc=hybrid_switched,
+        device=device,
+        opset=args.opset,
+        sample_rate=int(getattr(getattr(model, "preprocessor", None), "_sample_rate", 0) or 0) or None,
+        preprocessor_exported=preprocessor_exported,
+        notes=notes,
+    )
+
+    write_config(model, OmegaConf, output_dir, metadata)
+    write_report(output_dir, metadata)
+
+    print("Export complete:")
+    for name in (
+        "ctc-model.onnx",
+        "ctc-model.onnx.data",
+        "nemo128.onnx",
+        "vocab.txt",
+        "config.json",
+        "export-report.json",
+    ):
+        path = output_dir / name
+        if path.exists():
+            print(f"  - {path}")
+
+    if notes:
+        print("\nNotes:")
+        for note in notes:
+            print(f"  - {note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemo_export/export_nfa_ctc_to_onnx.py
+++ b/scripts/nemo_export/export_nfa_ctc_to_onnx.py
@@ -161,6 +161,7 @@ def ensure_output_dir(path: Path, overwrite: bool) -> None:
                 "ctc-model.onnx",
                 "ctc-model.onnx.data",
                 "vocab.txt",
+                "tokenizer.model",
                 "config.json",
                 "export-report.json",
             )
@@ -190,23 +191,43 @@ def replace_if_present(src: Path, dst: Path) -> None:
 
 
 def consolidate_external_data(onnx_path: Path) -> None:
-    """Rewrite the ONNX so all initializers live in <onnx_path>.data.
-    NeMo's default export may scatter weights across multiple data files
-    depending on size; the C# consumer wants a single sidecar."""
+    """Re-save an ONNX model so all external tensors live in a single sidecar file.
+
+    Behavior mirrors export_parakeet_nemo_to_onnx.consolidate_external_data:
+    no-op when already clean (single sidecar), full re-save + stale per-tensor
+    cleanup otherwise. size_threshold=0 so every initializer goes external
+    (matches Parakeet) — keeps the .onnx file small and the .data file the
+    sole weight carrier.
+    """
     import onnx
 
-    model = onnx.load(str(onnx_path), load_external_data=True)
-    data_target = onnx_path.with_suffix(onnx_path.suffix + ".data")
-    cleanup_target(data_target)
+    model = onnx.load(str(onnx_path))
+    locations: set[str] = set()
+    for t in model.graph.initializer:
+        for kv in t.external_data:
+            if kv.key == "location":
+                locations.add(kv.value)
+
+    sidecar_name = onnx_path.name + ".data"
+    already_clean = len(locations) == 0 or (len(locations) == 1 and sidecar_name in locations)
+    if already_clean:
+        return
+
+    print(f"  Consolidating {len(locations)} external data files → {sidecar_name} …")
     onnx.save_model(
         model,
         str(onnx_path),
         save_as_external_data=True,
         all_tensors_to_one_file=True,
-        location=data_target.name,
-        size_threshold=1024,
-        convert_attribute=False,
+        location=sidecar_name,
+        size_threshold=0,
     )
+
+    parent = onnx_path.parent
+    for loc in locations:
+        stale = parent / loc
+        if stale.exists() and stale.name != sidecar_name:
+            stale.unlink()
 
 
 # ── Hybrid-vs-pure CTC handling ─────────────────────────────────────────────
@@ -267,18 +288,16 @@ def export_ctc_graph(model: Any, output_dir: Path, opset: int) -> None:
             output_dir / "ctc-model.onnx.data",
         )
     else:
-        # Split export attempt (hybrid model didn't honor the strategy
-        # switch?). Try to find the encoder file.
-        encoder_src = output_dir / "encoder-nfa_ctc.onnx"
-        if encoder_src.exists():
-            raise RuntimeError(
-                "NeMo emitted a SPLIT export (encoder-nfa_ctc.onnx) instead of a single "
-                "CTC graph. This usually means the hybrid-model CTC switch didn't take. "
-                "Check the model's change_decoding_strategy support, or try a pure-CTC "
-                "checkpoint (e.g. stt_en_fastconformer_ctc_large)."
-            )
+        # NeMo didn't write to the stub path. Most common failure: hybrid
+        # model didn't honor the CTC switch and emitted a SPLIT export
+        # (encoder + decoder_joint). List what actually appeared so the
+        # next person diagnosing this doesn't have to ls the dir.
+        artifacts = sorted(p.name for p in output_dir.glob("*nfa_ctc*"))
         raise RuntimeError(
-            "NeMo export did not produce nfa_ctc.onnx or any recognized split artifact."
+            f"NeMo export did not produce nfa_ctc.onnx. Found instead: {artifacts or '(nothing matching *nfa_ctc*)'}. "
+            "If you see encoder-nfa_ctc.onnx + decoder_joint-nfa_ctc.onnx, the hybrid-model "
+            "CTC switch didn't take — try a pure-CTC checkpoint (e.g. stt_en_fastconformer_ctc_large) "
+            "or report the NeMo version that produced this output."
         )
 
     consolidate_external_data(target)
@@ -305,7 +324,9 @@ def export_preprocessor_via_parakeet(
     AudioToMelSpectrogramPreprocessor."""
     import sys
 
-    sys.path.insert(0, str(Path(__file__).parent))
+    helper_dir = str(Path(__file__).parent)
+    if helper_dir not in sys.path:
+        sys.path.insert(0, helper_dir)
     from export_parakeet_nemo_to_onnx import export_preprocessor  # type: ignore[import-not-found]
 
     export_preprocessor(
@@ -372,8 +393,76 @@ class ExportMetadata:
     device: str
     opset: int
     sample_rate: int | None
+    # The Viterbi DP in the C# follow-up converts frame indices to wall-clock
+    # timestamps as `frame_index * frame_shift_seconds * encoder_subsampling`.
+    # Captured at export time from the live NeMo model so the C# side doesn't
+    # have to re-derive them by probing the preprocessor / encoder ONNX shapes.
+    frame_shift_seconds: float | None
+    encoder_subsampling: int | None
     preprocessor_exported: bool
+    tokenizer_model_exported: bool
     notes: list[str]
+
+
+def extract_frame_timing(model: Any) -> tuple[float | None, int | None]:
+    """Read frame shift (seconds) + encoder subsampling factor from the
+    live NeMo model. Returns (None, None) when either can't be determined —
+    the C# side will warn rather than crash in that case."""
+    frame_shift = None
+    subsampling = None
+    preproc = getattr(model, "preprocessor", None)
+    if preproc is not None:
+        featurizer = getattr(preproc, "featurizer", None)
+        sr = getattr(preproc, "_sample_rate", None)
+        hop = getattr(featurizer, "hop_length", None) if featurizer is not None else None
+        if sr and hop:
+            frame_shift = float(hop) / float(sr)
+    encoder_cfg = getattr(getattr(model, "cfg", None), "encoder", None)
+    if encoder_cfg is not None:
+        # FastConformer / Conformer typically expose subsampling_factor;
+        # sometimes named differently (e.g. "subsampling" or "stride_factor").
+        for attr in ("subsampling_factor", "subsampling", "stride_factor"):
+            val = getattr(encoder_cfg, attr, None)
+            if val is not None:
+                try:
+                    subsampling = int(val)
+                    break
+                except (TypeError, ValueError):
+                    pass
+    return frame_shift, subsampling
+
+
+def export_tokenizer_model(model: Any, output_dir: Path) -> bool:
+    """Copy the sentencepiece tokenizer model file alongside vocab.txt so
+    the C# Viterbi side can tokenize reference transcripts with the exact
+    same encoding the CTC model was trained on. vocab.txt alone is
+    insufficient — it lists tokens but not the byte→token encoding rules.
+
+    Returns True if a tokenizer.model file was written."""
+    tokenizer = getattr(model, "tokenizer", None)
+    if tokenizer is None:
+        return False
+    # NeMo's BPE tokenizer wraps a SentencePieceProcessor at .tokenizer
+    # and exposes the source .model path at one of these attrs depending
+    # on NeMo version.
+    candidates = []
+    for attr in ("tokenizer_model_path", "model_path", "vocab_path"):
+        path = getattr(tokenizer, attr, None)
+        if path:
+            candidates.append(Path(str(path)))
+    inner = getattr(tokenizer, "tokenizer", None)
+    if inner is not None:
+        for attr in ("model_file", "model_path"):
+            path = getattr(inner, attr, None)
+            if path:
+                candidates.append(Path(str(path)))
+    for src in candidates:
+        if src.exists() and src.suffix == ".model":
+            dst = output_dir / "tokenizer.model"
+            cleanup_target(dst)
+            shutil.copyfile(str(src), str(dst))
+            return True
+    return False
 
 
 def write_config(model: Any, omega_conf: Any, output_dir: Path, metadata: ExportMetadata) -> None:
@@ -448,6 +537,23 @@ def main() -> None:
             )
 
     write_vocab(model, output_dir)
+    tokenizer_model_exported = export_tokenizer_model(model, output_dir)
+    if not tokenizer_model_exported:
+        notes.append(
+            "Could not locate the sentencepiece tokenizer .model file inside the loaded "
+            "NeMo model. The C# Viterbi side will need this to tokenize reference "
+            "transcripts with the same encoding the CTC model was trained on — without "
+            "it, only vocab.txt's token strings are available. Check NeMo version / "
+            "tokenizer attrs if this matters for your downstream consumer."
+        )
+
+    frame_shift_seconds, encoder_subsampling = extract_frame_timing(model)
+    if frame_shift_seconds is None or encoder_subsampling is None:
+        notes.append(
+            f"Could not fully determine frame timing (frame_shift={frame_shift_seconds}, "
+            f"subsampling={encoder_subsampling}). The C# Viterbi will need both to convert "
+            "frame indices to wall-clock timestamps."
+        )
 
     cfg_target = getattr(model, "cfg", None)
     metadata = ExportMetadata(
@@ -458,7 +564,10 @@ def main() -> None:
         device=device,
         opset=args.opset,
         sample_rate=int(getattr(getattr(model, "preprocessor", None), "_sample_rate", 0) or 0) or None,
+        frame_shift_seconds=frame_shift_seconds,
+        encoder_subsampling=encoder_subsampling,
         preprocessor_exported=preprocessor_exported,
+        tokenizer_model_exported=tokenizer_model_exported,
         notes=notes,
     )
 
@@ -471,6 +580,7 @@ def main() -> None:
         "ctc-model.onnx.data",
         "nemo128.onnx",
         "vocab.txt",
+        "tokenizer.model",
         "config.json",
         "export-report.json",
     ):

--- a/scripts/nemo_export/export_parakeet_nemo_to_onnx.py
+++ b/scripts/nemo_export/export_parakeet_nemo_to_onnx.py
@@ -249,6 +249,9 @@ def export_rnnt_pair(model: Any, output_dir: Path, opset: int) -> None:
     consolidate_external_data(output_dir / "decoder_joint-model.onnx")
 
 
+# Also consumed by export_nfa_ctc_to_onnx.py via sys.path import — the NeMo
+# preprocessor is identical for CTC and RNNT/TDT models. Keep this signature
+# stable (or move both to a shared module when a third consumer arrives).
 def export_preprocessor(
     model: Any,
     torch: Any,


### PR DESCRIPTION
## Summary

Adds `scripts/nemo_export/export_nfa_ctc_to_onnx.py` — the model-side half of NeMo Forced Aligner (NFA). NFA is a CTC ASR model + a Viterbi DP pass over the model's log-probs; this PR is the model export. The C# side (`IForcedAligner` interface, shared Viterbi helper, `NemoNfaAligner` implementation, `TranscriptionService` wiring) is intentionally a follow-up PR per issue #36's plan.

First step in driving issue #36 to completion. Unblocks Chatterbox Stage 1 #9 (word-level highlighting in the eventual Avalonia reader).

## Why now / why NFA over MMS

Issue #36 lists three viable aligners (MMS-300M, NFA + Conformer-CTC, wav2vec2-large-960h). MMS is the recommended default for breadth (1130+ languages); NFA is well-tuned for English and reuses the existing `scripts/nemo_export/` tooling pattern. We're starting with NFA because:

- The immediate consumer (Chatterbox audiobook reader) is English-first
- The export pipeline already has Parakeet + Sortformer using the same NeMo path, so this is incremental rather than a new ecosystem
- The Conformer-CTC backbone is well-tuned for English alignment (~50ms MAE on LibriSpeech)

MMS-300M export is a logical follow-up if/when multilingual coverage matters.

## What's in this PR

| File | Change |
|---|---|
| `scripts/nemo_export/export_nfa_ctc_to_onnx.py` | New (~360 LOC). Mirrors `export_parakeet_nemo_to_onnx.py`'s structure. |
| `scripts/nemo_export/README.md` | New `## NFA (CTC) Export` section + listed in the file inventory. |

## Three CTC-specific bits over the Parakeet pattern

1. **`switch_to_ctc_decoding_if_hybrid()`** — if the loaded model is a hybrid RNNT+CTC checkpoint (e.g. NFA's quickstart default `stt_en_fastconformer_hybrid_large_pc`), call `model.change_decoding_strategy('ctc')` so `model.export()` only wires the CTC head into the exported graph.
2. **`export_ctc_graph()`** — single-file export (no encoder + decoder_joint split — CTC has no joint network). Output graph: `features → log_probs + log_probs_lens`, with vocab dim of `V+1` (the trailing +1 is the CTC blank).
3. **Preprocessor delegation** — the NeMo log-mel frontend is identical between CTC and RNNT/TDT models, so this script imports `export_preprocessor` from the Parakeet script via a `sys.path` insert rather than duplicating ~200 lines of wrapper / custom / DFT mode logic. README points users at `--skip-preprocessor` if they already have a compatible `nemo128.onnx` from the Parakeet bundle.

## Output bundle

```
ctc-model.onnx            — encoder + CTC projection (single graph)
ctc-model.onnx.data       — external weights sidecar (single file via consolidate_external_data)
nemo128.onnx              — log-mel preprocessor
vocab.txt                 — sentencepiece + CTC blank at id len(vocab)
config.json               — metadata + full NeMo cfg dump
export-report.json        — what got exported, hybrid-switched flag, any failure notes
```

## Recommended source checkpoints (README documents this)

| Checkpoint | Type | Notes |
|---|---|---|
| `stt_en_fastconformer_hybrid_large_pc` | Hybrid RNNT+CTC | NFA's own quickstart default. Script handles the CTC-head switch. |
| `stt_en_fastconformer_ctc_large` | Pure CTC | Simpler export path. |
| `stt_en_conformer_ctc_large` | Pure CTC | Older, smaller. |

## Verification

- `python -m py_compile scripts/nemo_export/export_nfa_ctc_to_onnx.py` → OK
- `--help` parses + prints expected usage
- Module structure: all 12 expected helper symbols defined
- **Not run end-to-end** — no NeMo `.nemo` checkpoint on the dev machine. The script will exercise on the next person to run it with a real checkpoint. Same posture as the existing nemo_export scripts (reference exports for users with their own checkpoints).

## Test plan

- [ ] Run with `stt_en_fastconformer_hybrid_large_pc.nemo` → verify all 6 bundle files appear, `export-report.json` shows `hybrid_switched_to_ctc: true`
- [ ] Run with a pure-CTC checkpoint → verify `export-report.json` shows `hybrid_switched_to_ctc: false`
- [ ] Load `ctc-model.onnx` in `onnxruntime` and run a dummy forward pass → verify output shape `[1, T, V+1]` and that summing the last dim's softmax gives ~1 per frame
- [ ] CI build green (Python script — no .NET changes in this PR)

## Next PR (separate)

- `Vernacula.Base.IForcedAligner` interface with `(audio, text, language) → IReadOnlyList<WordTiming>`
- Shared static Viterbi DP helper (`CtcForcedAlignment.Align(logProbs, tokenSeq, blankIdx)`)
- `NemoNfaAligner` concrete implementation that loads this PR's bundle
- Wire into `TranscriptionService` behind a Settings toggle (per #36's design)
- Wire into Chatterbox CLI's long-form path (per-chunk alignment + JSON sidecar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)