### PR TITLE
corpus: en_gb enters the corpus as a coverage patch, not a language

### DIFF
--- a/docs/omnivoice_ipa_corpus_investigation.md
+++ b/docs/omnivoice_ipa_corpus_investigation.md
@@ -3823,3 +3823,140 @@ vi_vn and cs_cz inside the training set.
 
 Order, unchanged from the Run 51 restructure and from what the memory of this campaign keeps saying:
 fix upstream, re-derive, re-QC, then decide on a fine-tune — never the other way round.
+
+## Run 54 — 2026-09-03 — en-GB enters the corpus as a coverage patch, not a language
+
+**Question.** Upstream #1252 moved `en-GB` onto the superscript offglide convention (`əᶷ eᶦ aᶦ aᶷ`),
+which is what the model was already trained on for `en`. But the *units* en-GB produces are not the
+units en-US produces, and the v6 model has never seen most of them — hence "smoke" → "smik". What is
+the smallest amount of en-GB audio that closes that gap?
+
+**Framing.** The instruction was to add "what's needed to handle the diphthongs, triphthongs or
+offglide pairings that didn't appear in en-US, and limit to an accent that matches our
+phonemization." So this is deliberately *not* an `en_gb` corpus in the sense the other 28
+`POP_ORDER` entries are. It is a patch sized to a measured hole. Two consequences follow:
+
+- Only the two **southern** SLR83 archives are in scope. The other five dialects (Irish, Scottish,
+  Welsh, northern, midlands) phonemize to units `en-GB` does not emit — Run 53's r-colouring measure
+  separated them cleanly (southern 1.51 vs Irish 2.34 rhotic marks per utterance). Training on audio
+  whose realised vowels disagree with the IPA beside them is the exact drift this pipeline keeps
+  getting bitten by.
+- Utterance selection is greedy set-cover over *vowel units*, not a random sample.
+
+**Method.** Phonemized all 8,492 southern transcripts (4,161 female + 4,331 male) through `en-GB`,
+extracted vowel units with `[V]ː?[Vᶦᶷᵊ]ː?[Vᶦᶷᵊ]?`, counted the same units across the 28 `POP_ORDER`
+languages in the alignment DB, and greedily picked utterances maximising coverage of units sitting
+below `sampling_budget.N_TOKENS` (300).
+
+**Result — 1,281 of 8,492 utterances (759 female, 522 male):**
+
+```
+  unit      avail  trained   added   total
+  əᶷ        5,807      192   1,029   1,221
+  ɛə        1,830       37     392     429
+  aᶷə         524       33     267     300
+  ʊə          447       69     231     300
+  aᶦə         424      200     100     300
+  iːə         191      178     122     300
+  ɔᶦə         142       39     142     181   <- archive exhausted
+  əᶷɪ         141        6     141     147   <- archive exhausted
+  ɪɒ          116        0     116     116   <- archive exhausted
+```
+
+`əᶷ` — GOAT, the vowel in "smoke", the one that started this — goes from 192 occurrences to 1,221.
+`ɛə` (SQUARE) from 37 to 429.
+
+**Negative results worth keeping.**
+
+- **The female archive alone was not enough.** A first pass over the 4,161 female utterances left
+  `aᶷə` at 292 and `ʊə` at 287 with the archive exhausted — the units simply are not in those
+  transcripts. Adding the male archive closed both to exactly 300. The gender balance in the
+  selection (759F/522M) is a *consequence* of that, not a target I set; the male archive got picked
+  because it carried units the female one had run out of.
+- **43 units cannot reach 300 and never will.** They are rare in English itself (<100 occurrences in
+  8,492 utterances). `ɪɒ` has 116 available and 0 trained. No amount of data fixes this, and it
+  should not be fixed: a model that sees `əᶷɪ` rarely matches a world where `əᶷɪ` *is* rare.
+  The stopping point here is a judgement call, not a computed one.
+- **`ingest_dir.py` needs the export venv,** not `/mnt/data/omnivoice_ipa/venv` — that one has
+  neither `onnxruntime` nor `soundfile`.
+- **The encode was silently running on CPU at 0.69x realtime.** `--provider cuda` asks for
+  `CUDAExecutionProvider`, but both venvs had plain `onnxruntime`, not `onnxruntime-gpu` — ORT logs a
+  warning and falls back to CPU, and the warning was inside the `grep -v Warning` this script's
+  output is normally piped through. Measured: **5.14 s/utterance on CPU vs 0.10 s on GPU, 51x**, or
+  110 min vs 2 min for this job. `pip install onnxruntime-gpu` (1.29.0) into `export_venv` after
+  uninstalling `onnxruntime` — they collide on the module name, and the GPU wheel is a superset that
+  still provides the CPU EP. Worth checking `sess.get_providers()[0]` rather than trusting the flag.
+
+**Ingested.** 1,281 rows, 0 skipped, 2.40 h of audio, 759F/522M, in 133 s on GPU. Manifest ids match
+the npz keys exactly, every array is `[8, n_frames]` with `n_frames` agreeing with the manifest, and
+all 1,281 rows carry `ipa_src="phonemizer"`. A sample row shows the convention landing as intended —
+`kəntɹˈəᶷɫd` for "controlled", `lˈəᶷəd` for "lowered", the superscript offglide `əᶷ` the v6 model
+has only 192 examples of.
+
+**Caveat carried forward, in the manifest itself.** These rows are marked `ipa_src="phonemizer"`,
+not `"hand"` and not `""` — that is IPA *provenance*, and it stays true regardless of QC. The
+alignment verdict lives in `status`, which the pass below fills in.
+
+**Open decision for v7.** Adding `en_gb` takes `POP_ORDER` from 28 languages to 29, which makes v7 a
+different experiment than v6 rather than a strict improvement on it. That is a deliberate choice to
+put to the user before any fine-tune starts.
+
+
+## Run 55 — 2026-09-03 — Listening to the en-GB ingest: alignment, and rhoticity as an accent gate
+
+**Pass.** `asr_align_dir.py` — a new sibling of `asr_align_corpus.py`, written for the same reason
+`ingest_dir.py` is a sibling of `ingest_fleurs.py`: that script is bound to FLEURS in three places
+(streams audio out of `train.tar.gz`, reads a FLEURS TSV for sentence id and transcript, looks IPA up
+in `byid/<lang>.tsv`) and a directory-ingested corpus has none of them — it has a manifest already
+carrying `id`, `text` and `ipa`. Everything that decides what a score *means* is deliberately
+identical: same model, same fp16-on-cuda, same batching, same `INSERT OR REPLACE` into the same `utt`
+table, same resume-by-default. Two things differ, both forced by the corpus: the audio is **resampled**
+rather than skipped (the FLEURS path skips anything not already 16 kHz because an odd rate there means
+a broken member; SLR83 is 48 kHz, so skipping would align nothing), and `sentence_id` is the utterance
+id (FLEURS repeats a sentence across speakers; a directory corpus has one recording per id).
+
+**1,281 utterances in 22 s at 57/s. All 1,281 manifest rows matched audio, 0 unreadable, 0 short.**
+
+```
+lang     n      short  median  within-3MAD    investigate
+en_us    2601   0      0.1795  2436 (93.7%)   165
+en_gb    1281   0      0.2048  1265 (98.8%)    16
+```
+
+**The headline is that 0.2048 is boring**, and it had to be checked rather than assumed. The
+recognizer is en-US flavoured: it writes `oʊ` where we write `əᶷ` and `ɚ` where we write `ə`, and
+`fold()` drops modifier letters (category Lm) — so our `əᶷ` folds to one phone while its `oʊ` folds to
+two. That asymmetry is exactly the shape of Run 36's `ga_ie` bug, where a uniform per-utterance
+penalty flattened the distribution until the investigate list came out EMPTY. It did not happen here:
+en_gb sits 0.026 from en_us with a 1.2% tail, so the offset is real but too small to hide outliers.
+
+**The 16 flagged rows are category 3, not our bugs.** Spot-checked six: our IPA is correct in all of
+them and the recognizer is what failed — one emits "including bog" *before* "brought", another renders
+"snowing" as `s t n ɑː v ɛ n ɪ n`. Labelled `verified`/`investigate` by `asr_align_label.py --apply`;
+`corpus_filter` keeps `investigate` in (only `defective_audio` is excluded unconditionally), which is
+the right posture for an instrument that is roughly 75% accurate — a hint, not a verdict.
+
+### Rhoticity as an accent gate — the useful thing to do with an unreliable instrument
+
+The target accent is non-rhotic southern; a rhotic reader in the archive would teach the model an
+alignment our `en-GB` IPA never writes. Asking "did the recognizer hear a rhotic" is useless (it hears
+them everywhere, being en-US flavoured). Asking **which speakers hear more rhotics than their own IPA
+predicts, relative to each other**, is not. Per speaker, over `[ɹɻrɚɝ]` (Run 53's fix — the plain
+`[ɹɻr]` class is blind to r-coloured vowels): excess = (heard − ours) / utterance, scored by 3×MAD.
+
+**57 speakers, median excess 1.35, MAD 0.19. Exactly one outlier, and it is in the safe direction:**
+
+```
+  som_04766   18 utts  heard 4.44  ours 2.28  excess 2.17  z +2.96   (highest, still inside)
+  som_00610   21 utts  heard 2.67  ours 2.29  excess 0.38  z -3.48   <- most NON-rhotic
+```
+
+No speaker rejected. This is the first *evidence* the two archives are non-rhotic rather than merely
+*labelled* southern, which is what "limit to an accent that matches our phonemization" actually needed.
+
+**And a negative result that stops this from being over-read.** The ranking sorts almost perfectly by
+SEX: every `som_` (male) sits above every `sof_` (female), male excess 1.5–2.2 against female 1.0–1.5,
+with no overlap. Real rhoticity would not sort by sex. That is the recognizer substituting `ɚ` for `ə`
+at a sex-dependent rate — instrument bias — and it is why the absolute number cannot be thresholded
+and only the within-sex spread carries information. A gate built on the raw count would have
+"discovered" that all 29 male readers are rhotic.

