### PR TITLE
Chatterbox.Avalonia MVP: reader app (Stage 1 #10)

### DIFF
--- a/Vernacula.slnx
+++ b/Vernacula.slnx
@@ -21,6 +21,9 @@
   <Project Path="src/Vernacula.Avalonia/Vernacula.Avalonia.csproj">
     <Platform Project="x64" />
   </Project>
+  <Project Path="src/Chatterbox.Avalonia/Chatterbox.Avalonia.csproj">
+    <Platform Project="x64" />
+  </Project>
   <Project Path="tests/IndicConformerTest/IndicConformerTest.csproj">
     <Platform Project="x64" />
   </Project>

--- a/src/Chatterbox.Avalonia/App.axaml
+++ b/src/Chatterbox.Avalonia/App.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Chatterbox.App.App"
+             RequestedThemeVariant="Default">
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+
+</Application>

--- a/src/Chatterbox.Avalonia/App.axaml.cs
+++ b/src/Chatterbox.Avalonia/App.axaml.cs
@@ -1,0 +1,24 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using Chatterbox.App.ViewModels;
+using Chatterbox.App.Views;
+
+namespace Chatterbox.App;
+
+public sealed class App : Application
+{
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow
+            {
+                DataContext = new MainViewModel(),
+            };
+        }
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/Chatterbox.Avalonia/Chatterbox.Avalonia.csproj
+++ b/src/Chatterbox.Avalonia/Chatterbox.Avalonia.csproj
@@ -40,12 +40,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Matches Vernacula.Avalonia.csproj's ProjectReference style:
+         no Private attribute (defaults to true). EP property flows
+         through to base projects via SetConfiguration. -->
     <ProjectReference Include="..\Chatterbox.Base\Chatterbox.Base.csproj">
-      <Private>true</Private>
       <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>
     <ProjectReference Include="..\Vernacula.Base\Vernacula.Base.csproj">
-      <Private>true</Private>
       <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>
   </ItemGroup>

--- a/src/Chatterbox.Avalonia/Chatterbox.Avalonia.csproj
+++ b/src/Chatterbox.Avalonia/Chatterbox.Avalonia.csproj
@@ -1,0 +1,53 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Chatterbox.App</RootNamespace>
+    <AssemblyName>Chatterbox.App</AssemblyName>
+    <!-- Default to CUDA. Other EPs (Cpu, DirectML) are buildable via -p:EP=...
+         and flow through to Chatterbox.Base + Vernacula.Base. -->
+    <EP Condition="'$(EP)' == ''">Cuda</EP>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
+  <!-- Avalonia 11.3 + Fluent theme + Markdown rendering, mirroring
+       Vernacula.Avalonia's stack so a future merge is mechanical. -->
+  <ItemGroup>
+    <PackageReference Include="Avalonia"                    Version="11.3.9" />
+    <PackageReference Include="Avalonia.Desktop"            Version="11.3.9" />
+    <PackageReference Include="Avalonia.Themes.Fluent"      Version="11.3.9" />
+    <PackageReference Include="Avalonia.Fonts.Inter"        Version="11.3.9" />
+    <PackageReference Include="CommunityToolkit.Mvvm"       Version="8.4.0" />
+    <PackageReference Include="Markdown.Avalonia"           Version="11.0.2" />
+    <PackageReference Include="NAudio"                      Version="2.2.1" />
+  </ItemGroup>
+
+  <!-- Both pull OnnxRuntime under PrivateAssets, so we provide the
+       runtime variant explicitly via the EP property — matches the
+       pattern Chatterbox.CLI uses. -->
+  <ItemGroup Condition="'$(EP)' == 'Cuda'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(EP)' == 'Cpu'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chatterbox.Base\Chatterbox.Base.csproj">
+      <Private>true</Private>
+      <SetConfiguration>EP=$(EP)</SetConfiguration>
+    </ProjectReference>
+    <ProjectReference Include="..\Vernacula.Base\Vernacula.Base.csproj">
+      <Private>true</Private>
+      <SetConfiguration>EP=$(EP)</SetConfiguration>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/src/Chatterbox.Avalonia/Models/AlignmentSidecar.cs
+++ b/src/Chatterbox.Avalonia/Models/AlignmentSidecar.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Chatterbox.App.Models;
+
+/// <summary>
+/// Deserialized shape of the JSON sidecar emitted by Chatterbox.CLI
+/// (`--alignment-out` flag, PR #72). The snake_case JSON keys are
+/// mapped via <see cref="JsonPropertyNameAttribute"/> rather than a
+/// global naming policy so the consumer contract is explicit per
+/// field.
+/// </summary>
+public sealed class AlignmentSidecar
+{
+    [JsonPropertyName("audio_path")]
+    public string AudioPath { get; set; } = "";
+
+    [JsonPropertyName("sample_rate")]
+    public int SampleRate { get; set; }
+
+    [JsonPropertyName("audio_duration_seconds")]
+    public double AudioDurationSeconds { get; set; }
+
+    [JsonPropertyName("aligner")]
+    public string Aligner { get; set; } = "";
+
+    [JsonPropertyName("chunks")]
+    public List<ChunkRecord> Chunks { get; set; } = new();
+
+    [JsonPropertyName("words")]
+    public List<AlignedWord> Words { get; set; } = new();
+}
+
+public sealed class ChunkRecord
+{
+    [JsonPropertyName("index")]              public int Index { get; set; }
+    [JsonPropertyName("audio_start_seconds")] public double AudioStartSeconds { get; set; }
+    [JsonPropertyName("audio_end_seconds")]   public double AudioEndSeconds { get; set; }
+    [JsonPropertyName("text")]                public string Text { get; set; } = "";
+    [JsonPropertyName("word_count")]          public int WordCount { get; set; }
+}
+
+public sealed class AlignedWord
+{
+    [JsonPropertyName("text")]          public string Text { get; set; } = "";
+    [JsonPropertyName("start_seconds")] public double StartSeconds { get; set; }
+    [JsonPropertyName("end_seconds")]   public double EndSeconds { get; set; }
+    [JsonPropertyName("chunk_index")]   public int ChunkIndex { get; set; }
+}

--- a/src/Chatterbox.Avalonia/Program.cs
+++ b/src/Chatterbox.Avalonia/Program.cs
@@ -1,0 +1,20 @@
+using Avalonia;
+
+namespace Chatterbox.App;
+
+/// <summary>
+/// Avalonia entry point. The actual UI lives in <see cref="App"/>;
+/// this is just the static AppBuilder boilerplate.
+/// </summary>
+internal static class Program
+{
+    [System.STAThread]
+    public static int Main(string[] args)
+        => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -31,7 +31,6 @@ public sealed class PlaybackService : IDisposable
     private Process? _ffplayProcess;
     private DispatcherTimer? _tickTimer;
     private DateTime _startedUtc;
-    private string? _audioPath;
     private double _audioDurationSec;
 
     /// <summary>True when audio is currently playing (or believed to be —
@@ -62,7 +61,6 @@ public sealed class PlaybackService : IDisposable
         if (!File.Exists(audioPath))
             throw new FileNotFoundException("Audio file not found.", audioPath);
 
-        _audioPath = audioPath;
         _audioDurationSec = audioDurationSec;
 
         if (OperatingSystem.IsWindows())

--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Avalonia.Threading;
+using NAudio.Wave;
+
+namespace Chatterbox.App.Services;
+
+/// <summary>
+/// Cross-platform audio playback for the reader UI. Mirrors the
+/// pattern from Vernacula.Avalonia.TranscriptEditorViewModel:
+///
+///   - Windows: NAudio's WaveOutEvent (WinMM)
+///   - Other  : shell out to ffplay via Process.Start
+///
+/// A <see cref="DispatcherTimer"/> ticks at 50 ms regardless of
+/// playback backend, raising <see cref="PositionChanged"/> with the
+/// current playback time in seconds — the word-highlight loop binds
+/// to that event.
+///
+/// MVP only supports play / stop. Pause and seek are deliberately
+/// out of scope; the next iteration would add them once the highlight
+/// loop is verified visually.
+/// </summary>
+public sealed class PlaybackService : IDisposable
+{
+    private static readonly string? FfplayPath = FindExecutable("ffplay");
+
+    private WaveOutEvent? _waveOut;
+    private AudioFileReader? _reader;
+    private Process? _ffplayProcess;
+    private DispatcherTimer? _tickTimer;
+    private DateTime _startedUtc;
+    private string? _audioPath;
+    private double _audioDurationSec;
+
+    /// <summary>True when audio is currently playing (or believed to be —
+    /// the ffplay process may have already exited and we haven't
+    /// noticed yet).</summary>
+    public bool IsPlaying { get; private set; }
+
+    /// <summary>Current playback time in seconds from the start of the file.</summary>
+    public double PositionSeconds { get; private set; }
+
+    /// <summary>Fired on every <see cref="DispatcherTimer"/> tick during
+    /// playback (50 ms). Argument is current position in seconds.</summary>
+    public event Action<double>? PositionChanged;
+
+    /// <summary>Fired when playback finishes naturally (EOF) or is stopped
+    /// via <see cref="Stop"/>. Argument is the final position.</summary>
+    public event Action<double>? PlaybackStopped;
+
+    public bool CanPlayOnThisPlatform => OperatingSystem.IsWindows() || FfplayPath is not null;
+
+    public string? UnavailableReason => CanPlayOnThisPlatform
+        ? null
+        : "Audio playback requires Windows audio output or an `ffplay` executable in PATH.";
+
+    public void Play(string audioPath, double audioDurationSec)
+    {
+        Stop();
+        if (!File.Exists(audioPath))
+            throw new FileNotFoundException("Audio file not found.", audioPath);
+
+        _audioPath = audioPath;
+        _audioDurationSec = audioDurationSec;
+
+        if (OperatingSystem.IsWindows())
+        {
+            _reader = new AudioFileReader(audioPath);
+            _waveOut = new WaveOutEvent();
+            _waveOut.Init(_reader);
+            _waveOut.PlaybackStopped += OnWaveOutStopped;
+            _waveOut.Play();
+        }
+        else
+        {
+            if (FfplayPath is null)
+                throw new InvalidOperationException(UnavailableReason!);
+            if (!StartFfplay(audioPath))
+                throw new InvalidOperationException("Failed to start ffplay.");
+        }
+
+        IsPlaying = true;
+        PositionSeconds = 0;
+        _startedUtc = DateTime.UtcNow;
+        StartTickTimer();
+    }
+
+    public void Stop()
+    {
+        if (!IsPlaying && _tickTimer is null) return;
+
+        StopTickTimer();
+        if (_waveOut is not null)
+        {
+            _waveOut.PlaybackStopped -= OnWaveOutStopped;
+            try { _waveOut.Stop(); } catch { /* shutdown race */ }
+            _waveOut.Dispose();
+            _waveOut = null;
+        }
+        if (_reader is not null) { _reader.Dispose(); _reader = null; }
+        if (_ffplayProcess is not null)
+        {
+            try { if (!_ffplayProcess.HasExited) _ffplayProcess.Kill(entireProcessTree: true); }
+            catch { /* shutdown race */ }
+            _ffplayProcess.Dispose();
+            _ffplayProcess = null;
+        }
+        var finalPos = PositionSeconds;
+        IsPlaying = false;
+        PlaybackStopped?.Invoke(finalPos);
+    }
+
+    private void StartTickTimer()
+    {
+        _tickTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(50) };
+        _tickTimer.Tick += (_, _) =>
+        {
+            // Wall-clock-derived position. The audio backend's own clock
+            // would be slightly more accurate but adds backend-specific
+            // plumbing (WaveOut.GetPosition / parse ffplay -progress);
+            // wall-clock is good enough for the highlight loop's 50 ms
+            // tick + the alignment's per-word boundaries.
+            double pos = (DateTime.UtcNow - _startedUtc).TotalSeconds;
+            PositionSeconds = Math.Min(pos, _audioDurationSec);
+            PositionChanged?.Invoke(PositionSeconds);
+            if (PositionSeconds >= _audioDurationSec) Stop();
+        };
+        _tickTimer.Start();
+    }
+
+    private void StopTickTimer()
+    {
+        _tickTimer?.Stop();
+        _tickTimer = null;
+    }
+
+    private void OnWaveOutStopped(object? sender, StoppedEventArgs e)
+        => Dispatcher.UIThread.InvokeAsync(Stop);
+
+    private bool StartFfplay(string audioPath)
+    {
+        if (FfplayPath is null) return false;
+        var psi = new ProcessStartInfo(FfplayPath)
+        {
+            UseShellExecute = false,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("-nodisp");
+        psi.ArgumentList.Add("-autoexit");
+        psi.ArgumentList.Add("-loglevel"); psi.ArgumentList.Add("error");
+        psi.ArgumentList.Add(audioPath);
+
+        var p = new Process { StartInfo = psi, EnableRaisingEvents = true };
+        p.Exited += (_, _) => Dispatcher.UIThread.InvokeAsync(Stop);
+        if (!p.Start())
+        {
+            p.Dispose();
+            return false;
+        }
+        // Drain stdout/stderr so the pipe doesn't backpressure ffplay.
+        _ = p.StandardOutput.ReadToEndAsync();
+        _ = p.StandardError.ReadToEndAsync();
+        _ffplayProcess = p;
+        return true;
+    }
+
+    /// <summary>Locate an executable in the user's PATH. Returns null when
+    /// not found. Same logic as Vernacula.Avalonia's helper.</summary>
+    private static string? FindExecutable(string fileName)
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv)) return null;
+        char sep = OperatingSystem.IsWindows() ? ';' : ':';
+        string[] exts = OperatingSystem.IsWindows() ? new[] { ".exe", ".bat", ".cmd" } : new[] { "" };
+        foreach (var dir in pathEnv.Split(sep))
+        {
+            if (string.IsNullOrWhiteSpace(dir)) continue;
+            foreach (var ext in exts)
+            {
+                var candidate = Path.Combine(dir, fileName + ext);
+                if (File.Exists(candidate)) return candidate;
+            }
+        }
+        return null;
+    }
+
+    public void Dispose() => Stop();
+}

