### PR TITLE
Chatterbox.Avalonia: first-run polish (streaming, settings, click-to-seek, markdown toggle)

### DIFF
--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -47,10 +47,24 @@ public sealed class PlaybackService : IDisposable
     private DateTime _startedUtc;
     private int _sampleRate;
     private bool _endOfStream;
-    private double _totalEstimatedSec;   // best-known total duration (updates as chunks append)
+
+    // Best-known total duration; grows as chunks append. Read on the
+    // dispatcher tick (UI thread), written by AppendSamples (background
+    // thread). Guarded by _totalLock — torn reads of a double would
+    // briefly clamp PositionSeconds to garbage.
+    private readonly object _totalLock = new();
+    private double _totalEstimatedSec;
 
     public bool IsPlaying { get; private set; }
     public double PositionSeconds { get; private set; }
+
+    /// <summary>Running best-known total duration of the audio that's
+    /// been queued. Grows as chunks append during streaming; matches the
+    /// final audio duration after <see cref="EndOfStream"/>. Thread-safe.</summary>
+    public double TotalEstimatedSeconds
+    {
+        get { lock (_totalLock) return _totalEstimatedSec; }
+    }
 
     public event Action<double>? PositionChanged;
     public event Action<double>? PlaybackStopped;
@@ -71,7 +85,7 @@ public sealed class PlaybackService : IDisposable
 
         _sampleRate = sampleRate;
         _endOfStream = false;
-        _totalEstimatedSec = 0;
+        lock (_totalLock) _totalEstimatedSec = 0;
         PositionSeconds = 0;
 
         if (OperatingSystem.IsWindows())
@@ -104,14 +118,17 @@ public sealed class PlaybackService : IDisposable
 
     /// <summary>Append a chunk of float32 mono samples (Chatterbox's
     /// native format). Returns when the bytes are queued, not when
-    /// they've played. Call from the UI thread — <c>_totalEstimatedSec</c>
-    /// is read on the dispatcher timer tick and not synchronized, and
-    /// the ffplay-stdin write isn't serialized against concurrent
-    /// callers either.</summary>
+    /// they've played. <b>Do NOT call from the UI thread:</b> on the
+    /// ffplay backend, the stdin write blocks under backpressure (ffplay
+    /// only drains as fast as it plays, ~realtime), which would freeze
+    /// the dispatcher for seconds at a time. Call from a background
+    /// thread — the alignment-chain Task in SynthesisService is a
+    /// natural caller. Single-writer expected (the alignment chain is
+    /// serialized); no internal locking guards concurrent writers.</summary>
     public void AppendSamples(float[] samples)
     {
         if (samples.Length == 0) return;
-        _totalEstimatedSec += samples.Length / (double)_sampleRate;
+        lock (_totalLock) _totalEstimatedSec += samples.Length / (double)_sampleRate;
 
         if (OperatingSystem.IsWindows())
         {
@@ -202,7 +219,7 @@ public sealed class PlaybackService : IDisposable
             throw new FileNotFoundException("Audio file not found.", audioPath);
 
         _sampleRate = 0;  // unused on the file-playback path
-        _totalEstimatedSec = audioDurationSec;
+        lock (_totalLock) _totalEstimatedSec = audioDurationSec;
         seconds = Math.Clamp(seconds, 0, audioDurationSec);
         _endOfStream = true;
 
@@ -263,20 +280,20 @@ public sealed class PlaybackService : IDisposable
         _tickTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(50) };
         _tickTimer.Tick += (_, _) =>
         {
+            double total = TotalEstimatedSeconds;
             double pos = (DateTime.UtcNow - _startedUtc).TotalSeconds;
             // Clamp to estimated total (grows as chunks arrive). If we
             // outrun the buffer (clock past the last appended sample),
             // freeze at the estimate until more arrives — better than
             // showing fake forward motion.
-            if (_totalEstimatedSec > 0 && pos > _totalEstimatedSec)
-                pos = _totalEstimatedSec;
+            if (total > 0 && pos > total) pos = total;
             PositionSeconds = pos;
             PositionChanged?.Invoke(PositionSeconds);
 
             // Natural EOF: position reached the estimate AND no more
             // samples are coming. (Without _endOfStream we'd stop early
             // every time the user gets ahead of synthesis.)
-            if (_endOfStream && _totalEstimatedSec > 0 && PositionSeconds >= _totalEstimatedSec)
+            if (_endOfStream && total > 0 && PositionSeconds >= total)
                 Stop();
         };
         _tickTimer.Start();

--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -7,97 +7,242 @@ using NAudio.Wave;
 namespace Chatterbox.App.Services;
 
 /// <summary>
-/// Cross-platform audio playback for the reader UI. Mirrors the
-/// pattern from Vernacula.Avalonia.TranscriptEditorViewModel:
+/// Cross-platform streaming audio playback for the reader UI. Mirrors
+/// the platform split used by Vernacula.Avalonia.TranscriptEditorViewModel
+/// (WaveOutEvent on Windows, ffplay elsewhere) but in streaming form:
 ///
-///   - Windows: NAudio's WaveOutEvent (WinMM)
-///   - Other  : shell out to ffplay via Process.Start
+///   Windows: NAudio's <see cref="BufferedWaveProvider"/> fed into
+///            <see cref="WaveOutEvent"/>. Samples are appended as
+///            synthesis produces them; WaveOut pulls from the buffer
+///            continuously.
+///   Other  : <c>ffplay -f f32le -ar 24000 -ac 1 -i pipe:0</c>. Raw
+///            float32 PCM is written to ffplay's stdin chunk-by-chunk;
+///            it plays continuously and exits on EOF.
 ///
 /// A <see cref="DispatcherTimer"/> ticks at 50 ms regardless of
-/// playback backend, raising <see cref="PositionChanged"/> with the
-/// current playback time in seconds — the word-highlight loop binds
-/// to that event.
+/// backend, raising <see cref="PositionChanged"/> with the current
+/// playback time in seconds — the word-highlight loop binds to that
+/// event.
 ///
-/// MVP only supports play / stop. Pause and seek are deliberately
-/// out of scope; the next iteration would add them once the highlight
-/// loop is verified visually.
+/// Lifecycle: <see cref="StartStreaming"/> opens the playback pipeline
+/// for a given sample format; <see cref="AppendSamples"/> pushes audio
+/// (returns when the bytes are queued, not when they've played);
+/// <see cref="EndOfStream"/> signals no more samples will come (so
+/// <see cref="PlaybackStopped"/> can fire when the buffer drains);
+/// <see cref="Stop"/> tears down immediately. <see cref="SeekTo"/>
+/// jumps to an arbitrary position (within what's been buffered);
+/// behavior past-EOB is implementation-defined.
 /// </summary>
 public sealed class PlaybackService : IDisposable
 {
     private static readonly string? FfplayPath = FindExecutable("ffplay");
 
+    // Backend state (only one set in use at a time).
+    private BufferedWaveProvider? _bufferedProvider;
     private WaveOutEvent? _waveOut;
-    private AudioFileReader? _reader;
     private Process? _ffplayProcess;
+    private Stream? _ffplayStdin;
+
     private DispatcherTimer? _tickTimer;
     private DateTime _startedUtc;
-    private double _audioDurationSec;
+    private int _sampleRate;
+    private bool _endOfStream;
+    private double _totalEstimatedSec;   // best-known total duration (updates as chunks append)
 
-    /// <summary>True when audio is currently playing (or believed to be —
-    /// the ffplay process may have already exited and we haven't
-    /// noticed yet).</summary>
     public bool IsPlaying { get; private set; }
-
-    /// <summary>Current playback time in seconds from the start of the file.</summary>
     public double PositionSeconds { get; private set; }
 
-    /// <summary>Fired on every <see cref="DispatcherTimer"/> tick during
-    /// playback (50 ms). Argument is current position in seconds.</summary>
     public event Action<double>? PositionChanged;
-
-    /// <summary>Fired when playback finishes naturally (EOF) or is stopped
-    /// via <see cref="Stop"/>. Argument is the final position.</summary>
     public event Action<double>? PlaybackStopped;
 
     public bool CanPlayOnThisPlatform => OperatingSystem.IsWindows() || FfplayPath is not null;
-
     public string? UnavailableReason => CanPlayOnThisPlatform
         ? null
         : "Audio playback requires Windows audio output or an `ffplay` executable in PATH.";
 
-    public void Play(string audioPath, double audioDurationSec)
+    /// <summary>Open the playback pipeline for streaming and start it
+    /// playing immediately (silence until samples arrive). Calls
+    /// <see cref="Stop"/> on any in-progress playback first.</summary>
+    public void StartStreaming(int sampleRate, int channels)
     {
+        if (channels != 1)
+            throw new NotSupportedException("MVP supports mono only — Chatterbox always outputs mono.");
         Stop();
-        if (!File.Exists(audioPath))
-            throw new FileNotFoundException("Audio file not found.", audioPath);
 
-        _audioDurationSec = audioDurationSec;
+        _sampleRate = sampleRate;
+        _endOfStream = false;
+        _totalEstimatedSec = 0;
+        PositionSeconds = 0;
 
         if (OperatingSystem.IsWindows())
         {
-            _reader = new AudioFileReader(audioPath);
+            var fmt = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, 1);
+            // 30 s of headroom — long-form chunks deliver in 1-5 s
+            // bursts, vocoder is faster than realtime, so this never
+            // backs up in practice but the cap protects against runaway
+            // memory in pathological cases.
+            _bufferedProvider = new BufferedWaveProvider(fmt)
+            {
+                BufferLength = sampleRate * 4 /* bytes per float */ * 30,
+                DiscardOnBufferOverflow = false,
+            };
             _waveOut = new WaveOutEvent();
-            _waveOut.Init(_reader);
-            _waveOut.PlaybackStopped += OnWaveOutStopped;
+            _waveOut.Init(_bufferedProvider);
             _waveOut.Play();
         }
         else
         {
             if (FfplayPath is null)
                 throw new InvalidOperationException(UnavailableReason!);
-            if (!StartFfplay(audioPath))
-                throw new InvalidOperationException("Failed to start ffplay.");
+            StartFfplayStdin(sampleRate);
         }
 
         IsPlaying = true;
-        PositionSeconds = 0;
         _startedUtc = DateTime.UtcNow;
+        StartTickTimer();
+    }
+
+    /// <summary>Append a chunk of float32 mono samples (Chatterbox's
+    /// native format). Safe to call from any thread. Returns when the
+    /// bytes are queued, not when they've played.</summary>
+    public void AppendSamples(float[] samples)
+    {
+        if (samples.Length == 0) return;
+        _totalEstimatedSec += samples.Length / (double)_sampleRate;
+
+        if (OperatingSystem.IsWindows())
+        {
+            if (_bufferedProvider is null) return;
+            // BufferedWaveProvider takes a byte[] (it's PCM-agnostic).
+            // We're feeding IEEE-754 float32, so 4 bytes per sample.
+            var bytes = new byte[samples.Length * 4];
+            Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
+            _bufferedProvider.AddSamples(bytes, 0, bytes.Length);
+        }
+        else
+        {
+            if (_ffplayStdin is null) return;
+            var bytes = new byte[samples.Length * 4];
+            Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
+            try
+            {
+                _ffplayStdin.Write(bytes, 0, bytes.Length);
+                _ffplayStdin.Flush();
+            }
+            catch (Exception)
+            {
+                // Pipe broken (ffplay exited or was killed). The tick
+                // timer's EOF detection will pick it up on the next tick.
+            }
+        }
+    }
+
+    /// <summary>Signal that no more samples will be appended. The tick
+    /// timer will fire <see cref="PlaybackStopped"/> once the buffer
+    /// drains (Windows) or ffplay exits (other).</summary>
+    public void EndOfStream()
+    {
+        _endOfStream = true;
+        if (!OperatingSystem.IsWindows() && _ffplayStdin is not null)
+        {
+            // Closing stdin tells ffplay "no more input"; it'll play to
+            // the end of its decoded buffer then exit naturally.
+            try { _ffplayStdin.Close(); } catch { /* already closed */ }
+        }
+    }
+
+    /// <summary>Jump to an arbitrary position. On Windows this works on
+    /// whatever's been buffered. On ffplay it restarts the player at the
+    /// new offset, which only works when streaming has finished (we'd
+    /// need a full WAV on disk to seek into). MVP: seek before
+    /// EndOfStream is ignored on the ffplay path with a console note;
+    /// post-EOF seek works because the caller can pass the on-disk WAV
+    /// via <see cref="SeekIntoFile"/> instead.</summary>
+    public void SeekTo(double seconds)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            if (_bufferedProvider is null) return;
+            // BufferedWaveProvider doesn't expose seek directly — for an
+            // in-RAM stream the simplest thing is to truncate the buffer
+            // (drop anything before the seek point) and re-anchor the
+            // wall-clock. Forward seek = drop bytes; backward seek
+            // beyond what's in the buffer = clamp to current position.
+            // For MVP, we just re-anchor the wall-clock and let WaveOut
+            // continue playing what's in the buffer — meaning seek only
+            // affects the HIGHLIGHT, not the audio. Acceptable for
+            // click-to-highlight UX; full audio-seek is follow-up.
+            _startedUtc = DateTime.UtcNow.AddSeconds(-seconds);
+            PositionSeconds = seconds;
+            PositionChanged?.Invoke(PositionSeconds);
+        }
+        else
+        {
+            // Same MVP compromise: re-anchor wall-clock, highlight jumps,
+            // audio continues from wherever ffplay was. Seeking ffplay
+            // requires either a seekable input (file) or restarting the
+            // process — both are larger surgeries deferred for now.
+            _startedUtc = DateTime.UtcNow.AddSeconds(-seconds);
+            PositionSeconds = seconds;
+            PositionChanged?.Invoke(PositionSeconds);
+        }
+    }
+
+    /// <summary>Post-streaming seek into the on-disk WAV file. Restarts
+    /// the playback pipeline reading from the file (instead of the
+    /// stream) and jumps to <paramref name="seconds"/>. Use this for
+    /// scrubbing a finished synthesis where you have the full WAV.</summary>
+    public void SeekIntoFile(string audioPath, double audioDurationSec, double seconds)
+    {
+        Stop();
+        if (!File.Exists(audioPath))
+            throw new FileNotFoundException("Audio file not found.", audioPath);
+
+        _sampleRate = 0;  // unused on the file-playback path
+        _totalEstimatedSec = audioDurationSec;
+        seconds = Math.Clamp(seconds, 0, audioDurationSec);
+        _endOfStream = true;
+
+        if (OperatingSystem.IsWindows())
+        {
+            var reader = new AudioFileReader(audioPath)
+            {
+                CurrentTime = TimeSpan.FromSeconds(seconds),
+            };
+            _waveOut = new WaveOutEvent();
+            _waveOut.Init(reader);
+            _waveOut.PlaybackStopped += (_, _) => Dispatcher.UIThread.InvokeAsync(Stop);
+            _waveOut.Play();
+        }
+        else
+        {
+            if (FfplayPath is null)
+                throw new InvalidOperationException(UnavailableReason!);
+            StartFfplayFile(audioPath, seconds);
+        }
+
+        IsPlaying = true;
+        PositionSeconds = seconds;
+        _startedUtc = DateTime.UtcNow.AddSeconds(-seconds);
         StartTickTimer();
     }
 
     public void Stop()
     {
         if (!IsPlaying && _tickTimer is null) return;
-
         StopTickTimer();
         if (_waveOut is not null)
         {
-            _waveOut.PlaybackStopped -= OnWaveOutStopped;
             try { _waveOut.Stop(); } catch { /* shutdown race */ }
             _waveOut.Dispose();
             _waveOut = null;
         }
-        if (_reader is not null) { _reader.Dispose(); _reader = null; }
+        _bufferedProvider = null;
+        if (_ffplayStdin is not null)
+        {
+            try { _ffplayStdin.Close(); } catch { }
+            _ffplayStdin = null;
+        }
         if (_ffplayProcess is not null)
         {
             try { if (!_ffplayProcess.HasExited) _ffplayProcess.Kill(entireProcessTree: true); }
@@ -115,32 +260,49 @@ public sealed class PlaybackService : IDisposable
         _tickTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(50) };
         _tickTimer.Tick += (_, _) =>
         {
-            // Wall-clock-derived position. The audio backend's own clock
-            // would be slightly more accurate but adds backend-specific
-            // plumbing (WaveOut.GetPosition / parse ffplay -progress);
-            // wall-clock is good enough for the highlight loop's 50 ms
-            // tick + the alignment's per-word boundaries.
             double pos = (DateTime.UtcNow - _startedUtc).TotalSeconds;
-            PositionSeconds = Math.Min(pos, _audioDurationSec);
+            // Clamp to estimated total (grows as chunks arrive). If we
+            // outrun the buffer (clock past the last appended sample),
+            // freeze at the estimate until more arrives — better than
+            // showing fake forward motion.
+            if (_totalEstimatedSec > 0 && pos > _totalEstimatedSec)
+                pos = _totalEstimatedSec;
+            PositionSeconds = pos;
             PositionChanged?.Invoke(PositionSeconds);
-            if (PositionSeconds >= _audioDurationSec) Stop();
+
+            // Natural EOF: position reached the estimate AND no more
+            // samples are coming. (Without _endOfStream we'd stop early
+            // every time the user gets ahead of synthesis.)
+            if (_endOfStream && _totalEstimatedSec > 0 && PositionSeconds >= _totalEstimatedSec)
+                Stop();
         };
         _tickTimer.Start();
     }
 
