### PR TITLE
Chatterbox CLI: --alignment-out for per-word JSON sidecar

### DIFF
--- a/src/Chatterbox.CLI/Program.cs
+++ b/src/Chatterbox.CLI/Program.cs
@@ -16,6 +16,7 @@ using System.Globalization;
 using Chatterbox.Base;
 using Chatterbox.Base.Markdown;
 using NAudio.Wave;
+using Vernacula.Base.Alignment;
 using Vernacula.Base.Models;
 
 // ── Argument parsing ──────────────────────────────────────────────────────────
@@ -26,6 +27,8 @@ string? outPath       = null;
 string? text          = null;
 string? textFile      = null;
 string? tokenizerJson = null;
+string? alignmentOut  = null;  // JSON sidecar of per-word audio timings
+string? nfaBundle     = null;  // path to scripts/nemo_export/export_nfa_ctc_to_onnx.py output dir
 string  ep            = "auto";
 bool    verbose       = false;
 bool?   useIoBinding  = null;
@@ -60,6 +63,8 @@ try
             case "--text":           text          = Next("--text", i);           i++; break;
             case "--text-file":      textFile      = Next("--text-file", i);      i++; break;
             case "--tokenizer-json": tokenizerJson = Next("--tokenizer-json", i); i++; break;
+            case "--alignment-out":  alignmentOut  = Next("--alignment-out", i);  i++; break;
+            case "--nfa-bundle":     nfaBundle     = Next("--nfa-bundle", i);     i++; break;
             case "--ep":             ep            = Next("--ep", i).ToLowerInvariant(); i++; break;
             case "--verbose" or "-v": verbose      = true; break;
             case "--io-binding":     useIoBinding  = true; break;
@@ -144,6 +149,24 @@ voicePath = ExpandHome(voicePath);
 outPath   = ExpandHome(outPath ?? "chatterbox_out.wav");
 if (textFile is not null) textFile = ExpandHome(textFile);
 if (tokenizerJson is not null) tokenizerJson = ExpandHome(tokenizerJson);
+if (alignmentOut is not null) alignmentOut = ExpandHome(alignmentOut);
+if (nfaBundle is not null) nfaBundle = ExpandHome(nfaBundle);
+
+// --alignment-out requires --nfa-bundle. The aligner needs the exported
+// CTC ASR bundle; we don't auto-discover it because there's no canonical
+// location and we don't want to silently align with the wrong model.
+if (alignmentOut is not null && nfaBundle is null)
+{
+    Console.Error.WriteLine(
+        "--alignment-out requires --nfa-bundle <dir>. Export via "
+        + "scripts/nemo_export/export_nfa_ctc_to_onnx.py and pass the output dir here.");
+    return 2;
+}
+if (nfaBundle is not null && !Directory.Exists(nfaBundle))
+{
+    Console.Error.WriteLine($"--nfa-bundle not found: {nfaBundle}");
+    return 1;
+}
 
 if (!Directory.Exists(onnxDir))
 {
@@ -245,7 +268,10 @@ if (verbose) Console.WriteLine(
 // overhead for those. Tokenization happens per-path (whole text once vs per
 // chunk) so we don't waste a tokenize-everything pass on the chunked path.
 var chunks = ParagraphChunker.Chunk(textToSpeak);
-float[] samples;
+// Per-chunk audio is preserved past the synthesis step so the alignment
+// pass below can resample + align each chunk independently. Both branches
+// populate chunkAudios[] in input order; the final WAV is concat-of-chunks.
+float[][] chunkAudios;
 if (chunks.Count <= 1)
 {
     // One-shot path (existing behavior).
@@ -263,7 +289,15 @@ if (chunks.Count <= 1)
         $"LM: {lmResult.Steps} steps, generated {lmResult.RawGeneratedTokens.Count - 1} tokens");
 
     var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
-    samples = pipeline.Vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+    var oneShotAudio = pipeline.Vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+    // Normalize the one-shot path to the same shape as the chunked path
+    // (single-element chunkAudios + a one-element chunks list). Keeps the
+    // alignment + WAV-write code below path-agnostic. If the chunker
+    // returned 0 entries (defensive — shouldn't happen since we already
+    // checked textToSpeak isn't whitespace-only), treat the input as the
+    // single chunk so the alignment metadata still has a text reference.
+    if (chunks.Count == 0) chunks.Add(textToSpeak);
+    chunkAudios = new[] { oneShotAudio };
 }
 else
 {
@@ -296,20 +330,99 @@ else
         }
     }
 