--- a/src/Chatterbox.Avalonia/Services/SynthesisService.cs
+++ b/src/Chatterbox.Avalonia/Services/SynthesisService.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatterbox.App.Models;
+using Chatterbox.Base;
+using Chatterbox.Base.Markdown;
+using NAudio.Wave;
+using Vernacula.Base.Alignment;
+using Vernacula.Base.Models;
+
+namespace Chatterbox.App.Services;
+
+/// <summary>
+/// One-call synthesis + alignment for the reader UI. Mirrors what
+/// Chatterbox.CLI's `--alignment-out` path does end-to-end, just
+/// in-process and structured for the UI to consume:
+/// (audio WAV path, alignment data) returned together.
+///
+/// Sessions are lazily loaded on the first call and reused across
+/// subsequent invocations — the pipeline load is the big sticky cost
+/// (~5-10 s for Chatterbox + ~1 s for NFA), and rebuilding it per
+/// click would make the UI feel slow.
+/// </summary>
+public sealed class SynthesisService : IDisposable
+{
+    private readonly string _onnxBundleDir;
+    private readonly string? _nfaBundleDir;
+    private readonly string? _tokenizerJsonPath;
+    private readonly ExecutionProvider _ep;
+
+    private ChatterboxPipeline? _pipeline;
+    private NemoNfaAligner? _aligner;
+    private readonly object _gate = new();
+
+    /// <param name="onnxBundleDir">Path to the Chatterbox ONNX bundle
+    /// (output of scripts/chatterbox_export/export_chatterbox_to_onnx.py).</param>
+    /// <param name="nfaBundleDir">Optional NFA bundle path. When null,
+    /// synthesis runs without producing alignment data (the returned
+    /// <see cref="AlignmentSidecar.Words"/> stays empty).</param>
+    /// <param name="tokenizerJsonPath">Optional override for the
+    /// Chatterbox tokenizer.json; null = auto-locate from HF hub cache.</param>
+    public SynthesisService(
+        string onnxBundleDir,
+        string? nfaBundleDir = null,
+        string? tokenizerJsonPath = null,
+        ExecutionProvider ep = ExecutionProvider.Auto)
+    {
+        _onnxBundleDir = onnxBundleDir;
+        _nfaBundleDir = nfaBundleDir;
+        _tokenizerJsonPath = tokenizerJsonPath;
+        _ep = ep;
+    }
+
+    public sealed record SynthesisResult(string AudioPath, AlignmentSidecar Alignment);
+
+    /// <summary>
+    /// Synthesize <paramref name="text"/> in the voice of
+    /// <paramref name="voicePath"/>, write a WAV to <paramref name="outWavPath"/>,
+    /// and (when an NFA bundle is configured) produce per-word audio
+    /// timings. Runs on whatever thread you call it from — the UI
+    /// should call this via Task.Run to keep the dispatcher responsive.
+    /// </summary>
+    public SynthesisResult Synthesize(
+        string voicePath,
+        string text,
+        string outWavPath,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureLoaded();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Markdown-extract when text looks like markdown (loose heuristic:
+        // any of the common block markers). For the MVP this lets users
+        // paste markdown directly into the UI's text box; richer file-vs-
+        // string handling can come later.
+        var preparedText = LooksLikeMarkdown(text)
+            ? MarkdownTextExtractor.Extract(text).Text
+            : text;
+        if (string.IsNullOrWhiteSpace(preparedText))
+            throw new InvalidOperationException("Text is empty after markdown extraction.");
+
+        var chunks = ParagraphChunker.Chunk(preparedText);
+        var spk = _pipeline!.Embedder.Embed(voicePath);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        float[][] chunkAudios;
+        if (chunks.Count <= 1)
+        {
+            var tokenIds = _pipeline.Tokenizer!.WrapForLm(preparedText);
+            var lmResult = _pipeline.Lm.Generate(spk.CondEmb, tokenIds);
+            var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
+            var samples = _pipeline.Vocoder.Synthesize(
+                speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+            chunkAudios = new[] { samples };
+        }
+        else
+        {
+            var tokensPerChunk = chunks.Select(c => _pipeline.Tokenizer!.WrapForLm(c)).ToArray();
+            var synth = new ChunkedSynthesizer(_pipeline);
+            var result = synth.Synthesize(spk, tokensPerChunk);
+            chunkAudios = result.Waveforms.ToArray();
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Concatenate + write WAV (24 kHz mono float32 — same as CLI).
+        int totalSamples = chunkAudios.Sum(w => w.Length);
+        var allSamples = new float[totalSamples];
+        int off = 0;
+        foreach (var w in chunkAudios)
+        {
+            Array.Copy(w, 0, allSamples, off, w.Length);
+            off += w.Length;
+        }
+        var fmt = WaveFormat.CreateIeeeFloatWaveFormat(ChatterboxConstants.S3GenSr, 1);
+        using (var writer = new WaveFileWriter(outWavPath, fmt))
+            writer.WriteSamples(allSamples, 0, allSamples.Length);
+
+        // Alignment. When no NFA bundle is configured, return an empty
+        // sidecar (audio-only mode) — UI still shows playback, just
+        // without word highlighting.
+        var sidecar = new AlignmentSidecar
+        {
+            AudioPath = outWavPath,
+            SampleRate = ChatterboxConstants.S3GenSr,
+            AudioDurationSeconds = totalSamples / (double)ChatterboxConstants.S3GenSr,
+            Aligner = _aligner is null ? "none" : "nemo_nfa",
+        };
+        if (_aligner is not null)
+        {
+            int sampleOffset = 0;
+            for (int i = 0; i < chunkAudios.Length; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var chunkAudio24k = chunkAudios[i];
+                double chunkStartSec = sampleOffset / (double)ChatterboxConstants.S3GenSr;
+                double chunkEndSec = (sampleOffset + chunkAudio24k.Length) / (double)ChatterboxConstants.S3GenSr;
+                sampleOffset += chunkAudio24k.Length;
+
+                var chunkAudio16k = Vernacula.Base.AudioUtils.AudioTo16000Mono(
+                    chunkAudio24k, ChatterboxConstants.S3GenSr, channels: 1);
+                var words = _aligner.Align(chunkAudio16k, chunks[i], "en");
+
+                sidecar.Chunks.Add(new ChunkRecord
+                {
+                    Index = i,
+                    AudioStartSeconds = chunkStartSec,
+                    AudioEndSeconds = chunkEndSec,
+                    Text = chunks[i],
+                    WordCount = words.Count,
+                });
+                foreach (var w in words)
+                {
+                    sidecar.Words.Add(new AlignedWord
+                    {
+                        Text = w.Text,
+                        StartSeconds = chunkStartSec + w.StartSeconds,
+                        EndSeconds = chunkStartSec + w.EndSeconds,
+                        ChunkIndex = i,
+                    });
+                }
+            }
+        }
+        return new SynthesisResult(outWavPath, sidecar);
+    }
+
+    private void EnsureLoaded()
+    {
+        if (_pipeline is not null) return;
+        lock (_gate)
+        {
+            if (_pipeline is not null) return;
+            _pipeline = new ChatterboxPipeline(_onnxBundleDir, _ep, _tokenizerJsonPath);
+            if (_nfaBundleDir is not null && Directory.Exists(_nfaBundleDir))
+                _aligner = new NemoNfaAligner(_nfaBundleDir, _ep);
+        }
+    }
+
+    private static bool LooksLikeMarkdown(string text)
+        => text.Contains("\n#") || text.Contains("\n- ") || text.Contains("\n* ")
+           || text.Contains("\n```") || text.StartsWith("#") || text.StartsWith("- ");
+
+    public void Dispose()
+    {
+        _aligner?.Dispose();
+        _pipeline?.Dispose();
+    }
+}

--- a/src/Chatterbox.Avalonia/Services/SynthesisService.cs
+++ b/src/Chatterbox.Avalonia/Services/SynthesisService.cs
@@ -62,6 +62,12 @@ public sealed class SynthesisService : IDisposable
     /// and (when an NFA bundle is configured) produce per-word audio
     /// timings. Runs on whatever thread you call it from — the UI
     /// should call this via Task.Run to keep the dispatcher responsive.
+    ///
+    /// <paramref name="cancellationToken"/> is checked at chunk boundaries
+    /// and after the synthesis call. The underlying LM rollout
+    /// (<c>pipeline.Lm.Generate</c>) is uninterruptible once started —
+    /// a cancel during the ~30 s single-chunk rollout will take effect
+    /// only after that chunk completes.
     /// </summary>
     public SynthesisResult Synthesize(
         string voicePath,
@@ -72,13 +78,16 @@ public sealed class SynthesisService : IDisposable
         EnsureLoaded();
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Markdown-extract when text looks like markdown (loose heuristic:
-        // any of the common block markers). For the MVP this lets users
-        // paste markdown directly into the UI's text box; richer file-vs-
-        // string handling can come later.
-        var preparedText = LooksLikeMarkdown(text)
-            ? MarkdownTextExtractor.Extract(text).Text
-            : text;
+        // Always route the input through MarkdownTextExtractor. For plain
+        // prose the extractor is near-identity (paragraphs preserved). For
+        // markdown it strips heading markers / list bullets / link URLs /
+        // code blocks etc., none of which speak well. The CLI is fine
+        // dispatching on file extension (.md → extract, else pass-through)
+        // because it knows the source; the UI's text box doesn't carry an
+        // extension hint, and "always extract" is the safer default —
+        // false negatives from a heuristic would let raw URL text leak
+        // into the TTS stream.
+        var preparedText = MarkdownTextExtractor.Extract(text).Text;
         if (string.IsNullOrWhiteSpace(preparedText))
             throw new InvalidOperationException("Text is empty after markdown extraction.");
 
@@ -177,10 +186,6 @@ public sealed class SynthesisService : IDisposable
                 _aligner = new NemoNfaAligner(_nfaBundleDir, _ep);
         }
     }
-
-    private static bool LooksLikeMarkdown(string text)
-        => text.Contains("\n#") || text.Contains("\n- ") || text.Contains("\n* ")
-           || text.Contains("\n```") || text.StartsWith("#") || text.StartsWith("- ");
 
     public void Dispose()
     {

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Chatterbox.App.Models;
+using Chatterbox.App.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Chatterbox.App.ViewModels;
+
+/// <summary>
+/// Single VM for the reader MVP. State lives here:
+/// pickers (voice / Chatterbox bundle / NFA bundle), text, last
+/// synthesis result, playback position, current highlighted word
+/// index into <see cref="Words"/>. Bindings are compiled at AXAML
+/// load (csproj's AvaloniaUseCompiledBindingsByDefault=true).
+/// </summary>
+public sealed partial class MainViewModel : ObservableObject, IDisposable
+{
+    // Pickers — paths the user fills in via file/folder dialogs.
+    [ObservableProperty] private string _voicePath = "";
+    [ObservableProperty] private string _onnxBundleDir = "";
+    [ObservableProperty] private string _nfaBundleDir = "";
+
+    // Text input — either typed/pasted in the UI or loaded from a .md file.
+    [ObservableProperty] private string _text = "";
+
+    // Status line below the synthesize button.
+    [ObservableProperty] private string _statusMessage = "Ready.";
+
+    // True while a synthesis task is running. Disables most UI controls.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    private bool _isBusy;
+
+    // True after a successful synthesis — enables Play and the highlight loop.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    private bool _hasSynthesizedAudio;
+
+    // The aligned words from the last synthesis as per-item VMs so the
+    // AXAML can class-trigger the highlight on IsCurrent without a
+    // multi-binding converter.
+    public ObservableCollection<WordItemViewModel> Words { get; } = new();
+
+    // Index into Words[] of the word currently being spoken (or -1 when
+    // not playing or before the first word). Internal — UI doesn't bind
+    // to this directly, the per-word IsCurrent does the work.
+    private int _currentWordIndex = -1;
+
+    // Read-only audio position label for the UI footer.
+    [ObservableProperty] private string _positionLabel = "0.00 / 0.00 s";
+
+    private AlignmentSidecar? _lastAlignment;
+    private SynthesisService? _synthService;
+    private readonly PlaybackService _playback = new();
+    private CancellationTokenSource? _synthCts;
+
+    public MainViewModel()
+    {
+        _playback.PositionChanged += OnPlaybackPositionChanged;
+        _playback.PlaybackStopped += _ => Dispatcher.UIThread.Post(() =>
+        {
+            if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
+                Words[_currentWordIndex].IsCurrent = false;
+            _currentWordIndex = -1;
+            StatusMessage = "Playback stopped.";
+        });
+
+        if (!_playback.CanPlayOnThisPlatform)
+            StatusMessage = _playback.UnavailableReason!;
+    }
+
+    [RelayCommand]
+    private async Task PickVoiceAsync()
+    {
+        var path = await PickFileAsync("Pick a voice reference WAV",
+            new FilePickerFileType("Audio") { Patterns = new[] { "*.wav", "*.flac", "*.mp3" } });
+        if (path is not null) VoicePath = path;
+    }
+
+    [RelayCommand]
+    private async Task PickOnnxBundleAsync()
+    {
+        var path = await PickFolderAsync("Pick the Chatterbox ONNX bundle directory");
+        if (path is not null) OnnxBundleDir = path;
+    }
+
+    [RelayCommand]
+    private async Task PickNfaBundleAsync()
+    {
+        var path = await PickFolderAsync(
+            "Pick the NFA ONNX bundle directory (optional — without it, no word highlights)");
+        if (path is not null) NfaBundleDir = path;
+    }
+
+    [RelayCommand]
+    private async Task PickTextFileAsync()
+    {
+        var path = await PickFileAsync("Pick a markdown or text file",
+            new FilePickerFileType("Text") { Patterns = new[] { "*.md", "*.markdown", "*.txt" } });
+        if (path is null) return;
+        try { Text = await File.ReadAllTextAsync(path); }
+        catch (Exception ex) { StatusMessage = $"Read failed: {ex.Message}"; }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanSynthesize))]
+    private async Task SynthesizeAsync()
+    {
+        IsBusy = true;
+        StatusMessage = _synthService is null ? "Loading models (one-time)..." : "Synthesizing...";
+        Words.Clear();
+        _currentWordIndex = -1;
+        HasSynthesizedAudio = false;
+        _synthCts?.Dispose();
+        _synthCts = new CancellationTokenSource();
+        var token = _synthCts.Token;
+
+        try
+        {
+            // Lazy-construct the synthesis service so the heavy ORT
+            // session loads happen on the first synthesize click rather
+            // than at startup (faster cold UI).
+            _synthService ??= new SynthesisService(
+                OnnxBundleDir,
+                nfaBundleDir: string.IsNullOrWhiteSpace(NfaBundleDir) ? null : NfaBundleDir);
+
+            string outWav = Path.Combine(Path.GetTempPath(),
+                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss}.wav");
+
+            var result = await Task.Run(
+                () => _synthService.Synthesize(VoicePath, Text, outWav, token),
+                token);
+
+            _lastAlignment = result.Alignment;
+            HasSynthesizedAudio = true;
+            int idx = 0;
+            foreach (var w in result.Alignment.Words)
+                Words.Add(new WordItemViewModel(w, idx++));
+            StatusMessage = $"Synthesized {result.Alignment.AudioDurationSeconds:F2}s, "
+                + $"{result.Alignment.Words.Count} words. Ready to play.";
+        }
+        catch (OperationCanceledException)
+        {
+            StatusMessage = "Synthesis cancelled.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Synthesis failed: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private bool CanSynthesize()
+        => !IsBusy
+        && !string.IsNullOrWhiteSpace(VoicePath)
+        && !string.IsNullOrWhiteSpace(OnnxBundleDir)
+        && !string.IsNullOrWhiteSpace(Text);
+
+    [RelayCommand(CanExecute = nameof(CanPlay))]
+    private void Play()
+    {
+        if (_lastAlignment is null) return;
+        try
+        {
+            _playback.Play(_lastAlignment.AudioPath, _lastAlignment.AudioDurationSeconds);
+            StatusMessage = "Playing.";
+        }
+        catch (Exception ex) { StatusMessage = $"Play failed: {ex.Message}"; }
+    }
+
+    private bool CanPlay() => HasSynthesizedAudio && !IsBusy && _playback.CanPlayOnThisPlatform;
+
+    [RelayCommand]
+    private void Stop() => _playback.Stop();
+
+    private void OnPlaybackPositionChanged(double posSec)
+        => Dispatcher.UIThread.Post(() =>
+        {
+            // Binary-search the words list for the word whose interval
+            // contains posSec. Words are sorted by StartSeconds per the
+            // sidecar contract, so a linear scan from the current index
+            // forward would also work (amortized O(N) over a playback) —
+            // binary search is just as cheap and handles backwards seeks
+            // when scrubbing lands.
+            int idx = FindWordAt(posSec);
+            if (idx != _currentWordIndex)
+            {
+                if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
+                    Words[_currentWordIndex].IsCurrent = false;
+                _currentWordIndex = idx;
+                if (idx >= 0 && idx < Words.Count) Words[idx].IsCurrent = true;
+            }
+            double dur = _lastAlignment?.AudioDurationSeconds ?? 0;
+            PositionLabel = $"{posSec:F2} / {dur:F2} s";
+        });
+
+    private int FindWordAt(double posSec)
+    {
+        // Standard binary search over Words[i].StartSeconds. Returns the
+        // last word whose StartSeconds <= posSec, or -1 when posSec is
+        // before the first word. The "current word" is whatever started
+        // most recently; we don't gate on EndSeconds so brief inter-word
+        // gaps still show the trailing word highlighted (no flicker).
+        if (Words.Count == 0) return -1;
+        int lo = 0, hi = Words.Count - 1, best = -1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            if (Words[mid].StartSeconds <= posSec)
+            {
+                best = mid;
+                lo = mid + 1;
+            }
+            else { hi = mid - 1; }
+        }
+        return best;
+    }
+
+    private static async Task<string?> PickFileAsync(string title, FilePickerFileType filter)
+    {
+        var top = TopLevel();
+        if (top is null) return null;
+        var picks = await top.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = false,
+            FileTypeFilter = new[] { filter },
+        });
+        return picks.Count > 0 ? picks[0].TryGetLocalPath() : null;
+    }
+
+    private static async Task<string?> PickFolderAsync(string title)
+    {
+        var top = TopLevel();
+        if (top is null) return null;
+        var picks = await top.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = false,
+        });
+        return picks.Count > 0 ? picks[0].TryGetLocalPath() : null;
+    }
+
+    private static TopLevel? TopLevel()
+    {
+        if (Avalonia.Application.Current?.ApplicationLifetime
+            is IClassicDesktopStyleApplicationLifetime desktop
+            && desktop.MainWindow is not null)
+        {
+            return Avalonia.Controls.TopLevel.GetTopLevel(desktop.MainWindow);
+        }
+        return null;
+    }
+
+    public void Dispose()
+    {
+        _synthCts?.Cancel();
+        _synthCts?.Dispose();
+        _playback.Dispose();
+        _synthService?.Dispose();
+    }
+}

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -28,6 +28,21 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty] private string _onnxBundleDir = "";
     [ObservableProperty] private string _nfaBundleDir = "";
 