--- a/scripts/omnivoice_ipa/MOVED.md
+++ b/scripts/omnivoice_ipa/MOVED.md
@@ -1,0 +1,36 @@
+# The ASR-alignment tooling moved to vernacula-phonemizer
+
+`asr_align_corpus.py`, `asr_align_report.py`, `asr_align_label.py`, `scan_silent_audio.py`,
+`consonant_skeleton.py`, `confusion_pairs.py`, `judge_alignment.py` and `judge_cascade.py` now live in
+**`vernacula-phonemizer/tools/corpus/asr-align/`**, alongside `tools/referee-eval` and the FLEURS audio
+fetcher that was already there.
+
+⚠ **They were moved, not copied.** Two divergent copies is exactly what this move was meant to end: the
+two FLEURS downloaders had drifted until each held half of one fix — the phonemizer's verified against
+the REMOTE SIZE, the one here had a stall watchdog after an eleven-hour silent hang. Both halves are now
+in `vernacula-phonemizer/tools/corpus/fetch-fleurs-audio.py`.
+
+**Why there:** everything that tooling finds is a phonemizer fix, and a fix should be able to land in the
+same commit as its evidence. It also sat on two definitions of "the segmental backbone" — one in
+`referee-eval/config.ts`, one in `asr_align_report.py` — which can now be seen side by side.
+
+## The audio downloader is superseded
+
+`fetch_fleurs_all.py` is kept only for its TRANSCRIPT fetching. For AUDIO use
+`vernacula-phonemizer/tools/corpus/fetch-fleurs-audio.py`, which is strictly better and now carries both
+halves of the fix: it batches one metadata call instead of a HEAD per language, verifies each file against
+the REMOTE SIZE (so a short or interrupted download is re-fetched rather than counted as complete), and
+has the stall watchdog. ⚠ The presence check here was `os.listdir` of `data/`, which counts a language as
+cached the moment its FOLDER exists — `ast_es` and `nso_za` were both skipped indefinitely on the strength
+of an empty directory.
+
+## What is still here, and why
+
+The training-corpus pipeline, which answers *which pairs do we train on* rather than *is our IPA right*:
+
+    ingest_fleurs.py  corpus_filter.py  exclude_defective.py  sampling_budget.py
+    build_webdataset.py  publish_hf.py  publish_hf_dataset.py  patch_manifest_ipa.py
+
+`exclude_defective.py` reads the alignment DB's `status` column directly and has no code dependency on
+the moved tools, so this side still runs unchanged. The DB itself stays at
+`work/asr_align/align.sqlite`; both repos point at it via `ASR_ALIGN_ROOT` (default unchanged).