-    // Concatenate per-chunk waveforms in input order. No fades / silence
-    // injection between chunks — paragraph boundaries already cue the TTS
-    // to taper naturally, and the LM's STOP_SPEECH emits a brief trailing
-    // silence per chunk.
-    int totalSamples = result.Waveforms.Sum(w => w.Length);
-    samples = new float[totalSamples];
+    chunkAudios = result.Waveforms.ToArray();
+}
+
+// Concatenate per-chunk waveforms for the WAV write. No fades / silence
+// injection between chunks — paragraph boundaries already cue the TTS
+// to taper naturally, and the LM's STOP_SPEECH emits a brief trailing
+// silence per chunk.
+int totalSamples = chunkAudios.Sum(w => w.Length);
+var samples = new float[totalSamples];
+{
     int off = 0;
-    foreach (var w in result.Waveforms)
+    foreach (var w in chunkAudios)
     {
         Array.Copy(w, 0, samples, off, w.Length);
         off += w.Length;
     }
 }
 synthSw.Stop();
+
+// ── Forced alignment (optional, --alignment-out) ──────────────────────────────
+// Per-chunk: resample 24 kHz → 16 kHz, run NemoNfaAligner against the
+// chunk's reference text, translate chunk-relative timings to absolute
+// playback time via the cumulative chunk-sample offset. JSON sidecar
+// holds a flat words list (sorted by start_seconds) + a chunks summary;
+// flat is what the Avalonia app's binary-search-by-playback-time lookup
+// will need.
+if (alignmentOut is not null)
+{
+    var alignSw = Stopwatch.StartNew();
+    using var aligner = new NemoNfaAligner(nfaBundle!, epEnum);
+    if (verbose)
+        Console.WriteLine($"Aligning {chunks.Count} chunk(s) against {nfaBundle} ...");
+
+    var allWords = new List<object>();
+    var chunkRecords = new List<object>();
+    int sampleOffset = 0;
+    for (int i = 0; i < chunkAudios.Length; i++)
+    {
+        var chunkAudio24k = chunkAudios[i];
+        double chunkStartSec = sampleOffset / (double)ChatterboxConstants.S3GenSr;
+        double chunkEndSec = (sampleOffset + chunkAudio24k.Length) / (double)ChatterboxConstants.S3GenSr;
+        sampleOffset += chunkAudio24k.Length;
+
+        // 24 kHz mono float → 16 kHz mono float via AudioUtils. The cleanup
+        // pass (75 Hz HPF + mains-hum notches) is harmless for TTS audio
+        // and matches what other ASR consumers in Vernacula get.
+        var chunkAudio16k = Vernacula.Base.AudioUtils.AudioTo16000Mono(
+            chunkAudio24k, ChatterboxConstants.S3GenSr, channels: 1);
+        var words = aligner.Align(chunkAudio16k, chunks[i], "en");
+
+        foreach (var w in words)
+        {
+            allWords.Add(new
+            {
+                text = w.Text,
+                start_seconds = chunkStartSec + w.StartSeconds,
+                end_seconds = chunkStartSec + w.EndSeconds,
+                chunk_index = i,
+            });
+        }
+        chunkRecords.Add(new
+        {
+            index = i,
+            audio_start_seconds = chunkStartSec,
+            audio_end_seconds = chunkEndSec,
+            text = chunks[i],
+            word_count = words.Count,
+        });
+        if (verbose)
+            Console.WriteLine($"  chunk {i + 1}/{chunkAudios.Length}: "
+                + $"{chunkAudio24k.Length / (double)ChatterboxConstants.S3GenSr:F2}s audio → "
+                + $"{words.Count} aligned words");
+    }
+    alignSw.Stop();
+
+    var payload = new
+    {
+        audio_path = outPath,
+        sample_rate = ChatterboxConstants.S3GenSr,
+        audio_duration_seconds = totalSamples / (double)ChatterboxConstants.S3GenSr,
+        aligner = "nemo_nfa",
+        nfa_bundle = nfaBundle,
+        chunks = chunkRecords,
+        words = allWords,
+    };
+    var json = System.Text.Json.JsonSerializer.Serialize(payload,
+        new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+    File.WriteAllText(alignmentOut, json);
+
+    if (verbose)
+        Console.WriteLine($"Alignment: {alignSw.ElapsedMilliseconds} ms, "
+            + $"{allWords.Count} words → {alignmentOut}");
+}
 
 // ── Write WAV ─────────────────────────────────────────────────────────────────
 
@@ -363,6 +476,12 @@ static void PrintUsage()
                                    directml needs OnnxRuntime.DirectML).
           --tokenizer-json <path>  Path to chatterbox tokenizer.json. Default:
                                    auto-locate from the HF hub cache.