-    private void StopTickTimer()
+    private void StopTickTimer() { _tickTimer?.Stop(); _tickTimer = null; }
+
+    private void StartFfplayStdin(int sampleRate)
     {
-        _tickTimer?.Stop();
-        _tickTimer = null;
+        var psi = MakeFfplayBasePsi();
+        psi.ArgumentList.Add("-f"); psi.ArgumentList.Add("f32le");
+        psi.ArgumentList.Add("-ar"); psi.ArgumentList.Add(sampleRate.ToString());
+        psi.ArgumentList.Add("-ac"); psi.ArgumentList.Add("1");
+        psi.ArgumentList.Add("-i");  psi.ArgumentList.Add("pipe:0");
+        psi.RedirectStandardInput = true;
+        StartFfplay(psi);
     }
 
-    private void OnWaveOutStopped(object? sender, StoppedEventArgs e)
-        => Dispatcher.UIThread.InvokeAsync(Stop);
-
-    private bool StartFfplay(string audioPath)
+    private void StartFfplayFile(string audioPath, double startSec)
     {
-        if (FfplayPath is null) return false;
-        var psi = new ProcessStartInfo(FfplayPath)
+        var psi = MakeFfplayBasePsi();
+        psi.ArgumentList.Add("-ss"); psi.ArgumentList.Add(startSec.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture));
+        psi.ArgumentList.Add("-i");  psi.ArgumentList.Add(audioPath);
+        StartFfplay(psi);
+    }
+
+    private ProcessStartInfo MakeFfplayBasePsi()
+    {
+        var psi = new ProcessStartInfo(FfplayPath!)
         {
             UseShellExecute = false,
             RedirectStandardError = true,
@@ -150,24 +312,24 @@ public sealed class PlaybackService : IDisposable
         psi.ArgumentList.Add("-nodisp");
         psi.ArgumentList.Add("-autoexit");
         psi.ArgumentList.Add("-loglevel"); psi.ArgumentList.Add("error");
-        psi.ArgumentList.Add(audioPath);
+        return psi;
+    }
 
+    private void StartFfplay(ProcessStartInfo psi)
+    {
         var p = new Process { StartInfo = psi, EnableRaisingEvents = true };
         p.Exited += (_, _) => Dispatcher.UIThread.InvokeAsync(Stop);
         if (!p.Start())
         {
             p.Dispose();
-            return false;
+            throw new InvalidOperationException("Failed to start ffplay.");
         }
-        // Drain stdout/stderr so the pipe doesn't backpressure ffplay.
         _ = p.StandardOutput.ReadToEndAsync();
         _ = p.StandardError.ReadToEndAsync();
         _ffplayProcess = p;
-        return true;
+        if (psi.RedirectStandardInput) _ffplayStdin = p.StandardInput.BaseStream;
     }
 
-    /// <summary>Locate an executable in the user's PATH. Returns null when
-    /// not found. Same logic as Vernacula.Avalonia's helper.</summary>
     private static string? FindExecutable(string fileName)
     {
         var pathEnv = Environment.GetEnvironmentVariable("PATH");

--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -73,7 +73,21 @@ public sealed class PlaybackService : IDisposable
             IsPlayingChanged?.Invoke(value);
         }
     }
+
+    private bool _isPaused;
+    public bool IsPaused
+    {
+        get => _isPaused;
+        private set
+        {
+            if (_isPaused == value) return;
+            _isPaused = value;
+            IsPausedChanged?.Invoke(value);
+        }
+    }
+
     public double PositionSeconds { get; private set; }
+    private DateTime _pausedAt;
 
     /// <summary>Running best-known total duration of the audio that's
     /// been queued. Grows as chunks append during streaming; matches the
@@ -96,6 +110,10 @@ public sealed class PlaybackService : IDisposable
     /// <summary>Fired when <see cref="IsPlaying"/> transitions. Lets the
     /// UI re-query the Stop/Play CanExecute predicates.</summary>
     public event Action<bool>? IsPlayingChanged;
+
+    /// <summary>Fired when <see cref="IsPaused"/> transitions. Lets the
+    /// UI swap the Play/Pause/Resume button label.</summary>
+    public event Action<bool>? IsPausedChanged;
 
     public bool CanPlayOnThisPlatform => OperatingSystem.IsWindows() || FfplayPath is not null;
     public string? UnavailableReason => CanPlayOnThisPlatform
@@ -251,6 +269,77 @@ public sealed class PlaybackService : IDisposable
         }
     }
 
+    /// <summary>Suspend audio output without tearing down the backend.
+    /// On Windows uses <see cref="WaveOutEvent.Pause"/>; on Linux sends
+    /// SIGSTOP to the ffplay process so the kernel freezes it. The
+    /// internal audio buffer and writer task stay alive — Resume picks
+    /// up exactly where Pause left off. Wall-clock position is frozen
+    /// via _pausedAt; Resume shifts _startedUtc forward by the pause
+    /// duration so the highlight doesn't jump ahead.</summary>
+    public void Pause()
+    {
+        if (!IsPlaying || IsPaused) return;
+        if (OperatingSystem.IsWindows())
+        {
+            try { _waveOut?.Pause(); } catch { /* device race */ }
+        }
+        else if (_ffplayProcess is not null)
+        {
+            SendSignalToProcess(_ffplayProcess, "STOP");
+        }
+        _pausedAt = DateTime.UtcNow;
+        StopTickTimer();
+        // Order matters: clear IsPlaying BEFORE setting IsPaused so any
+        // subscriber that re-queries derived state sees both in a
+        // consistent (paused, not-playing) configuration.
+        IsPlaying = false;
+        IsPaused = true;
+    }
+
+    /// <summary>Resume playback from <see cref="Pause"/>. Shifts the
+    /// wall-clock anchor forward by the pause duration so position
+    /// resumes where it stopped, restarts the tick timer, and unfreezes
+    /// the audio backend.</summary>
+    public void Resume()
+    {
+        if (!IsPaused) return;
+        var pauseDuration = DateTime.UtcNow - _pausedAt;
+        _startedUtc = _startedUtc.Add(pauseDuration);
+        if (OperatingSystem.IsWindows())
+        {
+            try { _waveOut?.Play(); } catch { /* device race */ }
+        }
+        else if (_ffplayProcess is not null)
+        {
+            SendSignalToProcess(_ffplayProcess, "CONT");
+        }
+        IsPaused = false;
+        IsPlaying = true;
+        StartTickTimer();
+    }
+
+    /// <summary>Best-effort POSIX signal via the kill(1) utility. Used
+    /// for SIGSTOP/SIGCONT to pause/resume ffplay. Shelling out (rather
+    /// than P/Invoke libc) avoids hard-coding signal numbers, which
+    /// differ between Linux and macOS.</summary>
+    private static void SendSignalToProcess(Process proc, string sig)
+    {
+        if (proc.HasExited) return;
+        try
+        {
+            using var p = Process.Start(new ProcessStartInfo("kill")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList = { "-s", sig, proc.Id.ToString() },
+            });
+            p?.WaitForExit(500);
+        }
+        catch { /* best effort — pause/resume isn't worth crashing over */ }
+    }
+
     /// <summary>Jump to an arbitrary position. On Windows this works on
     /// whatever's been buffered. On ffplay it restarts the player at the
     /// new offset, which only works when streaming has finished (we'd
@@ -330,28 +419,26 @@ public sealed class PlaybackService : IDisposable
 
     public void Stop()
     {
-        if (!IsPlaying && _tickTimer is null) return;
+        // Allow Stop after Pause too — without IsPaused in this check
+        // we'd early-return because the timer was stopped by Pause and
+        // IsPlaying is false during pause.
+        if (!IsPlaying && !IsPaused && _waveOut is null && _ffplayProcess is null) return;
         StopTickTimer();
-        // Complete the channel first so the writer task exits cleanly
-        // instead of being killed mid-Write.
-        _audioChannel?.Writer.TryComplete();
-        _audioChannel = null;
-        // Don't wait for _writerTask here — Stop is sync and the writer
-        // might be blocked in a Windows AddSamples or a Linux pipe Write
-        // that hasn't unblocked yet. It'll exit on its own once the
-        // backend below is torn down.
-        _writerTask = null;
+
+        // ORDER MATTERS for immediate-stop UX. Audio backends are torn
+        // down FIRST so output goes silent right now. The channel +
+        // writer-task cleanup happens after — those don't produce
+        // sound, just internal state.
+        //
+        // Old order closed ffplay stdin before kill, which let ffplay
+        // drain its internal decoded-PCM buffer (sometimes seconds) on
+        // -autoexit before the kill landed. Killing first prevents
+        // that drain.
         if (_waveOut is not null)
         {
             try { _waveOut.Stop(); } catch { /* shutdown race */ }
             _waveOut.Dispose();
             _waveOut = null;
-        }
-        _bufferedProvider = null;
-        if (_ffplayStdin is not null)
-        {
-            try { _ffplayStdin.Close(); } catch { }
-            _ffplayStdin = null;
         }
         if (_ffplayProcess is not null)
         {
@@ -360,7 +447,20 @@ public sealed class PlaybackService : IDisposable
             _ffplayProcess.Dispose();
             _ffplayProcess = null;
         }
+        if (_ffplayStdin is not null)
+        {
+            try { _ffplayStdin.Close(); } catch { }
+            _ffplayStdin = null;
+        }
+        // Channel cleanup last; writer task will hit a broken pipe /
+        // disposed buffer and exit its loop on its own.
+        _audioChannel?.Writer.TryComplete();
+        _audioChannel = null;
+        _writerTask = null;
+        _bufferedProvider = null;
+
         var finalPos = PositionSeconds;
+        IsPaused = false;
         IsPlaying = false;
         PlaybackStopped?.Invoke(finalPos);
     }

--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using Avalonia.Threading;
 using NAudio.Wave;
 
@@ -43,19 +45,34 @@ public sealed class PlaybackService : IDisposable
     private Process? _ffplayProcess;
     private Stream? _ffplayStdin;
 
+    // Audio is enqueued via AppendSamples and drained by a background
+    // writer task. Without this decoupling, AppendSamples would block
+    // its caller (the alignment chain) under ffplay-stdin or
+    // BufferedWaveProvider backpressure, stalling subsequent chunks
+    // until the audio backend caught up — chunks would land in bursts
+    // instead of streaming.
+    private Channel<float[]>? _audioChannel;
+    private Task? _writerTask;
+
     private DispatcherTimer? _tickTimer;
     private DateTime _startedUtc;
     private int _sampleRate;
     private bool _endOfStream;
 
-    // Best-known total duration; grows as chunks append. Read on the
-    // dispatcher tick (UI thread), written by AppendSamples (background
-    // thread). Guarded by _totalLock — torn reads of a double would
-    // briefly clamp PositionSeconds to garbage.
     private readonly object _totalLock = new();
     private double _totalEstimatedSec;
 
-    public bool IsPlaying { get; private set; }
+    private bool _isPlaying;
+    public bool IsPlaying
+    {
+        get => _isPlaying;
+        private set
+        {
+            if (_isPlaying == value) return;
+            _isPlaying = value;
+            IsPlayingChanged?.Invoke(value);
+        }
+    }
     public double PositionSeconds { get; private set; }
 
     /// <summary>Running best-known total duration of the audio that's
@@ -68,6 +85,17 @@ public sealed class PlaybackService : IDisposable
 
     public event Action<double>? PositionChanged;
     public event Action<double>? PlaybackStopped;
+
+    /// <summary>Fired whenever <see cref="TotalEstimatedSeconds"/>
+    /// changes — i.e. on every <see cref="AppendSamples"/> call and when
+    /// <see cref="SeekIntoFile"/> sets a known total. Lets UI refresh
+    /// the position label even when the tick timer isn't running (e.g.
+    /// after the user clicked Stop while synth is still emitting).</summary>
+    public event Action<double>? TotalChanged;
+
+    /// <summary>Fired when <see cref="IsPlaying"/> transitions. Lets the
+    /// UI re-query the Stop/Play CanExecute predicates.</summary>
+    public event Action<bool>? IsPlayingChanged;
 
     public bool CanPlayOnThisPlatform => OperatingSystem.IsWindows() || FfplayPath is not null;
     public string? UnavailableReason => CanPlayOnThisPlatform
@@ -91,13 +119,12 @@ public sealed class PlaybackService : IDisposable
         if (OperatingSystem.IsWindows())
         {
             var fmt = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, 1);
-            // 30 s of headroom — long-form chunks deliver in 1-5 s
-            // bursts, vocoder is faster than realtime, so this never
-            // backs up in practice but the cap protects against runaway
-            // memory in pathological cases.
+            // 60 s of headroom — the writer task throttles when the
+            // buffer is more than half-full, so this is the absolute
+            // ceiling rather than the working size.
             _bufferedProvider = new BufferedWaveProvider(fmt)
             {
-                BufferLength = sampleRate * 4 /* bytes per float */ * 30,
+                BufferLength = sampleRate * 4 /* bytes per float */ * 60,
                 DiscardOnBufferOverflow = false,
             };
             _waveOut = new WaveOutEvent();
@@ -111,62 +138,115 @@ public sealed class PlaybackService : IDisposable
             StartFfplayStdin(sampleRate);
         }
 
+        // Unbounded so AppendSamples NEVER blocks its caller — the synth
+        // pipeline must stay free to produce the next chunk while audio
+        // backpressure naturally throttles the writer (not the producer).
+        _audioChannel = Channel.CreateUnbounded<float[]>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+        _writerTask = Task.Run(WriteLoop);
+
         IsPlaying = true;
         _startedUtc = DateTime.UtcNow;
         StartTickTimer();
     }
 
-    /// <summary>Append a chunk of float32 mono samples (Chatterbox's
-    /// native format). Returns when the bytes are queued, not when
-    /// they've played. <b>Do NOT call from the UI thread:</b> on the
-    /// ffplay backend, the stdin write blocks under backpressure (ffplay
-    /// only drains as fast as it plays, ~realtime), which would freeze
-    /// the dispatcher for seconds at a time. Call from a background
-    /// thread — the alignment-chain Task in SynthesisService is a
-    /// natural caller. Single-writer expected (the alignment chain is
-    /// serialized); no internal locking guards concurrent writers.</summary>
+    /// <summary>Append a chunk of float32 mono samples. Non-blocking:
+    /// enqueues to an internal channel that a background writer task
+    /// drains into the audio backend. Updating the total here (rather
+    /// than in the writer) keeps <see cref="TotalEstimatedSeconds"/>
+    /// accurate to what's been *produced*, not what's been played.</summary>
     public void AppendSamples(float[] samples)
     {
         if (samples.Length == 0) return;
-        lock (_totalLock) _totalEstimatedSec += samples.Length / (double)_sampleRate;
-
-        if (OperatingSystem.IsWindows())
+        double newTotal;
+        lock (_totalLock)
         {
-            if (_bufferedProvider is null) return;
-            // BufferedWaveProvider takes a byte[] (it's PCM-agnostic).
-            // We're feeding IEEE-754 float32, so 4 bytes per sample.
-            var bytes = new byte[samples.Length * 4];
-            Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
-            _bufferedProvider.AddSamples(bytes, 0, bytes.Length);
+            _totalEstimatedSec += samples.Length / (double)_sampleRate;
+            newTotal = _totalEstimatedSec;
         }
-        else
-        {
-            if (_ffplayStdin is null) return;
-            var bytes = new byte[samples.Length * 4];
-            Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
-            try
-            {
-                _ffplayStdin.Write(bytes, 0, bytes.Length);
-                _ffplayStdin.Flush();
-            }
-            catch (Exception)
-            {
-                // Pipe broken (ffplay exited or was killed). The tick
-                // timer's EOF detection will pick it up on the next tick.
-            }
-        }
+        TotalChanged?.Invoke(newTotal);
+        _audioChannel?.Writer.TryWrite(samples);
     }
 
