### PR TITLE
scripts: dev-side CI, where a skip is a failure

### DIFF
--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Dev-side CI. Runs the whole test suite the way hosted CI cannot: on a machine
+# that actually has the ONNX model packages and the test_audio/ tree.
+#
+# The point of this script is the skip check. Hosted CI runs the asset-gated
+# tests too, but with no models present they report 23 skips and a green tick --
+# a step that passes unconditionally is not coverage. Here the assets exist, so
+# a skip means the resolver stopped finding them, and that is a failure.
+#
+# Usage:
+#   scripts/ci_local.sh              # build, then run every test project
+#   scripts/ci_local.sh --no-build   # reuse the existing bin/x64 artifacts
+#
+# Set VERNACULA_CI_ALLOW_SKIPS=1 to downgrade the skip check to a warning, for
+# running this on a box that legitimately has no model assets.
+
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+BUILD=1
+[[ "${1:-}" == "--no-build" ]] && BUILD=0
+
+# Tests run against the artifacts the solution build produced (bin/x64/...).
+# Without -p:Platform=x64 dotnet test rebuilds into bin/ instead, so the thing
+# tested is not the thing built.
+TEST_ARGS=(--no-build -p:Platform=x64 -p:EP=Cpu)
+
+# project<TAB>needs_assets
+#
+# Only mark a project asset-gated when *every* skip in it means "the resolver
+# stopped finding the assets". Projects that also carry opt-in-heavy tests
+# (guarded by their own env var rather than by asset presence) do not qualify:
+# their skips are a deliberate default, not rot.
+PROJECTS=(
+  "tests/Vernacula.Tests	0"
+  "tests/Chatterbox.Tests	0"
+  "tests/AsrBackendCoverage	0"
+  "tests/IndicConformerTest	1"
+)
+
+if (( BUILD )); then
+  echo "==> Building Vernacula.slnx (EP=Cpu)"
+  if ! dotnet build Vernacula.slnx -p:EP=Cpu; then
+    echo "FAIL: solution build" >&2
+    exit 1
+  fi
+fi
+
+failures=()
+
+for entry in "${PROJECTS[@]}"; do
+  IFS=$'\t' read -r proj needs_assets <<<"$entry"
+  echo
+  echo "==> $proj"
+
+  out=$(dotnet test "$proj" "${TEST_ARGS[@]}" 2>&1)
+  status=$?
+  echo "$out" | tail -3
+
+  if (( status != 0 )); then
+    echo "$out" >&2
+    failures+=("$proj: test run failed")
+    continue
+  fi
+
+  # `dotnet test --no-build` against a project that was never built prints
+  # nothing and exits 0 -- a green run of zero tests. Nothing downstream can
+  # tell that apart from success, so require a summary line before believing
+  # any of this.
+  if ! grep -qE '^(Passed!|Failed!|Skipped!)' <<<"$out"; then
+    failures+=("$proj: no test summary -- nothing ran (missing build? wrong -p:Platform?)")
+    continue
+  fi
+
+  # dotnet test exits 0 when every test skips, so the summary line is the only
+  # place the distinction between "ran" and "did not run" survives.
+  if (( needs_assets )) && ! grep -qE 'Skipped: +0,' <<<"$out"; then
+    skipped=$(grep -oE 'Skipped: +[0-9]+' <<<"$out" | head -1)
+    if [[ -n "${VERNACULA_CI_ALLOW_SKIPS:-}" ]]; then
+      echo "WARN: $proj $skipped (assets missing; allowed by VERNACULA_CI_ALLOW_SKIPS)"
+    else
+      failures+=("$proj: $skipped -- asset-gated tests did not run on a box that has the assets")
+    fi
+  fi
+done
+
+echo
+if (( ${#failures[@]} )); then
+  echo "FAILED:"
+  printf '  - %s\n' "${failures[@]}"
+  exit 1
+fi
+echo "All test projects passed."


### PR DESCRIPTION
Companion to #81. That PR makes hosted CI run the asset-free tests; this one covers the tests a hosted runner structurally cannot run.

`tests/IndicConformerTest` gates every test on the IndicConformer ONNX package and the `test_audio/` tree. On a GitHub runner neither exists, so it reports 23 skips and passes — it would keep passing if IndicConformer were entirely broken. On a dev box the assets are there, so a skip means the resolver stopped finding them. `scripts/ci_local.sh` treats that as a failure.

Two observed behaviours make the check necessary rather than decorative:

- `dotnet test` exits 0 when every test skips. The summary line is the only place "ran" vs "did not run" survives.
- `dotnet test --no-build` against a project that was never built prints **nothing** and exits **0** — a green run of zero tests. So the script requires a summary line from every project before believing any of its output.

Tests run with `--no-build -p:Platform=x64` against the `bin/x64/...` artifacts the solution build produces, so dev-side and CI exercise the same binaries.

### Verified

| Run | Result |
|---|---|
| `scripts/ci_local.sh` on a box with the assets | 143 passed, 0 skipped, exit 0 |
| assets hidden | exit 1, names `tests/IndicConformerTest` |
| unbuilt tree, `--no-build` | exit 1, names all four projects |
| assets hidden + `VERNACULA_CI_ALLOW_SKIPS=1` | warns, exit 0 |

### Not addressed here

Nothing in either PR makes a check *block* a merge — that needs `dotnet-test / Tests (CPU)` configured as a required status check in branch protection, which is repo settings. The line in `docs/dev/asr_backend_dispatch.md` claiming the coverage test "blocks PR merges instead of silently rotting" is still ahead of what the repo enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189xwgd77UVMtyYQHCS2kk6