+          --alignment-out <path>   Write a JSON sidecar with per-word audio timings,
+                                   one entry per spoken word with absolute playback
+                                   start/end seconds. Requires --nfa-bundle.
+          --nfa-bundle <dir>       NFA CTC ASR bundle directory exported by
+                                   scripts/nemo_export/export_nfa_ctc_to_onnx.py.
+                                   Required when --alignment-out is set.
           --io-binding /           Force GPU-resident KV-cache chaining for the LM.
           --no-io-binding          Default: auto-detect from the effective EP.
           --exaggeration <float>   Conditioning scalar passed to embed_tokens. Default: 0.5.

--- a/src/Chatterbox.CLI/Program.cs
+++ b/src/Chatterbox.CLI/Program.cs
@@ -292,11 +292,9 @@ if (chunks.Count <= 1)
     var oneShotAudio = pipeline.Vocoder.Synthesize(speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
     // Normalize the one-shot path to the same shape as the chunked path
     // (single-element chunkAudios + a one-element chunks list). Keeps the
-    // alignment + WAV-write code below path-agnostic. If the chunker
-    // returned 0 entries (defensive — shouldn't happen since we already
-    // checked textToSpeak isn't whitespace-only), treat the input as the
-    // single chunk so the alignment metadata still has a text reference.
-    if (chunks.Count == 0) chunks.Add(textToSpeak);
+    // alignment + WAV-write code below path-agnostic. The textToSpeak
+    // whitespace check at the top of this section guarantees the chunker
+    // returns ≥1 entries, so we don't guard chunks.Count == 0 here.
     chunkAudios = new[] { oneShotAudio };
 }
 else
@@ -415,9 +413,18 @@ if (alignmentOut is not null)
         chunks = chunkRecords,
         words = allWords,
     };
+    // Snake-case schema (start_seconds, chunk_index, ...) is part of the
+    // consumer contract — don't add PropertyNamingPolicy.CamelCase here
+    // unless you also update every downstream parser. Default options
+    // preserve declared anonymous-type member names verbatim.
     var json = System.Text.Json.JsonSerializer.Serialize(payload,
         new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
-    File.WriteAllText(alignmentOut, json);
+    // Atomic write: serialize to a sibling .tmp, then rename. A SIGINT
+    // mid-File.WriteAllText would otherwise leave a truncated JSON that
+    // downstream consumers fail to parse.
+    var tmpPath = alignmentOut + ".tmp";
+    File.WriteAllText(tmpPath, json);
+    File.Move(tmpPath, alignmentOut, overwrite: true);
 
     if (verbose)
         Console.WriteLine($"Alignment: {alignSw.ElapsedMilliseconds} ms, "


### PR DESCRIPTION
## Summary

Wires PR #71's `NemoNfaAligner` into `Chatterbox.CLI`'s long-form synthesis path. Adds two CLI flags so a single invocation produces both the WAV and a JSON sidecar of per-word audio timings:

```
--alignment-out <path>   JSON sidecar with per-word audio timings
--nfa-bundle <dir>       NFA CTC ASR bundle (export via PR #70's
                         scripts/nemo_export/export_nfa_ctc_to_onnx.py)
```

This is the data the Avalonia app's word-highlighting consumer will read for click-to-position playback and follow-the-bouncing-ball during playback (Stage 1 #10). Chatterbox Stage 1 #9 is now fully wired end-to-end.

## What changed

**`src/Chatterbox.CLI/Program.cs`** (single file, +128/-9):

1. **Flag parsing + validation** — `--alignment-out` requires `--nfa-bundle` (validated at arg-parse; helpful error vs silently aligning with the wrong/no model)
2. **Synthesis path refactor** — both branches (`chunks ≤ 1` one-shot, `chunks > 1` long-form) now populate `chunkAudios[][]` in input order. The single-element case is the normalization for the one-shot path. WAV concatenation moved out of the chunked branch into a single block consuming either shape. Keeps the alignment + WAV-write code path-agnostic.
3. **Alignment pass** — when `--alignment-out` set: construct `NemoNfaAligner` once, resample each chunk 24 kHz → 16 kHz via `Vernacula.Base.AudioUtils.AudioTo16000Mono`, align against chunk reference text, translate chunk-relative timings to absolute via cumulative chunk-sample offsets, write JSON
4. **Help text** updated

## JSON schema

```json
{
  "audio_path": "...wav",
  "sample_rate": 24000,
  "audio_duration_seconds": 16.76,
  "aligner": "nemo_nfa",
  "nfa_bundle": "/path/to/nfa_ctc_onnx",
  "chunks": [
    { "index": 0, "audio_start_seconds": 0.0, "audio_end_seconds": 1.20,
      "text": "A short story.", "word_count": 3 },
    ...
  ],
  "words": [
    { "text": "A", "start_seconds": 0.16, "end_seconds": 0.24, "chunk_index": 0 },
    { "text": "short", "start_seconds": 0.32, "end_seconds": 0.40, "chunk_index": 0 },
    ...
  ]
}
```

`words[]` is the flat list sorted by `start_seconds` — what the Avalonia app's binary-search-by-playback-time lookup needs. `chunks[]` is the per-chunk summary for callers that want to render by chunk (e.g. show the current paragraph's reference text).

## End-to-end smoke

Re-exported the Chatterbox bundle to `/mnt/data/models/chatterbox_export/` (~3.7 GB, monolithic vocoder) + used the existing `/mnt/data/models/nfa_ctc_onnx/` NFA bundle from PR #70. Ran the CLI on a 3-paragraph short-story sample:

```
Chunked into 3 paragraphs (min/max char count: 14/147)
  chunk 1/3: LM 235 ms (31 steps), voc 1081 ms, audio 1.20s
  chunk 2/3: LM 1600 ms (196 steps), voc 1274 ms, audio 7.80s
  chunk 3/3: LM 1831 ms (195 steps), voc 945 ms, audio 7.76s
Aligning 3 chunk(s) against /mnt/data/models/nfa_ctc_onnx ...
  chunk 1/3: 1.20s audio → 3 aligned words
  chunk 2/3: 7.80s audio → 23 aligned words
  chunk 3/3: 7.76s audio → 24 aligned words
Alignment: 804 ms, 50 words → /tmp/cb_align_out.json
Synthesized 16.76s of audio
```

**JSON output verified**:
- 50 words with monotonically increasing absolute timestamps
- Final word "before." ends at 16.68s (close to total audio 16.76s)
- Chunk boundaries line up (chunk 2 starts at 1.20s where chunk 1 ended)
- Word timings look acoustically plausible ("grandfather" gets 0.56s for 3 syllables; function words like "a"/"the" 0.08-0.12s)

## Notes for reviewers

- **No new tests in this PR** — the new code is procedural orchestration (flag dispatch + JSON write). The alignment algorithm itself is covered by PR #71's 22 unit tests. The dispatch is covered by the end-to-end smoke above; I'd add a Vernacula.Tests case if the orchestration grows beyond ~50 lines.
- **Source-position mapping (markdown char range → spoken word) is deliberately deferred** to the Avalonia app PR. The current JSON schema is forward-compatible — extra fields like `source_char_start`/`source_char_end` can be added without breaking the flat-words consumer pattern.
- **`AudioTo16000Mono` includes a "cleanup" pass** (75 Hz HPF + mains-hum notches at 50/60 Hz). Harmless for TTS-synthesized audio and matches what other ASR consumers in Vernacula get. Avoiding it would mean duplicating the resampler logic with a "no cleanup" variant — not worth it for forced-alignment use.
- **Both paths now allocate per-chunk audio arrays** even when alignment isn't requested. Negligible overhead (a few MB for the longest realistic input); the simpler code path is worth it.

## Stage 1 + issue #36 progress

| | Status |
|---|---|
| Chatterbox Stage 1 #9 (forced alignment) | **✅ complete** (this PR closes the wiring loop) |
| Chatterbox Stage 1 #10 (Avalonia app) | Not started — JSON sidecar from this PR is the input |
| Issue #36 part 1 (NFA export) | ✅ PR #70 |
| Issue #36 part 2 (C# Viterbi) | ✅ PR #71 |
| Issue #36 part 3+ (TranscriptionService wiring, HF bundle, benchmark doc, MMS aligner) | Not started |

## Test plan

- [ ] CI build green
- [ ] `chatterbox --onnx-dir <chatterbox-bundle> --voice <wav> --text-file <some.md> --out <wav> --alignment-out <json> --nfa-bundle <nfa-bundle>` produces both files; JSON parses; word timings are monotonic; final word's end ≤ audio duration
- [ ] `--alignment-out` without `--nfa-bundle` exits with the validation error
- [ ] Existing CLI invocations without `--alignment-out` still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)