-    /// <summary>Signal that no more samples will be appended. The tick
-    /// timer will fire <see cref="PlaybackStopped"/> once the buffer
-    /// drains (Windows) or ffplay exits (other).</summary>
+    /// <summary>Background drain loop. Reads from the audio channel and
+    /// writes to whichever backend is active. On Windows it throttles
+    /// against the BufferedWaveProvider so we don't blow the 60 s cap;
+    /// on ffplay the stdin <see cref="Stream.Write"/> blocks naturally
+    /// when the pipe is full (kernel-level backpressure).</summary>
+    private async Task WriteLoop()
+    {
+        var channel = _audioChannel;
+        if (channel is null) return;
+        try
+        {
+            await foreach (var samples in channel.Reader.ReadAllAsync())
+            {
+                var bytes = new byte[samples.Length * 4];
+                Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
+
+                if (OperatingSystem.IsWindows())
+                {
+                    var bp = _bufferedProvider;
+                    if (bp is null) break;
+                    // Throttle when the buffer is over half-full so we
+                    // don't hit the 60 s cap. AddSamples would throw with
+                    // DiscardOnBufferOverflow=false; better to wait.
+                    while (bp.BufferedDuration.TotalSeconds > 30)
+                    {
+                        await Task.Delay(100).ConfigureAwait(false);
+                        if (_bufferedProvider is null) return;
+                    }
+                    try { bp.AddSamples(bytes, 0, bytes.Length); }
+                    catch (InvalidOperationException) { break; /* torn down */ }
+                }
+                else
+                {
+                    var stdin = _ffplayStdin;
+                    if (stdin is null) break;
+                    try
+                    {
+                        stdin.Write(bytes, 0, bytes.Length);
+                        stdin.Flush();
+                    }
+                    catch
+                    {
+                        // Pipe broken (ffplay exited or killed). Exit the
+                        // loop — the tick timer's EOF detection will
+                        // notice and Stop() the rest.
+                        break;
+                    }
+                }
+            }
+        }
+        catch (ChannelClosedException) { /* channel completed by Stop/EndOfStream */ }
+    }
+
+    /// <summary>Signal that no more samples will be appended. Completes
+    /// the audio channel so the writer task drains and exits; the tick
+    /// timer fires <see cref="PlaybackStopped"/> once the buffer empties
+    /// (Windows) or ffplay exits (other).</summary>
     public void EndOfStream()
     {
         _endOfStream = true;
+        _audioChannel?.Writer.TryComplete();
+        // ffplay stdin must be closed AFTER the writer task drains; we
+        // can't close it here or any pending WriteLoop iteration would
+        // hit a broken pipe. The WriteLoop's `await foreach` exits
+        // naturally on channel completion, then EndOfStreamDrain closes
+        // stdin to tell ffplay "play out the buffer and exit".
+        _ = EndOfStreamDrainAsync();
+    }
+
+    private async Task EndOfStreamDrainAsync()
+    {
+        var writer = _writerTask;
+        if (writer is not null)
+            try { await writer.ConfigureAwait(false); } catch { }
         if (!OperatingSystem.IsWindows() && _ffplayStdin is not null)
         {
-            // Closing stdin tells ffplay "no more input"; it'll play to
-            // the end of its decoded buffer then exit naturally.
             try { _ffplayStdin.Close(); } catch { /* already closed */ }
         }
     }
@@ -220,6 +300,7 @@ public sealed class PlaybackService : IDisposable
 
         _sampleRate = 0;  // unused on the file-playback path
         lock (_totalLock) _totalEstimatedSec = audioDurationSec;
+        TotalChanged?.Invoke(audioDurationSec);
         seconds = Math.Clamp(seconds, 0, audioDurationSec);
         _endOfStream = true;
 
@@ -251,6 +332,15 @@ public sealed class PlaybackService : IDisposable
     {
         if (!IsPlaying && _tickTimer is null) return;
         StopTickTimer();
+        // Complete the channel first so the writer task exits cleanly
+        // instead of being killed mid-Write.
+        _audioChannel?.Writer.TryComplete();
+        _audioChannel = null;
+        // Don't wait for _writerTask here — Stop is sync and the writer
+        // might be blocked in a Windows AddSamples or a Linux pipe Write
+        // that hasn't unblocked yet. It'll exit on its own once the
+        // backend below is torn down.
+        _writerTask = null;
         if (_waveOut is not null)
         {
             try { _waveOut.Stop(); } catch { /* shutdown race */ }

--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -42,6 +42,11 @@ public sealed class PlaybackService : IDisposable
     // Backend state (only one set in use at a time).
     private BufferedWaveProvider? _bufferedProvider;
     private WaveOutEvent? _waveOut;
+    // Held alongside _waveOut on the file-playback path so we can dispose
+    // it in Stop(). WaveOutEvent.Dispose() does NOT dispose the WaveStream
+    // it was given via Init — without holding our own ref, every Play
+    // would leak an open file handle (Windows keeps the WAV locked too).
+    private AudioFileReader? _fileReader;
     private Process? _ffplayProcess;
     private Stream? _ffplayStdin;
 
@@ -395,12 +400,12 @@ public sealed class PlaybackService : IDisposable
 
         if (OperatingSystem.IsWindows())
         {
-            var reader = new AudioFileReader(audioPath)
+            _fileReader = new AudioFileReader(audioPath)
             {
                 CurrentTime = TimeSpan.FromSeconds(seconds),
             };
             _waveOut = new WaveOutEvent();
-            _waveOut.Init(reader);
+            _waveOut.Init(_fileReader);
             _waveOut.PlaybackStopped += (_, _) => Dispatcher.UIThread.InvokeAsync(Stop);
             _waveOut.Play();
         }
@@ -439,6 +444,11 @@ public sealed class PlaybackService : IDisposable
             try { _waveOut.Stop(); } catch { /* shutdown race */ }
             _waveOut.Dispose();
             _waveOut = null;
+        }
+        if (_fileReader is not null)
+        {
+            _fileReader.Dispose();
+            _fileReader = null;
         }
         if (_ffplayProcess is not null)
         {

--- a/src/Chatterbox.Avalonia/Services/PlaybackService.cs
+++ b/src/Chatterbox.Avalonia/Services/PlaybackService.cs
@@ -103,8 +103,11 @@ public sealed class PlaybackService : IDisposable
     }
 
     /// <summary>Append a chunk of float32 mono samples (Chatterbox's
-    /// native format). Safe to call from any thread. Returns when the
-    /// bytes are queued, not when they've played.</summary>
+    /// native format). Returns when the bytes are queued, not when
+    /// they've played. Call from the UI thread — <c>_totalEstimatedSec</c>
+    /// is read on the dispatcher timer tick and not synchronized, and
+    /// the ffplay-stdin write isn't serialized against concurrent
+    /// callers either.</summary>
     public void AppendSamples(float[] samples)
     {
         if (samples.Length == 0) return;

--- a/src/Chatterbox.Avalonia/Services/SettingsService.cs
+++ b/src/Chatterbox.Avalonia/Services/SettingsService.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Chatterbox.App.Services;
+
+/// <summary>
+/// Persistent picker state for the reader. Mirrors
+/// Vernacula.Avalonia.SettingsService's JSON-in-LocalApplicationData
+/// pattern. Settings live at
+/// <c>%LocalApplicationData%/ChatterboxReader/settings.json</c>
+/// (Linux: <c>~/.local/share/ChatterboxReader/settings.json</c>).
+///
+/// The file is tiny (a handful of paths) so we serialize the whole
+/// thing on every save — no diffing. Read failures fall back to a
+/// fresh default; write failures are logged to stderr and swallowed
+/// (preferring a working UI over crashing the user out on disk-full
+/// or permission errors).
+/// </summary>
+public sealed class SettingsService
+{
+    private static readonly string SettingsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "ChatterboxReader", "settings.json");
+
+    public ReaderSettings Current { get; private set; } = new();
+
+    public void Load()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath)) return;
+            var json = File.ReadAllText(SettingsPath);
+            Current = JsonSerializer.Deserialize<ReaderSettings>(json) ?? new ReaderSettings();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[SettingsService] load failed, using defaults: {ex.Message}");
+            Current = new ReaderSettings();
+        }
+    }
+
+    public void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath)!);
+            File.WriteAllText(SettingsPath,
+                JsonSerializer.Serialize(Current, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[SettingsService] save failed: {ex.Message}");
+        }
+    }
+}
+
+public sealed class ReaderSettings
+{
+    public string VoicePath { get; set; } = "";
+    public string OnnxBundleDir { get; set; } = "";
+    public string NfaBundleDir { get; set; } = "";
+    public bool RenderMarkdown { get; set; } = false;
+}

--- a/src/Chatterbox.Avalonia/Services/SynthesisService.cs
+++ b/src/Chatterbox.Avalonia/Services/SynthesisService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,10 +15,10 @@ using Vernacula.Base.Models;
 namespace Chatterbox.App.Services;
 
 /// <summary>
-/// One-call synthesis + alignment for the reader UI. Mirrors what
-/// Chatterbox.CLI's `--alignment-out` path does end-to-end, just
-/// in-process and structured for the UI to consume:
-/// (audio WAV path, alignment data) returned together.
+/// Streaming synthesis + alignment for the reader UI. The non-streaming
+/// MVP path (single returned <see cref="SynthesisResult"/>) is still
+/// here as a convenience; the new streaming flow is what wires up to
+/// per-chunk playback and per-word highlighting.
 ///
 /// Sessions are lazily loaded on the first call and reused across
 /// subsequent invocations — the pipeline load is the big sticky cost
@@ -35,13 +36,6 @@ public sealed class SynthesisService : IDisposable
     private NemoNfaAligner? _aligner;
     private readonly object _gate = new();
 
-    /// <param name="onnxBundleDir">Path to the Chatterbox ONNX bundle
-    /// (output of scripts/chatterbox_export/export_chatterbox_to_onnx.py).</param>
-    /// <param name="nfaBundleDir">Optional NFA bundle path. When null,
-    /// synthesis runs without producing alignment data (the returned
-    /// <see cref="AlignmentSidecar.Words"/> stays empty).</param>
-    /// <param name="tokenizerJsonPath">Optional override for the
-    /// Chatterbox tokenizer.json; null = auto-locate from HF hub cache.</param>
     public SynthesisService(
         string onnxBundleDir,
         string? nfaBundleDir = null,
@@ -56,123 +50,201 @@ public sealed class SynthesisService : IDisposable
 
     public sealed record SynthesisResult(string AudioPath, AlignmentSidecar Alignment);
 
+    /// <summary>Per-chunk streaming event payload.</summary>
+    /// <param name="ChunkIndex">0-based index in input order.</param>
+    /// <param name="TotalChunks">Total chunks the synthesis will produce.</param>
+    /// <param name="Audio24k">Raw float32 mono samples at 24 kHz (Chatterbox's native rate).</param>
+    /// <param name="ChunkText">The reference text for this chunk (post-markdown-extraction).</param>
+    /// <param name="AudioStartSeconds">Absolute start in the concatenated audio timeline.</param>
+    /// <param name="Words">Per-word alignments with absolute timings, or empty when no NFA bundle is configured.</param>
+    public sealed record ChunkProducedEvent(
+        int ChunkIndex,
+        int TotalChunks,
+        float[] Audio24k,
+        string ChunkText,
+        double AudioStartSeconds,
+        IReadOnlyList<AlignedWord> Words);
+
+    /// <summary>Status-line events for the UI. Phase is a free-form short string
+    /// like "loading models", "synthesizing chunk 3/8", "aligning chunk 4/8".</summary>
+    public sealed record ProgressEvent(string Phase, int? ChunkIndex = null, int? TotalChunks = null);
+
     /// <summary>
-    /// Synthesize <paramref name="text"/> in the voice of
-    /// <paramref name="voicePath"/>, write a WAV to <paramref name="outWavPath"/>,
-    /// and (when an NFA bundle is configured) produce per-word audio
-    /// timings. Runs on whatever thread you call it from — the UI
-    /// should call this via Task.Run to keep the dispatcher responsive.
+    /// Synthesize text in <paramref name="voicePath"/>'s voice and stream
+    /// chunks back via <paramref name="onChunkProduced"/> as each one
+    /// completes. Returns the final concatenated WAV path + full
+    /// alignment sidecar once everything is done.
     ///
-    /// <paramref name="cancellationToken"/> is checked at chunk boundaries
-    /// and after the synthesis call. The underlying LM rollout
-    /// (<c>pipeline.Lm.Generate</c>) is uninterruptible once started —
-    /// a cancel during the ~30 s single-chunk rollout will take effect
-    /// only after that chunk completes.
+    /// <paramref name="onProgress"/> fires for major phase transitions
+    /// (model load, chunk start/done, alignment start/done) and for
+    /// every chunk index — bind it to the UI's status line so the user
+    /// sees forward motion through long runs.
+    ///
+    /// Cancellation: checked at chunk boundaries and after the synthesis
+    /// call. The LM rollout (~30 s per chunk worst case) is uninterruptible
+    /// once started; a cancel during a chunk's rollout takes effect only
+    /// after that chunk completes.
     /// </summary>
-    public SynthesisResult Synthesize(
+    public async Task<SynthesisResult> SynthesizeStreamingAsync(
         string voicePath,
         string text,
         string outWavPath,
+        Action<ChunkProducedEvent>? onChunkProduced = null,
+        Action<ProgressEvent>? onProgress = null,
         CancellationToken cancellationToken = default)
     {
-        EnsureLoaded();
+        onProgress?.Invoke(new ProgressEvent("loading models"));
+        // EnsureLoaded is sync + heavy; offload to the threadpool so the
+        // UI dispatcher doesn't stall on the first call (~5-10 s).
+        await Task.Run(EnsureLoaded, cancellationToken).ConfigureAwait(false);
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Always route the input through MarkdownTextExtractor. For plain
-        // prose the extractor is near-identity (paragraphs preserved). For
-        // markdown it strips heading markers / list bullets / link URLs /
-        // code blocks etc., none of which speak well. The CLI is fine
-        // dispatching on file extension (.md → extract, else pass-through)
-        // because it knows the source; the UI's text box doesn't carry an
-        // extension hint, and "always extract" is the safer default —
-        // false negatives from a heuristic would let raw URL text leak
-        // into the TTS stream.
+        // Always route through MarkdownTextExtractor — see the inline note
+        // in the pre-streaming version for why we don't heuristic-detect.
         var preparedText = MarkdownTextExtractor.Extract(text).Text;
         if (string.IsNullOrWhiteSpace(preparedText))
             throw new InvalidOperationException("Text is empty after markdown extraction.");
 
         var chunks = ParagraphChunker.Chunk(preparedText);
-        var spk = _pipeline!.Embedder.Embed(voicePath);
-        cancellationToken.ThrowIfCancellationRequested();
+        int totalChunks = chunks.Count;
+        onProgress?.Invoke(new ProgressEvent($"chunked into {totalChunks} paragraphs"));
 
-        float[][] chunkAudios;
-        if (chunks.Count <= 1)
-        {
-            var tokenIds = _pipeline.Tokenizer!.WrapForLm(preparedText);
-            var lmResult = _pipeline.Lm.Generate(spk.CondEmb, tokenIds);
-            var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
-            var samples = _pipeline.Vocoder.Synthesize(
-                speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
-            chunkAudios = new[] { samples };
-        }
-        else
-        {
-            var tokensPerChunk = chunks.Select(c => _pipeline.Tokenizer!.WrapForLm(c)).ToArray();
-            var synth = new ChunkedSynthesizer(_pipeline);
-            var result = synth.Synthesize(spk, tokensPerChunk);
-            chunkAudios = result.Waveforms.ToArray();
-        }
-        cancellationToken.ThrowIfCancellationRequested();
+        // Per-chunk state, shared between the synth callback and the
+        // post-synth concatenation + alignment-sidecar build. The
+        // ConcurrentDictionary holds the raw audio keyed by chunk index
+        // so we can both stream-emit and concatenate at the end.
+        var chunkAudios = new ConcurrentDictionary<int, float[]>();
+        var chunkTexts = chunks;  // input order; index aligns with idx
+        var allWords = new List<AlignedWord>();
+        var sidecarChunks = new List<ChunkRecord>();
+        int sampleOffsetCursor = 0;  // monotonic; updated under _alignmentLock
+        var alignmentLock = new object();
 
-        // Concatenate + write WAV (24 kHz mono float32 — same as CLI).
-        int totalSamples = chunkAudios.Sum(w => w.Length);
-        var allSamples = new float[totalSamples];
-        int off = 0;
-        foreach (var w in chunkAudios)
+        return await Task.Run(() =>
         {
-            Array.Copy(w, 0, allSamples, off, w.Length);
-            off += w.Length;
-        }
-        var fmt = WaveFormat.CreateIeeeFloatWaveFormat(ChatterboxConstants.S3GenSr, 1);
-        using (var writer = new WaveFileWriter(outWavPath, fmt))
-            writer.WriteSamples(allSamples, 0, allSamples.Length);
+            cancellationToken.ThrowIfCancellationRequested();
+            var spk = _pipeline!.Embedder.Embed(voicePath);
+            cancellationToken.ThrowIfCancellationRequested();
 
-        // Alignment. When no NFA bundle is configured, return an empty
-        // sidecar (audio-only mode) — UI still shows playback, just
-        // without word highlighting.
-        var sidecar = new AlignmentSidecar
-        {
-            AudioPath = outWavPath,
-            SampleRate = ChatterboxConstants.S3GenSr,
-            AudioDurationSeconds = totalSamples / (double)ChatterboxConstants.S3GenSr,
-            Aligner = _aligner is null ? "none" : "nemo_nfa",
-        };
-        if (_aligner is not null)
-        {
-            int sampleOffset = 0;
-            for (int i = 0; i < chunkAudios.Length; i++)
+            // Per-chunk streaming callback used by ChunkedSynthesizer (it
+            // fires this from the vocoder thread). We compute absolute
+            // offset, run alignment (if available) on this chunk only,
+            // and re-emit upward via onChunkProduced. ChunkedSynthesizer
+            // calls us in input order, so the lock just serializes the
+            // cursor + sidecar list appends.
+            void EmitChunk(int idx, float[] wav, ChunkTiming _t)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var chunkAudio24k = chunkAudios[i];
-                double chunkStartSec = sampleOffset / (double)ChatterboxConstants.S3GenSr;
-                double chunkEndSec = (sampleOffset + chunkAudio24k.Length) / (double)ChatterboxConstants.S3GenSr;
-                sampleOffset += chunkAudio24k.Length;
-
-                var chunkAudio16k = Vernacula.Base.AudioUtils.AudioTo16000Mono(
-                    chunkAudio24k, ChatterboxConstants.S3GenSr, channels: 1);
-                var words = _aligner.Align(chunkAudio16k, chunks[i], "en");
-
-                sidecar.Chunks.Add(new ChunkRecord
+                chunkAudios[idx] = wav;
+                IReadOnlyList<AlignedWord> wordsForChunk;
+                double chunkStartSec;
+                lock (alignmentLock)
                 {
-                    Index = i,
-                    AudioStartSeconds = chunkStartSec,
-                    AudioEndSeconds = chunkEndSec,
-                    Text = chunks[i],
-                    WordCount = words.Count,
-                });
-                foreach (var w in words)
-                {
-                    sidecar.Words.Add(new AlignedWord
+                    chunkStartSec = sampleOffsetCursor / (double)ChatterboxConstants.S3GenSr;
+                    double chunkEndSec = (sampleOffsetCursor + wav.Length) / (double)ChatterboxConstants.S3GenSr;
+                    sampleOffsetCursor += wav.Length;
+
+                    if (_aligner is not null)
                     {
-                        Text = w.Text,
-                        StartSeconds = chunkStartSec + w.StartSeconds,
-                        EndSeconds = chunkStartSec + w.EndSeconds,
-                        ChunkIndex = i,
-                    });
+                        onProgress?.Invoke(new ProgressEvent("aligning", idx + 1, totalChunks));
+                        var wav16k = Vernacula.Base.AudioUtils.AudioTo16000Mono(
+                            wav, ChatterboxConstants.S3GenSr, channels: 1);
+                        var localWords = _aligner.Align(wav16k, chunkTexts[idx], "en");
+                        var absWords = new List<AlignedWord>(localWords.Count);
+                        foreach (var w in localWords)
+                        {
+                            absWords.Add(new AlignedWord
+                            {
+                                Text = w.Text,
+                                StartSeconds = chunkStartSec + w.StartSeconds,
+                                EndSeconds = chunkStartSec + w.EndSeconds,
+                                ChunkIndex = idx,
+                            });
+                        }
+                        allWords.AddRange(absWords);
+                        sidecarChunks.Add(new ChunkRecord
+                        {
+                            Index = idx,
+                            AudioStartSeconds = chunkStartSec,
+                            AudioEndSeconds = chunkEndSec,
+                            Text = chunkTexts[idx],
+                            WordCount = absWords.Count,
+                        });
+                        wordsForChunk = absWords;
+                    }
+                    else
+                    {
+                        sidecarChunks.Add(new ChunkRecord
+                        {
+                            Index = idx,
+                            AudioStartSeconds = chunkStartSec,
+                            AudioEndSeconds = chunkEndSec,
+                            Text = chunkTexts[idx],
+                            WordCount = 0,
+                        });
+                        wordsForChunk = Array.Empty<AlignedWord>();
+                    }
                 }
+                onProgress?.Invoke(new ProgressEvent($"chunk {idx + 1}/{totalChunks} ready", idx + 1, totalChunks));
+                onChunkProduced?.Invoke(new ChunkProducedEvent(
+                    idx, totalChunks, wav, chunkTexts[idx], chunkStartSec, wordsForChunk));
             }
-        }
-        return new SynthesisResult(outWavPath, sidecar);
+
+            // Dispatch. Single-chunk path uses the bare pipeline (no
+            // ChunkedSynthesizer overhead); long-form uses the streaming
+            // callback. Both end up populating chunkAudios + invoking
+            // EmitChunk in input order.
+            if (totalChunks <= 1)
+            {
+                onProgress?.Invoke(new ProgressEvent("synthesizing", 1, 1));
+                var tokenIds = _pipeline.Tokenizer!.WrapForLm(preparedText);
+                var lmResult = _pipeline.Lm.Generate(spk.CondEmb, tokenIds);
+                var speechTokens = lmResult.BuildSpeechTokens(spk.AudioTokens);
+                var samples = _pipeline.Vocoder.Synthesize(
+                    speechTokens, spk.SpeakerEmbeddings, spk.SpeakerFeatures);
+                EmitChunk(0, samples,
+                    new ChunkTiming(0, 0, lmResult.Steps, 0, samples.Length));
+            }
+            else
+            {
+                onProgress?.Invoke(new ProgressEvent($"synthesizing {totalChunks} chunks"));
+                var tokensPerChunk = chunks.Select(c => _pipeline.Tokenizer!.WrapForLm(c)).ToArray();
+                var synth = new ChunkedSynthesizer(_pipeline);
+                synth.Synthesize(spk, tokensPerChunk, chunkProduced: EmitChunk);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Concatenate all chunks in input order + write the final WAV.
+            int totalSamples = chunkAudios.Sum(kv => kv.Value.Length);
+            var allSamples = new float[totalSamples];
+            int off = 0;
+            for (int i = 0; i < totalChunks; i++)
+            {
+                var w = chunkAudios[i];
+                Array.Copy(w, 0, allSamples, off, w.Length);
+                off += w.Length;
+            }
+            var fmt = WaveFormat.CreateIeeeFloatWaveFormat(ChatterboxConstants.S3GenSr, 1);
+            using (var writer = new WaveFileWriter(outWavPath, fmt))
+                writer.WriteSamples(allSamples, 0, allSamples.Length);
+
+            // Sidecar order: ChunkedSynthesizer's callback fires in input
+            // order, but we appended sidecarChunks under a lock — sorting
+            // by index makes the order explicit + future-proof against a
+            // reordering callback policy.
+            sidecarChunks.Sort((a, b) => a.Index.CompareTo(b.Index));
+
+            var sidecar = new AlignmentSidecar
+            {
+                AudioPath = outWavPath,
+                SampleRate = ChatterboxConstants.S3GenSr,
+                AudioDurationSeconds = totalSamples / (double)ChatterboxConstants.S3GenSr,
+                Aligner = _aligner is null ? "none" : "nemo_nfa",
+                Chunks = sidecarChunks,
+                Words = allWords,
+            };
+            return new SynthesisResult(outWavPath, sidecar);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     private void EnsureLoaded()

--- a/src/Chatterbox.Avalonia/Services/SynthesisService.cs
+++ b/src/Chatterbox.Avalonia/Services/SynthesisService.cs
@@ -263,6 +263,28 @@ public sealed class SynthesisService : IDisposable
         }, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>Concatenate <paramref name="chunks"/> in the given order
+    /// and write a 24 kHz mono float32 WAV. Used to persist a partial
+    /// result when the user cancels mid-synthesis — Chatterbox chunks
+    /// can be concatenated directly because the LM rollout state isn't
+    /// shared across chunks (each chunk is a self-contained synthesis
+    /// against the same conditioning).</summary>
+    public static void WriteWavFromChunks(string outPath, IReadOnlyList<float[]> chunks, int sampleRate)
+    {
+        int total = 0;
+        foreach (var c in chunks) total += c.Length;
+        var all = new float[total];
+        int off = 0;
+        foreach (var c in chunks)
+        {
+            Array.Copy(c, 0, all, off, c.Length);
+            off += c.Length;
+        }
+        var fmt = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, 1);
+        using var writer = new WaveFileWriter(outPath, fmt);
+        writer.WriteSamples(all, 0, all.Length);
+    }
+
     private void EnsureLoaded()
     {
         if (_pipeline is not null) return;

--- a/src/Chatterbox.Avalonia/Services/SynthesisService.cs
+++ b/src/Chatterbox.Avalonia/Services/SynthesisService.cs
@@ -117,73 +117,85 @@ public sealed class SynthesisService : IDisposable
         var chunkTexts = chunks;  // input order; index aligns with idx
         var allWords = new List<AlignedWord>();
         var sidecarChunks = new List<ChunkRecord>();
-        int sampleOffsetCursor = 0;  // monotonic; updated under _alignmentLock
-        var alignmentLock = new object();
+        int sampleOffsetCursor = 0;
 
-        return await Task.Run(() =>
+        return await Task.Run(async () =>
         {
             cancellationToken.ThrowIfCancellationRequested();
             var spk = _pipeline!.Embedder.Embed(voicePath);
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Per-chunk streaming callback used by ChunkedSynthesizer (it
-            // fires this from the vocoder thread). We compute absolute
-            // offset, run alignment (if available) on this chunk only,
-            // and re-emit upward via onChunkProduced. ChunkedSynthesizer
-            // calls us in input order, so the lock just serializes the
-            // cursor + sidecar list appends.
+            // Alignment is non-trivial CPU/GPU work (~25% of vocoder wall
+            // time on a typical chunk). Running it on the synth thread
+            // would block the next chunk's vocoder pass. Instead we chain
+            // alignment+emit onto a ContinueWith pipeline so the synth
+            // thread can return immediately after stamping the cursor.
+            // ContinueWith preserves input order, so allWords / sidecarChunks
+            // appends are lock-free.
+            Task alignChain = Task.CompletedTask;
+
             void EmitChunk(int idx, float[] wav, ChunkTiming _t)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 chunkAudios[idx] = wav;
-                IReadOnlyList<AlignedWord> wordsForChunk;
-                double chunkStartSec;
-                lock (alignmentLock)
-                {
-                    chunkStartSec = sampleOffsetCursor / (double)ChatterboxConstants.S3GenSr;
-                    double chunkEndSec = (sampleOffsetCursor + wav.Length) / (double)ChatterboxConstants.S3GenSr;
-                    sampleOffsetCursor += wav.Length;
+                // Cursor stamp is cheap; do it on the synth thread so we
+                // can hand the absolute timing to the alignment task.
+                // ChunkedSynthesizer calls EmitChunk in input order from a
+                // single thread, so no lock needed.
+                double chunkStartSec = sampleOffsetCursor / (double)ChatterboxConstants.S3GenSr;
+                double chunkEndSec = (sampleOffsetCursor + wav.Length) / (double)ChatterboxConstants.S3GenSr;
+                sampleOffsetCursor += wav.Length;
 
-                    if (_aligner is not null)
+                alignChain = alignChain.ContinueWith(
+                    _ => AlignAndEmit(idx, wav, chunkStartSec, chunkEndSec),
+                    cancellationToken,
+                    TaskContinuationOptions.None,
+                    TaskScheduler.Default);
+            }
+
+            void AlignAndEmit(int idx, float[] wav, double chunkStartSec, double chunkEndSec)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                IReadOnlyList<AlignedWord> wordsForChunk;
+                if (_aligner is not null)
+                {
+                    onProgress?.Invoke(new ProgressEvent("aligning", idx + 1, totalChunks));
+                    var wav16k = Vernacula.Base.AudioUtils.AudioTo16000Mono(
+                        wav, ChatterboxConstants.S3GenSr, channels: 1);
+                    var localWords = _aligner.Align(wav16k, chunkTexts[idx], "en");
+                    var absWords = new List<AlignedWord>(localWords.Count);
+                    foreach (var w in localWords)
                     {
-                        onProgress?.Invoke(new ProgressEvent("aligning", idx + 1, totalChunks));
-                        var wav16k = Vernacula.Base.AudioUtils.AudioTo16000Mono(
-                            wav, ChatterboxConstants.S3GenSr, channels: 1);
-                        var localWords = _aligner.Align(wav16k, chunkTexts[idx], "en");
-                        var absWords = new List<AlignedWord>(localWords.Count);
-                        foreach (var w in localWords)
+                        absWords.Add(new AlignedWord
                         {
-                            absWords.Add(new AlignedWord
-                            {
-                                Text = w.Text,
-                                StartSeconds = chunkStartSec + w.StartSeconds,
-                                EndSeconds = chunkStartSec + w.EndSeconds,
-                                ChunkIndex = idx,
-                            });
-                        }
-                        allWords.AddRange(absWords);
-                        sidecarChunks.Add(new ChunkRecord
-                        {
-                            Index = idx,
-                            AudioStartSeconds = chunkStartSec,
-                            AudioEndSeconds = chunkEndSec,
-                            Text = chunkTexts[idx],
-                            WordCount = absWords.Count,
+                            Text = w.Text,
+                            StartSeconds = chunkStartSec + w.StartSeconds,
+                            EndSeconds = chunkStartSec + w.EndSeconds,
+                            ChunkIndex = idx,
                         });
-                        wordsForChunk = absWords;
                     }
-                    else
+                    allWords.AddRange(absWords);
+                    sidecarChunks.Add(new ChunkRecord
                     {
-                        sidecarChunks.Add(new ChunkRecord
-                        {
-                            Index = idx,
-                            AudioStartSeconds = chunkStartSec,
-                            AudioEndSeconds = chunkEndSec,
-                            Text = chunkTexts[idx],
-                            WordCount = 0,
-                        });
-                        wordsForChunk = Array.Empty<AlignedWord>();
-                    }
+                        Index = idx,
+                        AudioStartSeconds = chunkStartSec,
+                        AudioEndSeconds = chunkEndSec,
+                        Text = chunkTexts[idx],
+                        WordCount = absWords.Count,
+                    });
+                    wordsForChunk = absWords;
+                }
+                else
+                {
+                    sidecarChunks.Add(new ChunkRecord
+                    {
+                        Index = idx,
+                        AudioStartSeconds = chunkStartSec,
+                        AudioEndSeconds = chunkEndSec,
+                        Text = chunkTexts[idx],
+                        WordCount = 0,
+                    });
+                    wordsForChunk = Array.Empty<AlignedWord>();
                 }
                 onProgress?.Invoke(new ProgressEvent($"chunk {idx + 1}/{totalChunks} ready", idx + 1, totalChunks));
                 onChunkProduced?.Invoke(new ChunkProducedEvent(
@@ -212,6 +224,11 @@ public sealed class SynthesisService : IDisposable
                 var synth = new ChunkedSynthesizer(_pipeline);
                 synth.Synthesize(spk, tokensPerChunk, chunkProduced: EmitChunk);
             }
+
+            // Drain the alignment chain before we build the sidecar — the
+            // last chunk's alignment is still in flight after Synthesize
+            // returns.
+            await alignChain.ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
 
             // Concatenate all chunks in input order + write the final WAV.
@@ -228,10 +245,9 @@ public sealed class SynthesisService : IDisposable
             using (var writer = new WaveFileWriter(outWavPath, fmt))
                 writer.WriteSamples(allSamples, 0, allSamples.Length);
 
-            // Sidecar order: ChunkedSynthesizer's callback fires in input
-            // order, but we appended sidecarChunks under a lock — sorting
-            // by index makes the order explicit + future-proof against a
-            // reordering callback policy.
+            // The ContinueWith alignment chain runs in input order so
+            // sidecarChunks should already be sorted; the explicit sort
+            // is a future-proof against a reordering callback policy.
             sidecarChunks.Sort((a, b) => a.Index.CompareTo(b.Index));
 
             var sidecar = new AlignmentSidecar

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -9,32 +9,136 @@ using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using Chatterbox.App.Models;
 using Chatterbox.App.Services;
+using Chatterbox.Base;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 namespace Chatterbox.App.ViewModels;
 
 /// <summary>
-/// Single VM for the reader MVP. State lives here:
-/// pickers (voice / Chatterbox bundle / NFA bundle), text, last
-/// synthesis result, playback position, current highlighted word
-/// index into <see cref="Words"/>. Bindings are compiled at AXAML
-/// load (csproj's AvaloniaUseCompiledBindingsByDefault=true).
+/// Reader VM. Holds picker state, persists it across runs via
+/// <see cref="SettingsService"/>, drives streaming synthesis +
+/// playback (chunks start playing as soon as the first one is ready),
+/// and toggles between the flat word-by-word view and a Markdown
+/// rendering of the source.
 /// </summary>
 public sealed partial class MainViewModel : ObservableObject, IDisposable
 {
-    // Pickers — paths the user fills in via file/folder dialogs.
-    [ObservableProperty] private string _voicePath = "";
-    [ObservableProperty] private string _onnxBundleDir = "";
+    // Pickers. NotifyCanExecuteChangedFor is what re-queries the
+    // SynthesizeCommand's CanExecute when the picker fills.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _voicePath = "";
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _onnxBundleDir = "";
+
+    // NFA bundle is OPTIONAL — synthesis runs without it (just no word
+    // highlight). Doesn't gate Synthesize, so no notify here.
     [ObservableProperty] private string _nfaBundleDir = "";
 
-    // Bundle-path changes invalidate the cached SynthesisService so the
-    // next Synthesize click rebuilds against the new paths. Without this,
-    // the lazy `_synthService ??= new SynthesisService(...)` would silently
-    // keep using the FIRST bundle pair the user picked, even after they
-    // changed pickers.
-    partial void OnOnnxBundleDirChanged(string value) => InvalidateSynthService();
-    partial void OnNfaBundleDirChanged(string value) => InvalidateSynthService();
+    // Text input — either typed/pasted in the UI or loaded from a .md file.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _text = "";
+
+    // Markdown vs plain word-grid rendering of the source pane. Persisted
+    // across runs.
+    [ObservableProperty] private bool _renderMarkdown;
+
+    // Status line below the synthesize button.
+    [ObservableProperty] private string _statusMessage = "Ready.";
+
+    // Active while synthesis is running. Disables most controls.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    private bool _isBusy;
+
+    // True after a synthesis finishes successfully. Enables replay.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    private bool _hasSynthesizedAudio;
+
+    // Aligned words from the running/last synthesis. Streamed in as
+    // chunks complete.
+    public ObservableCollection<WordItemViewModel> Words { get; } = new();
+
+    // -1 = nothing currently highlighted.
+    private int _currentWordIndex = -1;
+
+    [ObservableProperty] private string _positionLabel = "0.00 / 0.00 s";
+
+    private AlignmentSidecar? _lastAlignment;
+    private string? _lastAudioPath;
+    private SynthesisService? _synthService;
+    private readonly PlaybackService _playback = new();
+    private readonly SettingsService _settings = new();
+    private CancellationTokenSource? _synthCts;
+
+    // Gates the autosave during the initial settings load so we don't
+    // write N times as each property hydrates.
+    private bool _loadingSettings;
+
+    public MainViewModel()
+    {
+        _playback.PositionChanged += OnPlaybackPositionChanged;
+        _playback.PlaybackStopped += _ =>
+        {
+            if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
+                Words[_currentWordIndex].IsCurrent = false;
+            _currentWordIndex = -1;
+            // Don't overwrite synthesis-in-progress status with "stopped".
+            if (!IsBusy) StatusMessage = "Playback stopped.";
+        };
+
+        LoadSettings();
+
+        if (!_playback.CanPlayOnThisPlatform)
+            StatusMessage = _playback.UnavailableReason!;
+    }
+
+    // ── Settings persistence ─────────────────────────────────────────
+
+    private void LoadSettings()
+    {
+        _loadingSettings = true;
+        try
+        {
+            _settings.Load();
+            VoicePath = _settings.Current.VoicePath;
+            OnnxBundleDir = _settings.Current.OnnxBundleDir;
+            NfaBundleDir = _settings.Current.NfaBundleDir;
+            RenderMarkdown = _settings.Current.RenderMarkdown;
+        }
+        finally { _loadingSettings = false; }
+    }
+
+    private void PersistSettings()
+    {
+        if (_loadingSettings) return;
+        _settings.Current.VoicePath = VoicePath;
+        _settings.Current.OnnxBundleDir = OnnxBundleDir;
+        _settings.Current.NfaBundleDir = NfaBundleDir;
+        _settings.Current.RenderMarkdown = RenderMarkdown;
+        _settings.Save();
+    }
+
+    // Generated [ObservableProperty] partials let us hook each setter
+    // for the autosave + (for bundle paths) cached-service invalidation.
+    partial void OnVoicePathChanged(string value) => PersistSettings();
+    partial void OnOnnxBundleDirChanged(string value)
+    {
+        InvalidateSynthService();
+        PersistSettings();
+    }
+    partial void OnNfaBundleDirChanged(string value)
+    {
+        InvalidateSynthService();
+        PersistSettings();
+    }
+    partial void OnRenderMarkdownChanged(bool value) => PersistSettings();
 
     private void InvalidateSynthService()
     {
@@ -43,60 +147,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         stale?.Dispose();
     }
 
-    // Text input — either typed/pasted in the UI or loaded from a .md file.
-    [ObservableProperty] private string _text = "";
-
-    // Status line below the synthesize button.
-    [ObservableProperty] private string _statusMessage = "Ready.";
-
-    // True while a synthesis task is running. Disables most UI controls.
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
-    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
-    private bool _isBusy;
-
-    // True after a successful synthesis — enables Play and the highlight loop.
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
-    private bool _hasSynthesizedAudio;
-
-    // The aligned words from the last synthesis as per-item VMs so the
-    // AXAML can class-trigger the highlight on IsCurrent without a
-    // multi-binding converter.
-    public ObservableCollection<WordItemViewModel> Words { get; } = new();
-
-    // Index into Words[] of the word currently being spoken (or -1 when
-    // not playing or before the first word). Internal — UI doesn't bind
-    // to this directly, the per-word IsCurrent does the work.
-    private int _currentWordIndex = -1;
-
-    // Read-only audio position label for the UI footer.
-    [ObservableProperty] private string _positionLabel = "0.00 / 0.00 s";
-
-    private AlignmentSidecar? _lastAlignment;
-    private SynthesisService? _synthService;
-    private readonly PlaybackService _playback = new();
-    private CancellationTokenSource? _synthCts;
-
-    public MainViewModel()
-    {
-        // PlaybackService raises both events from its DispatcherTimer,
-        // which is already on the UI thread — no Dispatcher.Post wrapping
-        // needed. (An earlier draft posted defensively; the reviewer of
-        // PR #74 caught that we were paying 20 dispatcher-frame round-trips
-        // per second for no benefit.)
-        _playback.PositionChanged += OnPlaybackPositionChanged;
-        _playback.PlaybackStopped += _ =>
-        {
-            if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
-                Words[_currentWordIndex].IsCurrent = false;
-            _currentWordIndex = -1;
-            StatusMessage = "Playback stopped.";
-        };
-
-        if (!_playback.CanPlayOnThisPlatform)
-            StatusMessage = _playback.UnavailableReason!;
-    }
+    // ── Pickers ──────────────────────────────────────────────────────
 
     [RelayCommand]
     private async Task PickVoiceAsync()
@@ -131,41 +182,77 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         catch (Exception ex) { StatusMessage = $"Read failed: {ex.Message}"; }
     }
 
+    // ── Synthesis (streaming) ────────────────────────────────────────
+
     [RelayCommand(CanExecute = nameof(CanSynthesize))]
     private async Task SynthesizeAsync()
     {
         IsBusy = true;
         StatusMessage = _synthService is null ? "Loading models (one-time)..." : "Synthesizing...";
+        // Stop any in-progress playback from a prior run; clear the
+        // highlight + word list so the new synthesis streams in fresh.
+        _playback.Stop();
         Words.Clear();
         _currentWordIndex = -1;
         HasSynthesizedAudio = false;
+        _lastAlignment = null;
+        _lastAudioPath = null;
         _synthCts?.Dispose();
         _synthCts = new CancellationTokenSource();
         var token = _synthCts.Token;
 
         try
         {
-            // Lazy-construct the synthesis service so the heavy ORT
-            // session loads happen on the first synthesize click rather
-            // than at startup (faster cold UI).
             _synthService ??= new SynthesisService(
                 OnnxBundleDir,
                 nfaBundleDir: string.IsNullOrWhiteSpace(NfaBundleDir) ? null : NfaBundleDir);
 
             string outWav = Path.Combine(Path.GetTempPath(),
                 $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss}.wav");
+            bool streamingStarted = false;
 
-            var result = await Task.Run(
-                () => _synthService.Synthesize(VoicePath, Text, outWav, token),
-                token);
+            var result = await _synthService.SynthesizeStreamingAsync(
+                VoicePath, Text, outWav,
+                onChunkProduced: ev => Dispatcher.UIThread.Post(() =>
+                {
+                    // First chunk arrives → open the playback pipeline and
+                    // start streaming. Audio plays as soon as bytes are
+                    // appended; the wall-clock tick begins from now.
+                    if (!streamingStarted)
+                    {
+                        try
+                        {
+                            _playback.StartStreaming(ChatterboxConstants.S3GenSr, channels: 1);
+                            streamingStarted = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            StatusMessage = $"Playback open failed: {ex.Message}";
+                            return;
+                        }
+                    }
+                    _playback.AppendSamples(ev.Audio24k);
+                    int baseIdx = Words.Count;
+                    int wi = baseIdx;
+                    foreach (var w in ev.Words)
+                        Words.Add(new WordItemViewModel(w, wi++, SeekToWord));
+                }),
+                onProgress: p => Dispatcher.UIThread.Post(() =>
+                {
+                    StatusMessage = p.ChunkIndex is int idx && p.TotalChunks is int total
+                        ? $"{p.Phase} ({idx}/{total})"
+                        : p.Phase;
+                }),
+                cancellationToken: token);
 
             _lastAlignment = result.Alignment;
+            _lastAudioPath = result.AudioPath;
             HasSynthesizedAudio = true;
-            int idx = 0;
-            foreach (var w in result.Alignment.Words)
-                Words.Add(new WordItemViewModel(w, idx++));
-            StatusMessage = $"Synthesized {result.Alignment.AudioDurationSeconds:F2}s, "
-                + $"{result.Alignment.Words.Count} words. Ready to play.";
+            // Tell the playback service no more samples are coming so it
+            // can fire PlaybackStopped naturally when the buffer drains.
+            if (streamingStarted) _playback.EndOfStream();
+            StatusMessage = $"Done. {result.Alignment.AudioDurationSeconds:F2}s audio, "
+                + $"{result.Alignment.Words.Count} words.";
         }
         catch (OperationCanceledException)
         {
@@ -187,13 +274,17 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         && !string.IsNullOrWhiteSpace(OnnxBundleDir)
         && !string.IsNullOrWhiteSpace(Text);
 
+    // ── Playback ─────────────────────────────────────────────────────
+
     [RelayCommand(CanExecute = nameof(CanPlay))]
     private void Play()
     {
-        if (_lastAlignment is null) return;
+        // Replay path: synthesis is done, audio is on disk. Use
+        // SeekIntoFile(0) to play the saved WAV from the beginning.
+        if (_lastAudioPath is null || _lastAlignment is null) return;
         try
         {
-            _playback.Play(_lastAlignment.AudioPath, _lastAlignment.AudioDurationSeconds);
+            _playback.SeekIntoFile(_lastAudioPath, _lastAlignment.AudioDurationSeconds, 0);
             StatusMessage = "Playing.";
         }
         catch (Exception ex) { StatusMessage = $"Play failed: {ex.Message}"; }
@@ -204,15 +295,33 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void Stop() => _playback.Stop();
 
+    // Click-to-seek wiring. Each WordItemViewModel calls this back via a
+    // delegate set at construction (avoids per-word command boilerplate +
+    // keeps the VM list as a pure data collection).
+    private void SeekToWord(WordItemViewModel word)
+    {
+        // After synthesis completes we have an on-disk WAV and can do a
+        // real audio seek. Mid-synthesis we can only re-anchor the
+        // highlight clock (audio is being buffered as we go and seeking
+        // into a streaming buffer would be a much bigger surgery).
+        if (HasSynthesizedAudio && _lastAudioPath is not null && _lastAlignment is not null)
+        {
+            try
+            {
+                _playback.SeekIntoFile(_lastAudioPath, _lastAlignment.AudioDurationSeconds,
+                    word.StartSeconds);
+                StatusMessage = $"Seek → {word.StartSeconds:F2}s.";
+            }
+            catch (Exception ex) { StatusMessage = $"Seek failed: {ex.Message}"; }
+        }
+        else
+        {
+            _playback.SeekTo(word.StartSeconds);
+        }
+    }
+
     private void OnPlaybackPositionChanged(double posSec)
     {
-        // Already on the UI thread (PlaybackService's DispatcherTimer
-        // fires here). Binary-search the words list for the word whose
-        // interval contains posSec; Words is sorted by StartSeconds per
-        // the sidecar contract. A linear scan from the current index
-        // forward would also work (amortized O(N) over a playback);
-        // binary search is just as cheap and handles backwards seeks
-        // when scrubbing lands.
         int idx = FindWordAt(posSec);
         if (idx != _currentWordIndex)
         {
@@ -227,25 +336,18 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
 
     private int FindWordAt(double posSec)
     {
-        // Standard binary search over Words[i].StartSeconds. Returns the
-        // last word whose StartSeconds <= posSec, or -1 when posSec is
-        // before the first word. The "current word" is whatever started
-        // most recently; we don't gate on EndSeconds so brief inter-word
-        // gaps still show the trailing word highlighted (no flicker).
         if (Words.Count == 0) return -1;
         int lo = 0, hi = Words.Count - 1, best = -1;
         while (lo <= hi)
         {
             int mid = (lo + hi) >>> 1;
-            if (Words[mid].StartSeconds <= posSec)
-            {
-                best = mid;
-                lo = mid + 1;
-            }
-            else { hi = mid - 1; }
+            if (Words[mid].StartSeconds <= posSec) { best = mid; lo = mid + 1; }
+            else hi = mid - 1;
         }
         return best;
     }
+
+    // ── Picker plumbing ──────────────────────────────────────────────
 
     private static async Task<string?> PickFileAsync(string title, FilePickerFileType filter)
     {

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -61,10 +61,22 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [NotifyCanExecuteChangedFor(nameof(CancelSynthesisCommand))]
     private bool _isBusy;
 
-    // True after a synthesis finishes successfully. Enables replay.
+    // True once at least one chunk has been produced. Enables Play
+    // (including mid-synth replay-from-beginning of the partial result).
+    // Set on the first chunk-produced event; reset when a new
+    // Synthesize starts.
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
     private bool _hasSynthesizedAudio;
+
+    // Accumulators that persist across Play/Stop clicks during a synth
+    // run. _writtenChunks tracks how many chunks were included in the
+    // last WAV write — Play uses it to skip the rewrite when nothing
+    // new has arrived since the last replay.
+    private readonly List<float[]> _receivedAudio = new();
+    private readonly List<AlignedWord> _receivedWords = new();
+    private readonly object _receivedLock = new();
+    private int _writtenChunks;
 
     // Mirrors PlaybackService.IsPlaying so the AXAML CanExecute can
     // re-query. PlaybackService raises IsPlayingChanged; the handler
@@ -226,13 +238,12 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         _lastAudioPath = null;
         ChunksDone = 0;
         TotalChunks = 0;
-        // Accumulators for the partial-on-cancel path. The alignment
-        // chain emits chunks in input order so a List append is correct;
-        // we lock just for the memory barrier between the chain thread
-        // and the catch handler.
-        var receivedAudio = new List<float[]>();
-        var receivedWords = new List<AlignedWord>();
-        var receivedLock = new object();
+        lock (_receivedLock)
+        {
+            _receivedAudio.Clear();
+            _receivedWords.Clear();
+        }
+        _writtenChunks = 0;
         _synthCts?.Dispose();
         _synthCts = new CancellationTokenSource();
         var token = _synthCts.Token;
@@ -274,11 +285,18 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                             StatusMessage = $"Playback failed: {ex.Message}");
                     }
 
-                    // Accumulate for the partial-WAV-on-cancel path.
-                    lock (receivedLock)
+                    // Accumulate for replay-from-beginning. Play() reads
+                    // these to write a partial WAV on demand.
+                    bool firstChunk;
+                    lock (_receivedLock)
                     {
-                        receivedAudio.Add(ev.Audio24k);
-                        if (ev.Words.Count > 0) receivedWords.AddRange(ev.Words);
+                        firstChunk = _receivedAudio.Count == 0;
+                        _receivedAudio.Add(ev.Audio24k);
+                        if (ev.Words.Count > 0) _receivedWords.AddRange(ev.Words);
+                    }
+                    if (firstChunk)
+                    {
+                        Dispatcher.UIThread.Post(() => HasSynthesizedAudio = true);
                     }
 
                     // Word adds touch the ObservableCollection → must go
@@ -310,7 +328,11 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
 
             _lastAlignment = result.Alignment;
             _lastAudioPath = result.AudioPath;
-            HasSynthesizedAudio = true;
+            // The service already wrote the WAV with ALL received chunks,
+            // so cache the count to skip the rewrite if Play is clicked
+            // without any new chunks since.
+            lock (_receivedLock) _writtenChunks = _receivedAudio.Count;
+            HasSynthesizedAudio = true;  // idempotent — set on first chunk too
             // Tell the playback service no more samples are coming so it
             // can fire PlaybackStopped naturally when the buffer drains.
             if (streamingStarted) _playback.EndOfStream();
@@ -319,48 +341,14 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         }
         catch (OperationCanceledException)
         {
-            // Persist whatever chunks landed so the user can still play
-            // back what was synthesized before they hit Cancel. Without
-            // this, Cancel would discard a long-running partial result.
-            List<float[]> audioSnapshot;
-            List<AlignedWord> wordsSnapshot;
-            lock (receivedLock)
-            {
-                audioSnapshot = new List<float[]>(receivedAudio);
-                wordsSnapshot = new List<AlignedWord>(receivedWords);
-            }
-            string outWavCancelled = Path.Combine(Path.GetTempPath(),
-                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss}_partial.wav");
-            if (audioSnapshot.Count > 0)
-            {
-                try
-                {
-                    SynthesisService.WriteWavFromChunks(outWavCancelled, audioSnapshot,
-                        ChatterboxConstants.S3GenSr);
-                    int totalSamples = 0;
-                    foreach (var c in audioSnapshot) totalSamples += c.Length;
-                    double duration = totalSamples / (double)ChatterboxConstants.S3GenSr;
-                    _lastAudioPath = outWavCancelled;
-                    _lastAlignment = new AlignmentSidecar
-                    {
-                        AudioPath = outWavCancelled,
-                        SampleRate = ChatterboxConstants.S3GenSr,
-                        AudioDurationSeconds = duration,
-                        Aligner = string.IsNullOrWhiteSpace(NfaBundleDir) ? "none (partial)" : "nemo_nfa (partial)",
-                        Words = wordsSnapshot,
-                    };
-                    HasSynthesizedAudio = true;
-                    StatusMessage = $"Cancelled — saved {audioSnapshot.Count} chunk(s), {duration:F2}s playable.";
-                }
-                catch (Exception saveEx)
-                {
-                    StatusMessage = $"Cancelled; partial save failed: {saveEx.Message}";
-                }
-            }
-            else
-            {
-                StatusMessage = "Synthesis cancelled.";
-            }
+            // Play() will write a partial WAV on demand from the
+            // accumulated chunks — no need to write here. Just leave
+            // _lastAudioPath null so Play knows to (re)write.
+            int chunksReceived;
+            lock (_receivedLock) chunksReceived = _receivedAudio.Count;
+            StatusMessage = chunksReceived > 0
+                ? $"Cancelled — {chunksReceived} chunk(s) ready to play."
+                : "Synthesis cancelled.";
         }
         catch (Exception ex)
         {
@@ -398,8 +386,60 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand(CanExecute = nameof(CanPlay))]
     private void Play()
     {
-        // Replay path: synthesis is done, audio is on disk. Use
-        // SeekIntoFile(0) to play the saved WAV from the beginning.
+        // Snapshot the current received-chunks state. If new chunks
+        // landed since the last WAV write (or no WAV exists yet — e.g.
+        // user clicked Stop mid-synth then Play), write a fresh WAV
+        // including everything received so far.
+        List<float[]>? snapshot = null;
+        List<AlignedWord>? wordsSnap = null;
+        lock (_receivedLock)
+        {
+            if (_receivedAudio.Count == 0) return;
+            bool wavStale = _lastAudioPath is null
+                || !File.Exists(_lastAudioPath)
+                || _writtenChunks != _receivedAudio.Count;
+            if (wavStale)
+            {
+                snapshot = new List<float[]>(_receivedAudio);
+                wordsSnap = new List<AlignedWord>(_receivedWords);
+            }
+        }
+
+        // Stop any in-progress streaming playback so SeekIntoFile gets
+        // a clean backend. If we're mid-synth and the user clicked
+        // Play, subsequent chunks won't auto-play (streamingStarted
+        // stays latched in the synth lambda) — that's intentional, the
+        // user explicitly asked for replay.
+        _playback.Stop();
+
+        if (snapshot is not null)
+        {
+            var outWav = Path.Combine(Path.GetTempPath(),
+                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss}_play.wav");
+            try
+            {
+                SynthesisService.WriteWavFromChunks(outWav, snapshot, ChatterboxConstants.S3GenSr);
+                int totalSamples = 0;
+                foreach (var c in snapshot) totalSamples += c.Length;
+                double duration = totalSamples / (double)ChatterboxConstants.S3GenSr;
+                _lastAudioPath = outWav;
+                _lastAlignment = new AlignmentSidecar
+                {
+                    AudioPath = outWav,
+                    SampleRate = ChatterboxConstants.S3GenSr,
+                    AudioDurationSeconds = duration,
+                    Aligner = string.IsNullOrWhiteSpace(NfaBundleDir) ? "none" : "nemo_nfa",
+                    Words = wordsSnap!,
+                };
+                _writtenChunks = snapshot.Count;
+            }
+            catch (Exception ex)
+            {
+                StatusMessage = $"Save for playback failed: {ex.Message}";
+                return;
+            }
+        }
+
         if (_lastAudioPath is null || _lastAlignment is null) return;
         try
         {
@@ -409,10 +449,11 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         catch (Exception ex) { StatusMessage = $"Play failed: {ex.Message}"; }
     }
 
-    // Play is enabled when we have audio AND nothing is currently
-    // playing/synthesizing — i.e. not while a previous Synthesize is
-    // still streaming and not while the existing playback is active.
-    private bool CanPlay() => HasSynthesizedAudio && !IsBusy && !IsPlayingBack
+    // Play is enabled whenever we have at least one chunk AND audio
+    // isn't currently playing. IsBusy is intentionally NOT a gate —
+    // mid-synth Play replays the partial-so-far, which the user feedback
+    // confirmed is the natural mental model after clicking Stop.
+    private bool CanPlay() => HasSynthesizedAudio && !IsPlayingBack
         && _playback.CanPlayOnThisPlatform;
 
     /// <summary>Stops audio playback. Immediate — does NOT cancel any

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -51,10 +51,14 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty] private string _statusMessage = "Ready.";
 
     // Active while synthesis is running. Disables most controls.
+    // Note: gates SynthesizeCommand (don't allow re-start mid-run),
+    // PlayCommand (no replay while still generating), and the new
+    // CancelSynthesisCommand (only enabled when there's something to
+    // cancel). Stop is independent — it operates on playback only.
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
     [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
-    [NotifyCanExecuteChangedFor(nameof(StopCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CancelSynthesisCommand))]
     private bool _isBusy;
 
     // True after a synthesis finishes successfully. Enables replay.
@@ -64,7 +68,8 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
 
     // Mirrors PlaybackService.IsPlaying so the AXAML CanExecute can
     // re-query. PlaybackService raises IsPlayingChanged; the handler
-    // updates this field.
+    // updates this field. Gates Play (can't start when already playing)
+    // and Stop (nothing to stop when not playing).
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
     [NotifyCanExecuteChangedFor(nameof(StopCommand))]
@@ -221,6 +226,13 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         _lastAudioPath = null;
         ChunksDone = 0;
         TotalChunks = 0;
+        // Accumulators for the partial-on-cancel path. The alignment
+        // chain emits chunks in input order so a List append is correct;
+        // we lock just for the memory barrier between the chain thread
+        // and the catch handler.
+        var receivedAudio = new List<float[]>();
+        var receivedWords = new List<AlignedWord>();
+        var receivedLock = new object();
         _synthCts?.Dispose();
         _synthCts = new CancellationTokenSource();
         var token = _synthCts.Token;
@@ -262,6 +274,13 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                             StatusMessage = $"Playback failed: {ex.Message}");
                     }
 
+                    // Accumulate for the partial-WAV-on-cancel path.
+                    lock (receivedLock)
+                    {
+                        receivedAudio.Add(ev.Audio24k);
+                        if (ev.Words.Count > 0) receivedWords.AddRange(ev.Words);
+                    }
+
                     // Word adds touch the ObservableCollection → must go
                     // through the dispatcher. Capture ev by local so the
                     // closure doesn't race a subsequent chunk's event.
@@ -300,7 +319,48 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         }
         catch (OperationCanceledException)
         {
-            StatusMessage = "Synthesis cancelled.";
+            // Persist whatever chunks landed so the user can still play
+            // back what was synthesized before they hit Cancel. Without
+            // this, Cancel would discard a long-running partial result.
+            List<float[]> audioSnapshot;
+            List<AlignedWord> wordsSnapshot;
+            lock (receivedLock)
+            {
+                audioSnapshot = new List<float[]>(receivedAudio);
+                wordsSnapshot = new List<AlignedWord>(receivedWords);
+            }
+            string outWavCancelled = Path.Combine(Path.GetTempPath(),
+                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss}_partial.wav");
+            if (audioSnapshot.Count > 0)
+            {
+                try
+                {
+                    SynthesisService.WriteWavFromChunks(outWavCancelled, audioSnapshot,
+                        ChatterboxConstants.S3GenSr);
+                    int totalSamples = 0;
+                    foreach (var c in audioSnapshot) totalSamples += c.Length;
+                    double duration = totalSamples / (double)ChatterboxConstants.S3GenSr;
+                    _lastAudioPath = outWavCancelled;
+                    _lastAlignment = new AlignmentSidecar
+                    {
+                        AudioPath = outWavCancelled,
+                        SampleRate = ChatterboxConstants.S3GenSr,
+                        AudioDurationSeconds = duration,
+                        Aligner = string.IsNullOrWhiteSpace(NfaBundleDir) ? "none (partial)" : "nemo_nfa (partial)",
+                        Words = wordsSnapshot,
+                    };
+                    HasSynthesizedAudio = true;
+                    StatusMessage = $"Cancelled — saved {audioSnapshot.Count} chunk(s), {duration:F2}s playable.";
+                }
+                catch (Exception saveEx)
+                {
+                    StatusMessage = $"Cancelled; partial save failed: {saveEx.Message}";
+                }
+            }
+            else
+            {
+                StatusMessage = "Synthesis cancelled.";
+            }
         }
         catch (Exception ex)
         {
@@ -317,6 +377,21 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         && !string.IsNullOrWhiteSpace(VoicePath)
         && !string.IsNullOrWhiteSpace(OnnxBundleDir)
         && !string.IsNullOrWhiteSpace(Text);
+
+    /// <summary>Cancels in-flight synthesis. Cancellation is checked
+    /// at chunk boundaries — the LM rollout for the chunk that's
+    /// currently being generated can't be interrupted, so a click here
+    /// takes effect after the current chunk finishes (a few seconds at
+    /// worst). Any chunks that completed before cancel are written to a
+    /// partial WAV so Play still works.</summary>
+    [RelayCommand(CanExecute = nameof(CanCancelSynthesis))]
+    private void CancelSynthesis()
+    {
+        _synthCts?.Cancel();
+        StatusMessage = "Cancelling — will stop after the current chunk.";
+    }
+
+    private bool CanCancelSynthesis() => IsBusy;
 
     // ── Playback ─────────────────────────────────────────────────────
 
@@ -340,19 +415,15 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     private bool CanPlay() => HasSynthesizedAudio && !IsBusy && !IsPlayingBack
         && _playback.CanPlayOnThisPlatform;
 
+    /// <summary>Stops audio playback. Immediate — does NOT cancel any
+    /// in-flight synthesis (use the Cancel button for that). The two
+    /// were combined in an earlier iteration; the user fed back that
+    /// the controls felt muddled, so they're separate now.</summary>
     [RelayCommand(CanExecute = nameof(CanStop))]
-    private void Stop()
-    {
-        // Cancel synthesis too — otherwise the alignment chain keeps
-        // running, words keep landing, and the user thinks "Stop" didn't
-        // actually stop anything.
-        _synthCts?.Cancel();
-        _playback.Stop();
-    }
+    private void Stop() => _playback.Stop();
 
-    // Stop is enabled when there's something TO stop: either an active
-    // synth run or active playback.
-    private bool CanStop() => IsBusy || IsPlayingBack;
+    // Stop is enabled iff something is actually playing.
+    private bool CanStop() => IsPlayingBack;
 
     // Click-to-seek wiring. Each WordItemViewModel calls this back via a
     // delegate set at construction (avoids per-word command boilerplate +

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -50,14 +50,12 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     // Status line below the synthesize button.
     [ObservableProperty] private string _statusMessage = "Ready.";
 
-    // Active while synthesis is running. Disables most controls.
-    // Note: gates SynthesizeCommand (don't allow re-start mid-run),
-    // PlayCommand (no replay while still generating), and the new
-    // CancelSynthesisCommand (only enabled when there's something to
-    // cancel). Stop is independent — it operates on playback only.
+    // Active while synthesis is running. Gates SynthesizeCommand
+    // (don't allow re-start mid-run) and CancelSynthesisCommand (only
+    // enabled while there's a synth to cancel). PlayPause and Stop are
+    // intentionally independent — mid-synth replay is allowed.
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
-    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
     [NotifyCanExecuteChangedFor(nameof(CancelSynthesisCommand))]
     private bool _isBusy;
 
@@ -66,7 +64,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     // Set on the first chunk-produced event; reset when a new
     // Synthesize starts.
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    [NotifyCanExecuteChangedFor(nameof(PlayPauseCommand))]
     private bool _hasSynthesizedAudio;
 
     // Accumulators that persist across Play/Stop clicks during a synth
@@ -78,14 +76,28 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     private readonly object _receivedLock = new();
     private int _writtenChunks;
 
-    // Mirrors PlaybackService.IsPlaying so the AXAML CanExecute can
-    // re-query. PlaybackService raises IsPlayingChanged; the handler
-    // updates this field. Gates Play (can't start when already playing)
-    // and Stop (nothing to stop when not playing).
+    // Mirrors PlaybackService.IsPlaying ("audio currently coming out").
+    // False both when stopped and when paused. PlayPauseLabel /
+    // CanStop derive from this + IsPausedBack.
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    [NotifyCanExecuteChangedFor(nameof(PlayPauseCommand))]
     [NotifyCanExecuteChangedFor(nameof(StopCommand))]
+    [NotifyPropertyChangedFor(nameof(PlayPauseLabel))]
     private bool _isPlayingBack;
+
+    // Mirrors PlaybackService.IsPaused. Distinct from !IsPlayingBack:
+    // a paused session keeps its backend alive (so Resume is cheap and
+    // doesn't restart from the beginning) whereas a stopped one is
+    // fully torn down.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(PlayPauseCommand))]
+    [NotifyCanExecuteChangedFor(nameof(StopCommand))]
+    [NotifyPropertyChangedFor(nameof(PlayPauseLabel))]
+    private bool _isPausedBack;
+
+    public string PlayPauseLabel => IsPausedBack ? "▶ Resume"
+        : IsPlayingBack ? "⏸ Pause"
+        : "▶ Play";
 
     // Chunk progress drives the determinate progress bar. ChunksDone is
     // bound to ProgressBar.Value; TotalChunks to .Maximum. Both zero
@@ -125,6 +137,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             if (!IsBusy) StatusMessage = "Playback stopped.";
         };
         _playback.IsPlayingChanged += playing => Dispatcher.UIThread.Post(() => IsPlayingBack = playing);
+        _playback.IsPausedChanged += paused => Dispatcher.UIThread.Post(() => IsPausedBack = paused);
         // Refresh the position label whenever the total grows — without
         // this it would only update on tick-timer ticks, so after Stop
         // (which kills the timer) any chunks still landing would update
@@ -383,13 +396,32 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
 
     // ── Playback ─────────────────────────────────────────────────────
 
-    [RelayCommand(CanExecute = nameof(CanPlay))]
-    private void Play()
+    /// <summary>Single play / pause / resume toggle. Behavior depends
+    /// on the current state:
+    /// - Paused  → Resume (cheap, audio backend kept alive)
+    /// - Playing → Pause (suspends WaveOut or sends SIGSTOP to ffplay)
+    /// - Idle    → Play from the beginning of the current WAV (writing
+    ///   a partial WAV from received chunks first if needed)
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanPlayPause))]
+    private void PlayPause()
     {
-        // Snapshot the current received-chunks state. If new chunks
-        // landed since the last WAV write (or no WAV exists yet — e.g.
-        // user clicked Stop mid-synth then Play), write a fresh WAV
-        // including everything received so far.
+        if (IsPausedBack)
+        {
+            _playback.Resume();
+            StatusMessage = "Resumed.";
+            return;
+        }
+        if (IsPlayingBack)
+        {
+            _playback.Pause();
+            StatusMessage = "Paused.";
+            return;
+        }
+
+        // Idle — start from beginning. Snapshot the current
+        // received-chunks state; if new chunks landed since the last
+        // WAV write (or no WAV exists yet), write a fresh one.
         List<float[]>? snapshot = null;
         List<AlignedWord>? wordsSnap = null;
         lock (_receivedLock)
@@ -449,11 +481,9 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         catch (Exception ex) { StatusMessage = $"Play failed: {ex.Message}"; }
     }
 
-    // Play is enabled whenever we have at least one chunk AND audio
-    // isn't currently playing. IsBusy is intentionally NOT a gate —
-    // mid-synth Play replays the partial-so-far, which the user feedback
-    // confirmed is the natural mental model after clicking Stop.
-    private bool CanPlay() => HasSynthesizedAudio && !IsPlayingBack
+    // PlayPause is enabled whenever we have at least one chunk. The
+    // command body branches on play/pause/idle state internally.
+    private bool CanPlayPause() => HasSynthesizedAudio
         && _playback.CanPlayOnThisPlatform;
 
     /// <summary>Stops audio playback. Immediate — does NOT cancel any
@@ -463,8 +493,9 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand(CanExecute = nameof(CanStop))]
     private void Stop() => _playback.Stop();
 
-    // Stop is enabled iff something is actually playing.
-    private bool CanStop() => IsPlayingBack;
+    // Stop is enabled when audio is playing OR paused — both states
+    // have a live backend that needs tearing down.
+    private bool CanStop() => IsPlayingBack || IsPausedBack;
 
     // Click-to-seek wiring. Each WordItemViewModel calls this back via a
     // delegate set at construction (avoids per-word command boilerplate +

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -54,12 +54,27 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
     [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    [NotifyCanExecuteChangedFor(nameof(StopCommand))]
     private bool _isBusy;
 
     // True after a synthesis finishes successfully. Enables replay.
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
     private bool _hasSynthesizedAudio;
+
+    // Mirrors PlaybackService.IsPlaying so the AXAML CanExecute can
+    // re-query. PlaybackService raises IsPlayingChanged; the handler
+    // updates this field.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(PlayCommand))]
+    [NotifyCanExecuteChangedFor(nameof(StopCommand))]
+    private bool _isPlayingBack;
+
+    // Chunk progress drives the determinate progress bar. ChunksDone is
+    // bound to ProgressBar.Value; TotalChunks to .Maximum. Both zero
+    // when idle (the bar's IsVisible binding to IsBusy hides it then).
+    [ObservableProperty] private int _chunksDone;
+    [ObservableProperty] private int _totalChunks;
 
     // Aligned words from the running/last synthesis. Streamed in as
     // chunks complete.
@@ -92,6 +107,13 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             // Don't overwrite synthesis-in-progress status with "stopped".
             if (!IsBusy) StatusMessage = "Playback stopped.";
         };
+        _playback.IsPlayingChanged += playing => Dispatcher.UIThread.Post(() => IsPlayingBack = playing);
+        // Refresh the position label whenever the total grows — without
+        // this it would only update on tick-timer ticks, so after Stop
+        // (which kills the timer) any chunks still landing would update
+        // the total internally but the label would stay frozen.
+        _playback.TotalChanged += total => Dispatcher.UIThread.Post(() =>
+            PositionLabel = $"{_playback.PositionSeconds:F2} / {total:F2} s");
 
         LoadSettings();
 
@@ -197,6 +219,8 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         HasSynthesizedAudio = false;
         _lastAlignment = null;
         _lastAudioPath = null;
+        ChunksDone = 0;
+        TotalChunks = 0;
         _synthCts?.Dispose();
         _synthCts = new CancellationTokenSource();
         var token = _synthCts.Token;
@@ -239,13 +263,17 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                     }
 
                     // Word adds touch the ObservableCollection → must go
-                    // through the dispatcher. Capture ev.Words by local so
-                    // the closure doesn't race a subsequent chunk's event.
+                    // through the dispatcher. Capture ev by local so the
+                    // closure doesn't race a subsequent chunk's event.
                     var wordsForChunk = ev.Words;
+                    int chunksDone = ev.ChunkIndex + 1;
+                    int totalChunks = ev.TotalChunks;
                     Dispatcher.UIThread.Post(() =>
                     {
                         foreach (var w in wordsForChunk)
                             Words.Add(new WordItemViewModel(w, Words.Count, SeekToWord));
+                        ChunksDone = chunksDone;
+                        TotalChunks = totalChunks;
                     });
                 },
                 onProgress: p => Dispatcher.UIThread.Post(() =>
@@ -253,6 +281,11 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                     StatusMessage = p.ChunkIndex is int idx && p.TotalChunks is int total
                         ? $"{p.Phase} ({idx}/{total})"
                         : p.Phase;
+                    // Pick up the total at the "chunked into N paragraphs"
+                    // phase so the progress bar can render proportionally
+                    // before any chunk has landed.
+                    if (p.TotalChunks is int t && t > TotalChunks)
+                        TotalChunks = t;
                 }),
                 cancellationToken: token);
 
@@ -301,10 +334,25 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         catch (Exception ex) { StatusMessage = $"Play failed: {ex.Message}"; }
     }
 
-    private bool CanPlay() => HasSynthesizedAudio && !IsBusy && _playback.CanPlayOnThisPlatform;
+    // Play is enabled when we have audio AND nothing is currently
+    // playing/synthesizing — i.e. not while a previous Synthesize is
+    // still streaming and not while the existing playback is active.
+    private bool CanPlay() => HasSynthesizedAudio && !IsBusy && !IsPlayingBack
+        && _playback.CanPlayOnThisPlatform;
 
-    [RelayCommand]
-    private void Stop() => _playback.Stop();
+    [RelayCommand(CanExecute = nameof(CanStop))]
+    private void Stop()
+    {
+        // Cancel synthesis too — otherwise the alignment chain keeps
+        // running, words keep landing, and the user thinks "Stop" didn't
+        // actually stop anything.
+        _synthCts?.Cancel();
+        _playback.Stop();
+    }
+
+    // Stop is enabled when there's something TO stop: either an active
+    // synth run or active playback.
+    private bool CanStop() => IsBusy || IsPlayingBack;
 
     // Click-to-seek wiring. Each WordItemViewModel calls this back via a
     // delegate set at construction (avoids per-word command boilerplate +

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -213,30 +213,41 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
 
             var result = await _synthService.SynthesizeStreamingAsync(
                 VoicePath, Text, outWav,
-                onChunkProduced: ev => Dispatcher.UIThread.Post(() =>
+                onChunkProduced: ev =>
                 {
-                    // First chunk arrives → open the playback pipeline and
-                    // start streaming. Audio plays as soon as bytes are
-                    // appended; the wall-clock tick begins from now.
-                    if (!streamingStarted)
+                    // Audio appending runs HERE — on the alignment-chain
+                    // thread (background), NOT on the dispatcher. On the
+                    // ffplay backend, AppendSamples blocks under pipe
+                    // backpressure (ffplay only drains as fast as it
+                    // plays). If we did this on the UI thread, the
+                    // progress bar would freeze, queued Word adds would
+                    // stack up, and the user would see chunks arrive in
+                    // bursts instead of streaming live.
+                    try
                     {
-                        try
+                        if (!streamingStarted)
                         {
                             _playback.StartStreaming(ChatterboxConstants.S3GenSr, channels: 1);
                             streamingStarted = true;
                         }
-                        catch (Exception ex)
-                        {
-                            StatusMessage = $"Playback open failed: {ex.Message}";
-                            return;
-                        }
+                        _playback.AppendSamples(ev.Audio24k);
                     }
-                    _playback.AppendSamples(ev.Audio24k);
-                    int baseIdx = Words.Count;
-                    int wi = baseIdx;
-                    foreach (var w in ev.Words)
-                        Words.Add(new WordItemViewModel(w, wi++, SeekToWord));
-                }),
+                    catch (Exception ex)
+                    {
+                        Dispatcher.UIThread.Post(() =>
+                            StatusMessage = $"Playback failed: {ex.Message}");
+                    }
+
+                    // Word adds touch the ObservableCollection → must go
+                    // through the dispatcher. Capture ev.Words by local so
+                    // the closure doesn't race a subsequent chunk's event.
+                    var wordsForChunk = ev.Words;
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        foreach (var w in wordsForChunk)
+                            Words.Add(new WordItemViewModel(w, Words.Count, SeekToWord));
+                    });
+                },
                 onProgress: p => Dispatcher.UIThread.Post(() =>
                 {
                     StatusMessage = p.ChunkIndex is int idx && p.TotalChunks is int total
@@ -330,8 +341,11 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             _currentWordIndex = idx;
             if (idx >= 0 && idx < Words.Count) Words[idx].IsCurrent = true;
         }
-        double dur = _lastAlignment?.AudioDurationSeconds ?? 0;
-        PositionLabel = $"{posSec:F2} / {dur:F2} s";
+        // Use the live playback total — it grows as chunks append during
+        // streaming, and matches _lastAlignment.AudioDurationSeconds once
+        // synthesis finishes. (Reading _lastAlignment alone would show
+        // "/ 0.00 s" for the entire stream.)
+        PositionLabel = $"{posSec:F2} / {_playback.TotalEstimatedSeconds:F2} s";
     }
 
     private int FindWordAt(double posSec)

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -267,8 +267,10 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                 OnnxBundleDir,
                 nfaBundleDir: string.IsNullOrWhiteSpace(NfaBundleDir) ? null : NfaBundleDir);
 
