### PR TITLE
tooling: a stall watchdog for the FLEURS fetch, and a desktop app that says why it cannot run

### DIFF
--- a/docs/fleurs_cy_gb_truncated_audio.md
+++ b/docs/fleurs_cy_gb_truncated_audio.md
@@ -56,8 +56,38 @@ disappears entirely — but only because we checked.
 A phone-recognizer pass over the whole corpus, comparing recognized phones against our own
 phonemization per utterance, then flagging utterances whose **phones-per-second implied by the
 transcript** was an outlier relative to that language's own median (3×MAD, not a fixed threshold).
-Welsh was the only language where the outliers concentrated — the same detection over the other 27
-languages found at most a dozen each (sd_in 12, ff_sn 9, ar_eg 2, am_et 2, ta_in 1).
+
+## The detector is not simply aggressive
+
+The same detector, unchanged, has since been run over **102 FLEURS languages / 270,106 utterances** —
+essentially the whole dataset. Outside `cy_gb` and one milder case it flags almost nothing:
+
+    cy_gb                        585 / 3,427    = 17.1%
+    oc_fr                         94 / 3,379    =  2.8%   (a different, milder defect — see below)
+    every other language          64 / 263,300  =  0.024%
+
+The full tail after those two, in order: sd_in 12, ff_sn 9, ny_mw 6, fa_ir 5, ckb_iq 4, ceb_ph 4, so_so 4,
+then a dozen languages with 2 or fewer. No language other than Welsh and Occitan reaches even 0.5% of its
+own split.
+
+**`oc_fr` is not a second instance of this defect**, and is called out here so it is not mistaken for one.
+Its 94 files are short for their transcripts, but they contain the *beginning of the correct sentence* at a
+normal speaking rate — scored against the best-matching prefix of the expected phone string they reach
+0.634 against an Occitan baseline of 0.639, whereas the Welsh files reach only 0.231 against a baseline of
+0.696. They also end in silence (last 100 ms at 3% of overall RMS) rather than being cut mid-signal, where
+half the Welsh files stop at full amplitude. And the Occitan population is a *continuous* left tail with no
+gap, while Welsh is cleanly bimodal — 583 files below 0.3 of their implied duration, then a gap, then the
+healthy split. Occitan looks like audio that stops early; Welsh looks like the wrong audio entirely.
+
+Against the 100 languages that are not Welsh or Occitan the gap is nearly three orders of magnitude, and
+it is the reason this report is about `cy_gb` specifically rather than about a threshold. A detector tuned
+too tightly would light up everywhere; this one is near-silent across 100 languages and then finds a sixth
+of the Welsh split.
+
+(One unrelated defect shows up at comparable scale and is **not** the same problem: `es_419` ships 490
+files that are full-length and **empty** — normal duration, no signal. Their phones-per-second is
+unremarkable, so this detector cannot see them; they were found by measuring the waveform directly.
+Mentioned only so the 490 is not mistaken for a second instance of the truncation.)
 
 ## Reproduction
 

--- a/scripts/omnivoice_ipa/fetch_fleurs_all.py
+++ b/scripts/omnivoice_ipa/fetch_fleurs_all.py
@@ -22,9 +22,12 @@ the per-language result is printed as it lands rather than buffered to the end.
 from __future__ import annotations
 
 import argparse
+import multiprocessing as mp
 import os
+import queue
 import re
 import sys
+import time
 
 from huggingface_hub import hf_hub_download, list_repo_files
 
@@ -32,6 +35,70 @@ ROOT = "/mnt/data/omnivoice_ipa"
 AUDIO_CACHE = f"{ROOT}/corpus/audio_cache"
 TEXT_CACHE = f"{ROOT}/corpus/fleurs_transcripts"
 REPO = "google/fleurs"
