### PR TITLE
NFA C# Viterbi forced aligner (issue #36 part 2)

### DIFF
--- a/Vernacula.slnx
+++ b/Vernacula.slnx
@@ -30,4 +30,7 @@
   <Project Path="tests/Chatterbox.Tests/Chatterbox.Tests.csproj">
     <Platform Project="x64" />
   </Project>
+  <Project Path="tests/Vernacula.Tests/Vernacula.Tests.csproj">
+    <Platform Project="x64" />
+  </Project>
 </Solution>

--- a/src/Vernacula.Base/Alignment/CtcForcedAlignment.cs
+++ b/src/Vernacula.Base/Alignment/CtcForcedAlignment.cs
@@ -1,0 +1,189 @@
+namespace Vernacula.Base.Alignment;
+
+/// <summary>
+/// One token's frame span in a CTC Viterbi alignment.
+/// </summary>
+/// <param name="TokenId">The token's id in the model's vocabulary.</param>
+/// <param name="TokenPosition">Index in the original (un-blanked) target
+/// sequence — useful for matching back to per-token metadata like word
+/// boundaries.</param>
+/// <param name="StartFrame">First frame (inclusive) the Viterbi backtrack
+/// assigned to this token.</param>
+/// <param name="EndFrame">Last frame (inclusive) the backtrack assigned
+/// to this token.</param>
+public sealed record TokenAlignment(int TokenId, int TokenPosition, int StartFrame, int EndFrame);
+
+/// <summary>
+/// CTC forced-alignment Viterbi DP — the algorithmic core of NFA, MMS
+/// forced aligner, torchaudio.functional.forced_align, etc. All those
+/// systems run the same algorithm over CTC log-probs; only the
+/// acoustic model differs.
+///
+/// Given:
+///   <see cref="LogProbs"/>: [T, V+1] log-softmax over vocab + blank
+///   target token sequence (no blanks): the reference text tokenized
+///   blank_id: which column is the CTC blank (conventionally V)
+///
+/// Returns: one <see cref="TokenAlignment"/> per target token, with
+/// the frames assigned to it by the optimal-path backtrack. Per-token
+/// frames are contiguous and non-overlapping; tokens may be assigned
+/// zero frames (degenerate; happens when the optimal path emits the
+/// token at a single frame between blanks).
+///
+/// Algorithm summary (the "modified Viterbi" for CTC):
+/// - Build a blanked target of length 2N+1: [blank, t0, blank, t1, …, t_{N-1}, blank]
+/// - DP: log_alpha[t, s] = log_probs[t, blankedTarget[s]] + max of:
+///   - log_alpha[t-1, s]          (stay)
+///   - log_alpha[t-1, s-1]        (advance)
+///   - log_alpha[t-1, s-2]        (skip blank — only when current is
+///                                 not blank and the prev-token ≠ this
+///                                 token; otherwise CTC merging rules
+///                                 forbid the skip)
+/// - Final: max(log_alpha[T-1, 2N-1], log_alpha[T-1, 2N])
+/// - Backtrack to recover per-frame state, then aggregate frames per
+///   original-target-token position.
+/// </summary>
+public static class CtcForcedAlignment
+{
+    /// <summary>
+    /// Run Viterbi forced alignment. <paramref name="logProbs"/> is a
+    /// row-major [T, V+1] log-softmax matrix; <paramref name="numFrames"/>
+    /// = T; <paramref name="vocabPlusBlank"/> = V+1.
+    /// </summary>
+    /// <param name="targetTokens">Target token ids (no blanks). Must be
+    /// non-empty and all ids must be in [0, vocabPlusBlank) and != blankId.</param>
+    /// <param name="blankId">CTC blank token id (conventionally V, i.e.
+    /// vocabPlusBlank-1 — but pass it explicitly for clarity).</param>
+    /// <exception cref="ArgumentException">When the inputs are
+    /// internally inconsistent (empty target, target token equals blank,
+    /// T &lt; required minimum length to fit the target).</exception>
+    public static IReadOnlyList<TokenAlignment> Align(
+        float[] logProbs, int numFrames, int vocabPlusBlank,
+        IReadOnlyList<int> targetTokens, int blankId)
+    {
+        int n = targetTokens.Count;
+        if (n == 0) throw new ArgumentException("targetTokens must be non-empty.", nameof(targetTokens));
+        if (blankId < 0 || blankId >= vocabPlusBlank)
+            throw new ArgumentException($"blankId {blankId} out of range [0,{vocabPlusBlank}).", nameof(blankId));
+        for (int i = 0; i < n; i++)
+        {
+            int t = targetTokens[i];
+            if (t < 0 || t >= vocabPlusBlank)
+                throw new ArgumentException($"targetTokens[{i}] = {t} out of range.", nameof(targetTokens));
+            if (t == blankId)
+                throw new ArgumentException($"targetTokens[{i}] is the blank id — target must not contain blanks.", nameof(targetTokens));
+        }
+        // Minimum frames needed: each token needs ≥1 frame; same-token
+        // pairs additionally need a blank between them (CTC merging rule).
+        int minFrames = n;
+        for (int i = 1; i < n; i++)
+            if (targetTokens[i] == targetTokens[i - 1]) minFrames++;
+        if (numFrames < minFrames)
+            throw new ArgumentException(
+                $"numFrames={numFrames} is too small to fit a {n}-token target requiring ≥{minFrames} frames "
+                + "(same-token repeats need separating blanks).",
+                nameof(numFrames));
+
+        // Build the blanked target: 2N+1 states alternating blank/token.
+        int s_n = 2 * n + 1;
+        var blanked = new int[s_n];
+        for (int s = 0; s < s_n; s++)
+            blanked[s] = (s % 2 == 0) ? blankId : targetTokens[s / 2];
+
+        const float NegInf = float.NegativeInfinity;
+        // log_alpha[t, s] flattened as alpha[t * s_n + s].
+        var alpha = new float[numFrames * s_n];
+        for (int i = 0; i < alpha.Length; i++) alpha[i] = NegInf;
+        // backptr[t, s] in {0=stay, 1=advance, 2=skip}; -1 means unreachable.
+        // Stored as sbyte to keep the trellis small for long alignments.
+        var backptr = new sbyte[numFrames * s_n];
+
+        // Init (t=0): can be in state 0 (blank) or state 1 (first token).
+        alpha[0 * s_n + 0] = logProbs[0 * vocabPlusBlank + blankId];
+        backptr[0 * s_n + 0] = 0;
+        alpha[0 * s_n + 1] = logProbs[0 * vocabPlusBlank + blanked[1]];
+        backptr[0 * s_n + 1] = 0;
+
+        // DP.
+        for (int t = 1; t < numFrames; t++)
+        {
+            int alphaRow = t * s_n;
+            int prevRow = (t - 1) * s_n;
+            int logRow = t * vocabPlusBlank;
+            for (int s = 0; s < s_n; s++)
+            {
+                float stay = alpha[prevRow + s];
+                float advance = (s >= 1) ? alpha[prevRow + s - 1] : NegInf;
+                bool canSkip = s >= 2
+                    && blanked[s] != blankId
+                    && blanked[s] != blanked[s - 2];
+                float skip = canSkip ? alpha[prevRow + s - 2] : NegInf;
+
+                float best = stay;
+                sbyte choice = 0;
+                if (advance > best) { best = advance; choice = 1; }
+                if (skip > best) { best = skip; choice = 2; }
+                if (float.IsNegativeInfinity(best))
+                {
+                    backptr[alphaRow + s] = -1;
+                    continue;
+                }
+                alpha[alphaRow + s] = best + logProbs[logRow + blanked[s]];
+                backptr[alphaRow + s] = choice;
+            }
+        }
+
+        // Pick the better of the two valid final states (final token or
+        // trailing blank).
+        int sLastTok = 2 * n - 1;
+        int sLastBlank = 2 * n;
+        int lastRow = (numFrames - 1) * s_n;
+        int finalState = alpha[lastRow + sLastTok] >= alpha[lastRow + sLastBlank] ? sLastTok : sLastBlank;
+        if (float.IsNegativeInfinity(alpha[lastRow + finalState]))
+            throw new InvalidOperationException(
+                "Viterbi DP found no valid path. This usually means logProbs are degenerate "
+                + "(all -inf) or numFrames is too small for the target.");
+
+        // Backtrack: record state per frame.
+        var statePerFrame = new int[numFrames];
+        int state = finalState;
+        statePerFrame[numFrames - 1] = state;
+        for (int t = numFrames - 1; t > 0; t--)
+        {
+            sbyte choice = backptr[t * s_n + state];
+            state -= choice;  // 0=stay, 1=advance, 2=skip
+            statePerFrame[t - 1] = state;
+        }
+
+        // Aggregate frames per token-position. A token at original index k
+        // owns the frames where statePerFrame == 2k+1.
+        var startFrame = new int[n];
+        var endFrame = new int[n];
+        for (int k = 0; k < n; k++) { startFrame[k] = -1; endFrame[k] = -1; }
+        for (int t = 0; t < numFrames; t++)
+        {
+            int s = statePerFrame[t];
+            if (s % 2 == 1)  // odd state = token
+            {
+                int k = s / 2;
+                if (startFrame[k] < 0) startFrame[k] = t;
+                endFrame[k] = t;
+            }
+        }
+
+        var result = new TokenAlignment[n];
+        for (int k = 0; k < n; k++)
+        {
+            // A token with no frames assigned can happen if the Viterbi
+            // path skipped through it as a blank-flanked advance; we
+            // surface the degenerate case (start=end=-1 wouldn't be
+            // meaningful) by collapsing to the frame just before the
+            // next token took over, but in practice CTC Viterbi over
+            // a feasible target always assigns ≥1 frame per token.
+            int sf = startFrame[k] >= 0 ? startFrame[k] : (k > 0 ? endFrame[k - 1] : 0);
+            int ef = endFrame[k] >= 0 ? endFrame[k] : sf;
+            result[k] = new TokenAlignment(targetTokens[k], k, sf, ef);
+        }
+        return result;
+    }
+}