+    // Bundle-path changes invalidate the cached SynthesisService so the
+    // next Synthesize click rebuilds against the new paths. Without this,
+    // the lazy `_synthService ??= new SynthesisService(...)` would silently
+    // keep using the FIRST bundle pair the user picked, even after they
+    // changed pickers.
+    partial void OnOnnxBundleDirChanged(string value) => InvalidateSynthService();
+    partial void OnNfaBundleDirChanged(string value) => InvalidateSynthService();
+
+    private void InvalidateSynthService()
+    {
+        var stale = _synthService;
+        _synthService = null;
+        stale?.Dispose();
+    }
+
     // Text input — either typed/pasted in the UI or loaded from a .md file.
     [ObservableProperty] private string _text = "";
 
@@ -65,14 +80,19 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
 
     public MainViewModel()
     {
+        // PlaybackService raises both events from its DispatcherTimer,
+        // which is already on the UI thread — no Dispatcher.Post wrapping
+        // needed. (An earlier draft posted defensively; the reviewer of
+        // PR #74 caught that we were paying 20 dispatcher-frame round-trips
+        // per second for no benefit.)
         _playback.PositionChanged += OnPlaybackPositionChanged;
-        _playback.PlaybackStopped += _ => Dispatcher.UIThread.Post(() =>
+        _playback.PlaybackStopped += _ =>
         {
             if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
                 Words[_currentWordIndex].IsCurrent = false;
             _currentWordIndex = -1;
             StatusMessage = "Playback stopped.";
-        });
+        };
 
         if (!_playback.CanPlayOnThisPlatform)
             StatusMessage = _playback.UnavailableReason!;