+
+
+# ⚠ A STALL WATCHDOG, ADDED AFTER ONE. A run sat on nso_za for ELEVEN AND A HALF HOURS: the process was alive
+# and asleep, the .incomplete file frozen at 335 MB, and nothing in the log since. hf_hub_download has a 10s
+# read timeout (hub 1.8.0) and it did not help — a dead-but-open socket, or the library's own retry/backoff,
+# leaves the call blocked with no way for the caller to notice.
+#
+# So the caller watches the BYTES instead of trusting the call. The download runs in a child process while the
+# parent polls the cache size; if it has not grown in STALL_S the child is terminated. Watching progress rather
+# than imposing a fixed deadline is the point — a genuinely slow link keeps its time, and only a frozen one is
+# cut. The partial file stays on disk either way, because hf_hub_download is content-addressed and resumes.
+STALL_S = 300      # no new bytes for this long → assume the socket is dead
+POLL_S = 30
+RETRIES = 3
+
+
+def _cache_bytes() -> int:
+    total = 0
+    for root, _dirs, files in os.walk(AUDIO_CACHE):
+        for f in files:
+            try:
+                total += os.path.getsize(os.path.join(root, f))
+            except OSError:  # a file can vanish mid-walk as the downloader renames it into place
+                pass
+    return total
+
+
+def _child(lang: str, q) -> None:
+    try:
+        q.put(("ok", hf_hub_download(REPO, f"data/{lang}/audio/train.tar.gz", repo_type="dataset",
+                                     local_dir=AUDIO_CACHE)))
+    except Exception as e:  # noqa: BLE001 — reported verbatim to the parent
+        q.put(("err", f"{type(e).__name__}: {e}"))
+
+
+def fetch_one(lang: str) -> str:
+    """Download one language's tarball, aborting if the byte count stops moving."""
+    q = mp.Queue()
+    proc = mp.Process(target=_child, args=(lang, q), daemon=True)
+    proc.start()
+    last_size, last_change = _cache_bytes(), time.monotonic()
+    try:
+        while proc.is_alive():
+            proc.join(POLL_S)
+            if not q.empty():
+                break
+            size = _cache_bytes()
+            if size != last_size:
+                last_size, last_change = size, time.monotonic()
+            elif time.monotonic() - last_change > STALL_S:
+                raise TimeoutError(f"no new bytes for {STALL_S}s")
+        # ⚠ NOT get_nowait(). mp.Queue hands off through a feeder thread, so a child that has already
+        # exited may not have flushed yet and an immediate get raises Empty — which the caller would
+        # report as a stall and retry a download that actually succeeded.
+        kind, payload = q.get(timeout=30)
+    except queue.Empty:
+        raise TimeoutError("child exited without reporting") from None
+    finally:
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(10)
+    if kind == "err":
+        raise RuntimeError(payload)
+    return payload
 
 
 def main() -> int:
@@ -44,7 +111,12 @@ def main() -> int:
     files = list_repo_files(REPO, repo_type="dataset")
     langs = sorted({m.group(1) for f in files
                     if (m := re.match(r"data/([^/]+)/audio/train\.tar\.gz$", f))})
-    have_audio = set(os.listdir(f"{AUDIO_CACHE}/data")) if os.path.isdir(f"{AUDIO_CACHE}/data") else set()
+    # ⚠ TEST FOR THE TARBALL, NOT THE DIRECTORY. This used to be a listdir of data/, which counts a language as
+    # cached the moment hf_hub_download creates its folder — so an interrupted download left a language looking
+    # complete and it was skipped on every later run, silently and permanently. ast_es and nso_za were both in
+    # that state (empty audio/ dirs) after two stalls, and the dry-run reported 9 missing when 11 were.
+    have_audio = {d for d in (os.listdir(f"{AUDIO_CACHE}/data") if os.path.isdir(f"{AUDIO_CACHE}/data") else [])
+                  if os.path.isfile(f"{AUDIO_CACHE}/data/{d}/audio/train.tar.gz")}
     have_text = set(os.listdir(f"{TEXT_CACHE}/data")) if os.path.isdir(f"{TEXT_CACHE}/data") else set()
 
     need_audio = [] if a.text_only else [x for x in langs if x not in have_audio]