--- a/scripts/omnivoice_ipa/ingest_dir.py
+++ b/scripts/omnivoice_ipa/ingest_dir.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Ingest a DIRECTORY of audio + transcripts into the corpus — the non-FLEURS path.
+
+`ingest_fleurs.py` is bound to FLEURS in three places: it downloads `data/<lang>/audio/train.tar.gz`,
+it reads a FLEURS TSV for sentence ids and gender, and it looks IPA up in the alignment DB keyed by
+the FLEURS wav name. A corpus that is not FLEURS has none of those, so this is a sibling rather than
+a flag on that script — the two share only the encode step, and entangling them would put a second
+"where does IPA come from" branch in the file whose header already warns that two IPA sources is the
+drift this pipeline has been bitten by before.
+
+Written for OpenSLR SLR83 (UK/Ireland English dialects, CC BY-SA 4.0) so `en_gb` can enter the
+fine-tune, but it takes any `<id>\t<transcript>` index beside audio files.
+
+⚠ IPA COMES FROM THE PHONEMIZER, PER UTTERANCE, and the rows are marked `ipa_src="phonemizer"`.
+There is no alignment-DB entry for this audio yet, so nothing here has been checked against what the
+reader actually said. That is a weaker guarantee than the FLEURS path gives and the manifest says so,
+rather than letting a consumer assume every row was QC'd.
+
+  python3 ingest_dir.py --dir /path/to/slr83/southern_english_female --lang en_gb --phon-lang en-GB
+"""
+from __future__ import annotations
+
+import argparse, glob, json, os, subprocess, sys, tempfile, time
+
+import numpy as np
+import onnxruntime as ort
+import soundfile as sf
+import librosa
+
+SR_OUT = 24000
+MIN_SECONDS, MAX_SECONDS = 1.0, 30.0
+OUT = "/mnt/data/omnivoice_ipa/corpus/tokens"
+ENCODER = "/mnt/data/omnivoice_ipa/onnx/higgs_encoder.onnx"
+# Override with VERNACULA_PHONEMIZER so the default is not a statement about one machine --
+# the same convention the asr-align tools use for ASR_ALIGN_ROOT.
+PHONEMIZER = os.environ.get("VERNACULA_PHONEMIZER",
+                            os.path.expanduser("~/Programming/vernacula-phonemizer"))
+
+IDENT = __import__("re").compile(r"^[0-9a-f]{16,}$|^[A-Za-z0-9_+/=-]{24,}$")
+
+
+def read_index(root: str, audio: dict[str, str]) -> dict[str, str]:
+    """{id: transcript} from whatever index files the corpus ships.
+
+    ⚠ THE TRANSCRIPT IS NOT THE LONGEST COLUMN. That rule put Common Voice's 128-character `client_id`
+    into 21 reference voices as their transcript (web-demo #86). Prefer a declared header; otherwise
+    take the longest column that is not an opaque identifier.
+    """
+    TEXT_COLS = ("sentence", "transcript", "transcription", "text", "raw_text", "normalized_text")
+    out: dict[str, str] = {}
+    idx = [f for f in glob.glob(f"{root}/**/*", recursive=True)
+           if f.lower().endswith((".tsv", ".csv", ".txt")) and "readme" not in f.lower()]
+    for path in idx:
+        lines = open(path, encoding="utf8", errors="replace").read().split("\n")
+        first = next((l for l in lines if l.strip()), "")
+        sep = "\t" if "\t" in first else ","
+        head = [h.strip().strip('"').lower() for h in first.split(sep)]
+        tcol = next((i for i, h in enumerate(head) if h in TEXT_COLS), -1)
+        icol = next((i for i, h in enumerate(head) if h in ("path", "file", "filename", "id", "utt_id")), -1)
+        for n, line in enumerate(lines):
+            if not line.strip() or (tcol >= 0 and n == 0):
+                continue
+            parts = [p.strip().strip('"') for p in line.split(sep)]
+            uid = parts[icol] if icol >= 0 and icol < len(parts) and parts[icol] in audio else \
+                next((p for p in parts if p in audio), None)
+            if uid is None:
+                continue
+            if tcol >= 0 and tcol < len(parts):
+                t = parts[tcol]
+            else:
+                t = next(iter(sorted((p for p in parts if p != uid and not IDENT.match(p)),
+                                     key=len, reverse=True)), "")
+            if t and len(t) > 3 and not IDENT.match(t):
+                out.setdefault(uid, t)
+    return out
+
+
+def phonemize(texts: list[str], lang: str) -> list[str]:
+    """One phonemizer process for the whole corpus — a per-utterance spawn costs more than the encode."""
+    tmp_in = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False, encoding="utf8")
+    tmp_in.write("\n".join(t.replace("\n", " ") for t in texts)); tmp_in.close()
+    tmp_out = tempfile.mktemp(suffix=".txt")
+    probe = os.path.join(PHONEMIZER, f"ingest-phonemize.{os.getpid()}.tmp.mts")
+    with open(probe, "w", encoding="utf8") as f:
+        f.write(
+            'import { readFileSync, writeFileSync } from "node:fs";\n'
+            'import { phonemizeAsync } from "./src/index.ts";\n'
+            f'const lines = readFileSync({json.dumps(tmp_in.name)}, "utf8").split("\\n");\n'
+            "const out = [];\n"
+            "for (const l of lines) {\n"
+            f'  try {{ out.push((await phonemizeAsync(l, {json.dumps(lang)})).replace(/[\\r\\n]+/g, " ").trim()); }}\n'
+            '  catch { out.push(""); }\n'
+            "}\n"
+            f'writeFileSync({json.dumps(tmp_out)}, out.join("\\n"), "utf8");\n')
+    try:
+        subprocess.run(["npx", "tsx", os.path.basename(probe)], cwd=PHONEMIZER, check=True,
+                       stdout=subprocess.DEVNULL)
+        return open(tmp_out, encoding="utf8").read().split("\n")
+    finally:
+        for p in (probe, tmp_in.name, tmp_out):
+            try: os.remove(p)
+            except OSError: pass
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dir", required=True, help="directory of audio + an index file")
+    ap.add_argument("--lang", required=True, help="corpus language key, e.g. en_gb")
+    ap.add_argument("--phon-lang", help="phonemizer code (default: --lang with _ -> -)")
+    ap.add_argument("--provider", default="cuda", choices=("cpu", "cuda"))
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--ids", help="JSON list of utterance ids; ingest only these. en_gb is a coverage "
+                                 "patch, not a corpus — it ships the utterances that carry the vowel "
+                                 "units en_us never trained, not every utterance in the archive.")
+    ap.add_argument("--append", action="store_true",
+                    help="merge into an existing codes/manifest pair rather than replacing it "
+                         "(SLR83 ships one archive per dialect; en_gb is their union)")
+    a = ap.parse_args()
+    phon = a.phon_lang or a.lang.replace("_", "-")
+
+    audio = {}
+    for f in glob.glob(f"{a.dir}/**/*", recursive=True):
+        if f.lower().endswith((".wav", ".flac", ".mp3", ".opus")):
+            b = os.path.basename(f)
+            audio[b] = f
+            audio[os.path.splitext(b)[0]] = f
+    text = read_index(a.dir, audio)
+    print(f"  {len(set(audio.values())):,} audio files, {len(text):,} transcripts matched")
+    if not text:
+        print("  no transcripts matched — check the index format", file=sys.stderr); return 1
+
+    if a.ids:
+        keep = set(json.load(open(a.ids, encoding="utf8")))
+        text = {k: v for k, v in text.items() if k in keep or os.path.splitext(k)[0] in keep}
+        print(f"  {len(text):,} of {len(keep):,} requested ids present here")
+    items = sorted(text.items())[: a.limit or None]
+    t0 = time.time()
+    ipas = phonemize([t for _, t in items], phon)
+    print(f"  phonemized {sum(1 for i in ipas if i):,}/{len(items):,} in {time.time()-t0:.0f}s")
+
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"] if a.provider == "cuda" else ["CPUExecutionProvider"]
+    sess = ort.InferenceSession(ENCODER, providers=providers)
+    in_name = sess.get_inputs()[0].name
+    codes_out, manifest = {}, []
+    n_skip = 0
+    for (uid, t), ipa in zip(items, ipas):
+        if not ipa:
+            n_skip += 1; continue
+        wav, sr = sf.read(audio[uid], dtype="float32")
+        if wav.ndim > 1: wav = wav.mean(axis=1)
+        if not (MIN_SECONDS <= len(wav) / sr <= MAX_SECONDS):
+            n_skip += 1; continue
+        if sr != SR_OUT:
+            wav = librosa.resample(wav, orig_sr=sr, target_sr=SR_OUT, res_type="soxr_hq")
+        pad = (-len(wav)) % 960          # the encoder's two paths disagree by a frame otherwise
+        x = np.pad(wav, (0, pad)).reshape(1, 1, -1).astype(np.float32)
+        codes = sess.run(["audio_codes"], {in_name: x})[0][0]
+        key = os.path.splitext(os.path.basename(audio[uid]))[0]
+        codes_out[key] = codes.astype(np.int16)
+        manifest.append(dict(id=key, sentence_id=None, lang=a.lang, ipa=ipa, gender=None,
+                             dur_s=round(len(wav) / SR_OUT, 2), n_frames=int(codes.shape[-1]),
+                             # ⚠ NOT "hand", NOT "" — this row's IPA has never been checked against
+                             # the audio. A consumer can tell it apart from a DB-derived row.
+                             ipa_src="phonemizer", status="", text=t))
+        if len(manifest) % 500 == 0:
+            print(f"    {len(manifest):,} encoded…", flush=True)
+
+    cp, mp = f"{OUT}/codes_{a.lang}.npz", f"{OUT}/manifest_{a.lang}.jsonl"
+    if a.append and os.path.exists(cp):
+        prev = np.load(cp)
+        merged = {k: prev[k] for k in prev.files}
+        dup = sum(1 for k in codes_out if k in merged)
+        merged.update(codes_out)
+        codes_out = merged
+        old_rows = [json.loads(l) for l in open(mp, encoding="utf8") if l.strip()]
+        seen = {r["id"] for r in manifest}
+        manifest = [r for r in old_rows if r["id"] not in seen] + manifest
+        print(f"  appended to {len(old_rows):,} existing rows ({dup} ids replaced)")
+    np.savez_compressed(cp, **codes_out)
+    with open(mp, "w", encoding="utf8") as f:
+        for r in manifest:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"  {len(manifest):,} rows, {n_skip:,} skipped -> {os.path.basename(cp)} "
+          f"({os.path.getsize(cp)/1e6:.0f} MB), {time.time()-t0:.0f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/omnivoice_ipa/ingest_dir.py
+++ b/scripts/omnivoice_ipa/ingest_dir.py
@@ -12,9 +12,11 @@ Written for OpenSLR SLR83 (UK/Ireland English dialects, CC BY-SA 4.0) so `en_gb`
 fine-tune, but it takes any `<id>\t<transcript>` index beside audio files.
 
 ⚠ IPA COMES FROM THE PHONEMIZER, PER UTTERANCE, and the rows are marked `ipa_src="phonemizer"`.
-There is no alignment-DB entry for this audio yet, so nothing here has been checked against what the
-reader actually said. That is a weaker guarantee than the FLEURS path gives and the manifest says so,
-rather than letting a consumer assume every row was QC'd.
+That is IPA PROVENANCE and it stays true regardless of QC — it is not a quality verdict. Freshly
+ingested rows have never been checked against what the reader actually said, which is a weaker
+guarantee than the FLEURS path gives, and they say so by carrying an EMPTY `status`: no verdict, not
+"clean". Run the alignment pass (`asr_align_dir.py` in vernacula-phonemizer) and propagate its labels
+into `status` before treating these rows as QC'd.
 
   python3 ingest_dir.py --dir /path/to/slr83/southern_english_female --lang en_gb --phon-lang en-GB
 """
@@ -140,6 +142,15 @@ def main() -> int:
 
     providers = ["CUDAExecutionProvider", "CPUExecutionProvider"] if a.provider == "cuda" else ["CPUExecutionProvider"]
     sess = ort.InferenceSession(ENCODER, providers=providers)
+    # ⚠ ORT FALLS BACK TO CPU SILENTLY. Requesting CUDAExecutionProvider when the installed wheel is
+    # plain `onnxruntime` rather than `onnxruntime-gpu` logs a warning and runs on CPU anyway -- and
+    # this script's output is normally piped through a `grep -v Warning`, so the flag looked honoured.
+    # Measured cost of not noticing: 5.14 s/utterance instead of 0.10, 110 min instead of 2.
+    active = sess.get_providers()[0]
+    if a.provider == "cuda" and active != "CUDAExecutionProvider":
+        print(f"  ⚠ --provider cuda REQUESTED BUT RUNNING ON {active} -- expect ~50x slower.\n"
+              f"    pip install onnxruntime-gpu (uninstall onnxruntime first; they collide).",
+              file=sys.stderr, flush=True)
     in_name = sess.get_inputs()[0].name
     codes_out, manifest = {}, []
     n_skip = 0
@@ -156,6 +167,10 @@ def main() -> int:
         x = np.pad(wav, (0, pad)).reshape(1, 1, -1).astype(np.float32)
         codes = sess.run(["audio_codes"], {in_name: x})[0][0]
         key = os.path.splitext(os.path.basename(audio[uid]))[0]
+        if key in codes_out:      # two files, one stem: silently keeping the last would be a lie
+            print(f"  ⚠ duplicate id {key}, keeping the first", file=sys.stderr)
+            n_skip += 1
+            continue
         codes_out[key] = codes.astype(np.int16)
         manifest.append(dict(id=key, sentence_id=None, lang=a.lang, ipa=ipa, gender=None,
                              dur_s=round(len(wav) / SR_OUT, 2), n_frames=int(codes.shape[-1]),
@@ -166,20 +181,40 @@ def main() -> int:
             print(f"    {len(manifest):,} encoded…", flush=True)
 
     cp, mp = f"{OUT}/codes_{a.lang}.npz", f"{OUT}/manifest_{a.lang}.jsonl"
-    if a.append and os.path.exists(cp):
+    # ⚠ BOTH files, not just the npz: guarding on `cp` alone crashed in `open(mp)` below when a
+    # previous run had been interrupted between the two writes.
+    if a.append and os.path.exists(cp) and os.path.exists(mp):
         prev = np.load(cp)
         merged = {k: prev[k] for k in prev.files}
         dup = sum(1 for k in codes_out if k in merged)
         merged.update(codes_out)
         codes_out = merged
         old_rows = [json.loads(l) for l in open(mp, encoding="utf8") if l.strip()]
+        old_by_id = {r["id"]: r for r in old_rows}
+        # ⚠ RE-INGESTING A ROW MUST NOT DISCARD ITS VERDICT. `status` is a review decision that came
+        # from the alignment pass or from a person; `ipa`, `codes` and `n_frames` are derivations of
+        # the audio. Replacing the whole row reset 1,265 `verified` labels to "" on a re-run, and an
+        # empty status reads as NO VERDICT, so nothing downstream would have flagged the loss.
+        # Same lesson corpus_filter records: label at build, decide later, never fuse the two.
+        kept = 0
+        for r in manifest:
+            was = old_by_id.get(r["id"])
+            if was and was.get("status") and not r.get("status"):
+                r["status"] = was["status"]
+                kept += 1
         seen = {r["id"] for r in manifest}
         manifest = [r for r in old_rows if r["id"] not in seen] + manifest
-        print(f"  appended to {len(old_rows):,} existing rows ({dup} ids replaced)")
-    np.savez_compressed(cp, **codes_out)
-    with open(mp, "w", encoding="utf8") as f:
+        print(f"  appended to {len(old_rows):,} existing rows ({dup} ids replaced, "
+              f"{kept} verdicts carried forward)")
+    # ⚠ Write both, THEN publish both. These two files are one artifact -- a manifest row without its
+    # codes is unusable and codes without a row are invisible -- and this is a long GPU job that has
+    # been interrupted before. Writing in place left them disagreeing on exactly that failure.
+    np.savez_compressed(cp + ".tmp.npz", **codes_out)
+    with open(mp + ".tmp", "w", encoding="utf8") as f:
         for r in manifest:
             f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    os.replace(cp + ".tmp.npz", cp)
+    os.replace(mp + ".tmp", mp)
     print(f"  {len(manifest):,} rows, {n_skip:,} skipped -> {os.path.basename(cp)} "
           f"({os.path.getsize(cp)/1e6:.0f} MB), {time.time()-t0:.0f}s")
     return 0


### PR DESCRIPTION
Upstream vernacula-phonemizer#1252 moved `en-GB` onto the superscript offglide convention the model was already trained on for `en` (`əᶷ eᶦ aᶦ aᶷ`). But the **units** en-GB produces are not the units en-US produces, and v6 has never seen most of them — which is why *"smoke"* came out as *"smik"*.

This adds the smallest amount of en-GB audio that closes that measured hole.

## Sized to a hole, not to a language

It is deliberately **not** an `en_gb` corpus in the sense the other 28 `POP_ORDER` entries are. Two things follow:

- **Only the two southern SLR83 archives are in scope.** The other five dialects phonemize to units `en-GB` does not emit — the r-colouring measure separates them cleanly (southern 1.51 vs Irish 2.34 rhotic marks per utterance). Training on audio whose realised vowels disagree with the IPA beside them is the exact drift this pipeline keeps getting bitten by.
- **Selection is greedy set-cover over vowel units,** not a random sample.

**1,281 of 8,492 utterances · 2.40 h · 759F / 522M**

| unit | trained | added | total |
|---|---|---|---|
| `əᶷ` GOAT — the *smoke* vowel | 192 | 1,029 | **1,221** |
| `ɛə` SQUARE | 37 | 392 | 429 |
| `aᶷə` · `ʊə` · `aᶦə` · `iːə` | 33–200 | — | **300 each** |
| `ɔᶦə` · `əᶷɪ` · `ɪɒ` | 0–39 | all available | 116–181 |

## Two negative results worth keeping

**The female archive alone was not enough.** A first pass over the 4,161 female utterances left `aᶷə` at 292 and `ʊə` at 287 *with the archive exhausted* — the units are simply not in those transcripts. Adding the male archive closed both to exactly 300. The gender balance in the selection is a **consequence** of that, not a target I set.

**43 units cannot reach 300 and never will.** They are rare in English itself (<100 occurrences in 8,492 utterances; `ɪɒ` has 116 available and 0 trained). That is not a defect to fix — a model that sees `əᶷɪ` rarely matches a world where `əᶷɪ` *is* rare. The stopping point here is a judgement call, not a computed one.

## `ingest_dir.py` is a sibling, not a flag

`ingest_fleurs.py` downloads a FLEURS tarball, reads a FLEURS TSV for sentence ids and gender, and looks IPA up in the alignment DB by FLEURS wav name. Its header already warns that two IPA sources is the drift to avoid, so adding a second *"where does IPA come from"* branch there would be the wrong shape.

Rows are marked `ipa_src="phonemizer"` — that is IPA **provenance** and stays true regardless of QC. The alignment verdict lives in `status`.

## Alignment

Run through `asr_align_dir.py` (vernacula-phonemizer#1258):

```
lang     n      short  median  within-3MAD    investigate
en_us    2601   0      0.1795  2436 (93.7%)   165
en_gb    1281   0      0.2048  1265 (98.8%)    16
```

`corpus_filter.load_manifest("en_gb")` → **1,281 kept, 0 dropped** (only `defective_audio` is excluded unconditionally; `investigate` is a work log, not a verdict, which is the right posture for a ~75%-accurate instrument).

Spot-checked six flagged rows — our IPA is correct in all of them and the recognizer is what failed.

## Rhoticity as an accent gate

The target accent is non-rhotic southern; a rhotic reader would teach an alignment our `en-GB` IPA never writes. Asking *"did the recognizer hear a rhotic"* is useless — being en-US flavoured, it hears them everywhere. Asking which speakers hear more rhotics **than their own IPA predicts, relative to each other**, is not.

57 speakers, median excess 1.35/utt, MAD 0.19. **Exactly one outlier, in the safe direction:** `som_00610` at z = −3.48, the *most* non-rhotic reader. No speaker rejected — the first evidence these archives are non-rhotic rather than merely labelled southern.

**And the negative result that stops this being over-read:** the ranking sorts almost perfectly by sex — every male speaker above every female, no overlap. Real rhoticity would not do that. It is the recognizer substituting `ɚ` for `ə` at a sex-dependent rate, which is why only the within-sex spread carries information. A gate built on the raw count would have "discovered" that all 29 male readers are rhotic.

## Not in this PR

`POP_ORDER` still has 28 languages. Adding `en_gb` makes v7 a **different experiment** than v6 rather than a strict improvement on it, so that stays a separate, deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc