### PR TITLE
docs: say what CI actually runs, and what it cannot

### DIFF
--- a/docs/dev/asr_backend_dispatch.md
+++ b/docs/dev/asr_backend_dispatch.md
@@ -18,11 +18,40 @@ defaults to throw, plus a coverage test backstop.
 
 ## Run the coverage test
 
-Tests run automatically in CI (`.github/workflows/dotnet-test.yml`),
-which builds the solution with `-p:EP=Cpu` and runs this test (must
-pass) plus `tests/IndicConformerTest` on every push to `main` and on
-every pull request. The dispatch-fan-out coverage test therefore blocks
-PR merges instead of silently rotting. To run it locally:
+CI (`.github/workflows/dotnet-test.yml`) builds the solution with
+`-p:EP=Cpu` on every push to `main` and every pull request, then runs
+four test projects against the artifacts it just built:
+
+| Project | On a hosted runner |
+| --- | --- |
+| `tests/Vernacula.Tests` | 22 tests — runs |
+| `tests/Chatterbox.Tests` | 35 tests — runs |
+| `tests/AsrBackendCoverage` | 63 tests — runs; this is the fan-out backstop |
+| `tests/IndicConformerTest` | 23 tests — **all skip** |
+
+`IndicConformerTest` gates every test on the IndicConformer ONNX
+package and the `test_audio/` tree, neither of which exists on a
+runner. It reports 23 skips and passes, and `dotnet test` exits 0 when
+everything skips — so that step proves only that the project compiles.
+It is kept for the skip count, not as coverage. The tests that need
+model assets run on a dev box:
+
+```bash
+scripts/ci_local.sh          # build, then all four projects
+```
+
+That script fails if an asset-gated test skips on a machine that has
+the assets, on the reasoning that a skip there means the resolver
+stopped finding them.
+
+`Tests (CPU)` is a required status check on `main`, so the
+dispatch-fan-out coverage test blocks PR merges instead of silently
+rotting. Two things that look like breakage but are not: a pull request
+from a fork sits at `action_required` until a maintainer clicks
+"Approve and run", and a pull request whose branch predates a change to
+the workflow will not run the new version until its branch is updated.
+
+To run just this test locally:
 
 ```bash
 dotnet test tests/AsrBackendCoverage


### PR DESCRIPTION
Follow-up to #81 and #82. Rewrites the "Run the coverage test" section of `docs/dev/asr_backend_dispatch.md`, which described a CI setup that no longer matches the repo and made one claim that was never true.

**What was wrong**

- It said CI runs the coverage test "plus `tests/IndicConformerTest`". CI now runs four projects.
- It said the coverage test "blocks PR merges instead of silently rotting." Nothing in the workflow provides that — it comes from `Tests (CPU)` being a required status check, which is repo settings.
- It said nothing about `IndicConformerTest` being unable to contribute coverage on a runner.

**What it says now**

Per-project counts as observed on the `push: main` run of `eed9c0b`:

| Project | On a hosted runner |
| --- | --- |
| `tests/Vernacula.Tests` | 22 — runs |
| `tests/Chatterbox.Tests` | 35 — runs |
| `tests/AsrBackendCoverage` | 63 — runs |
| `tests/IndicConformerTest` | 23 — **all skip** |

Plus the reason that last row passes anyway (`dotnet test` exits 0 when everything skips), a pointer to `scripts/ci_local.sh` for the tests a runner structurally cannot run, and the two behaviours that cost time to diagnose while setting this up:

- a fork PR sits at `action_required` until a maintainer clicks "Approve and run"
- a PR whose branch predates a workflow change won't run the new version until its branch is updated

**Before merging**

The doc states `Tests (CPU)` is a required status check on `main`. The `protect-main` ruleset is configured with exactly that check but its enforcement is currently `disabled`, so the claim isn't true yet. Flip enforcement to Active and it is — otherwise this PR just re-introduces the same overclaim in better prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189xwgd77UVMtyYQHCS2kk6