--- a/src/Vernacula.Base/Alignment/IForcedAligner.cs
+++ b/src/Vernacula.Base/Alignment/IForcedAligner.cs
@@ -1,0 +1,34 @@
+namespace Vernacula.Base.Alignment;
+
+/// <summary>
+/// Model-agnostic interface for forced-alignment backends. Given audio
+/// and the known text it contains, returns per-word audio-time
+/// alignments. Multiple implementations are expected (per issue #36):
+/// <see cref="NemoNfaAligner"/> for NeMo CTC checkpoints landed first;
+/// future MMS / wav2vec2 implementations plug behind the same interface.
+///
+/// Threading contract: implementations may hold expensive resources
+/// (ORT sessions, in-memory tokenizers). One instance per concurrent
+/// caller; the interface does not promise re-entrancy on a single
+/// instance.
+/// </summary>
+public interface IForcedAligner : IDisposable
+{
+    /// <summary>
+    /// Align <paramref name="text"/> to <paramref name="audio16k"/>.
+    /// </summary>
+    /// <param name="audio16k">Mono 16 kHz float32 PCM in [-1, 1].
+    /// Implementations resample if their underlying model expects
+    /// a different rate, but 16 kHz is the universal default.</param>
+    /// <param name="text">The reference text to align. Implementations
+    /// tokenize with whatever encoder the underlying model uses.</param>
+    /// <param name="languageIso">BCP-47 / ISO-639 hint, e.g. "en", "ja-Hira".
+    /// English-only aligners (<see cref="NemoNfaAligner"/> with the
+    /// recommended NVIDIA checkpoints) ignore this and assume English.
+    /// Multilingual aligners (future MMS) use it to gate phoneme inventory.</param>
+    /// <returns>Word timings in input order. Empty when text contains no
+    /// alignable tokens (e.g. punctuation-only). May omit words the
+    /// aligner couldn't place — callers should treat the result as a
+    /// best-effort alignment, not a 1:1 mapping of input words.</returns>
+    IReadOnlyList<WordTiming> Align(float[] audio16k, string text, string languageIso);
+}

--- a/src/Vernacula.Base/Alignment/NemoNfaAligner.cs
+++ b/src/Vernacula.Base/Alignment/NemoNfaAligner.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Inference;
+using Vernacula.Base.Models;
+
+namespace Vernacula.Base.Alignment;
+
+/// <summary>
+/// NFA-style forced aligner backed by a NeMo CTC ASR model exported via
+/// <c>scripts/nemo_export/export_nfa_ctc_to_onnx.py</c>. Loads the bundle,
+/// runs the preprocessor + CTC encoder, executes
+/// <see cref="CtcForcedAlignment.Align"/>, and groups sentencepiece
+/// tokens into words by the <c>▁</c> word-boundary marker.
+///
+/// Bundle expected on disk (per the export script's contract):
+///   nemo128.onnx              — log-mel preprocessor
+///   ctc-model.onnx            — encoder + CTC log-softmax head
+///   tokenizer.model           — sentencepiece model bytes
+///   export-report.json        — frame_shift_seconds + encoder_subsampling
+///                               + sample_rate metadata
+///
+/// Construction loads two ORT sessions and ~250 KB of SP model into
+/// memory — non-trivial cost; instantiate once per process and reuse.
+/// Not thread-safe per ORT's session semantics; one instance per
+/// concurrent caller.
+/// </summary>
+public sealed class NemoNfaAligner : IForcedAligner
+{
+    private readonly InferenceSession _preproc;
+    private readonly InferenceSession _ctc;
+    private readonly SimpleSpTokenizer _tokenizer;
+    private readonly int _vocabSize;     // V (excludes blank)
+    private readonly int _blankId;       // == V by export convention
+    private readonly double _secondsPerEncoderFrame;
+    private readonly int _expectedSampleRate;
+
+    // U+2581 LOWER ONE EIGHTH BLOCK — the sentencepiece word-boundary marker
+    // that prefixes the first token of each word in a Llama/SP vocab.
+    private const char SpWordBoundary = '▁';
+
+    /// <summary>Load the bundle at <paramref name="bundleDir"/>.</summary>
+    /// <param name="ep">Execution provider for the ORT sessions. Auto
+    /// resolves to CUDA when available, then DirectML, then CPU.</param>
+    public NemoNfaAligner(string bundleDir, ExecutionProvider ep = ExecutionProvider.Auto)
+    {
+        string preprocPath = Path.Combine(bundleDir, "nemo128.onnx");
+        string ctcPath = Path.Combine(bundleDir, "ctc-model.onnx");
+        string tokenizerPath = Path.Combine(bundleDir, "tokenizer.model");
+        string reportPath = Path.Combine(bundleDir, "export-report.json");
+
+        foreach (var p in new[] { preprocPath, ctcPath, tokenizerPath, reportPath })
+            if (!File.Exists(p))
+                throw new FileNotFoundException(
+                    $"NFA bundle missing required file: {p}. "
+                    + "Re-export via scripts/nemo_export/export_nfa_ctc_to_onnx.py.", p);
+
+        _preproc = OrtSessionBuilder.CreateCachedSession(preprocPath, ep);
+        _ctc = OrtSessionBuilder.CreateCachedSession(ctcPath, ep);
+
+        // SimpleSpTokenizer over vocab.txt — stopgap for Microsoft.ML.Tokenizers
+        // 2.0.0's unigram-SP loader bug on the NeMo FastConformer's SP model.
+        // See SimpleSpTokenizer's class docs for the quality envelope.
+        // (tokenizer.model is still in the bundle for a future drop-in when
+        // a working unigram-SP loader lands.)
+        _tokenizer = new SimpleSpTokenizer(Path.Combine(bundleDir, "vocab.txt"));
+        _vocabSize = _tokenizer.VocabSize;
+        _blankId = _vocabSize;
+
+        var report = JsonDocument.Parse(File.ReadAllText(reportPath)).RootElement;
+
+        // frame_shift_seconds and encoder_subsampling come from the
+        // export-report. Combined, they give the seconds-per-encoder-frame
+        // factor we use to convert frame indices → audio time.
+        double frameShift = report.GetProperty("frame_shift_seconds").GetDouble();
+        int subsampling = report.GetProperty("encoder_subsampling").GetInt32();
+        _secondsPerEncoderFrame = frameShift * subsampling;
+
+        _expectedSampleRate = report.TryGetProperty("sample_rate", out var srProp)
+            ? srProp.GetInt32() : 16000;
+    }
+
+    public IReadOnlyList<WordTiming> Align(float[] audio16k, string text, string languageIso)
+    {
+        if (audio16k.Length == 0 || string.IsNullOrWhiteSpace(text))
+            return Array.Empty<WordTiming>();
+
+        var (logProbs, numEncoderFrames, vocabPlusBlank) = RunPreprocAndCtc(audio16k);
+
+        // Tokenize the reference text. Greedy-LPM SP — ids correspond to
+        // the columns of logProbs (modulo blank at index _blankId).
+        var encoded = _tokenizer.Encode(text);
+        if (encoded.Count == 0) return Array.Empty<WordTiming>();
+
+        // CTC alignment can't handle a target with a blank in it.
+        // Defensive filter; SP shouldn't emit the blank piece.
+        var tokenIds = new List<int>(encoded.Count);
+        var tokenStrings = new List<string>(encoded.Count);
+        foreach (var (id, piece) in encoded)
+        {
+            if (id == _blankId) continue;
+            tokenIds.Add(id);
+            tokenStrings.Add(piece);
+        }
+        if (tokenIds.Count == 0) return Array.Empty<WordTiming>();
+
+        // Feasibility check: target needs at least N frames (+1 per
+        // same-token adjacency for the CTC blank between them).
+        int minFrames = tokenIds.Count;
+        for (int i = 1; i < tokenIds.Count; i++)
+            if (tokenIds[i] == tokenIds[i - 1]) minFrames++;
+        if (numEncoderFrames < minFrames)
+        {
+            // Audio is too short for the reference text. Return empty —
+            // the caller's transcript was longer than the audio could
+            // possibly contain. (We could throw, but empty matches the
+            // interface's "best-effort" doc.)
+            return Array.Empty<WordTiming>();
+        }
+
+        var tokenAlignments = CtcForcedAlignment.Align(
+            logProbs, numEncoderFrames, vocabPlusBlank, tokenIds, _blankId);
+
+        return GroupTokensIntoWords(tokenAlignments, tokenStrings, _secondsPerEncoderFrame);
+    }
+
+    /// <summary>
+    /// Group token-level alignments into word-level by sentencepiece's
+    /// <c>▁</c> word-boundary convention: a token starting with <c>▁</c>
+    /// begins a new word; tokens without <c>▁</c> continue the current
+    /// word. Word start = first token's start; word end = last token's end.
+    /// Internal-static so Vernacula.Tests can exercise it without
+    /// instantiating the full aligner (which needs the bundle on disk).
+    /// </summary>
+    internal static IReadOnlyList<WordTiming> GroupTokensIntoWords(
+        IReadOnlyList<TokenAlignment> tokenAlignments,
+        IReadOnlyList<string> tokenStrings,
+        double secondsPerEncoderFrame)
+    {
+        var words = new List<WordTiming>();
+        var currentPieces = new List<string>();
+        int currentStartFrame = -1;
+        int currentEndFrame = -1;
+
+        void Flush()
+        {
+            if (currentPieces.Count == 0) return;
+            // Join pieces, strip ALL word-boundary markers (just the leading
+            // one in well-formed SP output, but defensive). The output is
+            // the readable word.
+            string joined = string.Concat(currentPieces).Replace(SpWordBoundary.ToString(), "");
+            if (joined.Length > 0)
+            {
+                words.Add(new WordTiming(
+                    Text: joined,
+                    StartSeconds: currentStartFrame * secondsPerEncoderFrame,
+                    EndSeconds: (currentEndFrame + 1) * secondsPerEncoderFrame));
+            }
+            currentPieces.Clear();
+            currentStartFrame = -1;
+            currentEndFrame = -1;
+        }
+
+        for (int k = 0; k < tokenAlignments.Count; k++)
+        {
+            var ta = tokenAlignments[k];
+            string piece = tokenStrings[k];
+            // SP marks word starts with leading ▁. The very first token
+            // of a sentence may or may not have ▁ depending on
+            // AddDummyPrefix; treat the first token as a word start
+            // either way.
+            bool startsWord = currentPieces.Count == 0 || piece.StartsWith(SpWordBoundary);
+            if (startsWord) Flush();
+            if (currentStartFrame < 0) currentStartFrame = ta.StartFrame;
+            currentEndFrame = ta.EndFrame;
+            currentPieces.Add(piece);
+        }
+        Flush();
+        return words;
+    }
+
+    /// <summary>
+    /// Run the preprocessor and CTC graph on the audio. Returns the
+    /// CTC log-probs as a flat [T_enc * (V+1)] float[], plus T_enc and
+    /// V+1 for the Viterbi helper.
+    /// </summary>
+    private (float[] logProbs, int numEncoderFrames, int vocabPlusBlank) RunPreprocAndCtc(float[] audio16k)
+    {
+        // Preprocessor: waveforms [1, samples] + waveforms_lens [1] →
+        // features [1, 80, T_feat] + features_lens [1].
+        var wavTensor = new DenseTensor<float>(audio16k, new[] { 1, audio16k.Length });
+        var wavLens = new DenseTensor<long>(new long[] { audio16k.Length }, new[] { 1 });
+        DenseTensor<float> features;
+        DenseTensor<long> featuresLens;
+        using (var preprocOut = _preproc.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("waveforms", wavTensor),
+            NamedOnnxValue.CreateFromTensor("waveforms_lens", wavLens),
+        }))
+        {
+            var outList = preprocOut.ToList();
+            // The preprocessor returns features and features_lens in
+            // declaration order — features is rank-3, features_lens is
+            // rank-1. Materialize into fresh DenseTensors so the
+            // disposable can be released.
+            var featsRaw = outList[0].AsTensor<float>();
+            features = new DenseTensor<float>(featsRaw.ToArray(), featsRaw.Dimensions.ToArray());
+            var lensRaw = outList[1].AsTensor<long>();
+            featuresLens = new DenseTensor<long>(lensRaw.ToArray(), lensRaw.Dimensions.ToArray());
+        }
+
+        // CTC graph: audio_signal [B, 80, T_feat] + length [B] →
+        // logprobs [B, T_enc, V+1]. T_enc per batch = ceil(features_lens / subsampling),
+        // but ORT computes it for us — we just read it from the output shape.
+        using var ctcOut = _ctc.Run(new[]
+        {
+            NamedOnnxValue.CreateFromTensor("audio_signal", features),
+            NamedOnnxValue.CreateFromTensor("length", featuresLens),
+        });
+        var logProbsTensor = ctcOut.First().AsTensor<float>();
+        var shape = logProbsTensor.Dimensions.ToArray();
+        // shape = [1, T_enc, V+1]
+        int numEncoderFrames = shape[1];
+        int vocabPlusBlank = shape[2];
+        if (vocabPlusBlank != _vocabSize + 1)
+            throw new InvalidOperationException(
+                $"CTC output vocab dim ({vocabPlusBlank}) doesn't match expected V+1 ({_vocabSize + 1}). "
+                + "Bundle's vocab.txt and ctc-model.onnx are out of sync.");
+        return (logProbsTensor.ToArray(), numEncoderFrames, vocabPlusBlank);
+    }
+
+    public void Dispose()
+    {
+        _preproc.Dispose();
+        _ctc.Dispose();
+        // LlamaTokenizer doesn't implement IDisposable — its underlying
+        // SP model is GC-managed.
+    }
+}

--- a/src/Vernacula.Base/Alignment/NemoNfaAligner.cs
+++ b/src/Vernacula.Base/Alignment/NemoNfaAligner.cs
@@ -48,8 +48,9 @@ public sealed class NemoNfaAligner : IForcedAligner
         string ctcPath = Path.Combine(bundleDir, "ctc-model.onnx");
         string tokenizerPath = Path.Combine(bundleDir, "tokenizer.model");
         string reportPath = Path.Combine(bundleDir, "export-report.json");
+        string vocabPath = Path.Combine(bundleDir, "vocab.txt");
 
