### PR TITLE
Detect CUDA 13 / cuDNN 9 on Windows (recursive bin search)

### DIFF
--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -524,8 +524,10 @@ internal class ModelManagerService
 
     /// <summary>
     /// MSIX packaged apps use a restricted DLL search that excludes the system PATH.
-    /// Explicitly register CUDA Toolkit directories so onnxruntime_providers_cuda.dll
-    /// can find cudart, cublas, cudnn, etc. at runtime.
+    /// Explicitly register the directories that actually hold cudart, cublas, cudnn, etc.
+    /// so onnxruntime_providers_cuda.dll can find them at runtime. Resolution lives in
+    /// <see cref="HardwareInfo.GetWindowsCudaDllDirectories"/>, which also handles the
+    /// CUDA 13 bin\x64 relocation and the standalone cuDNN 9 install tree.
     /// </summary>
     internal static void AddCudaToSearchPath()
     {
@@ -534,25 +536,8 @@ internal class ModelManagerService
             return;
         }
 
-        var dirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        // CUDA Toolkit installer sets CUDA_PATH (e.g. C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8)
-        string? cudaPath = Environment.GetEnvironmentVariable("CUDA_PATH");
-        if (!string.IsNullOrEmpty(cudaPath))
-            dirs.Add(Path.Combine(cudaPath, "bin"));
-
-        // Also scan PATH for any CUDA/cuDNN entries (handles cuDNN installed separately)
-        string? path = Environment.GetEnvironmentVariable("PATH");
-        if (path != null)
-            foreach (var entry in path.Split(';'))
-                if (!string.IsNullOrWhiteSpace(entry) &&
-                    (entry.Contains("CUDA",  StringComparison.OrdinalIgnoreCase) ||
-                     entry.Contains("cuDNN", StringComparison.OrdinalIgnoreCase)))
-                    dirs.Add(entry.Trim());
-
-        foreach (var dir in dirs)
-            if (Directory.Exists(dir))
-                AddDllDirectory(dir);
+        foreach (var dir in HardwareInfo.GetWindowsCudaDllDirectories())
+            AddDllDirectory(dir);
     }
 
     public (bool Available, string Message) CheckCuda()

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -142,12 +142,7 @@ public static class HardwareInfo
     public static bool IsCudaToolkitInstalled()
     {
         if (OperatingSystem.IsWindows())
-        {
-            // Search recursively: CUDA 13 relocated the Windows runtime DLLs out of
-            // <CUDA_PATH>\bin into a bin\x64 subfolder, so a flat glob on bin\ misses them.
-            return GetWindowsCudaSearchRoots()
-                .Any(dir => AnyFileMatches(dir, "cudart64_*.dll"));
-        }
+            return _windowsCudaScan.Value.HasCudart;
 
         if (OperatingSystem.IsLinux())
         {
@@ -191,14 +186,7 @@ public static class HardwareInfo
     public static bool IsCudnnInstalled()
     {
         if (OperatingSystem.IsWindows())
-        {
-            // cuDNN 9 installs to its own tree (C:\Program Files\NVIDIA\CUDNN\vX.Y\bin\<cuda>\),
-            // not into the CUDA Toolkit bin and not on PATH by default — so search recursively
-            // across both the Toolkit and the standalone cuDNN install roots.
-            return GetWindowsCudaSearchRoots()
-                .Any(dir => AnyFileMatches(dir, "cudnn64_*.dll")
-                         || AnyFileMatches(dir, "cudnn_*.dll"));
-        }
+            return _windowsCudaScan.Value.HasCudnn;
 
         if (OperatingSystem.IsLinux())
         {
@@ -392,35 +380,81 @@ public static class HardwareInfo
     }
 
     /// <summary>
-    /// Windows: the concrete directories that actually contain a CUDA or cuDNN runtime DLL.
-    /// Unlike <see cref="GetWindowsCudaSearchRoots"/> (search roots to scan recursively),
-    /// these are the leaf directories to register with AddDllDirectory so an MSIX-packaged
-    /// onnxruntime can locate cudart / cudnn at load time.
+    /// Windows: the concrete directories that actually contain a CUDA or cuDNN runtime DLL
+    /// (cudart, cublas, cufft, nvrtc, cudnn, …). Unlike <see cref="GetWindowsCudaSearchRoots"/>
+    /// (roots to scan), these are the leaf directories to register with AddDllDirectory so an
+    /// MSIX-packaged onnxruntime can locate the CUDA EP's dependencies at load time.
     /// </summary>
-    public static IReadOnlyCollection<string> GetWindowsCudaDllDirectories()
+    public static IReadOnlyCollection<string> GetWindowsCudaDllDirectories() =>
+        _windowsCudaScan.Value.DllDirectories;
+
+    /// <summary>
+    /// Result of a single recursive scan of the Windows CUDA/cuDNN search roots:
+    /// whether the Toolkit runtime (cudart) and cuDNN are present, and the leaf
+    /// directories holding the runtime DLLs the CUDA execution provider needs.
+    /// </summary>
+    private sealed record WindowsCudaScan(
+        bool HasCudart,
+        bool HasCudnn,
+        IReadOnlyCollection<string> DllDirectories);
+
+    // Toolkit / cuDNN presence is fixed for the lifetime of the process (installs don't
+    // appear or vanish mid-run), and CanProbeCudaExecutionProvider fans this query out
+    // across every ONNX model-init site — so the recursive scan is done once and cached,
+    // mirroring _bf16Cache below. A newly-installed CUDA is picked up on next launch.
+    private static readonly Lazy<WindowsCudaScan> _windowsCudaScan = new(ScanWindowsCuda);
+
+    private static WindowsCudaScan ScanWindowsCuda()
     {
-        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var dllDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (!OperatingSystem.IsWindows())
-            return result;
+            return new WindowsCudaScan(false, false, dllDirs);
+
+        // Bounded recursion: the DLLs sit at most ~2 levels below a search root
+        // (Toolkit bin\x64, cuDNN bin\<cuda>\). Capping depth + ignoring inaccessible
+        // and reparse-point dirs keeps an over-broad PATH root (e.g. one whose name merely
+        // contains "cuda") from triggering an unbounded walk or aborting on a single
+        // permission error mid-enumeration.
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            MaxRecursionDepth     = 3,
+            IgnoreInaccessible    = true,
+            AttributesToSkip      = FileAttributes.ReparsePoint
+                                  | FileAttributes.Hidden
+                                  | FileAttributes.System,
+        };
+
+        bool hasCudart = false, hasCudnn = false;
 
         foreach (var root in GetWindowsCudaSearchRoots())
         {
-            foreach (var pattern in new[] { "cudart64_*.dll", "cudnn64_*.dll", "cudnn_*.dll" })
+            try
             {
-                try
+                foreach (var file in Directory.EnumerateFiles(root, "*.dll", options))
                 {
-                    foreach (var file in Directory.EnumerateFiles(root, pattern, SearchOption.AllDirectories))
+                    var name = Path.GetFileName(file);
+                    bool isCudart = name.StartsWith("cudart64_", StringComparison.OrdinalIgnoreCase);
+                    bool isCudnn  = name.StartsWith("cudnn",     StringComparison.OrdinalIgnoreCase);
+                    bool isCudaDep = isCudart || isCudnn
+                        || name.StartsWith("cublas", StringComparison.OrdinalIgnoreCase)
+                        || name.StartsWith("cufft",  StringComparison.OrdinalIgnoreCase)
+                        || name.StartsWith("nvrtc",  StringComparison.OrdinalIgnoreCase);
+
+                    if (isCudart) hasCudart = true;
+                    if (isCudnn)  hasCudnn  = true;
+                    if (isCudaDep)
                     {
                         var dir = Path.GetDirectoryName(file);
                         if (!string.IsNullOrEmpty(dir))
-                            result.Add(dir);
+                            dllDirs.Add(dir);
                     }
                 }
-                catch { }
             }
+            catch { }
         }
 
-        return result;
+        return new WindowsCudaScan(hasCudart, hasCudnn, dllDirs);
     }
 
     private static IEnumerable<string> SafeGetDirectories(string parent, string pattern)
@@ -432,17 +466,6 @@ public static class HardwareInfo
                 : Array.Empty<string>();
         }
         catch { return Array.Empty<string>(); }
-    }
-
-    /// <summary>True if <paramref name="dir"/> or any subdirectory contains a file matching <paramref name="pattern"/>.</summary>
-    private static bool AnyFileMatches(string dir, string pattern)
-    {
-        try
-        {
-            return Directory.Exists(dir)
-                && Directory.EnumerateFiles(dir, pattern, SearchOption.AllDirectories).Any();
-        }
-        catch { return false; }
     }
 
     private static bool HasFile(string dir, string pattern)

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -143,12 +143,10 @@ public static class HardwareInfo
     {
         if (OperatingSystem.IsWindows())
         {
-            string? cudaPath = GetCudaToolkitPath();
-            if (string.IsNullOrEmpty(cudaPath)) return false;
-
-            var binDir = Path.Combine(cudaPath, "bin");
-            return Directory.Exists(binDir)
-                && Directory.GetFiles(binDir, "cudart64_*.dll").Length > 0;
+            // Search recursively: CUDA 13 relocated the Windows runtime DLLs out of
+            // <CUDA_PATH>\bin into a bin\x64 subfolder, so a flat glob on bin\ misses them.
+            return GetWindowsCudaSearchRoots()
+                .Any(dir => AnyFileMatches(dir, "cudart64_*.dll"));
         }
 
         if (OperatingSystem.IsLinux())
@@ -194,28 +192,12 @@ public static class HardwareInfo
     {
         if (OperatingSystem.IsWindows())
         {
-            string? cudaPath = GetCudaToolkitPath();
-            if (!string.IsNullOrEmpty(cudaPath))
-            {
-                var binDir = Path.Combine(cudaPath, "bin");
-                if (Directory.Exists(binDir) && HasWindowsCudnnDll(binDir))
-                    return true;
-            }
-
-            string? pathEnv = Environment.GetEnvironmentVariable("PATH");
-            if (pathEnv is null) return false;
-            foreach (var entry in pathEnv.Split(Path.PathSeparator))
-            {
-                if (string.IsNullOrWhiteSpace(entry)) continue;
-                try
-                {
-                    if (Directory.Exists(entry) && HasWindowsCudnnDll(entry))
-                        return true;
-                }
-                catch { }
-            }
-
-            return false;
+            // cuDNN 9 installs to its own tree (C:\Program Files\NVIDIA\CUDNN\vX.Y\bin\<cuda>\),
+            // not into the CUDA Toolkit bin and not on PATH by default — so search recursively
+            // across both the Toolkit and the standalone cuDNN install roots.
+            return GetWindowsCudaSearchRoots()
+                .Any(dir => AnyFileMatches(dir, "cudnn64_*.dll")
+                         || AnyFileMatches(dir, "cudnn_*.dll"));
         }
 
         if (OperatingSystem.IsLinux())
@@ -345,9 +327,123 @@ public static class HardwareInfo
         return dirs.Where(Directory.Exists);
     }
 
-    private static bool HasWindowsCudnnDll(string dir) =>
-        Directory.GetFiles(dir, "cudnn64_*.dll").Length > 0 ||
-        Directory.GetFiles(dir, "cudnn_*.dll").Length > 0;
+    /// <summary>
+    /// Windows: every directory under which CUDA Toolkit or cuDNN runtime DLLs may live.
+    /// Each returned directory is meant to be searched <em>recursively</em>, because the
+    /// runtime DLLs no longer sit directly in a flat bin\ folder:
+    /// <list type="bullet">
+    ///   <item>CUDA 13 moved the Toolkit runtime DLLs into a bin\x64 subfolder.</item>
+    ///   <item>cuDNN 9 installs its DLLs under bin\&lt;cuda-major.minor&gt;\.</item>
+    /// </list>
+    /// Covers CUDA_PATH, any versioned CUDA_PATH_V* (e.g. CUDA_PATH_V13_3), the default
+    /// Toolkit install root (in case no env var is set), the standalone cuDNN install
+    /// tree, and any CUDA/cuDNN directories already on PATH.
+    /// </summary>
+    private static IEnumerable<string> GetWindowsCudaSearchRoots()
+    {
+        var roots = new List<string>();
+
+        void AddToolkitBin(string? toolkitRoot)
+        {
+            if (!string.IsNullOrWhiteSpace(toolkitRoot))
+                roots.Add(Path.Combine(toolkitRoot, "bin"));
+        }
+
+        // CUDA Toolkit roots from the environment.
+        AddToolkitBin(Environment.GetEnvironmentVariable("CUDA_PATH"));
+        try
+        {
+            foreach (System.Collections.DictionaryEntry e in Environment.GetEnvironmentVariables())
+            {
+                if (e.Key is string key
+                    && key.StartsWith("CUDA_PATH_V", StringComparison.OrdinalIgnoreCase))
+                    AddToolkitBin(e.Value as string);
+            }
+        }
+        catch { }
+
+        string programFiles = Environment.GetEnvironmentVariable("ProgramFiles")
+                              ?? @"C:\Program Files";
+
+        // Default Toolkit install location, in case CUDA_PATH is unset.
+        foreach (var root in SafeGetDirectories(
+                     Path.Combine(programFiles, "NVIDIA GPU Computing Toolkit", "CUDA"), "v*"))
+            AddToolkitBin(root);
+
+        // Standalone cuDNN install tree: C:\Program Files\NVIDIA\CUDNN\vX.Y\bin\<cuda>\.
+        foreach (var root in SafeGetDirectories(
+                     Path.Combine(programFiles, "NVIDIA", "CUDNN"), "v*"))
+            roots.Add(Path.Combine(root, "bin"));
+
+        // PATH entries the user may have added manually for CUDA or cuDNN.
+        string? pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (pathEnv != null)
+        {
+            foreach (var entry in pathEnv.Split(Path.PathSeparator))
+            {
+                if (!string.IsNullOrWhiteSpace(entry) &&
+                    (entry.Contains("CUDA", StringComparison.OrdinalIgnoreCase) ||
+                     entry.Contains("CUDNN", StringComparison.OrdinalIgnoreCase)))
+                    roots.Add(entry.Trim());
+            }
+        }
+
+        return roots.Where(Directory.Exists).Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Windows: the concrete directories that actually contain a CUDA or cuDNN runtime DLL.
+    /// Unlike <see cref="GetWindowsCudaSearchRoots"/> (search roots to scan recursively),
+    /// these are the leaf directories to register with AddDllDirectory so an MSIX-packaged
+    /// onnxruntime can locate cudart / cudnn at load time.
+    /// </summary>
+    public static IReadOnlyCollection<string> GetWindowsCudaDllDirectories()
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!OperatingSystem.IsWindows())
+            return result;
+
+        foreach (var root in GetWindowsCudaSearchRoots())
+        {
+            foreach (var pattern in new[] { "cudart64_*.dll", "cudnn64_*.dll", "cudnn_*.dll" })
+            {
+                try
+                {
+                    foreach (var file in Directory.EnumerateFiles(root, pattern, SearchOption.AllDirectories))
+                    {
+                        var dir = Path.GetDirectoryName(file);
+                        if (!string.IsNullOrEmpty(dir))
+                            result.Add(dir);
+                    }
+                }
+                catch { }
+            }
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<string> SafeGetDirectories(string parent, string pattern)
+    {
+        try
+        {
+            return Directory.Exists(parent)
+                ? Directory.GetDirectories(parent, pattern)
+                : Array.Empty<string>();
+        }
+        catch { return Array.Empty<string>(); }
+    }
+
+    /// <summary>True if <paramref name="dir"/> or any subdirectory contains a file matching <paramref name="pattern"/>.</summary>
+    private static bool AnyFileMatches(string dir, string pattern)
+    {
+        try
+        {
+            return Directory.Exists(dir)
+                && Directory.EnumerateFiles(dir, pattern, SearchOption.AllDirectories).Any();
+        }
+        catch { return false; }
+    }
 
     private static bool HasFile(string dir, string pattern)
     {


### PR DESCRIPTION
Fixes #78.

## Problem

A user on Windows 11 with **CUDA Toolkit 13.3** and **cuDNN 9.23** installed saw vernacula-desktop detect the GPU correctly but report **CUDA Toolkit** and **cuDNN** as *not found*.

Two stacked bugs in `HardwareInfo`, both from detection written for the older CUDA 12 / cuDNN 8 layout:

1. **CUDA Toolkit miss** — old code did a flat glob `<CUDA_PATH>\bin\cudart64_*.dll`. CUDA 13 relocated the Windows runtime DLLs out of `bin\` into a `bin\x64` subfolder, so the flat glob matched nothing (the [`cudart64_130.dll` problem](https://forums.developer.nvidia.com/t/cudart64-130-dll-error-cuda-13-on-windows-11/343392)).
2. **cuDNN miss** — old code only checked `<CUDA_PATH>\bin` and `PATH`. cuDNN 9 installs to its own tree, `C:\Program Files\NVIDIA\CUDNN\vX.Y\bin\<cuda>\` ([NVIDIA docs](https://docs.nvidia.com/deeplearning/cudnn/installation/latest/windows.html)) — neither location — so it was never found unless manually added to PATH.

## Fix

Search **recursively** under each known root rather than hardcoding the `bin\x64` name (not clearly documented, and could change again) — layout-agnostic and future-proof. New `GetWindowsCudaSearchRoots()` covers: `CUDA_PATH`, any versioned `CUDA_PATH_V*` var, the default Toolkit install dir (fallback when no env var is set), the standalone cuDNN tree, and CUDA/cuDNN `PATH` entries.

The runtime DLL-search-path registration in `ModelManagerService.AddCudaToSearchPath()` had the **same** two blind spots, so it now reuses the shared `HardwareInfo.GetWindowsCudaDllDirectories()`. The fix therefore benefits actual CUDA execution at load time, not just the settings label.

## Testing

Both `Vernacula.Base` and `Vernacula.Avalonia` build clean (0 warnings). Path facts verified against NVIDIA docs/forums; not yet confirmed on a live CUDA 13.3 + cuDNN 9.23 machine (no Windows host here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)