### PR TITLE
export: rebuild the browser model from v7, and make the recipe reproducible

### DIFF
--- a/docs/web_demo_investigation.md
+++ b/docs/web_demo_investigation.md
@@ -1595,3 +1595,59 @@ say whether it is stale with respect to `voices.jsonc`.
 
 **Still unlistened:** the 18 clips that postdate the pass — 6 new es-419 and the 12 re-rendered
 `pap`/`quc` donors.
+
+## Run 31 — 2026-09-04 — v7 to the browser, and a recipe that lived in /tmp
+
+**Task.** The HF repo's `ipa_diff.onnx` was replaced with the v7 extraction, but the browser demo
+does not use the diff — it fetches `omnivoice_transformer_ipa.int4.onnx`, the merged-and-quantized
+build, which was dated Sep 1 and therefore still **v6**. Rebuilding it from v7 turned up three
+things worth recording.
+
+### The shipped recipe could not be rebuilt from this repo
+
+Run 4 locked the config as "w4 block-32 weight-only + int8 per-row embedding = 471.8 MB". Two parts
+of that were not actually reproducible:
+
+1. `quantize_lm.py` has no `nodes_to_exclude`, so it cannot express the audio-heads exemption Run 3
+   went to the trouble of testing.
+2. The embedding compressor existed **only as `/tmp/quant_embed.py`**, with v6-shaped paths baked
+   in as constants. The 472 MB artifact the demo has served for two months came out of a scratch
+   file. That is how a recipe becomes folklore.
+
+Both are now in `scripts/_export_utils/` with the paths as arguments.
+
+### ⚠ The shipped v6 build QUANTIZES the audio heads — the locked-config line omits it
+
+Building v7 with `--exclude /model/audio_heads/MatMul` gave **500.1 MB**, not 471.8. The 28 MB gap
+is exactly Run 3's heads-fp32 premium (965.5 vs 937.1 MB before the embedding step). Arithmetic
+settles which one shipped: 937.1 − 621 + 155 = 471.1 ≈ **471.8**, so the artifact in production has
+the heads quantized, despite Run 3 arguing the exemption is "nearly free" and worth having.
+
+Rebuilt without the exclusion, so v7 differs from v6 in exactly one variable. Whether the heads
+should be exempt is a real question — Run 4's listening test found both fine — but it is a SEPARATE
+change and bundling it into a model swap would make any regression unattributable.
+
+### ⚠ `onnx.save` CONCATENATES to an existing external-data file
+
+The second build came out at **968 MB** — the first run's 500 MB sidecar plus the new one. It still
+loaded, which is the dangerous part. `quantize_lm.py` already carried a guard and a comment saying
+exactly this; the embedding script did not, because it had never been run twice over one
+destination. Guard added.
+
+### And the sidecar name is recorded INSIDE the .onnx
+
+A build named `..._v7.int4.onnx` looks for `..._v7.int4.onnx.data`, so it cannot simply be uploaded
+under the canonical name — the demo passes the canonical sidecar and the load fails. Versions are
+therefore built in their own directory with canonical filenames inside; `publish_hf.py` prefers
+`onnx_web/<version>/` and falls back to the flat v6 layout.
+
+**Published and verified by sha256 against the local sources:**
+
+```
+omnivoice_transformer_ipa.int4.onnx        1.6 MB    match
+omnivoice_transformer_ipa.int4.onnx.data 470.2 MB    match   (byte-identical SIZE to v6 — like-for-like)
+ipa_diff.onnx                             32.1 MB    match
+```
+
+v7 int4 loads, runs, and is demonstrably not a copy of v6: 0.00% identical logit elements,
+max|Δ| 18.7, argmax agreement 9.25%. Both CLI and browser are now on v7.

--- a/scripts/_export_utils/quantize_embedding.py
+++ b/scripts/_export_utils/quantize_embedding.py
@@ -33,8 +33,21 @@ t = time.time()
 m = onnx.load(src)
 g = m.graph
 init = {i.name: i for i in g.initializer}
+# Both lookups are model-specific, so say so rather than dying with KeyError / StopIteration on a
+# graph that simply names things differently.
+if NAME not in init:
+    raise SystemExit(f"{src}: no initializer named {NAME} — is this an OmniVoice transformer export?")
 E = numpy_helper.to_array(init[NAME]).astype(np.float32)
-gather = next(n for n in g.node if n.op_type == "Gather" and n.input[0] == NAME)
+# ⚠ REFUSE AN ALREADY-COMPRESSED TABLE. After a first pass the initializer and its Gather both
+# still exist — only the dtype changed — so "is the Gather still there" does NOT detect a repeat.
+# Running twice quantizes int8-of-int8, and the size moves 471.8 -> 472.4 MB, which is invisible.
+if init[NAME].data_type != TensorProto.FLOAT:
+    raise SystemExit(f"{src}: {NAME} is already "
+                     f"{TensorProto.DataType.Name(init[NAME].data_type)}, not fp32 — "
+                     "this graph has been through quantize_embedding already.")
+gather = next((n for n in g.node if n.op_type == "Gather" and n.input[0] == NAME), None)
+if gather is None:
+    raise SystemExit(f"{src}: {NAME} exists but no Gather consumes it")
 out, ids = gather.output[0], gather.input[1]
 
 g.initializer.remove(init[NAME])

--- a/scripts/_export_utils/quantize_embedding.py
+++ b/scripts/_export_utils/quantize_embedding.py
@@ -1,0 +1,75 @@
+"""Compress model.llm.embed_tokens.weight, which MatMulNBits cannot reach.
+
+The table is 151676 x 1024 fp32 = 621 MB and is consumed by a Gather, not a MatMul, so the
+weight-only quantizer skips it by construction — it is 621 MB of the w4 model's 937 MB. Two
+variants, both rewriting the graph so the dequantization happens on the GATHERED SLICE (a handful
+of rows) rather than on the whole table:
+
+  fp16 : Gather(fp16 table, ids) -> Cast(fp32)                        621 -> 310 MB
+  int8 : per-row symmetric scales; Gather(int8 table) and Gather(scales),
+         then Cast + Mul                                              621 -> 155 MB
+
+Per-ROW scales for int8, not per-tensor: the IPA fine-tune retrained 5,572 rows of this table, so
+it is not the uniformly-distributed, quantization-tolerant tensor an embedding usually is.
+
+⚠ THIS LIVED IN /tmp UNTIL v7. The 472 MB browser build shipped for two months from a scratch
+script with v6-shaped constants baked in, so the published artifact could not be rebuilt from this
+repo — which is how a recipe becomes folklore. Source and destination are arguments now.
+
+  python3 quantize_embedding.py int8 --src <...wo4b32.onnx> --dst <...int4.onnx>
+"""
+import argparse, os, time, numpy as np, onnx
+from onnx import helper, numpy_helper, TensorProto
+
+_ap = argparse.ArgumentParser()
+_ap.add_argument("mode", choices=("fp16", "int8"))
+_ap.add_argument("--src", required=True)
+_ap.add_argument("--dst", required=True)
+_A = _ap.parse_args()
+mode, src, dst = _A.mode, _A.src, _A.dst
+NAME = "model.llm.embed_tokens.weight"
+
+t = time.time()
+m = onnx.load(src)
+g = m.graph
+init = {i.name: i for i in g.initializer}
+E = numpy_helper.to_array(init[NAME]).astype(np.float32)
+gather = next(n for n in g.node if n.op_type == "Gather" and n.input[0] == NAME)
+out, ids = gather.output[0], gather.input[1]
+
+g.initializer.remove(init[NAME])
+new_nodes, new_inits = [], []
+if mode == "fp16":
+    new_inits.append(numpy_helper.from_array(E.astype(np.float16), NAME))
+    gather.output[0] = out + "__q"
+    new_nodes.append(helper.make_node("Cast", [out + "__q"], [out], to=TensorProto.FLOAT,
+                                      name=gather.name + "/emb_cast"))
+else:
+    s = np.abs(E).max(axis=1, keepdims=True) / 127.0
+    s[s == 0] = 1.0
+    q = np.clip(np.rint(E / s), -127, 127).astype(np.int8)
+    new_inits += [numpy_helper.from_array(q, NAME),
+                  numpy_helper.from_array(s.astype(np.float32), NAME + "__scale")]
+    gather.output[0] = out + "__q"
+    new_nodes += [
+        helper.make_node("Gather", [NAME + "__scale", ids], [out + "__s"], name=gather.name + "/emb_scale"),
+        helper.make_node("Cast", [out + "__q"], [out + "__qf"], to=TensorProto.FLOAT, name=gather.name + "/emb_cast"),
+        helper.make_node("Mul", [out + "__qf", out + "__s"], [out], name=gather.name + "/emb_mul"),
+    ]
+g.initializer.extend(new_inits)
+# Insert immediately after the Gather so the graph stays topologically sorted.
+idx = list(g.node).index(gather)
+nodes = list(g.node)[: idx + 1] + new_nodes + list(g.node)[idx + 1 :]
+del g.node[:]
+g.node.extend(nodes)
+
+# ⚠ WIPE THE STALE SIDECAR FIRST. `onnx.save` CONCATENATES to an existing external-data file
+# rather than truncating it, so a second run over the same destination produces a model whose data
+# file is the sum of both — 968 MB instead of 472, and it still loads, which is the dangerous part.
+# quantize_lm.py already carries this guard; this script did not, and rebuilding v7 hit it.
+if os.path.exists(dst + ".data"):
+    os.remove(dst + ".data")
+onnx.save(m, dst, save_as_external_data=True, location=os.path.basename(dst) + ".data",
+          all_tensors_to_one_file=True, size_threshold=1024)
+tot = os.path.getsize(dst) + os.path.getsize(dst + ".data")
+print(f"emb-{mode}: {tot/1e6:.1f} MB in {time.time()-t:.0f}s -> {os.path.basename(dst)}")

--- a/scripts/_export_utils/quantize_lm.py
+++ b/scripts/_export_utils/quantize_lm.py
@@ -111,7 +111,8 @@ def quantize_int8_dynamic(input_path: Path, output_path: Path) -> None:
     print(f"[int8] done in {time.time() - t0:.1f}s")
 
 
-def quantize_int4(input_path: Path, output_path: Path, block_size: int = 32) -> None:
+def quantize_int4(input_path: Path, output_path: Path, block_size: int = 32,
+                  exclude: list[str] | None = None) -> None:
     # RTN (round-to-nearest) weight-only 4-bit MatMul quantization.
     # accuracy_level=4 = "int8 activations during the int4 MatMul"
     # (vs 0=fp32, 1=fp16, 2=bf16, 3=int4 activations). int8 acts give
@@ -129,12 +130,19 @@ def quantize_int4(input_path: Path, output_path: Path, block_size: int = 32) -> 
     print(f"[int4] running MatMulNBitsQuantizer (RTN, block_size={block_size}) ...")
     t0 = time.time()
     cfg = RTNWeightOnlyQuantConfig()
+    # ⚠ SOME MatMuls MUST STAY fp32, and the quantizer takes every one it can reach by default.
+    # For OmniVoice that is `/model/audio_heads/MatMul`: its logits over the 1025-token audio
+    # vocabulary drive the top-k unmask decision on EVERY diffusion step, so error there flips token
+    # choices outright rather than being smoothed downstream. One node, ~8.4M params, 34 MB fp32 —
+    # exempting it costs ~28 MB of the 472 MB build (web demo Run 3). Without this flag the shipped
+    # recipe cannot be reproduced from this repo at all.
     q = MatMulNBitsQuantizer(
         model=model,
         block_size=block_size,
         is_symmetric=True,  # symmetric = simpler kernels, slightly worse quality
         accuracy_level=4,
         algo_config=cfg,
+        nodes_to_exclude=list(exclude or []),
     )
     q.process()
     print(f"[int4] done in {time.time() - t0:.1f}s; saving ...")
@@ -157,6 +165,8 @@ def main() -> int:
     ap.add_argument("--output", required=True, type=Path, help="Destination quantized .onnx")
     ap.add_argument("--mode", required=True, choices=["fp16", "int8", "int4"])
     ap.add_argument("--block-size", type=int, default=32, help="int4 RTN block size (default 32)")
+    ap.add_argument("--exclude", default="", help="[int4] comma-separated node names to leave fp32, "
+                                                 "e.g. /model/audio_heads/MatMul")
     ap.add_argument(
         "--no-keep-io-types",
         action="store_true",
@@ -180,7 +190,8 @@ def main() -> int:
     elif args.mode == "int8":
         quantize_int8_dynamic(args.input, args.output)
     elif args.mode == "int4":
-        quantize_int4(args.input, args.output, block_size=args.block_size)
+        quantize_int4(args.input, args.output, block_size=args.block_size,
+                      exclude=[n for n in args.exclude.split(",") if n.strip()])
     else:
         print(f"ERROR: unknown mode {args.mode}", file=sys.stderr)
         return 1

--- a/scripts/omnivoice_ipa/publish_hf.py
+++ b/scripts/omnivoice_ipa/publish_hf.py
@@ -33,6 +33,12 @@ BASE_SNAPSHOT = "/mnt/data/models/omnivoice/k2-fsa-OmniVoice"
 BASE_SHA256 = "2ea0980e184bbf8457048fbb3ed2a01f8f8c3816a8ee9fbff3ce0886c1aeeb4a"
 
 
+def webfile(version, name):
+    """The browser build for `version`, falling back to the flat onnx_web/ layout that predates it."""
+    v = f"{ONNX_WEB}/{version}/{name}"
+    return v if os.path.exists(v) else f"{ONNX_WEB}/{name}"
+
+
 def files(version):
     """(local path, path-in-repo) for one diff version."""
     return [
@@ -47,8 +53,14 @@ def files(version):
         (f"{ONNX}/ipa_diff_{version}.onnx", "ipa_diff.onnx"),
         # Browser build: the fine-tune already merged in, then quantized. Ships alone — no base,
         # no diff, no fold. Its sidecar name is recorded inside the .onnx, so both keep these names.
-        (f"{ONNX_WEB}/omnivoice_transformer_ipa.int4.onnx", "omnivoice_transformer_ipa.int4.onnx"),
-        (f"{ONNX_WEB}/omnivoice_transformer_ipa.int4.onnx.data", "omnivoice_transformer_ipa.int4.onnx.data"),
+        #
+        # ⚠ VERSIONED BY DIRECTORY, NOT BY FILENAME, and that is forced: the .onnx records its
+        # sidecar's filename INTERNALLY, so a build named `..._v7.int4.onnx` looks for
+        # `..._v7.int4.onnx.data` and cannot simply be uploaded under the canonical name — the demo
+        # passes the canonical one and the load fails. So each version is built under its own
+        # directory with the canonical filenames inside it. `onnx_web/` itself remains the v6 build.
+        (webfile(version, "omnivoice_transformer_ipa.int4.onnx"), "omnivoice_transformer_ipa.int4.onnx"),
+        (webfile(version, "omnivoice_transformer_ipa.int4.onnx.data"), "omnivoice_transformer_ipa.int4.onnx.data"),
         # The Qwen3 tokenizer, straight from the upstream snapshot. Needed by any consumer that
         # synthesises text rather than replaying captured ids, and a browser has nowhere else to
         # get it. Apache-2.0, like the upstream CODE — the WEIGHTS in this repo are not; see the

--- a/scripts/omnivoice_ipa/publish_hf.py
+++ b/scripts/omnivoice_ipa/publish_hf.py
@@ -33,10 +33,28 @@ BASE_SNAPSHOT = "/mnt/data/models/omnivoice/k2-fsa-OmniVoice"
 BASE_SHA256 = "2ea0980e184bbf8457048fbb3ed2a01f8f8c3816a8ee9fbff3ce0886c1aeeb4a"
 
 
+# The one version built before browser builds were versioned by directory. Anything else MUST have
+# its own directory.
+LEGACY_WEB_VERSION = "v6"
+
+
 def webfile(version, name):
-    """The browser build for `version`, falling back to the flat onnx_web/ layout that predates it."""
+    """The browser build for `version`.
+
+    ⚠ NO SILENT FALLBACK. Returning the flat `onnx_web/` copy whenever `onnx_web/<version>/` is
+    absent means `--version v8` with no v8 build publishes the V6 browser model while the card
+    announces v8 — a stale artifact shipped under a fresh name, which is the exact bug already fixed
+    three times in this pipeline (extract_diff, apply_diff, and this script's own diff selection).
+    The flat layout is honoured only for the version that predates the directory scheme.
+    """
     v = f"{ONNX_WEB}/{version}/{name}"
-    return v if os.path.exists(v) else f"{ONNX_WEB}/{name}"
+    if os.path.exists(v):
+        return v
+    if version == LEGACY_WEB_VERSION:
+        return f"{ONNX_WEB}/{name}"
+    raise SystemExit(f"no browser build for {version}: expected {v}\n"
+                     f"  build it first, or pass --version {LEGACY_WEB_VERSION} to publish the "
+                     f"pre-versioning layout.")
 
 
 def files(version):


### PR DESCRIPTION
The HF repo's `ipa_diff.onnx` is now the v7 extraction — but **the browser demo does not use the diff**. It fetches `omnivoice_transformer_ipa.int4.onnx`, the merged-and-quantized build, which was dated Sep 1 and therefore still v6. Both are v7 now.

| consumer | before | after |
|---|---|---|
| CLI / desktop (base + diff) | v7 | v7 |
| Browser demo (int4 merged) | **v6** | **v7** |

## The shipped recipe could not be rebuilt from this repo

Run 4 locked the config as *"w4 block-32 weight-only + int8 per-row embedding = 471.8 MB"*. Two parts of that were not actually reproducible:

- `quantize_lm.py` has no `nodes_to_exclude`, so it cannot express the audio-heads exemption Run 3 went to the trouble of testing.
- The embedding compressor existed **only as `/tmp/quant_embed.py`**, with v6-shaped paths baked in as constants. The 472 MB artifact the demo has served for two months came out of a scratch file.

Both now live in `scripts/_export_utils/` with paths as arguments.

## ⚠ The shipped v6 build quantizes the audio heads — the locked-config line omits it

Building v7 *with* `--exclude /model/audio_heads/MatMul` gave **500.1 MB**, not 471.8. The 28 MB gap is exactly Run 3's heads-fp32 premium (965.5 vs 937.1 MB before the embedding step), and the arithmetic settles which one shipped:

```
937.1 − 621 + 155 = 471.1 ≈ 471.8   ← heads QUANTIZED
965.5 − 621 + 155 = 499.5 ≈ 500.1   ← heads fp32 (what I built first)
```

Rebuilt without the exclusion, so **v7 differs from v6 in exactly one variable**. Whether the heads should be exempt is a real question — Run 4 found both fine by ear — but it is a separate change, and bundling it into a model swap would make any regression unattributable.

## ⚠ `onnx.save` concatenates to an existing external-data file

The second build came out at **968 MB** — the first run's 500 MB sidecar plus the new one — and **it still loaded**, which is the dangerous part. `quantize_lm.py` already carried a guard and a comment saying exactly this; the embedding script did not, because it had never been run twice over one destination.

## ⚠ The sidecar filename is recorded inside the `.onnx`

A build named `..._v7.int4.onnx` looks for `..._v7.int4.onnx.data`, so it cannot be uploaded under the canonical name — the demo passes the canonical sidecar and the load fails. Versions now build into their own directory with canonical filenames inside; `publish_hf.py` prefers `onnx_web/<version>/` and falls back to the flat v6 layout.

## Verification

- sizes match v6 byte-for-byte (`470,242,800` data) — the like-for-like signal
- the v7 int4 loads and runs on the WASM backend, all logits finite
- it is **not a copy**: 0.00% identical logit elements against v6, max|Δ| 18.7, argmax agreement 9.25%
- all three published files match their local sources by sha256

Docs: web demo Run 31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)