+            // ms precision avoids collisions when the user re-Synthesizes
+            // (or clicks Play, below) twice in the same second.
             string outWav = Path.Combine(Path.GetTempPath(),
-                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss}.wav");
+                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss_fff}.wav");
             bool streamingStarted = false;
 
             var result = await _synthService.SynthesizeStreamingAsync(
@@ -447,7 +449,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         if (snapshot is not null)
         {
             var outWav = Path.Combine(Path.GetTempPath(),
-                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss}_play.wav");
+                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss_fff}_play.wav");
             try
             {
                 SynthesisService.WriteWavFromChunks(outWav, snapshot, ChatterboxConstants.S3GenSr);

--- a/src/Chatterbox.Avalonia/ViewModels/WordItemViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/WordItemViewModel.cs
@@ -1,5 +1,7 @@
+using System;
 using Chatterbox.App.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Chatterbox.App.ViewModels;
 
@@ -7,17 +9,21 @@ namespace Chatterbox.App.ViewModels;
 /// Per-word presentation wrapper. The aligner emits flat
 /// <see cref="AlignedWord"/> records; the UI needs an extra
 /// <see cref="IsCurrent"/> bool that the AXAML can class-trigger on
-/// to apply the highlight style. MainViewModel toggles this on the
-/// current word as playback advances.
+/// to apply the highlight style. MainViewModel toggles it as
+/// playback advances. The <see cref="ClickCommand"/> calls back to
+/// MainViewModel for click-to-seek.
 /// </summary>
 public sealed partial class WordItemViewModel : ObservableObject
 {
-    public WordItemViewModel(AlignedWord word, int index)
+    private readonly Action<WordItemViewModel>? _onClicked;
+
+    public WordItemViewModel(AlignedWord word, int index, Action<WordItemViewModel>? onClicked = null)
     {
         Index = index;
         Text = word.Text;
         StartSeconds = word.StartSeconds;
         EndSeconds = word.EndSeconds;
+        _onClicked = onClicked;
     }
 
     public int Index { get; }
@@ -26,4 +32,7 @@ public sealed partial class WordItemViewModel : ObservableObject
     public double EndSeconds { get; }
 
     [ObservableProperty] private bool _isCurrent;
+
+    [RelayCommand]
+    private void Click() => _onClicked?.Invoke(this);
 }

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml
@@ -111,9 +111,18 @@
                     Command="{Binding SynthesizeCommand}"
                     FontWeight="SemiBold"
                     HorizontalAlignment="Stretch" />
-            <ProgressBar IsIndeterminate="True"
-                         IsVisible="{Binding IsBusy}"
-                         Height="3" Margin="0,4,0,0" />
+            <!-- Determinate once TotalChunks > 0 (set by the "chunked into
+                 N paragraphs" progress event); indeterminate during the
+                 model-load + chunking prefix. ShowProgressText surfaces
+                 the "X/N" without needing a separate label. -->
+            <ProgressBar IsVisible="{Binding IsBusy}"
+                         IsIndeterminate="{Binding !TotalChunks}"
+                         Minimum="0"
+                         Maximum="{Binding TotalChunks}"
+                         Value="{Binding ChunksDone}"
+                         ShowProgressText="True"
+                         ProgressTextFormat="{}{0:0} / {3:0} chunks"
+                         Height="14" Margin="0,4,0,0" />
 
             <Separator Margin="0,12,0,0" />
 

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml
@@ -107,14 +107,24 @@
 
             <Separator Margin="0,12,0,0" />
 
-            <Button Content="Synthesize"
-                    Command="{Binding SynthesizeCommand}"
-                    FontWeight="SemiBold"
-                    HorizontalAlignment="Stretch" />
+            <!-- ── Synthesis ─────────────────────────────────────── -->
+            <TextBlock Text="Synthesis" FontWeight="SemiBold"
+                       Margin="0,4,0,2" />
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Button Content="Synthesize"
+                        Command="{Binding SynthesizeCommand}"
+                        FontWeight="SemiBold" MinWidth="110" />
+                <!-- Cancel only enabled mid-run. Cancellation takes effect
+                     after the current chunk (the LM rollout is not
+                     interruptible); any chunks completed before cancel
+                     are saved as a partial WAV that Play can use. -->
+                <Button Content="Cancel"
+                        Command="{Binding CancelSynthesisCommand}"
+                        MinWidth="80" />
+            </StackPanel>
             <!-- Determinate once TotalChunks > 0 (set by the "chunked into
                  N paragraphs" progress event); indeterminate during the
-                 model-load + chunking prefix. ShowProgressText surfaces
-                 the "X/N" without needing a separate label. -->
+                 model-load + chunking prefix. -->
             <ProgressBar IsVisible="{Binding IsBusy}"
                          IsIndeterminate="{Binding !TotalChunks}"
                          Minimum="0"
@@ -126,6 +136,9 @@
 
             <Separator Margin="0,12,0,0" />
 
+            <!-- ── Playback ──────────────────────────────────────── -->
+            <TextBlock Text="Playback" FontWeight="SemiBold"
+                       Margin="0,4,0,2" />
             <StackPanel Orientation="Horizontal" Spacing="6">
                 <Button Content="▶ Play" Command="{Binding PlayCommand}"
                         MinWidth="80" />

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml
@@ -3,54 +3,65 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:Chatterbox.App.ViewModels"
+        xmlns:md="clr-namespace:Markdown.Avalonia;assembly=Markdown.Avalonia"
         x:Class="Chatterbox.App.Views.MainWindow"
         x:DataType="vm:MainViewModel"
         mc:Ignorable="d"
         Width="1100" Height="720" MinWidth="800" MinHeight="500"
-        Title="Chatterbox Reader (MVP)">
+        Title="Chatterbox Reader">
 
     <Grid ColumnDefinitions="*,360" Margin="12">
 
-        <!-- ── Left pane: word-by-word highlight + input ──────────────── -->
+        <!-- ── Left pane: input + source view (toggleable) ────────────── -->
         <Border Grid.Column="0" BorderBrush="#33ffffff" BorderThickness="1"
                 CornerRadius="4" Padding="12" Margin="0,0,12,0">
             <Grid RowDefinitions="Auto,Auto,*">
-                <TextBlock Grid.Row="0" Text="Source text"
-                           FontWeight="SemiBold" Margin="0,0,0,4" />
+                <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,4">
+                    <TextBlock Text="Source text" FontWeight="SemiBold" VerticalAlignment="Center" />
+                    <CheckBox Grid.Column="1" Content="Render markdown"
+                              IsChecked="{Binding RenderMarkdown}"
+                              VerticalAlignment="Center" />
+                </Grid>
 
-                <!-- Input box for typing/pasting markdown. Disabled while
-                     a synthesis is running so the source can't drift mid-flight. -->
                 <TextBox Grid.Row="1" Text="{Binding Text}"
                          AcceptsReturn="True" TextWrapping="Wrap"
                          MinHeight="120" MaxHeight="220"
                          IsEnabled="{Binding !IsBusy}"
                          Watermark="Paste markdown or text here, or pick a file from the right pane." />
 
-                <!-- Word-highlight pane: shows the aligned words from
-                     the last synthesis, with the current word emphasized.
-                     Empty until Words is populated. -->
-                <ScrollViewer Grid.Row="2" Margin="0,12,0,0">
-                    <ItemsControl ItemsSource="{Binding Words}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="vm:WordItemViewModel">
-                                <!-- Each word's IsCurrent toggles the .current
-                                     class; MainViewModel updates it on every
-                                     50 ms playback tick. The styled selector
-                                     is defined in Window.Styles below. -->
-                                <TextBlock Text="{Binding Text}"
-                                           FontSize="18" Margin="2,2,4,2"
-                                           Classes.current="{Binding IsCurrent}" />
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </ScrollViewer>
-
-                <!-- Falls back to a hint when there are no words yet (pre-synthesis). -->
+                <!-- Source view: switches between the word-by-word highlight
+                     grid (for click-to-seek + reading along with playback)
+                     and a Markdown.Avalonia rendering of the raw input.
+                     Word-highlight only fires in the words view; the
+                     markdown view doesn't carry source-position mapping
+                     (that's deferred to a follow-up — see PR #72). -->
+                <Panel Grid.Row="2" Margin="0,12,0,0">
+                    <ScrollViewer IsVisible="{Binding !RenderMarkdown}">
+                        <ItemsControl ItemsSource="{Binding Words}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:WordItemViewModel">
+                                    <!-- Each word is a borderless Button so it
+                                         participates in the click → SeekToWord
+                                         pipeline (the click handler on a bare
+                                         TextBlock requires a behavior; a styled
+                                         Button is simpler). The .current class
+                                         toggles via IsCurrent for the highlight. -->
+                                    <Button Command="{Binding ClickCommand}"
+                                            Content="{Binding Text}"
+                                            Classes="word"
+                                            Classes.current="{Binding IsCurrent}" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                    <md:MarkdownScrollViewer IsVisible="{Binding RenderMarkdown}"
+                                             Markdown="{Binding Text}" />
+                </Panel>
             </Grid>
         </Border>
 
@@ -115,8 +126,22 @@
     </Grid>
 
     <Window.Styles>
-        <!-- Current-word highlight: a stronger weight + accent color. -->
-        <Style Selector="TextBlock.current">
+        <!-- Word buttons: borderless, transparent, click-to-seek. The
+             .current class is the highlight applied while the audio is
+             on that word. -->
+        <Style Selector="Button.word">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="2,2" />
+            <Setter Property="Margin" Value="0,0,2,0" />
+            <Setter Property="FontSize" Value="18" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.word:pointerover /template/ ContentPresenter">
+            <Setter Property="Background" Value="#22ffffff" />
+        </Style>
+        <Style Selector="Button.word.current">
             <Setter Property="FontWeight" Value="Bold" />
             <Setter Property="Foreground" Value="#5ad" />
         </Style>

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml
@@ -34,7 +34,7 @@
                      and a Markdown.Avalonia rendering of the raw input.
                      Word-highlight only fires in the words view; the
                      markdown view doesn't carry source-position mapping
-                     (that's deferred to a follow-up — see PR #72). -->
+                     (deferred — needs a follow-up issue). -->
                 <Panel Grid.Row="2" Margin="0,12,0,0">
                     <ScrollViewer IsVisible="{Binding !RenderMarkdown}">
                         <ItemsControl ItemsSource="{Binding Words}">
@@ -67,12 +67,17 @@
 
         <!-- ── Right pane: pickers, synthesize, playback ────────────── -->
         <StackPanel Grid.Column="1" Spacing="10">
+            <!-- All pickers are disabled during synthesis. Changing the
+                 ONNX or NFA bundle mid-run would dispose the SynthesisService
+                 the running task is still calling into → use-after-dispose.
+                 Gating the buttons is cheaper than deferring invalidation. -->
             <TextBlock Text="Voice (.wav)" FontWeight="SemiBold" />
             <Grid ColumnDefinitions="*,Auto">
                 <TextBox Text="{Binding VoicePath}" IsReadOnly="True"
                          Watermark="No voice picked" />
                 <Button Grid.Column="1" Content="Pick…"
-                        Command="{Binding PickVoiceCommand}" Margin="6,0,0,0" />
+                        Command="{Binding PickVoiceCommand}"
+                        IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
             </Grid>
 
             <TextBlock Text="Chatterbox ONNX bundle" FontWeight="SemiBold" Margin="0,8,0,0" />
@@ -80,7 +85,8 @@
                 <TextBox Text="{Binding OnnxBundleDir}" IsReadOnly="True"
                          Watermark="No bundle picked" />
                 <Button Grid.Column="1" Content="Pick…"
-                        Command="{Binding PickOnnxBundleCommand}" Margin="6,0,0,0" />
+                        Command="{Binding PickOnnxBundleCommand}"
+                        IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
             </Grid>
 
             <TextBlock Text="NFA bundle (optional, enables word highlight)"
@@ -89,12 +95,14 @@
                 <TextBox Text="{Binding NfaBundleDir}" IsReadOnly="True"
                          Watermark="No NFA bundle picked" />
                 <Button Grid.Column="1" Content="Pick…"
-                        Command="{Binding PickNfaBundleCommand}" Margin="6,0,0,0" />
+                        Command="{Binding PickNfaBundleCommand}"
+                        IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
             </Grid>
 
             <TextBlock Text="Text source" FontWeight="SemiBold" Margin="0,12,0,0" />
             <Button Content="Load text/markdown file…"
                     Command="{Binding PickTextFileCommand}"
+                    IsEnabled="{Binding !IsBusy}"
                     HorizontalAlignment="Stretch" />
 
             <Separator Margin="0,12,0,0" />

--- a/src/Chatterbox.Avalonia/Views/MainWindow.axaml
+++ b/src/Chatterbox.Avalonia/Views/MainWindow.axaml
@@ -140,8 +140,11 @@
             <TextBlock Text="Playback" FontWeight="SemiBold"
                        Margin="0,4,0,2" />
             <StackPanel Orientation="Horizontal" Spacing="6">
-                <Button Content="▶ Play" Command="{Binding PlayCommand}"
-                        MinWidth="80" />
+                <!-- Single toggle: label changes between ▶ Play /
+                     ⏸ Pause / ▶ Resume based on PlaybackService state. -->
+                <Button Content="{Binding PlayPauseLabel}"
+                        Command="{Binding PlayPauseCommand}"
+                        MinWidth="100" />
                 <Button Content="■ Stop" Command="{Binding StopCommand}"
                         MinWidth="80" />
             </StackPanel>

--- a/src/Chatterbox.Base/ChunkedSynthesizer.cs
+++ b/src/Chatterbox.Base/ChunkedSynthesizer.cs
@@ -82,18 +82,26 @@ public sealed class ChunkedSynthesizer
     /// mode). At groupSize&gt;1 all chunks must share the same prompt
     /// length (MVP — same constraint as <see cref="AcousticLM.GenerateBatch"/>).
     /// </param>
+    /// <param name="chunkProduced">Optional per-chunk callback fired
+    /// from the vocoder thread as each chunk completes — passed
+    /// (chunkIndex, waveform, ChunkTiming). Use it to stream audio to a
+    /// player while the rest of the synthesis is still running. Fires
+    /// in input order; the callback runs synchronously, so don't block
+    /// on it (queue the waveform to an external buffer and return).</param>
     public ChunkSynthesisResult Synthesize(
         SpeakerEmbedding speaker,
         IReadOnlyList<long[]> textTokenIdsPerChunk,
         bool? useIoBinding = null,
         float exaggeration = ChatterboxConstants.DefaultExaggeration,
         int maxSteps = ChatterboxConstants.DefaultMaxLmSteps,
-        int groupSize = 1)
+        int groupSize = 1,
+        Action<int, float[], ChunkTiming>? chunkProduced = null)
     {
         if (groupSize < 1)
             throw new ArgumentException("groupSize must be >= 1.", nameof(groupSize));
         if (groupSize > 1)
-            return SynthesizeInGroups(speaker, textTokenIdsPerChunk, groupSize, useIoBinding, exaggeration, maxSteps);
+            return SynthesizeInGroups(speaker, textTokenIdsPerChunk, groupSize,
+                useIoBinding, exaggeration, maxSteps, chunkProduced);
 
         int n = textTokenIdsPerChunk.Count;
         if (n == 0)
@@ -164,7 +172,9 @@ public sealed class ChunkedSynthesizer
                     speechTokens, speaker.SpeakerEmbeddings, speaker.SpeakerFeatures);
                 sw.Stop();
                 waveforms[idx] = wav;
-                timings[idx] = new ChunkTiming(idx, lmMs, lmSteps, sw.ElapsedMilliseconds, wav.Length);
+                var timing = new ChunkTiming(idx, lmMs, lmSteps, sw.ElapsedMilliseconds, wav.Length);
+                timings[idx] = timing;
+                chunkProduced?.Invoke(idx, wav, timing);
             }
         }
         catch
@@ -194,7 +204,8 @@ public sealed class ChunkedSynthesizer
         int groupSize,
         bool? useIoBinding,
         float exaggeration,
-        int maxSteps)
+        int maxSteps,
+        Action<int, float[], ChunkTiming>? chunkProduced)
     {
         int n = textTokenIdsPerChunk.Count;
         if (n == 0)
@@ -276,8 +287,10 @@ public sealed class ChunkedSynthesizer
                     // shares (group wall / B). This lets the summary compute
                     // "per-chunk LM" and "per-chunk voc" symmetrically with
                     // the serial path.
-                    timings[idx] = new ChunkTiming(
+                    var timing = new ChunkTiming(
                         idx, lmMs / B, lmSteps[b], vocMs / B, groupWavs[b].Length);
+                    timings[idx] = timing;
+                    chunkProduced?.Invoke(idx, groupWavs[b], timing);
                 }
             }
         }


### PR DESCRIPTION
## Summary

First-run polish on the Avalonia reader MVP (PR #74). Fixes a Synthesize-button bug and addresses the five-item first-run feedback list.

**Bugfix:** Synthesize stayed disabled even after all pickers were filled. Root cause: missing `[NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]` on `_voicePath`, `_onnxBundleDir`, and `_text`. NFA bundle is intentionally optional and not gated.

**Feedback addressed:**
- **Settings persistence** — voice path, ONNX bundle, NFA bundle, render-markdown toggle round-trip through `LocalApplicationData/ChatterboxReader/settings.json`. New `SettingsService` owns JSON I/O. `_loadingSettings` gate suppresses the per-property autosave cascade during hydration.
- **Streaming synthesis** — `SynthesisService.SynthesizeStreamingAsync` emits per-chunk + progress events. `ChunkedSynthesizer` gained an optional `chunkProduced` callback threaded through serial and grouped consumer loops. Per-chunk alignment so word timings are available as each chunk lands.
- **Streaming playback** — `PlaybackService.StartStreaming` / `AppendSamples` / `EndOfStream`. Windows: `BufferedWaveProvider` + `WaveOutEvent`. Other platforms: `ffplay -f f32le -ar 24000 -ac 1 -i pipe:0` with stdin pipe. 50 ms `DispatcherTimer` for position updates. Total duration grows as chunks append so the highlight doesn't clamp early.
- **Click-to-seek** — words are now borderless `Button.word`s with a `ClickCommand` routed to `MainViewModel.SeekToWord`. Post-synth seek is real (`AudioFileReader.CurrentTime` on Windows, ffplay `-ss` elsewhere). Mid-stream seek only re-anchors the highlight wall-clock for now (audio continues from buffer) — documented as MVP compromise in the code.
- **Markdown render toggle** — `<CheckBox Content=\"Render markdown\">` in the source-pane header switches a `Panel` between the word-grid (with click-to-seek + highlight) and a `Markdown.Avalonia` `MarkdownScrollViewer` bound to the raw text. Source-position mapping for the markdown view is deferred (noted inline; future PR).
- **Progress visibility** — `SynthesisService` emits \"loading models\", \"chunked into N paragraphs\", \"synthesizing N chunks\", \"aligning (i/N)\", \"chunk i/N ready\"; bound to `StatusMessage` so long runs show forward motion.

Filed #75 for text normalization (`<unk>` tokens on shorthand/symbols/numbers/abbreviations) as a separate follow-up — not in this PR's scope.

## Test plan

- [x] `dotnet build src/Chatterbox.Avalonia/Chatterbox.Avalonia.csproj -c Release` — 0 warnings, 0 errors
- [x] App launches without AXAML/binding errors (8 s smoke run, no startup crash)
- [ ] Manual smoke on Linux: pick voice + ONNX bundle, paste short text, hit Synthesize — verify status updates flow, first chunk starts streaming before all chunks generate
- [ ] Manual smoke with NFA bundle attached: verify words render as buttons, clicking a word past the current playhead seeks (post-synth) and the highlight follows
- [ ] Toggle \"Render markdown\" mid-session — verify the view swaps and re-toggle restores the word-grid
- [ ] Restart app — verify all four picker fields + the markdown toggle are restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)