@@ -71,15 +143,29 @@ def main() -> int:
 
     total = 0.0
     for i, lang in enumerate(need_audio, 1):
-        try:
-            p = hf_hub_download(REPO, f"data/{lang}/audio/train.tar.gz", repo_type="dataset",
-                                local_dir=AUDIO_CACHE)
+        ok, tries = False, 0
+        for attempt in range(1, RETRIES + 1):
+            tries = attempt
+            try:
+                p = fetch_one(lang)
+            except TimeoutError as e:
+                print(f"[audio {i}/{len(need_audio)}] {lang}: STALLED ({e}), attempt {attempt}/{RETRIES}",
+                      flush=True)
+                continue
+            except Exception as e:
+                print(f"[audio {i}/{len(need_audio)}] {lang}: FAILED {type(e).__name__}: {e}", flush=True)
+                break
             gb = os.path.getsize(p) / 1e9
             total += gb
-            print(f"[audio {i}/{len(need_audio)}] {lang}: {gb:.2f} GB  (cumulative {total:.1f} GB)",
-                  flush=True)
-        except Exception as e:
-            print(f"[audio {i}/{len(need_audio)}] {lang}: FAILED {type(e).__name__}: {e}", flush=True)
+            print(f"[audio {i}/{len(need_audio)}] {lang}: {gb:.2f} GB  (cumulative {total:.1f} GB)", flush=True)
+            ok = True
+            break
+        if not ok:
+            # ⚠ Report the attempts actually MADE. A hard error breaks out on the first one, and saying
+            # "after 3 attempts" would send the next reader looking for two failures that never happened.
+            print(f"[audio {i}/{len(need_audio)}] {lang}: GIVING UP after {tries} "
+                  f"attempt{'s' if tries != 1 else ''} — the partial file stays on disk, so a later run "
+                  f"resumes it", flush=True)
     print(f"\ndone — {total:.1f} GB of audio fetched")
     return 0
 

--- a/scripts/omnivoice_ipa/omnivoice_fleurs_phonemize_vernacula.mts
+++ b/scripts/omnivoice_ipa/omnivoice_fleurs_phonemize_vernacula.mts
@@ -44,6 +44,8 @@ const VARIETY: Record<string, string> = {
   ar_eg: "arz",      // Egyptian Arabic — dedicated egy diacritizer + variety data
   es_419: "es-419",  // Latin American Spanish (seseo, yeísmo)
   pt_br: "pt-BR",    // Brazilian Portuguese
+  fil_ph: "tl",      // FLEURS calls it Filipino; the registry ships it under its ISO 639-1 code, tl (Tagalog)
+  ny_mw: "nya",      // Chichewa/Nyanja: FLEURS uses the 639-1 code `ny`, the registry the 639-3 code `nya`
 };
 
 /** Registry code for a FLEURS code. */

--- a/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Chatterbox.Avalonia/ViewModels/MainViewModel.cs
@@ -209,6 +209,49 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             RefreshKokoroVoices();
         }
         finally { _loadingSettings = false; }