@@ -185,25 +205,25 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     private void Stop() => _playback.Stop();
 
     private void OnPlaybackPositionChanged(double posSec)
-        => Dispatcher.UIThread.Post(() =>
+    {
+        // Already on the UI thread (PlaybackService's DispatcherTimer
+        // fires here). Binary-search the words list for the word whose
+        // interval contains posSec; Words is sorted by StartSeconds per
+        // the sidecar contract. A linear scan from the current index
+        // forward would also work (amortized O(N) over a playback);
+        // binary search is just as cheap and handles backwards seeks
+        // when scrubbing lands.
+        int idx = FindWordAt(posSec);
+        if (idx != _currentWordIndex)
         {
-            // Binary-search the words list for the word whose interval
-            // contains posSec. Words are sorted by StartSeconds per the
-            // sidecar contract, so a linear scan from the current index
-            // forward would also work (amortized O(N) over a playback) —
-            // binary search is just as cheap and handles backwards seeks
-            // when scrubbing lands.
-            int idx = FindWordAt(posSec);
-            if (idx != _currentWordIndex)
-            {
-                if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
-                    Words[_currentWordIndex].IsCurrent = false;
-                _currentWordIndex = idx;
-                if (idx >= 0 && idx < Words.Count) Words[idx].IsCurrent = true;
-            }
-            double dur = _lastAlignment?.AudioDurationSeconds ?? 0;
-            PositionLabel = $"{posSec:F2} / {dur:F2} s";
-        });
+            if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
+                Words[_currentWordIndex].IsCurrent = false;
+            _currentWordIndex = idx;
+            if (idx >= 0 && idx < Words.Count) Words[idx].IsCurrent = true;
+        }
+        double dur = _lastAlignment?.AudioDurationSeconds ?? 0;
+        PositionLabel = $"{posSec:F2} / {dur:F2} s";
+    }
 
     private int FindWordAt(double posSec)
     {

--- a/src/Chatterbox.Avalonia/ViewModels/WordItemViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/WordItemViewModel.cs
@@ -1,0 +1,29 @@
+using Chatterbox.App.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Chatterbox.App.ViewModels;
+
+/// <summary>
+/// Per-word presentation wrapper. The aligner emits flat
+/// <see cref="AlignedWord"/> records; the UI needs an extra
+/// <see cref="IsCurrent"/> bool that the AXAML can class-trigger on
+/// to apply the highlight style. MainViewModel toggles this on the
+/// current word as playback advances.
+/// </summary>
+public sealed partial class WordItemViewModel : ObservableObject
+{
+    public WordItemViewModel(AlignedWord word, int index)
+    {
+        Index = index;
+        Text = word.Text;
+        StartSeconds = word.StartSeconds;
+        EndSeconds = word.EndSeconds;
+    }
+
+    public int Index { get; }
+    public string Text { get; }
+    public double StartSeconds { get; }
+    public double EndSeconds { get; }
+
+    [ObservableProperty] private bool _isCurrent;
+}

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml
@@ -1,0 +1,125 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:Chatterbox.App.ViewModels"
+        x:Class="Chatterbox.App.Views.MainWindow"
+        x:DataType="vm:MainViewModel"
+        mc:Ignorable="d"
+        Width="1100" Height="720" MinWidth="800" MinHeight="500"
+        Title="Chatterbox Reader (MVP)">
+
+    <Grid ColumnDefinitions="*,360" Margin="12">
+
+        <!-- ── Left pane: word-by-word highlight + input ──────────────── -->
+        <Border Grid.Column="0" BorderBrush="#33ffffff" BorderThickness="1"
+                CornerRadius="4" Padding="12" Margin="0,0,12,0">
+            <Grid RowDefinitions="Auto,Auto,*">
+                <TextBlock Grid.Row="0" Text="Source text"
+                           FontWeight="SemiBold" Margin="0,0,0,4" />
+
+                <!-- Input box for typing/pasting markdown. Disabled while
+                     a synthesis is running so the source can't drift mid-flight. -->
+                <TextBox Grid.Row="1" Text="{Binding Text}"
+                         AcceptsReturn="True" TextWrapping="Wrap"
+                         MinHeight="120" MaxHeight="220"
+                         IsEnabled="{Binding !IsBusy}"
+                         Watermark="Paste markdown or text here, or pick a file from the right pane." />
+
+                <!-- Word-highlight pane: shows the aligned words from
+                     the last synthesis, with the current word emphasized.
+                     Empty until Words is populated. -->
+                <ScrollViewer Grid.Row="2" Margin="0,12,0,0">
+                    <ItemsControl ItemsSource="{Binding Words}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:WordItemViewModel">
+                                <!-- Each word's IsCurrent toggles the .current
+                                     class; MainViewModel updates it on every
+                                     50 ms playback tick. The styled selector
+                                     is defined in Window.Styles below. -->
+                                <TextBlock Text="{Binding Text}"
+                                           FontSize="18" Margin="2,2,4,2"
+                                           Classes.current="{Binding IsCurrent}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+
+                <!-- Falls back to a hint when there are no words yet (pre-synthesis). -->
+            </Grid>
+        </Border>
+
+        <!-- ── Right pane: pickers, synthesize, playback ────────────── -->
+        <StackPanel Grid.Column="1" Spacing="10">
+            <TextBlock Text="Voice (.wav)" FontWeight="SemiBold" />
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBox Text="{Binding VoicePath}" IsReadOnly="True"
+                         Watermark="No voice picked" />
+                <Button Grid.Column="1" Content="Pick…"
+                        Command="{Binding PickVoiceCommand}" Margin="6,0,0,0" />
+            </Grid>
+
+            <TextBlock Text="Chatterbox ONNX bundle" FontWeight="SemiBold" Margin="0,8,0,0" />
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBox Text="{Binding OnnxBundleDir}" IsReadOnly="True"
+                         Watermark="No bundle picked" />
+                <Button Grid.Column="1" Content="Pick…"
+                        Command="{Binding PickOnnxBundleCommand}" Margin="6,0,0,0" />
+            </Grid>
+
+            <TextBlock Text="NFA bundle (optional, enables word highlight)"
+                       FontWeight="SemiBold" Margin="0,8,0,0" />
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBox Text="{Binding NfaBundleDir}" IsReadOnly="True"
+                         Watermark="No NFA bundle picked" />
+                <Button Grid.Column="1" Content="Pick…"
+                        Command="{Binding PickNfaBundleCommand}" Margin="6,0,0,0" />
+            </Grid>
+
+            <TextBlock Text="Text source" FontWeight="SemiBold" Margin="0,12,0,0" />
+            <Button Content="Load text/markdown file…"
+                    Command="{Binding PickTextFileCommand}"
+                    HorizontalAlignment="Stretch" />
+
+            <Separator Margin="0,12,0,0" />
+
+            <Button Content="Synthesize"
+                    Command="{Binding SynthesizeCommand}"
+                    FontWeight="SemiBold"
+                    HorizontalAlignment="Stretch" />
+            <ProgressBar IsIndeterminate="True"
+                         IsVisible="{Binding IsBusy}"
+                         Height="3" Margin="0,4,0,0" />
+
+            <Separator Margin="0,12,0,0" />
+
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Button Content="▶ Play" Command="{Binding PlayCommand}"
+                        MinWidth="80" />
+                <Button Content="■ Stop" Command="{Binding StopCommand}"
+                        MinWidth="80" />
+            </StackPanel>
+            <TextBlock Text="{Binding PositionLabel}" Margin="0,4,0,0"
+                       Foreground="#999" />
+
+            <Separator Margin="0,12,0,0" />
+            <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap"
+                       Foreground="#bbb" />
+        </StackPanel>
+
+    </Grid>
+
+    <Window.Styles>
+        <!-- Current-word highlight: a stronger weight + accent color. -->
+        <Style Selector="TextBlock.current">
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Foreground" Value="#5ad" />
+        </Style>
+    </Window.Styles>
+
+</Window>

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -8,4 +9,15 @@ public partial class MainWindow : Window
     public MainWindow() => InitializeComponent();
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    protected override void OnClosed(EventArgs e)
+    {
+        // The VM owns the synthesis service (ORT sessions, several GB of
+        // model weights) and the playback service (potentially a live
+        // ffplay subprocess). Process exit reclaims memory, but a forced
+        // ffplay child outliving the GUI is a real failure mode — dispose
+        // explicitly on window close.
+        (DataContext as IDisposable)?.Dispose();
+        base.OnClosed(e);
+    }
 }

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Chatterbox.App.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow() => InitializeComponent();
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+}


### PR DESCRIPTION
## Summary

Closes Chatterbox Stage 1 #10 in a deliberately narrow MVP form. New `src/Chatterbox.Avalonia/` project: small two-pane Avalonia reader that exercises the full pipeline shipped in PRs #66-#72 — synthesize markdown via Chatterbox, align via `NemoNfaAligner`, play the result with a word-by-word highlight following audio time.

12 new files, ~980 LOC. Project layout mirrors `Vernacula.Avalonia`'s conventions exactly so the "eventually folded into Vernacula.Avalonia" merge from `chatterbox.scratch.md` stays mechanical.

## What's in the box

```
src/Chatterbox.Avalonia/
  Chatterbox.Avalonia.csproj           — EP-aware ORT dep, refs Chatterbox.Base + Vernacula.Base
  Program.cs                            — AppBuilder entry
  App.axaml{,.cs}                       — FluentTheme + MainWindow boot
  Views/MainWindow.axaml{,.cs}          — Two-pane layout
  ViewModels/MainViewModel.cs           — Single VM; lazy SynthesisService, 50 ms tick → binary-search current word
  ViewModels/WordItemViewModel.cs       — Per-word presentation wrapper with IsCurrent bool
  Services/SynthesisService.cs          — Wraps pipeline + ChunkedSynthesizer + NemoNfaAligner; lazy-load + reuse
  Services/PlaybackService.cs           — Windows WaveOutEvent / others ffplay; same dispatch as TranscriptEditorViewModel
  Models/AlignmentSidecar.cs            — POCO for the JSON sidecar shape from PR #72
```

## Conventions mirrored from Vernacula.Avalonia

| Concern | Approach |
|---|---|
| Theming | `FluentTheme` |
| MVVM | `CommunityToolkit.Mvvm` `[ObservableProperty]` / `[RelayCommand]` |
| Bindings | Compiled bindings (`AvaloniaUseCompiledBindingsByDefault=true`) |
| Audio playback | `if (OperatingSystem.IsWindows()) WaveOutEvent else ffplay via Process.Start` — same split as `TranscriptEditorViewModel.StartFfplayPlayback` |
| Highlight tick | `DispatcherTimer` at 50 ms (same as transcript editor) |
| ORT EP | `-p:EP=Cuda|Cpu|...` build property flows through to base projects |

## End-to-end wiring

1. User picks voice WAV + Chatterbox ONNX bundle dir (required) + NFA bundle dir (optional — without it, no word highlight)
2. User pastes or loads markdown text in the left text box
3. Click **Synthesize** → `SynthesisService` runs on `Task.Run`, lazy-loads the pipeline on first click (~5-10 s cold), produces WAV + per-word alignment in-process (no shell-out)
4. Click **Play** → `PlaybackService` dispatches to platform backend; 50 ms tick → `Words.BinarySearch(t)` → toggle `IsCurrent` on the matched `WordItemViewModel` → AXAML `Classes.current` trigger applies highlight

## End-to-end smoke

Linux dev box, ffplay playback path:
- App launches cleanly, main window renders without crashing
- Full solution build green (the 2 `Tmds.DBus.Protocol` warnings are pre-existing, unrelated to this PR)

Real Windows + real bundles smoke is the obvious test-plan item below.

## Intentionally deferred to follow-up PRs

This MVP is scope-tight on purpose:
- **Pause / seek / scrub bar** — timeline UI is its own design pass
- **Speech rate + pitch controls** — Chatterbox supports `exaggeration`; one slider away
- **Real Markdown rendering** via `Markdown.Avalonia` — current UI shows the extracted plain text in a `WrapPanel`; source-position fields needed for source-char-mapped highlights haven't landed yet (PR #72 deferred them to "the Avalonia PR" — which is *this* PR, but the data isn't there)
- **Voice library / saved-voices** — file picker only for now
- **Project save/load**
- **Settings UI** — EP picker, max-steps, etc. Defaults work; no UI yet
- **Localization** — `LocExtension` pattern from Vernacula.Avalonia not pulled in

## Notes for reviewers

- **No new tests** — purely UI orchestration over already-tested layers. Real test is the manual end-to-end smoke (load voice + bundle + markdown → synthesize → play → watch the highlight follow).
- **`SynthesisService` is lazy + sticky** — the heavy `ChatterboxPipeline` + `NemoNfaAligner` sessions construct on first `Synthesize` call and are reused. Click-to-resynth doesn't pay the model-load cost twice.
- **`PlaybackService` uses wall-clock for position** — the audio backend's own clock (WaveOut.GetPosition / ffplay -progress) would be more accurate but backend-specific. Wall-clock is good enough for 50 ms tick + the alignment's per-word granularity.
- **The MVP renders extracted text, not styled markdown.** That's the right call for now: source-position mapping (which would let real markdown render with click-to-position) was explicitly deferred from PR #72. When the next pass adds source positions to the JSON sidecar, swapping the `WrapPanel` for `Markdown.Avalonia` with a custom run overlay becomes the design question.

## Test plan

- [ ] CI build green
- [ ] On Windows: run the app, pick `/path/to/chatterbox_export/`, voice WAV, `/path/to/nfa_ctc_onnx/` (optional), paste a short markdown sample, synthesize → wait for the model-load message, click Play → audio plays through WaveOutEvent, highlight follows
- [ ] On Linux/macOS: same flow; verify ffplay is in PATH, audio plays externally, highlight still follows the 50 ms tick
- [ ] Without `--nfa-bundle`: synthesis produces WAV, plays back, no word highlight (the left pane stays empty after synthesis — expected MVP behavior)
- [ ] Invalid voice / bundle paths produce a clean error in the status line, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)