-        foreach (var p in new[] { preprocPath, ctcPath, tokenizerPath, reportPath })
+        foreach (var p in new[] { preprocPath, ctcPath, tokenizerPath, reportPath, vocabPath })
             if (!File.Exists(p))
                 throw new FileNotFoundException(
                     $"NFA bundle missing required file: {p}. "
@@ -63,7 +64,7 @@ public sealed class NemoNfaAligner : IForcedAligner
         // See SimpleSpTokenizer's class docs for the quality envelope.
         // (tokenizer.model is still in the bundle for a future drop-in when
         // a working unigram-SP loader lands.)
-        _tokenizer = new SimpleSpTokenizer(Path.Combine(bundleDir, "vocab.txt"));
+        _tokenizer = new SimpleSpTokenizer(vocabPath);
         _vocabSize = _tokenizer.VocabSize;
         _blankId = _vocabSize;
 
@@ -72,12 +73,37 @@ public sealed class NemoNfaAligner : IForcedAligner
         // frame_shift_seconds and encoder_subsampling come from the
         // export-report. Combined, they give the seconds-per-encoder-frame
         // factor we use to convert frame indices → audio time.
-        double frameShift = report.GetProperty("frame_shift_seconds").GetDouble();
-        int subsampling = report.GetProperty("encoder_subsampling").GetInt32();
+        // The export script writes both unconditionally, but a buggy /
+        // older bundle could have them null or missing — wrap with a
+        // bundle-explicit error rather than letting JsonElement throw
+        // its less-helpful InvalidOperationException.
+        double frameShift = RequireDouble(report, "frame_shift_seconds", reportPath);
+        int subsampling = RequireInt(report, "encoder_subsampling", reportPath);
         _secondsPerEncoderFrame = frameShift * subsampling;
 
         _expectedSampleRate = report.TryGetProperty("sample_rate", out var srProp)
+            && srProp.ValueKind == JsonValueKind.Number
             ? srProp.GetInt32() : 16000;
+    }
+
+    private static double RequireDouble(JsonElement obj, string name, string reportPath)
+    {
+        if (!obj.TryGetProperty(name, out var p) || p.ValueKind != JsonValueKind.Number)
+            throw new InvalidOperationException(
+                $"{reportPath}: missing or non-numeric '{name}'. Re-export via "
+                + "scripts/nemo_export/export_nfa_ctc_to_onnx.py with a current "
+                + "NeMo version that exposes the field.");
+        return p.GetDouble();
+    }
+
+    private static int RequireInt(JsonElement obj, string name, string reportPath)
+    {
+        if (!obj.TryGetProperty(name, out var p) || p.ValueKind != JsonValueKind.Number)
+            throw new InvalidOperationException(
+                $"{reportPath}: missing or non-numeric '{name}'. Re-export via "
+                + "scripts/nemo_export/export_nfa_ctc_to_onnx.py with a current "
+                + "NeMo version that exposes the field.");
+        return p.GetInt32();
     }
 
     public IReadOnlyList<WordTiming> Align(float[] audio16k, string text, string languageIso)
@@ -183,6 +209,13 @@ public sealed class NemoNfaAligner : IForcedAligner
     /// Run the preprocessor and CTC graph on the audio. Returns the
     /// CTC log-probs as a flat [T_enc * (V+1)] float[], plus T_enc and
     /// V+1 for the Viterbi helper.
+    ///
+    /// TODO(perf): when both sessions are CUDA-backed, chain via IoBinding
+    /// to keep features GPU-resident across the preproc→CTC handoff and
+    /// keep logprobs on-device until the host actually consumes them. At
+    /// typical alignment sizes (~410 KB of logprobs for 8 s, ~3 MB for
+    /// 60 s) the host roundtrip here is dominated by the CTC kernel cost,
+    /// so this is a deferred optimization, not urgent.
     /// </summary>
     private (float[] logProbs, int numEncoderFrames, int vocabPlusBlank) RunPreprocAndCtc(float[] audio16k)
     {
@@ -233,7 +266,7 @@ public sealed class NemoNfaAligner : IForcedAligner
     {
         _preproc.Dispose();
         _ctc.Dispose();
-        // LlamaTokenizer doesn't implement IDisposable — its underlying
-        // SP model is GC-managed.
+        // SimpleSpTokenizer doesn't implement IDisposable — its dictionaries
+        // are GC-managed.
     }
 }

--- a/src/Vernacula.Base/Alignment/SimpleSpTokenizer.cs
+++ b/src/Vernacula.Base/Alignment/SimpleSpTokenizer.cs
@@ -70,7 +70,23 @@ public sealed class SimpleSpTokenizer
         _pieceToId = new Dictionary<string, int>(pairs.Count, StringComparer.Ordinal);
         foreach (var (id, piece) in pairs) _pieceToId[piece] = id;
 
-        _unknownId = _pieceToId.TryGetValue(unknownToken, out var unkId) ? unkId : 0;
+        // When the vocab doesn't carry an <unk> entry (atypical for SP
+        // models but possible), we'd otherwise fall back to id 0 — which
+        // is usually a real token like <s> or a printable piece, not an
+        // unknown. Surface this at construction so silent OOV bugs don't
+        // bite at encode time. In-domain English text essentially never
+        // triggers the unknown branch, but the warning helps the next
+        // person hitting it.
+        if (!_pieceToId.TryGetValue(unknownToken, out var unkId))
+        {
+            Console.Error.WriteLine(
+                $"[SimpleSpTokenizer] WARNING: '{unknownToken}' not in {vocabPath}; "
+                + "OOV chars will be emitted as id 0 (which is probably not <unk>). "
+                + "For an in-domain English vocab this rarely matters; verify if your "
+                + "input contains unusual scripts or symbols.");
+            unkId = 0;
+        }
+        _unknownId = unkId;
     }
 
     /// <summary>Encode <paramref name="text"/> to (piece_id, piece_text) pairs.
@@ -106,6 +122,16 @@ public sealed class SimpleSpTokenizer
         // Strategy: build a working buffer that starts with ▁ and contains
         // the word; greedy-match longest prefix against vocab; emit; repeat
         // from the consumed offset.
+        //
+        // Edge case: if the vocab contains ▁ as a standalone piece AND
+        // doesn't contain the fused ▁{first-chars} form for this word, LPM
+        // will emit ▁ alone then restart on the bare word, producing two
+        // tokens where SP-unigram would emit one fused piece. The grouper
+        // downstream handles a leading ▁-only token gracefully (filtered
+        // as empty after the ▁-strip), so the audible alignment is still
+        // correct — just with a phantom zero-duration "word" that gets
+        // dropped. Doesn't matter for in-domain English; flagged here for
+        // anyone reusing this on a non-English or sparser vocab.
         string buf = SpWordBoundary + word.ToString();
         int pos = 0;
         while (pos < buf.Length)
@@ -132,7 +158,11 @@ public sealed class SimpleSpTokenizer
     {
         // Scan from longest possible match down to 1 char. The SP vocab
         // has a maximum piece length (typically <= 16 chars for English),
-        // so this O(maxLen × dict-lookup) per piece is fine.
+        // so this O(maxLen × dict-lookup) per piece is fine. 32 is an
+        // upper bound on the longest piece in NeMo FastConformer English
+        // vocabs we've seen; raise it if a different SP model loads
+        // pieces longer than that (would otherwise silently truncate the
+        // match search and produce sub-optimal tokenization).
         int maxTry = Math.Min(32, text.Length - start);
         for (int len = maxTry; len >= 1; len--)
         {

--- a/src/Vernacula.Base/Alignment/SimpleSpTokenizer.cs
+++ b/src/Vernacula.Base/Alignment/SimpleSpTokenizer.cs
@@ -1,0 +1,144 @@
+namespace Vernacula.Base.Alignment;
+
+/// <summary>
+/// Minimal greedy longest-prefix-match sentencepiece-style tokenizer
+/// over <c>vocab.txt</c>. Stopgap for forced-alignment input encoding
+/// while we wait for a working unigram-SP loader in
+/// <c>Microsoft.ML.Tokenizers</c> — version 2.0.0's
+/// <c>SentencePieceTokenizer.Create</c> throws <c>IndexOutOfRangeException</c>
+/// on the NeMo FastConformer's SP model (the loader's
+/// <c>SentencePieceUnigramModel..ctor</c> assumes BOS/EOS pieces the
+/// NeMo proto doesn't define).
+///
+/// Behavior:
+/// - Lowercases NOTHING (matches the <c>_pc</c> "punctuation + capitalization"
+///   models the export targets).
+/// - Splits the input on Unicode whitespace; prepends the SP word-boundary
+///   marker <c>▁</c> (U+2581) to the first piece of each word.
+/// - Greedy longest-prefix-match against vocab.txt entries. Falls back to
+///   the unknown token id when no prefix matches (skips the char so the
+///   tokenization makes forward progress; a more faithful byte-fallback
+///   would split into UTF-8 bytes and look up <c>&lt;0xXX&gt;</c> tokens).
+///
+/// Quality envelope: for clean in-domain English (the
+/// <c>stt_en_fastconformer_hybrid_large_pc</c> domain), greedy LPM
+/// matches the unigram-optimal tokenization most of the time; the worst
+/// case is occasional sub-optimal piece breaks (e.g. splitting "evening"
+/// as ▁ev/ening instead of ▁eve/ning) that change a few CTC-frame
+/// boundaries. Acceptable for word-level alignment; not appropriate
+/// for downstream uses needing exact-tokenization parity with the
+/// model's training pipeline.
+/// </summary>
+public sealed class SimpleSpTokenizer
+{
+    // U+2581 LOWER ONE EIGHTH BLOCK = sentencepiece word boundary
+    private const char SpWordBoundary = '▁';
+
+    private readonly Dictionary<string, int> _pieceToId;
+    private readonly string[] _idToPiece;
+    private readonly int _unknownId;
+
+    /// <summary>Number of vocabulary entries (excludes the CTC blank,
+    /// which lives at index <see cref="VocabSize"/> in the model's output
+    /// but isn't part of this tokenizer's surface).</summary>
+    public int VocabSize => _idToPiece.Length;
+
+    /// <summary>Build from vocab.txt. Expected format: one line per
+    /// piece, <c>{piece}{ws}{id}</c>. The trailing blank entry (id ==
+    /// vocab_size) is recognized and excluded from the tokenizer's
+    /// surface; the caller uses it as the CTC blank id directly.</summary>
+    public SimpleSpTokenizer(string vocabPath, string blankToken = "<blk>", string unknownToken = "<unk>")
+    {
+        var lines = File.ReadAllLines(vocabPath)
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .ToList();
+        // Build id → piece array; the file is already sorted by id so we
+        // just track the max id we see and pad. Skip the blank entry.
+        var pairs = new List<(int Id, string Piece)>(lines.Count);
+        foreach (var line in lines)
+        {
+            int sp = line.LastIndexOf(' ');
+            if (sp < 0) continue;
+            string piece = line.Substring(0, sp);
+            if (!int.TryParse(line.AsSpan(sp + 1), out int id)) continue;
+            if (piece == blankToken) continue;
+            pairs.Add((id, piece));
+        }
+        int maxId = pairs.Max(p => p.Id);
+        _idToPiece = new string[maxId + 1];
+        foreach (var (id, piece) in pairs) _idToPiece[id] = piece;
+        _pieceToId = new Dictionary<string, int>(pairs.Count, StringComparer.Ordinal);
+        foreach (var (id, piece) in pairs) _pieceToId[piece] = id;
+
+        _unknownId = _pieceToId.TryGetValue(unknownToken, out var unkId) ? unkId : 0;
+    }
+
+    /// <summary>Encode <paramref name="text"/> to (piece_id, piece_text) pairs.
+    /// Whitespace becomes the SP <c>▁</c> word-boundary marker on the next
+    /// piece. Punctuation is treated as part of the current word for the
+    /// purposes of greedy matching (the SP vocab contains pieces with and
+    /// without leading punctuation; LPM lets the longer matches win).</summary>
+    public List<(int Id, string Piece)> Encode(string text)
+    {
+        var result = new List<(int Id, string Piece)>();
+        if (string.IsNullOrEmpty(text)) return result;
+
+        // Split on whitespace runs into "words" (any non-whitespace span).
+        int i = 0;
+        int n = text.Length;
+        while (i < n)
+        {
+            // Skip leading whitespace.
+            while (i < n && char.IsWhiteSpace(text[i])) i++;
+            if (i >= n) break;
+            // Find the end of this whitespace-delimited span.
+            int wordStart = i;
+            while (i < n && !char.IsWhiteSpace(text[i])) i++;
+            int wordEnd = i;
+            // Prepend ▁ to mark the word start, then greedy LPM through it.
+            EncodeWordWithBoundary(text.AsSpan(wordStart, wordEnd - wordStart), result);
+        }
+        return result;
+    }
+
+    private void EncodeWordWithBoundary(ReadOnlySpan<char> word, List<(int Id, string Piece)> result)
+    {
+        // Strategy: build a working buffer that starts with ▁ and contains
+        // the word; greedy-match longest prefix against vocab; emit; repeat
+        // from the consumed offset.
+        string buf = SpWordBoundary + word.ToString();
+        int pos = 0;
+        while (pos < buf.Length)
+        {
+            int matchLen = LongestPrefixMatch(buf, pos);
+            if (matchLen == 0)
+            {
+                // No vocab piece matches even the single char at pos. Emit
+                // the unknown token and advance one char. (A faithful
+                // byte-fallback would emit one <0xXX> piece per UTF-8 byte;
+                // we trade fidelity for simplicity here since
+                // English-domain inputs hit this branch ~never.)
+                result.Add((_unknownId, _idToPiece[_unknownId] ?? "<unk>"));
+                pos++;
+                continue;
+            }
+            string piece = buf.Substring(pos, matchLen);
+            result.Add((_pieceToId[piece], piece));
+            pos += matchLen;
+        }
+    }
+
+    private int LongestPrefixMatch(string text, int start)
+    {
+        // Scan from longest possible match down to 1 char. The SP vocab
+        // has a maximum piece length (typically <= 16 chars for English),
+        // so this O(maxLen × dict-lookup) per piece is fine.
+        int maxTry = Math.Min(32, text.Length - start);
+        for (int len = maxTry; len >= 1; len--)
+        {
+            if (_pieceToId.ContainsKey(text.Substring(start, len)))
+                return len;
+        }
+        return 0;
+    }
+}

--- a/src/Vernacula.Base/Alignment/WordTiming.cs
+++ b/src/Vernacula.Base/Alignment/WordTiming.cs
@@ -1,0 +1,25 @@
+namespace Vernacula.Base.Alignment;
+
+/// <summary>
+/// One word's audio-time alignment as produced by an
+/// <see cref="IForcedAligner"/>. Times are seconds from the start of
+/// the audio buffer the aligner was given — callers translating to
+/// playback-absolute time (e.g. for long-form concatenated audio)
+/// add the chunk's audio offset themselves.
+///
+/// Source-position mapping (which character range in some source
+/// document this word came from) is deliberately NOT here — that's
+/// caller-side concern. The word-highlighting consumer in the
+/// Avalonia app combines these timings with the
+/// <see cref="Chatterbox.Base.Markdown.MarkdownTextExtractor"/>'s
+/// source-range index by matching the aligner's emitted word text
+/// against the extracted text's word stream.
+/// </summary>
+/// <param name="Text">The word as the aligner saw it. Sentencepiece-style
+/// tokens with the leading <c>▁</c> word-boundary marker have been
+/// joined and the marker stripped; this is human-readable.</param>
+/// <param name="StartSeconds">Start of the word in audio time.</param>
+/// <param name="EndSeconds">End of the word in audio time. May equal
+/// <see cref="StartSeconds"/> for zero-frame degenerate words; consumers
+/// should not assume strict inequality.</param>
+public sealed record WordTiming(string Text, double StartSeconds, double EndSeconds);

--- a/src/Vernacula.Base/Vernacula.Base.csproj
+++ b/src/Vernacula.Base/Vernacula.Base.csproj
@@ -40,6 +40,21 @@
   <ItemGroup>
     <PackageReference Include="NAudio"            Version="2.2.1" />
     <PackageReference Include="MathNet.Numerics"  Version="5.0.0" />
+    <!-- Note: NemoNfaAligner uses an in-house SimpleSpTokenizer (greedy LPM
+         over vocab.txt). Microsoft.ML.Tokenizers 2.0.0's
+         SentencePieceTokenizer.Create throws IndexOutOfRangeException on
+         the NeMo FastConformer's unigram-SP proto — the loader's
+         SentencePieceUnigramModel..ctor assumes BOS/EOS pieces the NeMo
+         model doesn't define. Drop in a real SP unigram loader (when
+         either ML.Tokenizers fixes the bug or a usable third-party lib
+         appears) by swapping SimpleSpTokenizer for it; tokenizer.model
+         is preserved in the export bundle for exactly that drop-in. -->
+  </ItemGroup>
+
+  <!-- Vernacula.Tests exercises internal helpers (e.g. NemoNfaAligner.GroupTokensIntoWords)
+       that are deliberately not part of the public API. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Vernacula.Tests" />
   </ItemGroup>
 
 </Project>

--- a/tests/Vernacula.Tests/CtcForcedAlignmentTests.cs
+++ b/tests/Vernacula.Tests/CtcForcedAlignmentTests.cs
@@ -1,0 +1,213 @@
+using Vernacula.Base.Alignment;
+using Xunit;
+
+namespace Vernacula.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="CtcForcedAlignment"/>. The Viterbi DP is the
+/// algorithmic heart of NFA-style forced alignment — tests fix correctness
+/// on hand-crafted log-prob matrices where the optimal path is known by
+/// construction, plus edge cases (single-token, same-token-repeat
+/// requiring inserted blank, target too long for frames).
+///
+/// Vocab convention in these tests: ids 0..V-1 are tokens, id V is blank.
+/// vocabPlusBlank = V+1.
+/// </summary>
+public class CtcForcedAlignmentTests
+{
+    // Helper: build a log-probs row that picks a clear winner at one
+    // column and pushes other columns to a tiny log-prob. Makes the
+    // optimal path unambiguous.
+    private static float[] OneHotFrame(int vocabPlusBlank, int hotCol, float hotLogp = -0.01f, float coldLogp = -10.0f)
+    {
+        var row = new float[vocabPlusBlank];
+        for (int i = 0; i < vocabPlusBlank; i++) row[i] = coldLogp;
+        row[hotCol] = hotLogp;
+        return row;
+    }
+
+    private static float[] Concat(params float[][] rows)
+    {
+        int len = rows.Sum(r => r.Length);
+        var flat = new float[len];
+        int off = 0;
+        foreach (var r in rows) { Array.Copy(r, 0, flat, off, r.Length); off += r.Length; }
+        return flat;
+    }
+
+    // ── Basic correctness ────────────────────────────────────────────
+
+    [Fact]
+    public void Single_token_single_frame_assigns_the_frame()
+    {
+        // vocab: [tok0=0, blank=1]. Target [0]. T=1, frame strongly favors tok0.
+        var logp = Concat(OneHotFrame(2, 0));
+        var result = CtcForcedAlignment.Align(logp, numFrames: 1, vocabPlusBlank: 2,
+            targetTokens: new[] { 0 }, blankId: 1);
+        Assert.Single(result);
+        Assert.Equal(0, result[0].StartFrame);
+        Assert.Equal(0, result[0].EndFrame);
+        Assert.Equal(0, result[0].TokenId);
+        Assert.Equal(0, result[0].TokenPosition);
+    }
+
+    [Fact]
+    public void Two_distinct_tokens_split_frames()
+    {
+        // Target [0, 1]. T=4. Frames 0-1 favor tok0; frames 2-3 favor tok1.
+        var logp = Concat(
+            OneHotFrame(3, 0), OneHotFrame(3, 0),
+            OneHotFrame(3, 1), OneHotFrame(3, 1));
+        var result = CtcForcedAlignment.Align(logp, numFrames: 4, vocabPlusBlank: 3,
+            targetTokens: new[] { 0, 1 }, blankId: 2);
+        Assert.Equal(2, result.Count);
+        // tok0 owns frames 0-1, tok1 owns frames 2-3.
+        Assert.Equal((0, 1), (result[0].StartFrame, result[0].EndFrame));
+        Assert.Equal((2, 3), (result[1].StartFrame, result[1].EndFrame));
+    }
+
+    [Fact]
+    public void Same_token_repeat_requires_blank_between()
+    {
+        // Target [0, 0]. T=3 (the minimum: tok-blank-tok).
+        // Frame 0 favors tok0, frame 1 favors blank, frame 2 favors tok0.
+        var logp = Concat(
+            OneHotFrame(2, 0),
+            OneHotFrame(2, 1),
+            OneHotFrame(2, 0));
+        var result = CtcForcedAlignment.Align(logp, numFrames: 3, vocabPlusBlank: 2,
+            targetTokens: new[] { 0, 0 }, blankId: 1);
+        Assert.Equal(2, result.Count);
+        Assert.Equal((0, 0), (result[0].StartFrame, result[0].EndFrame));
+        Assert.Equal((2, 2), (result[1].StartFrame, result[1].EndFrame));
+    }
+
+    // ── Error paths ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Empty_target_throws()
+    {
+        var logp = OneHotFrame(2, 0);
+        Assert.Throws<ArgumentException>(() =>
+            CtcForcedAlignment.Align(logp, 1, 2, Array.Empty<int>(), 1));
+    }
+
+    [Fact]
+    public void Target_too_long_for_frames_throws()
+    {
+        // Target [0, 1, 0]. Minimum T=3 (all distinct).
+        var logp = Concat(OneHotFrame(3, 0), OneHotFrame(3, 1));  // T=2
+        Assert.Throws<ArgumentException>(() =>
+            CtcForcedAlignment.Align(logp, 2, 3, new[] { 0, 1, 0 }, 2));
+    }
+
+    [Fact]
+    public void Same_token_pair_needs_blank_between_throws_when_T_too_small()
+    {
+        // Target [0, 0]. Minimum T=3 (tok-blank-tok). T=2 should fail.
+        var logp = Concat(OneHotFrame(2, 0), OneHotFrame(2, 0));
+        Assert.Throws<ArgumentException>(() =>
+            CtcForcedAlignment.Align(logp, 2, 2, new[] { 0, 0 }, 1));
+    }
+
+    [Fact]
+    public void Target_token_equals_blank_throws()
+    {
+        var logp = OneHotFrame(2, 0);
+        Assert.Throws<ArgumentException>(() =>
+            CtcForcedAlignment.Align(logp, 1, 2, new[] { 1 }, blankId: 1));
+    }
+
+    [Fact]
+    public void Blank_id_out_of_range_throws()
+    {
+        var logp = OneHotFrame(2, 0);
+        Assert.Throws<ArgumentException>(() =>
+            CtcForcedAlignment.Align(logp, 1, 2, new[] { 0 }, blankId: 99));
+    }
+
+    [Fact]
+    public void Target_token_out_of_range_throws()
+    {
+        var logp = OneHotFrame(2, 0);
+        Assert.Throws<ArgumentException>(() =>
+            CtcForcedAlignment.Align(logp, 1, 2, new[] { 99 }, blankId: 1));
+    }
+
+    // ── Realistic shape ──────────────────────────────────────────────
+
+    [Fact]
+    public void Trailing_blanks_after_last_token_are_handled()
+    {
+        // Target [0]. T=4. tok0 fires once at frame 0; the rest is blank.
+        var logp = Concat(
+            OneHotFrame(2, 0),
+            OneHotFrame(2, 1),
+            OneHotFrame(2, 1),
+            OneHotFrame(2, 1));
+        var result = CtcForcedAlignment.Align(logp, 4, 2, new[] { 0 }, 1);
+        Assert.Single(result);
+        // tok0 owns at least frame 0 (could extend if alpha[stay] beats blank).
+        Assert.Equal(0, result[0].StartFrame);
+        // End frame is wherever the Viterbi path last assigned the token,
+        // typically frame 0 here since blank dominates frames 1-3.
+        Assert.True(result[0].EndFrame >= 0);
+    }
+
+    [Fact]
+    public void Leading_blanks_before_first_token_are_handled()
+    {
+        // Target [0]. T=4. Blanks first, tok0 fires at frame 3.
+        var logp = Concat(
+            OneHotFrame(2, 1),
+            OneHotFrame(2, 1),
+            OneHotFrame(2, 1),
+            OneHotFrame(2, 0));
+        var result = CtcForcedAlignment.Align(logp, 4, 2, new[] { 0 }, 1);
+        Assert.Single(result);
+        Assert.Equal(3, result[0].StartFrame);
+        Assert.Equal(3, result[0].EndFrame);
+    }
+
+    [Fact]
+    public void Token_position_field_matches_input_order()
+    {
+        var logp = Concat(
+            OneHotFrame(4, 0), OneHotFrame(4, 1), OneHotFrame(4, 2));
+        var result = CtcForcedAlignment.Align(logp, 3, 4, new[] { 0, 1, 2 }, 3);
+        Assert.Equal(3, result.Count);
+        for (int k = 0; k < 3; k++)
+        {
+            Assert.Equal(k, result[k].TokenPosition);
+            Assert.Equal(k, result[k].TokenId);
+        }
+    }
+
+    [Fact]
+    public void Long_realistic_alignment_does_not_throw()
+    {
+        // 100 frames, 5-token target. Random-ish log-probs but with the
+        // target tokens slightly favored in chronological order so the
+        // optimal alignment is non-degenerate.
+        const int T = 100;
+        const int VPlusBlank = 6;  // 5 tokens + blank
+        const int blank = 5;
+        var target = new[] { 0, 1, 2, 3, 4 };
+        var logp = new float[T * VPlusBlank];
+        for (int t = 0; t < T; t++)
+        {
+            // Favor blank everywhere, slightly favor the chronologically-
+            // appropriate target token in its window.
+            for (int v = 0; v < VPlusBlank; v++) logp[t * VPlusBlank + v] = -2.0f;
+            logp[t * VPlusBlank + blank] = -1.0f;
+            int window = t * target.Length / T;
+            logp[t * VPlusBlank + target[Math.Min(window, target.Length - 1)]] = -0.5f;
+        }
+        var result = CtcForcedAlignment.Align(logp, T, VPlusBlank, target, blank);
+        Assert.Equal(5, result.Count);
+        // Tokens should be in monotone-increasing frame order.
+        for (int k = 1; k < 5; k++)
+            Assert.True(result[k].StartFrame >= result[k - 1].StartFrame,
+                $"token {k} starts before token {k - 1}");
+    }
+}

--- a/tests/Vernacula.Tests/Vernacula.Tests.csproj
+++ b/tests/Vernacula.Tests/Vernacula.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- CPU-only test host. Same convention as tests/Chatterbox.Tests:
+         override the Vernacula.Base EP to Cpu so the test process doesn't
+         need CUDA at runtime. CtcForcedAlignment is pure-CPU. -->
+    <Platforms>x64</Platforms>
+    <RootNamespace>Vernacula.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit.v3" Version="1.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
+      <Private>true</Private>
+      <SetConfiguration>EP=Cpu</SetConfiguration>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/Vernacula.Tests/WordGroupingTests.cs
+++ b/tests/Vernacula.Tests/WordGroupingTests.cs
@@ -1,0 +1,134 @@
+using Vernacula.Base.Alignment;
+using Xunit;
+
+namespace Vernacula.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="NemoNfaAligner.GroupTokensIntoWords"/>. The
+/// grouping is pure-data — takes per-token alignments and SP-prefixed
+/// token strings, returns word-level timings — so testing it in isolation
+/// (without loading the NeMo bundle) is the right cost/coverage trade.
+/// </summary>
+public class WordGroupingTests
+{
+    // ▁ = U+2581, the sentencepiece word-boundary marker. Tokens starting
+    // with this character begin a new word; tokens without it continue
+    // the current word.
+    private const string SP = "▁";
+    private const double FrameSec = 0.08;  // FastConformer encoder: 10 ms hop × 8 subsampling
+
+    private static TokenAlignment TA(int pos, int start, int end) =>
+        new(TokenId: 0, TokenPosition: pos, StartFrame: start, EndFrame: end);
+
+    [Fact]
+    public void Single_word_single_token()
+    {
+        var alignments = new[] { TA(0, 0, 4) };
+        var strings = new[] { SP + "hello" };
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        Assert.Single(words);
+        Assert.Equal("hello", words[0].Text);
+        Assert.Equal(0.0, words[0].StartSeconds, 5);
+        Assert.Equal(5 * FrameSec, words[0].EndSeconds, 5);  // (endFrame=4)+1 frames * sec/frame
+    }
+
+    [Fact]
+    public void Single_word_multi_subword_tokens()
+    {
+        // "▁hello" + "world" (no ▁ on the 2nd → glued to the first)
+        var alignments = new[] { TA(0, 0, 2), TA(1, 3, 5) };
+        var strings = new[] { SP + "hello", "world" };
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        Assert.Single(words);
+        Assert.Equal("helloworld", words[0].Text);
+        Assert.Equal(0.0, words[0].StartSeconds, 5);
+        Assert.Equal(6 * FrameSec, words[0].EndSeconds, 5);
+    }
+
+    [Fact]
+    public void Two_words_each_with_word_boundary_marker()
+    {
+        // "▁the" + "▁quick"
+        var alignments = new[] { TA(0, 0, 2), TA(1, 4, 7) };
+        var strings = new[] { SP + "the", SP + "quick" };
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        Assert.Equal(2, words.Count);
+        Assert.Equal("the", words[0].Text);
+        Assert.Equal("quick", words[1].Text);
+        Assert.Equal(0.0, words[0].StartSeconds, 5);
+        Assert.Equal(3 * FrameSec, words[0].EndSeconds, 5);
+        Assert.Equal(4 * FrameSec, words[1].StartSeconds, 5);
+        Assert.Equal(8 * FrameSec, words[1].EndSeconds, 5);
+    }
+
+    [Fact]
+    public void First_token_without_word_boundary_still_starts_a_word()
+    {
+        // SP's AddDummyPrefix=false case: the very first token of a
+        // sentence may not have ▁. The grouper must still treat it as
+        // a word start so the output isn't empty.
+        var alignments = new[] { TA(0, 0, 3) };
+        var strings = new[] { "Hello" };  // no leading ▁
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        Assert.Single(words);
+        Assert.Equal("Hello", words[0].Text);
+    }
+
+    [Fact]
+    public void Three_words_with_multi_subword_middle_word()
+    {
+        // "▁the" + "▁en" + "vironment" + "▁is" — "environment" splits
+        // across two subwords; middle word should still group correctly.
+        var alignments = new[] {
+            TA(0, 0, 1),
+            TA(1, 2, 3),
+            TA(2, 4, 7),
+            TA(3, 9, 10),
+        };
+        var strings = new[] { SP + "the", SP + "en", "vironment", SP + "is" };
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        Assert.Equal(3, words.Count);
+        Assert.Equal("the", words[0].Text);
+        Assert.Equal("environment", words[1].Text);
+        Assert.Equal("is", words[2].Text);
+        // middle word spans frames 2..7 → 2*FrameSec to 8*FrameSec
+        Assert.Equal(2 * FrameSec, words[1].StartSeconds, 5);
+        Assert.Equal(8 * FrameSec, words[1].EndSeconds, 5);
+    }
+
+    [Fact]
+    public void Empty_token_list_returns_empty()
+    {
+        var words = NemoNfaAligner.GroupTokensIntoWords(
+            Array.Empty<TokenAlignment>(), Array.Empty<string>(), FrameSec);
+        Assert.Empty(words);
+    }
+
+    [Fact]
+    public void Word_boundary_only_token_is_emitted_as_empty_and_skipped()
+    {
+        // Pathological: a token consisting of just ▁ (no following chars).
+        // After stripping ▁, the joined word is empty — should be filtered.
+        var alignments = new[] { TA(0, 0, 1), TA(1, 2, 3) };
+        var strings = new[] { SP, SP + "hello" };
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        Assert.Single(words);
+        Assert.Equal("hello", words[0].Text);
+    }
+
+    [Fact]
+    public void Timings_use_frame_plus_one_convention_for_end()
+    {
+        // End time = (endFrame + 1) * sec/frame so a single-frame token
+        // gets a non-zero duration (start = end_inclusive=N → start=N*F,
+        // end=(N+1)*F). Important for click-to-position UX: zero-width
+        // intervals don't highlight cleanly.
+        var alignments = new[] { TA(0, 5, 5) };  // single frame 5
+        var strings = new[] { SP + "x" };
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        Assert.Single(words);
+        Assert.Equal(5 * FrameSec, words[0].StartSeconds, 5);
+        Assert.Equal(6 * FrameSec, words[0].EndSeconds, 5);
+        Assert.True(words[0].EndSeconds > words[0].StartSeconds);
+    }
+}

--- a/tests/Vernacula.Tests/WordGroupingTests.cs
+++ b/tests/Vernacula.Tests/WordGroupingTests.cs
@@ -117,6 +117,22 @@ public class WordGroupingTests
     }
 
     [Fact]
+    public void Word_boundary_on_first_token_does_not_emit_extra_empty_word()
+    {
+        // Regression: the grouper's `startsWord = first-token || piece.StartsWith(▁)`
+        // would trigger Flush() on an empty buffer at the very first token
+        // when the token starts with ▁ (the common case). Flush's early-return
+        // at "currentPieces.Count == 0" must prevent an extra empty word.
+        var alignments = new[] { TA(0, 0, 2), TA(1, 4, 5) };
+        var strings = new[] { SP + "hello", SP + "world" };
+        var words = NemoNfaAligner.GroupTokensIntoWords(alignments, strings, FrameSec);
+        // Expect exactly 2 words; no leading empty word from the first-token Flush.
+        Assert.Equal(2, words.Count);
+        Assert.Equal("hello", words[0].Text);
+        Assert.Equal("world", words[1].Text);
+    }
+
+    [Fact]
     public void Timings_use_frame_plus_one_convention_for_end()
     {
         // End time = (endFrame + 1) * sec/frame so a single-frame token


### PR DESCRIPTION
## Summary

Builds on PR #70's NFA ONNX export with the C# Viterbi side: `IForcedAligner` interface, shared `CtcForcedAlignment` Viterbi DP, and the `NemoNfaAligner` concrete implementation.

**End-to-end smoke** against a real NeMo bundle on 8 s of conversational English (`stt_en_fastconformer_hybrid_large_pc` exported via PR #70) produces 30 sensible word timings:

```
aligner load: 883 ms
align: 287 ms, 30 words
  [0.080 - 0.160]  All
  [0.320 - 0.560]  kinds
  [0.640 - 0.720]  of
  [0.720 - 1.200]  telephone
  [1.280 - 1.600]  calls.
  [1.600 - 1.760]  Of
  [1.760 - 2.080]  course,
  ...
  [7.520 - 8.080]  Garrett.
```

(reference text spanned 00:00:00–00:00:08 per the source transcript; the alignment hugs that envelope correctly.)

## What's in this PR

**`src/Vernacula.Base/Alignment/`** (5 new files):

| File | Role |
|---|---|
| `IForcedAligner.cs` | Model-agnostic interface per issue #36 spec |
| `WordTiming.cs` | `(Text, StartSeconds, EndSeconds)` record |
| `CtcForcedAlignment.cs` | Static Viterbi DP — modified-CTC algorithm with 2N+1 blanked target, stay/advance/skip transitions, backtrack aggregating frames per token. Returns `TokenAlignment[]`. |
| `NemoNfaAligner.cs` | Concrete `IForcedAligner` over the PR-#70 bundle. Loads `nemo128.onnx` + `ctc-model.onnx` + vocab + metadata; pipeline: text → SP tokens → preproc → CTC → Viterbi → SP-▁ word grouping → frame×(`frame_shift_seconds × encoder_subsampling`). |
| `SimpleSpTokenizer.cs` | Greedy LPM SP-style tokenizer over `vocab.txt` (see "Tokenizer caveat" below). |

**`tests/Vernacula.Tests/`** (new xunit.v3 CPU-only project):

- `CtcForcedAlignmentTests.cs` — **13 tests**: single-token, distinct pairs, same-token-repeat (needs blank between), error paths (empty target, target-too-long, blank-id mismatch, token-out-of-range), leading/trailing blanks, monotonic frame order on a 100-frame 5-token alignment
- `WordGroupingTests.cs` — **8 tests**: single/multi-subword words, two-word `▁` boundary, first-token-without-`▁` edge case, mixed three-word with subword split, empty input, `▁`-only token filtered, `frame+1` end-time convention

**All 21 tests pass.** `InternalsVisibleTo("Vernacula.Tests")` added so the tests exercise `NemoNfaAligner.GroupTokensIntoWords` directly without loading the bundle.

## Tokenizer caveat (real, documented)

`Microsoft.ML.Tokenizers 2.0.0`'s `SentencePieceTokenizer.Create` throws `IndexOutOfRangeException` on the NeMo FastConformer's unigram-SP proto — the loader's `SentencePieceUnigramModel..ctor` assumes BOS/EOS pieces NeMo's ASR model doesn't define.

Workaround: **`SimpleSpTokenizer`** — greedy longest-prefix-match over `vocab.txt`. For clean in-domain English (the model's training domain), greedy LPM matches unigram-optimal tokenization most of the time; the worst case is occasional sub-optimal piece breaks that change a few CTC-frame boundaries. Acceptable for word-level alignment UX; not appropriate for tasks needing exact training-pipeline parity.

**Drop-in replacement path** is clean: `tokenizer.model` is preserved in the export bundle, and `NemoNfaAligner` holds a single `SimpleSpTokenizer` field — swap that for a real SP unigram loader (when ML.Tokenizers fixes the bug or a usable third-party lib appears) and the rest of the pipeline works unchanged. The csproj has an inline note explaining this.

## Algorithm reference

`CtcForcedAlignment.Align` implements the standard modified-Viterbi for CTC forced alignment (same algorithm as `torchaudio.functional.forced_align`, NeMo NFA's own Viterbi, the MMS aligner). Class docstring carries the full description; the DP is ~100 LOC, allocation-free in the inner loop.

## Notes for reviewers

- **Pure-CPU code** — no CUDA branch in the Viterbi or grouping. The aligner's ORT sessions run on whatever EP is passed (default `Auto` → CUDA → DirectML → CPU).
- **`NemoNfaAligner` is `IDisposable`** — owns two ORT sessions. One instance per concurrent caller (ORT session thread-safety).
- The `NemoNfaAligner.Align` method returns an empty list for inputs the alignment can't fit (audio too short for the reference text). Caller treats the result as best-effort per the interface docs.
- No tests for `NemoNfaAligner.Align` itself in this PR — that would need a model fixture or a mock ORT session. End-to-end smoke (this PR description) is the integration coverage; the per-method unit tests cover the algorithmic pieces (Viterbi, word grouping).

## Intentionally deferred to follow-up PRs (issue #36 scope)

- **Real SP unigram loader** — replace `SimpleSpTokenizer` when ML.Tokenizers fixes its loader or a usable third-party lib appears
- **`TranscriptionService` wiring** behind a Settings toggle — the cross-backend integration that unlocks word timings for Cohere/Qwen3/Granite/VibeVoice
- **Chatterbox CLI per-chunk alignment + JSON sidecar** — Stage 1 #9's Chatterbox-specific consumer (the audiobook reader)
- **HF bundle upload + model card** under `christopherthompson81/`
- **Cross-language benchmark doc** at `docs/dev/forced_alignment_investigation.md` per issue #36's DoD
- **Avalonia app word-highlighting consumer**

## Test plan

- [ ] CI build green
- [ ] `dotnet test tests/Vernacula.Tests/` → 21/21 pass
- [ ] Run the alignment end-to-end on a fresh `nfa_ctc_onnx` bundle + a known English audio sample; verify timings look monotonic and word boundaries are within ~100 ms of audible word starts/ends
- [ ] `NemoNfaAligner.Dispose` cleans up both ORT sessions (no resource leak in a long-running host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)