+        UpdatePrerequisiteStatus();
+    }
+
+    /// <summary>
+    /// Explains a disabled Synthesize button. The path checks in
+    /// <see cref="CanSynthesize"/> keep the app from failing deep inside
+    /// model loading, but a greyed-out button with no reason is its own
+    /// dead end — so name the missing path here. Silent when the config is
+    /// fine, so it never overwrites a synthesis/playback status.
+    /// </summary>
+    /// <summary>The last message <see cref="UpdatePrerequisiteStatus"/> put on screen, so it can
+    /// take it back down without clobbering a status written by anything else.</summary>
+    private string? _prerequisiteStatus;
+
+    private void UpdatePrerequisiteStatus()
+    {
+        if (IsBusy) return;
+        string? missing = SelectedBackend switch
+        {
+            TtsBackendKind.Kokoro =>
+                !DirExists(KokoroModelDir) ? $"Kokoro model dir not found: {Describe(KokoroModelDir)}"
+                : !DirExists(KokoroDataDir) ? $"espeak-ng data dir not found: {Describe(KokoroDataDir)}"
+                : string.IsNullOrWhiteSpace(KokoroVoice) ? "No Kokoro voice selected."
+                : null,
+            _ =>
+                !DirExists(OnnxBundleDir) ? $"ONNX bundle dir not found: {Describe(OnnxBundleDir)}"
+                : !FileExists(VoicePath) ? $"Reference voice clip not found: {Describe(VoicePath)}"
+                : null,
+        };
+        // ⚠ CLEAR OUR OWN MESSAGE WHEN IT IS RESOLVED. Only setting it left the old
+        // "not found" text on screen after the user fixed the path -- the button went
+        // live while the status still said it could not run, which reads as a bug in
+        // the button. Only a message this method wrote is cleared, so a synthesis or
+        // playback status set elsewhere is never stepped on.
+        if (missing is not null) { StatusMessage = missing; _prerequisiteStatus = missing; }
+        else if (_prerequisiteStatus is not null && StatusMessage == _prerequisiteStatus)
+        {
+            StatusMessage = string.Empty;
+            _prerequisiteStatus = null;
+        }
+
+        static string Describe(string? path) =>
+            string.IsNullOrWhiteSpace(path) ? "(not set)" : path;
     }
 
     private void PersistSettings()
@@ -227,11 +270,16 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
 
     // Generated [ObservableProperty] partials let us hook each setter
     // for the autosave + (for model dirs) cached-service invalidation.
-    partial void OnVoicePathChanged(string value) => PersistSettings();
+    partial void OnVoicePathChanged(string value)
+    {
+        PersistSettings();
+        UpdatePrerequisiteStatus();
+    }
     partial void OnOnnxBundleDirChanged(string value)
     {
         InvalidateSynthService();
         PersistSettings();
+        UpdatePrerequisiteStatus();
     }
     partial void OnRenderMarkdownChanged(bool value) => PersistSettings();
     // Live structured preview: rebuild the karaoke blocks as the source text changes
@@ -244,19 +292,26 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     {
         InvalidateSynthService();
         PersistSettings();
+        UpdatePrerequisiteStatus();
     }
     partial void OnKokoroModelDirChanged(string value)
     {
         InvalidateSynthService();
         RefreshKokoroVoices();
         PersistSettings();
+        UpdatePrerequisiteStatus();
     }
     partial void OnKokoroDataDirChanged(string value)
     {
         InvalidateSynthService();
         PersistSettings();
+        UpdatePrerequisiteStatus();
     }
-    partial void OnKokoroVoiceChanged(string value) => PersistSettings();
+    partial void OnKokoroVoiceChanged(string value)
+    {
+        PersistSettings();
+        UpdatePrerequisiteStatus();
+    }
     partial void OnKokoroSpeedChanged(float value) => PersistSettings();
 
     // Discover Kokoro voices by scanning <modelDir>/voices/*.bin (produced by
@@ -486,6 +541,10 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         }
         catch (Exception ex)
         {
+            // The status label is a single line and easy to miss; the full
+            // exception goes to stderr so a failure is diagnosable from the
+            // terminal without reproducing it under a debugger.
+            Console.Error.WriteLine($"[Synthesize] failed: {ex}");
             StatusMessage = $"Synthesis failed: {ex.Message}";
         }
         finally
@@ -500,14 +559,25 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         return SelectedBackend switch
         {
             TtsBackendKind.Kokoro =>
-                !string.IsNullOrWhiteSpace(KokoroModelDir)
-                && !string.IsNullOrWhiteSpace(KokoroDataDir)
+                DirExists(KokoroModelDir)
+                && DirExists(KokoroDataDir)
                 && !string.IsNullOrWhiteSpace(KokoroVoice),
             _ =>
-                !string.IsNullOrWhiteSpace(VoicePath)
-                && !string.IsNullOrWhiteSpace(OnnxBundleDir),
+                FileExists(VoicePath)
+                && DirExists(OnnxBundleDir),
         };
     }
+
+    // Existence checks, not just non-empty checks. settings.json holds
+    // absolute paths from whenever the user last picked them, so a moved
+    // repo or an unmounted drive leaves a plausible-looking string behind.
+    // Without these, Synthesize stays enabled and fails deep inside model
+    // loading, which reads to the user as "the button did nothing".
+    private static bool DirExists(string? path) =>
+        !string.IsNullOrWhiteSpace(path) && Directory.Exists(path);
+
+    private static bool FileExists(string? path) =>
+        !string.IsNullOrWhiteSpace(path) && File.Exists(path);
 
     /// <summary>Cancels in-flight synthesis. Cancellation is checked
     /// at chunk boundaries — the LM rollout for the chunk that's


### PR DESCRIPTION
Four small unrelated things, none big enough for its own PR.

## The FLEURS fetch could hang forever

A run sat on `nso_za` for **eleven and a half hours**: the process alive and asleep, the `.incomplete` file frozen at 335 MB, nothing in the log. `hf_hub_download` has a 10 s read timeout and it did not help — a dead-but-open socket leaves the call blocked with no way for the caller to notice.

So the caller now **watches the bytes instead of trusting the call**. The download runs in a child process while the parent polls the cache size; a child that has not grown the byte count in 300 s is terminated and retried. Watching *progress* rather than imposing a fixed deadline is the point — a genuinely slow link keeps its time, and only a frozen one is cut. The partial file stays on disk either way, because `hf_hub_download` is content-addressed and resumes.

## The presence check counted a language as cached the moment its folder existed

`os.listdir(data/)` is true as soon as `hf_hub_download` creates the directory, so an interrupted download left a language looking **complete** and it was skipped on every later run — silently and permanently.

`ast_es` and `nso_za` were both in that state with empty `audio/` dirs, and the dry run reported 9 missing when 11 were. Now it tests for the tarball itself. A dry run today reports **102/102 cached**.

## Two FLEURS codes had no registry mapping

| FLEURS | registry | why |
|---|---|---|
| `fil_ph` | `tl` | FLEURS calls it Filipino; the registry ships it under the ISO 639-1 code |
| `ny_mw` | `nya` | FLEURS uses the 639-1 code, the registry the 639-3 one |

## The desktop app's Synthesize button went dead with no explanation

The guards tested that a path was **non-empty**, but `settings.json` holds absolute paths from whenever the user last picked them — so a moved repo or an unmounted drive leaves a plausible-looking string behind. The button stayed enabled and failed deep inside model loading, which reads to the user as *"the button did nothing"*.

Now the checks are `Directory.Exists` / `File.Exists`, and a disabled button **names the missing path**. The message is cleared once resolved, and only when it is still the one this code wrote, so a synthesis or playback status is never stepped on. Synthesis exceptions also go to stderr in full — the status label is one line and easy to miss, and a failure should be diagnosable from the terminal without reproducing it under a debugger.

## Docs

Records that the `cy_gb` truncation detector is **not simply aggressive**. Over 102 languages / 270,106 utterances:

```
cy_gb                 585 / 3,427    = 17.1%
oc_fr                  94 / 3,379    =  2.8%   (a different, milder defect)
every other language   64 / 263,300  =  0.024%
```

Occitan is distinguished rather than lumped in: its files contain the *beginning of the correct sentence* at a normal rate (0.634 against a 0.639 baseline, where Welsh reaches 0.231 against 0.696), they end in silence rather than being cut mid-signal, and the population is a continuous left tail where Welsh is cleanly bimodal. Occitan looks like audio that stops early; Welsh looks like the wrong audio entirely.

## Checks

- `dotnet build` — succeeded, 0 warnings, 0 errors
- `fetch_fleurs_all.py --dry-run` — 102/102 audio and text cached under the stricter check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc