### PR TITLE
kokoro: G2P frontend on vernacula-phonemizer; drop the espeak-ng-portable submodule

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # ⚠ SUBMODULES ARE REQUIRED, and actions/checkout does not fetch them by default.
-      # Vernacula.Tts.Base has a ProjectReference into external/espeak-ng-portable and
-      # Vernacula.Tts.CLI into external/vernacula-phonemizer, so without these the build fails
+      # Vernacula.Tts.Base and Vernacula.Tts.CLI have ProjectReferences into
+      # external/vernacula-phonemizer, so without it the build fails
       # with MSB9008 (referenced project does not exist) followed by CS0234 on the namespace —
       # an error that looks like a missing package and is really a missing checkout.
-      # It passed on main only because main has neither reference.
+      # It passed on main only because main has no such reference.
       - name: Checkout
         uses: actions/checkout@v7
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "external/espeak-ng-portable"]
-	path = external/espeak-ng-portable
-	url = https://github.com/christopherthompson81/espeak-ng-portable.git
 [submodule "external/vernacula-phonemizer"]
 	path = external/vernacula-phonemizer
 	url = https://github.com/christopherthompson81/vernacula-phonemizer.git

--- a/docs/kokoro_vphon_investigation.md
+++ b/docs/kokoro_vphon_investigation.md
@@ -1,0 +1,110 @@
+# Kokoro on vernacula-phonemizer — investigation log
+
+Kokoro's G2P frontend was the pure-C# espeak-ng port in `external/espeak-ng-portable`
+(`Phonemize.Run` → `KokoroFormat.Render`, docs/kokoro_onnx_investigation.md Runs 9–12). That
+submodule is private and is not going to be published; vernacula-phonemizer is. This log is the
+move: one Kokoro-alphabet render target over vernacula-phonemizer's canonical IPA, and the
+submodule gone.
+
+## Run 1 — 2026-09-05 ~07:50 — what do the two engines actually emit?
+
+Two throwaway console apps (scratchpad; they cannot share a process because both submodules
+build an assembly called `Vernacula.Phonemizer`) over 14 sentences chosen for the things a
+Kokoro mapping has to get right: the five diphthongs, NURSE/lettER, flaps, syllabic consonants,
+affricates, numbers/currency/dates, quotes and dashes, en-GB vs en-US.
+
+Old: `Phonemize.RunWithSourceWords` + `KokoroFormat.Render`. New: `PhonemizeAsync` (`en`,
+`en-GB`) and `PhonemizeTrace` (for spans).
+
+Where vernacula-phonemizer's IPA differs from espeak's, i.e. what a new render target has to
+re-key:
+
+| feature | espeak-ng-portable | vernacula-phonemizer |
+|---|---|---|
+| offglides | digraphs `oʊ eɪ aɪ aʊ ɔɪ`, GB `əʊ` | superscript `oᶷ eᶦ aᶦ aᶷ ɔᶦ`, GB `əᶷ` |
+| affricates / aspiration / l | `dʒ tʃ t l` | `d͡ʒ t͡ʃ tʰ ɫ` |
+| en-us flap | `ɾ`, or `ʔn̩` for button | `t̬` and `d̬` (voicing diacritic) |
+| NURSE / lettER | `ɜː` / `ɚ` | `ɝ` / `ɚ` |
+| clause punctuation | collapsed to `\n`, re-injected from source text | kept, as its own token: `dˈɔːɡ , dˈʌzənt` |
+| en-GB SQUARE | `eə` (rendered `Aə` — the `e→A` rule fired: a bug) | `ɛə` |
+| palatal glide | `ðɪʲ` | `iʲə` in uranium |
+
+`ᵻ` appears in both (remember); secondary stress `ˌ` is rarer in the new stream (espeak put
+one on "over", "about"). `PhonemizeTrace` reports `Traced=true` for both `en` and `en-GB`, with
+`InputSpan` (into the caller's text) and `IpaSpan` (into the IPA) on every token, including the
+normalizer's expansions: `$3.14` → three tokens all with input span [23,28), `24` → one token
+emitting two groups. That is a better source-word map than the old engine's, which only counted.
+
+The neural (`PhonemizeAsync`) and traced (sync) readings differ only on OOV words — "Kokoro"
+reads `koᶷkʰˈɔːɹoᶷ` vs `kʰˈɑːkʰɔːɹoᶷ` — never in word count, on this set.
+
+## Run 2 — 2026-09-05 ~08:10 — the new render target, old vs new word parity
+
+`Vernacula.Tts.Base.KokoroFormat.Render` re-keyed on the table above (tie bar, aspiration, ʲ
+dropped; `t̬→T`, `d̬→d`; `ɫ→l`; superscript diphthongs → `O A I W Y`, GB `əᶷ→Q`; leftover
+`ᶦ ᶷ → ɪ ʊ`; `ɝ→ɜɹ`, `ɚ→əɹ`; GB `ɛə→ɛː`; en-us strips `ː`; detached punctuation re-attached
+to the preceding word). Compared to the old engine's Kokoro output, per word, punctuation
+stripped, over the 14 sentences × 2 accents:
+
+    word parity old-vs-new: 137/178 = 77.0%
+
+Every one of the 41 differences is the phonemizer's reading, not the rendering; sorted:
+
+- **new is closer to misaki's lexicon** (which is what Kokoro heard in training): `dˈɔɡ` (old
+  `dˈɑɡ`), `mˈWntən`, `jəɹˈAniəm` (old `jʊɹɹˈAniəm`, a doubled r), `ˈɛləmənts`, `bˈʌTən` (old
+  `bˈʌtn` from `ʔn̩`), GB `ðˈɛː`/`ʃˈɛː` (old `ðˈAə` — the bug above), `ˈA ˈɛm` for a.m. (old
+  `ə ˈɛm`), `ˈɪzənt ðæt ðə` (old ran `ðætðə` together: 7 groups for 8 words).
+- **arguable either way**: `wˈɑz`/`ðæn`/`ənd` — vernacula-phonemizer gives citation forms where
+  espeak gave the reduced `wʌz`/`ðən`/`ænd`; `lˈɛŋkθ`; `ɪɡzˈæmpəl`; `θˈɑɹiəm`; no `ˌ` on "over".
+- **group-count differences**, all from normalization: `$3.14` old "three dollars and fourteen
+  cents" (18 groups) vs new "three dollars fourteen" (16) — worth an upstream issue, the "and …
+  cents" is the natural reading; `2024` old "two thousand twenty four" vs new "twenty twenty
+  four"; `Mr.` both "mister".
+
+Render-level checks all hold: every output codepoint over the set is in `KokoroVocab` (the
+test `EveryOutputCodepointIsInTheVocab` fixes three of the sentences), and the Kokoro
+alphabet symbols land where misaki puts them (`ʧ ʤ T O A I W Y Q ɜɹ əɹ ɛː ᵊ`-less).
+
+## Run 3 — 2026-09-05 ~08:30 — source-word map, audio, the CUDA runtime, and CI
+
+**Map.** `KokoroPhonemizer.Phonemize` builds the group→source-word map from `PhonemizeTrace`
+(each token's `InputSpan.Start` → the whitespace-delimited word containing it, repeated once per
+group in its `IpaSpan`) and applies it to the `PhonemizeAsync` reading when the two have the same
+number of spoken groups, else to the traced reading. First pass mapped `Mr. Smith` to `0,0`:
+both tokens carry the input span [0,9), which covers two written words. Fixed by advancing to
+the next word inside a shared span; `$3.14` stays `5,5,5` because its span is one word.
+
+    Mr. Smith arrived at 10:30 a.m. on Tuesday, March 3rd, 2024.   0,1,2,3,4,4,5,5,6,7,8,9,10,10,10
+    I thought about it for $3.14 and the 2nd time — really… she said "no".   0,1,2,3,4,5,5,5,6,7,8,9,11,12,13,14
+
+(Word 10 "—" and word 10 "…" are unpronounceable; `SpeakAligned` gives them zero-length markers.)
+All 14 sentences map; no fallbacks.
+
+**Audio.** `vernacula-tts-backends --backend kokoro` on CPU, data dir auto-resolved from the
+submodule: af_heart 54 tokens → 3.8 s in 750 ms (5.1× real-time); bf_emma with the GB reading
+3.0 s in 652 ms. Both play.
+
+**The CUDA runtime.** vernacula-phonemizer references the plain CPU `Microsoft.ML.OnnxRuntime`
+and it now flows through `Vernacula.Tts.Base` into every consumer. Checked rather than assumed:
+rebuilt `Vernacula.Tts.Backends.CLI` with `-p:EP=Cuda` after deleting its `runtimes/`, and the
+shipped `libonnxruntime.so` is sha `1aacefdf…` = the `microsoft.ml.onnxruntime.gpu.linux`
+package's, not the CPU package's `d132535d…`; `libonnxruntime_providers_cuda.so` present. The
+direct `ExcludeAssets="all"` reference (the trick Vernacula.Tts.CLI already used) went into the
+three Cuda consumers of Kokoro: Backends.CLI, Avalonia, KokoroPerf.
+
+**CI simulation.** Deleted the four test projects' `bin/`, ran the workflow's two commands
+(`dotnet build Vernacula.slnx -p:EP=Cpu`; `dotnet test <proj> --no-build -p:Platform=x64`):
+22 / 55 (+4 skipped) / 63 / 23, all passed. Two false alarms on the way, both worth knowing:
+`dotnet build` of the solution wrote nothing for `Vernacula.Tts.Tests` at all, and the cause was
+that **something is rewriting `Vernacula.slnx` while I work** — twice now the four renamed
+projects were silently dropped from it (an editor with the pre-rename solution open, most
+likely). `git checkout -- Vernacula.slnx` and the step passes. Also `Assert.Skip`-gated tests
+here need the submodule's `data/`, which the workflow now checks out.
+
+**Removed.** `external/espeak-ng-portable` (submodule deinit + `git rm`), every ProjectReference
+to it, and the `--data-dir`-required check in the Backends CLI (the data dir now resolves from
+the vernacula-phonemizer submodule; the reader re-resolves a saved pre-migration path). CI
+needs only vernacula-phonemizer now — which is the repo being made public.
+
+Not done: `$3.14 → "and … cents"` upstream; a re-listen of the reader's word highlighting with
+the new map (it is exercised by `KokoroPhonemizerTests`, not by ear).

--- a/src/Vernacula.Tts.Avalonia/Services/KokoroSynthesisService.cs
+++ b/src/Vernacula.Tts.Avalonia/Services/KokoroSynthesisService.cs
@@ -24,13 +24,13 @@ namespace Vernacula.Tts.App.Services;
 public sealed class KokoroSynthesisService : ITtsBackend
 {
     private readonly string _onnxDir;
-    private readonly string _dataDir;
+    private readonly string? _dataDir;
     private readonly ExecutionProvider _ep;
 
     private KokoroTts? _tts;
     private readonly object _gate = new();
 
-    public KokoroSynthesisService(string onnxDir, string phonemizerDataDir,
+    public KokoroSynthesisService(string onnxDir, string? phonemizerDataDir,
                                   ExecutionProvider ep = ExecutionProvider.Auto)
     {
         _onnxDir = onnxDir;

--- a/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
+++ b/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
@@ -39,13 +39,21 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" />
   </ItemGroup>
 
+  <!--
+    Vernacula.Phonemizer (via Vernacula.Tts.Base) takes a plain (CPU) Microsoft.ML.OnnxRuntime
+    reference. Left alone it flows into this app's output next to the EP variant above and both
+    ship a native onnxruntime library — whichever lands last wins, which is how a CUDA build
+    silently ends up on the CPU runtime. A DIRECT reference outranks the transitive one, and
+    ExcludeAssets="all" then contributes nothing, so the EP package is the only runtime shipped.
+  -->
+  <ItemGroup Condition="'$(EP)' != 'Cpu'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" ExcludeAssets="all" />
+  </ItemGroup>
+
   <ItemGroup>
     <!-- Matches Vernacula.Avalonia.csproj's ProjectReference style:
          no Private attribute (defaults to true). EP property flows
          through to base projects via SetConfiguration. -->
-    <!-- Kokoro's G2P frontend. Direct rather than transitive through Vernacula.Tts.Base — see the
-         PrivateAssets note on that project's reference to it. -->
-    <ProjectReference Include="..\..\external\espeak-ng-portable\csharp\src\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" />
     <ProjectReference Include="..\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
       <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>

--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -202,8 +202,10 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             SelectedBackend = Enum.TryParse<TtsBackendKind>(_settings.Current.TtsBackend, out var b)
                 ? b : TtsBackendKind.Chatterbox;
             KokoroModelDir = _settings.Current.KokoroModelDir;
-            KokoroDataDir = string.IsNullOrWhiteSpace(_settings.Current.KokoroDataDir)
-                ? (ResolveDefaultKokoroDataDir() ?? "") : _settings.Current.KokoroDataDir;
+            // A saved dir that is not a phonemizer data root is a path from before the Kokoro
+            // frontend moved to vernacula-phonemizer; re-resolve rather than fail at load time.
+            KokoroDataDir = PhonemizerData.IsDataRoot(_settings.Current.KokoroDataDir ?? "")
+                ? _settings.Current.KokoroDataDir : (PhonemizerData.Resolve(null) ?? "");
             KokoroVoice = _settings.Current.KokoroVoice;
             KokoroSpeed = _settings.Current.KokoroSpeed > 0 ? _settings.Current.KokoroSpeed : 1.0f;
             RefreshKokoroVoices();
@@ -230,7 +232,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         {
             TtsBackendKind.Kokoro =>
                 !DirExists(KokoroModelDir) ? $"Kokoro model dir not found: {Describe(KokoroModelDir)}"
-                : !DirExists(KokoroDataDir) ? $"espeak-ng data dir not found: {Describe(KokoroDataDir)}"
+                : !PhonemizerData.IsDataRoot(KokoroDataDir) ? $"vernacula-phonemizer data dir not found: {Describe(KokoroDataDir)}"
                 : string.IsNullOrWhiteSpace(KokoroVoice) ? "No Kokoro voice selected."
                 : null,
             _ =>
@@ -328,20 +330,6 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             KokoroVoice = KokoroVoices[0];
     }
 
-    // Best-effort default for the phonemizer data dir: walk up from the app
-    // base dir looking for the espeak-ng-portable submodule's data/ tree.
-    private static string? ResolveDefaultKokoroDataDir()
-    {
-        var dir = AppContext.BaseDirectory;
-        for (var i = 0; i < 8 && dir is not null; i++)
-        {
-            var candidate = Path.Combine(dir, "external", "espeak-ng-portable", "data");
-            if (Directory.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir.TrimEnd(Path.DirectorySeparatorChar));
-        }
-        return null;
-    }
-
     private void InvalidateSynthService()
     {
         var stale = _synthService;
@@ -376,7 +364,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private async Task PickKokoroDataDirAsync()
     {
-        var path = await PickFolderAsync("Pick the espeak-ng-portable data/ directory");
+        var path = await PickFolderAsync("Pick the vernacula-phonemizer data/ directory");
         if (path is not null) KokoroDataDir = path;
     }
 

--- a/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
+++ b/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
@@ -144,7 +144,7 @@
                             IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
                 </Grid>
 
-                <TextBlock Text="Phonemizer data dir (espeak-ng-portable/data)"
+                <TextBlock Text="Phonemizer data dir (vernacula-phonemizer/data)"
                            FontWeight="SemiBold" Margin="0,8,0,0" />
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBox Text="{Binding KokoroDataDir}" IsReadOnly="True"

--- a/src/Vernacula.Tts.Backends.CLI/Program.cs
+++ b/src/Vernacula.Tts.Backends.CLI/Program.cs
@@ -35,7 +35,8 @@ bool    verbose       = false;
 bool?   useIoBinding  = null;
 float   exaggeration  = ChatterboxConstants.DefaultExaggeration;
 // Kokoro backend (--backend kokoro): --voice is a voice name (af_heart), --onnx-dir is
-// the kokoro model dir (kokoro.onnx + voices/), --data-dir is the espeak-ng-portable data/.
+// the kokoro model dir (kokoro.onnx + voices/), --data-dir the vernacula-phonemizer data/
+// (optional: resolved from the submodule when omitted).
 string  backend       = "chatterbox";
 string? dataDir       = null;
 float   speed         = 1.0f;
@@ -215,13 +216,11 @@ if (backend == "kokoro")
         Console.Error.WriteLine("--backend kokoro requires --voice <voice name, e.g. af_heart>.");
         return 2;
     }
-    if (dataDir is null)
+    if (dataDir is not null)
     {
-        Console.Error.WriteLine("--backend kokoro requires --data-dir <espeak-ng-portable data/ dir>.");
-        return 2;
+        dataDir = ExpandHome(dataDir);
+        if (!Directory.Exists(dataDir)) { Console.Error.WriteLine($"--data-dir not found: {dataDir}"); return 1; }
     }
-    dataDir = ExpandHome(dataDir);
-    if (!Directory.Exists(dataDir)) { Console.Error.WriteLine($"--data-dir not found: {dataDir}"); return 1; }
     if (textFile is not null && !File.Exists(textFile)) { Console.Error.WriteLine($"--text-file not found: {textFile}"); return 1; }
 
     string kText;
@@ -694,8 +693,8 @@ static void PrintUsage()
           --help / -h              Show this message.
 
         Backends (--backend <name>, default "chatterbox"):
-          kokoro     Kokoro-82M. --voice is a voice name (e.g. af_heart); requires
-                     --data-dir <espeak-ng-portable data/>.
+          kokoro     Kokoro-82M. --voice is a voice name (e.g. af_heart). --data-dir is the
+                     vernacula-phonemizer data/ (resolved from the submodule when omitted).
           omnivoice  OmniVoice diffusion TTS. --onnx-dir holds omnivoice_transformer
                      [_fp16].onnx + higgs_encoder/decoder.onnx; --tokenizer-json is the
                      Qwen3 tokenizer.json (required). Modes:

--- a/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
+++ b/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
@@ -35,10 +35,18 @@
     <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 
+  <!--
+    Vernacula.Phonemizer (via Vernacula.Tts.Base) takes a plain (CPU) Microsoft.ML.OnnxRuntime
+    reference. Left alone it flows into this app's output next to the EP variant above and both
+    ship a native onnxruntime library — whichever lands last wins, which is how a CUDA build
+    silently ends up on the CPU runtime. A DIRECT reference outranks the transitive one, and
+    ExcludeAssets="all" then contributes nothing, so the EP package is the only runtime shipped.
+  -->
+  <ItemGroup Condition="'$(EP)' != 'Cpu'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" ExcludeAssets="all" />
+  </ItemGroup>
+
   <ItemGroup>
-    <!-- Kokoro's G2P frontend. Direct rather than transitive through Vernacula.Tts.Base — see the
-         PrivateAssets note on that project's reference to it. -->
-    <ProjectReference Include="..\..\external\espeak-ng-portable\csharp\src\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" />
     <ProjectReference Include="..\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
       <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>

--- a/src/Vernacula.Tts.Base/Kokoro.cs
+++ b/src/Vernacula.Tts.Base/Kokoro.cs
@@ -19,7 +19,7 @@ public sealed record KokoroOutput(float[] Audio, long[] PredDur, long[] InputIds
 ///
 /// The graph entry point is <c>forward_with_tokens</c> — the G2P frontend is
 /// outside the graph. Callers supply a Kokoro-alphabet phoneme string (from
-/// <c>Vernacula.Phonemizer.KokoroFormat.Render</c>); this class handles
+/// <see cref="KokoroFormat.Render"/>); this class handles
 /// tokenization (<see cref="KokoroVocab"/>), voice-style selection, and the
 /// ONNX run. See scripts/kokoro_export and docs/kokoro_onnx_investigation.md.
 ///

--- a/src/Vernacula.Tts.Base/KokoroFormat.cs
+++ b/src/Vernacula.Tts.Base/KokoroFormat.cs
@@ -1,0 +1,93 @@
+using System.Text.RegularExpressions;
+
+namespace Vernacula.Tts.Base;
+
+/// <summary>
+/// Renders vernacula-phonemizer's canonical IPA into the phoneme alphabet hexgrad/Kokoro-82M was
+/// trained on. Kokoro's alphabet is misaki's: espeak-ng IPA after the deterministic post-processing
+/// in misaki's <c>EspeakFallback.__call__</c> (diphthongs collapsed to single letters, the rhotic
+/// schwa split, en-us length marks dropped). This is that post-processing, re-keyed on what
+/// vernacula-phonemizer actually emits instead of what espeak does — which differs in five places:
+///
+///   · offglides are SUPERSCRIPT (<c>oᶷ eᶦ aᶦ aᶷ ɔᶦ</c>, en-GB <c>əᶷ</c>) rather than digraphs;
+///   · affricates carry a tie bar (<c>d͡ʒ t͡ʃ</c>), stops carry aspiration (<c>tʰ</c>), and l is
+///     dark (<c>ɫ</c>) where espeak wrote plain <c>dʒ tʃ t l</c>;
+///   · the en-us flap is <c>t̬</c> / <c>d̬</c> (voicing diacritic), not <c>ɾ</c>;
+///   · the stressed rhotic vowel is <c>ɝ</c> (espeak: <c>ɜː</c>), the unstressed one <c>ɚ</c>;
+///   · clause punctuation SURVIVES, as its own space-delimited token (<c>… dˈɔːɡ , dˈʌzənt</c>),
+///     where espeak collapsed it — so the punctuation Kokoro uses for pauses is re-attached here
+///     rather than reconstructed from the source text.
+///
+/// Kokoro tolerates slightly different IPA, so byte-exact misaki parity is not the bar; the bar is
+/// that every output codepoint is in <see cref="KokoroVocab"/> and the common words land on the
+/// same tokens misaki would give them. docs/kokoro_vphon_investigation.md has the measurements.
+/// </summary>
+public static class KokoroFormat
+{
+    // Ordered sequential replacements, like misaki's E2M. Where one key is a prefix of another
+    // the longer runs first (a diphthong before its bare offglide).
+    private static readonly (string Old, string New)[] Common =
+    [
+        ("͡", ""),       // tie bar: d͡ʒ → dʒ, t͡ʃ → tʃ, consumed below
+        ("ʰ", ""),            // aspiration: tʰ → t
+        ("ʲ", ""),            // palatal glide: iʲə → iə (misaki's lexicon: jʊɹˈAniəm)
+        ("t̬", "T"),     // flapped t → Kokoro's flap token
+        ("d̬", "d"),     // flapped d: misaki's lexicon keeps d (θˈɜɹdi)
+        ("ɫ", "l"),
+        ("oᶷ", "O"),          // misaki o^ʊ
+        ("eᶦ", "A"),          // misaki e^ɪ
+        ("aᶦ", "I"),          // misaki a^ɪ
+        ("aᶷ", "W"),          // misaki a^ʊ
+        ("ɔᶦ", "Y"),          // misaki ɔ^ɪ
+        ("ᶦ", "ɪ"),           // any offglide not consumed by a diphthong above
+        ("ᶷ", "ʊ"),
+        ("dʒ", "ʤ"),
+        ("tʃ", "ʧ"),
+        ("ɝ", "ɜɹ"),          // NURSE: misaki writes ɜɹ for en-us
+        ("ɚ", "əɹ"),          // misaki ɚ → əɹ
+        ("ɐ", "ə"),
+        ("r", "ɹ"),
+        ("x", "k"),
+        ("ç", "k"),
+        ("ɬ", "l"),
+        ("̃", ""),       // nasalisation tilde
+        ("ʔ", "t"),
+        ("ɾ", "T"),
+        // ᵻ (U+1D7B) is deliberately unmapped: it is Kokoro vocab id 177, not out-of-vocab.
+    ];
+
+    // A punctuation token the phonemizer emitted on its own, with the space that precedes it.
+    // Kokoro's training data attaches punctuation to the word before it (`wˈɜɹld.`), and the
+    // word-alignment code counts a run of non-space tokens as one word, so it must not stand alone.
+    private static readonly Regex DetachedPunctRe = new(@" +([,.;:!?…—]+)(?= |$)", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Render canonical IPA from vernacula-phonemizer (<c>en</c> or <c>en-GB</c>) into a Kokoro-vocab
+    /// phoneme string. Set <paramref name="british"/> for text phonemized as en-GB (lang_code 'b',
+    /// the bf_/bm_ voices); default is en-us ('a').
+    /// </summary>
+    public static string Render(string ipa, bool british = false)
+    {
+        if (string.IsNullOrEmpty(ipa)) return ipa ?? string.Empty;
+
+        var ps = ipa.Trim();
+        if (british)
+            ps = ps.Replace("əᶷ", "Q");    // misaki ə^ʊ — before Common turns the ᶷ into ʊ
+
+        foreach (var (old, neu) in Common)
+            ps = ps.Replace(old, neu);
+
+        if (british)
+        {
+            ps = ps.Replace("ɛə", "ɛː");   // misaki e^ə (SQUARE); en-gb keeps its length marks
+        }
+        else
+        {
+            ps = ps.Replace("ː", "");      // en-us drops length marks
+        }
+
+        ps = ps.Replace("o", "ɔ");         // misaki: espeak < 1.52 compatibility; O is already consumed
+        ps = DetachedPunctRe.Replace(ps, "$1");
+        return ps;
+    }
+}

--- a/src/Vernacula.Tts.Base/KokoroPhonemizer.cs
+++ b/src/Vernacula.Tts.Base/KokoroPhonemizer.cs
@@ -1,0 +1,126 @@
+using Vernacula.Phonemizer;
+
+namespace Vernacula.Tts.Base;
+
+/// <summary>
+/// One phonemized text: the Kokoro-alphabet string, and for each phoneme group in it (a run of
+/// tokens between space tokens — one per spoken word) the index of the whitespace-delimited source
+/// word it came from. <see cref="GroupSourceWords"/> is null when the phonemizer could not account
+/// for every group; callers fall back to an even split.
+/// </summary>
+public sealed record KokoroPhonemization(string Phonemes, IReadOnlyList<int>? GroupSourceWords);
+
+/// <summary>
+/// Kokoro's G2P frontend: text → canonical IPA (vernacula-phonemizer, <c>en</c> / <c>en-GB</c>) →
+/// Kokoro's alphabet (<see cref="KokoroFormat"/>). Needs only the phonemizer's data tree, not the
+/// model, so it is usable — and testable — without an ONNX session.
+///
+/// ⚠ TWO PHONEMIZER ENTRIES ARE USED PER CALL, ON PURPOSE. <c>PhonemizeAsync</c> is the best
+/// reading (English routes out-of-vocabulary words through its BiLSTM), but only the synchronous
+/// <c>PhonemizeTrace</c> reports which characters of the input each IPA span came from — and that
+/// map is what word-level alignment needs. The neural path changes how an OOV word is READ, not
+/// how many words there are, so the trace's per-word group counts describe the async output too;
+/// this is checked, and when the two disagree the traced reading is used so the map is never wrong.
+/// </summary>
+public sealed class KokoroPhonemizer
+{
+    /// <param name="dataDir">The vernacula-phonemizer <c>data/</c> root. Null resolves it the way
+    /// <see cref="PhonemizerData.Resolve"/> does (VERNACULA_DATA_DIR, then the submodule).</param>
+    public KokoroPhonemizer(string? dataDir = null)
+    {
+        if (PhonemizerData.Resolve(dataDir) is null)
+            throw new DirectoryNotFoundException(PhonemizerData.NotFoundMessage());
+        Registry.EnsureLanguages();
+    }
+
+    private static string Lang(bool british) => british ? "en-GB" : "en";
+
+    /// <summary>Text → Kokoro-alphabet phoneme string.</summary>
+    public string ToPhonemes(string text, bool british = false) => Phonemize(text, british).Phonemes;
+
+    /// <summary>Inner phoneme-token count (excludes the 2 pad tokens) for <paramref name="text"/>.</summary>
+    public int CountTokens(string text, bool british = false)
+        => Math.Max(0, KokoroVocab.Encode(ToPhonemes(text, british)).Length - 2);
+
+    /// <summary>Text → Kokoro phonemes plus the phoneme-group → source-word map.</summary>
+    public KokoroPhonemization Phonemize(string text, bool british = false)
+    {
+        var lang = Lang(british);
+        var trace = global::Vernacula.Phonemizer.Phonemizer.PhonemizeTrace(text, lang);
+        var map = GroupSourceWords(trace, text);
+
+        string ipa;
+        try
+        {
+            // Every caller is already off the UI thread (Task.Run in the reader, top-level in the
+            // CLIs), and the phonemizer awaits with ConfigureAwait(false), so blocking here is safe.
+            ipa = global::Vernacula.Phonemizer.Phonemizer.PhonemizeAsync(text, lang).GetAwaiter().GetResult();
+        }
+        catch (Exception)
+        {
+            ipa = trace.Ipa;   // a missing OOV model must not take the utterance down
+        }
+        // The map was built from the traced reading; use it only for a reading with the same shape.
+        if (map is not null && CountWordGroups(ipa) != map.Count)
+            ipa = trace.Ipa;
+
+        return new KokoroPhonemization(KokoroFormat.Render(ipa, british), map);
+    }
+
+    /// <summary>
+    /// One source-word index per spoken IPA group, from the trace's spans. A token's input span
+    /// says which source word it was; its IPA span says how many groups it became (a number reads
+    /// as several words). Null when any token is missing a span, since a partial map would assign
+    /// the wrong words to every group after the gap.
+    /// </summary>
+    private static List<int>? GroupSourceWords(PhonemeTrace trace, string text)
+    {
+        if (!trace.Traced) return null;
+
+        // Character offset → index of the whitespace-delimited word containing it.
+        var wordAt = new int[text.Length];
+        var w = -1; var inWord = false;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (char.IsWhiteSpace(text[i])) { inWord = false; wordAt[i] = w + 1; continue; }
+            if (!inWord) { w++; inWord = true; }
+            wordAt[i] = w;
+        }
+        var wordCount = w + 1;
+
+        var map = new List<int>();
+        (int Start, int End)? lastSpan = null;
+        var lastWord = -1;
+        foreach (var tok in trace.Tokens)
+        {
+            if (tok.InputSpan is not { } input || input.Start < 0 || input.Start >= text.Length) return null;
+            int groups;
+            if (tok.IpaSpan is { } span)
+                groups = CountWordGroups(trace.Ipa[span.Start..span.End]);
+            else if (tok.Emitted.Count > 0)
+                groups = tok.Emitted.Count;
+            else
+                return null;
+            // Tokens that share one input span came from one normalizer rewrite. When the span is
+            // one written word ("$3.14" → three, dollars, fourteen) they all belong to it; when it
+            // covers several ("Mr. Smith" → mister, Smith) each successive token takes the next
+            // word in the span, so the highlight moves with the speech instead of sticking.
+            var lastInSpan = wordAt[Math.Min(input.End, text.Length) - 1];
+            var word = lastSpan == input ? Math.Min(lastWord + 1, lastInSpan) : wordAt[input.Start];
+            if (word >= wordCount) return null;
+            for (var g = 0; g < groups; g++) map.Add(word);
+            lastSpan = input; lastWord = word;
+        }
+        return map;
+    }
+
+    /// <summary>Space-delimited groups that contain a letter — i.e. not the phonemizer's
+    /// stand-alone punctuation tokens, which <see cref="KokoroFormat"/> folds into the word before.</summary>
+    private static int CountWordGroups(string ipa)
+    {
+        var n = 0;
+        foreach (var g in ipa.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            if (g.Any(char.IsLetter)) n++;
+        return n;
+    }
+}

--- a/src/Vernacula.Tts.Base/KokoroTts.cs
+++ b/src/Vernacula.Tts.Base/KokoroTts.cs
@@ -2,9 +2,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Vernacula.Tts.Base.Markdown;
 using Vernacula.Base.Models;
-using Vernacula.Phonemizer;
-using Vernacula.Phonemizer.Data;
-using Vernacula.Phonemizer.Types;
 
 namespace Vernacula.Tts.Base;
 
@@ -15,33 +12,25 @@ public sealed record KokoroWord(string Text, double StartSec, double EndSec);
 public sealed record KokoroSpeech(float[] Audio, IReadOnlyList<KokoroWord> Words);
 
 /// <summary>
-/// End-to-end Kokoro-82M text-to-speech: text → phonemes → audio. Composes the
-/// pure-C# espeak-ng port (<see cref="Phonemize"/>), the Kokoro render format
-/// (<see cref="KokoroFormat"/>), and the ONNX inference path (<see cref="Kokoro"/>).
-///
-/// G2P uses the misaki-style frontend for English: phonemize to IPA, then render
-/// to Kokoro's alphabet. The phonemizer needs its language data directory (the
-/// <c>data/</c> tree shipped with the espeak-ng-portable submodule) — pass its
-/// path as <c>phonemizerDataDir</c>; en/en-gb subfolders are loaded from there.
+/// End-to-end Kokoro-82M text-to-speech: text → phonemes → audio. Composes the G2P frontend
+/// (<see cref="KokoroPhonemizer"/>: vernacula-phonemizer IPA rendered into Kokoro's alphabet by
+/// <see cref="KokoroFormat"/>) and the ONNX inference path (<see cref="Kokoro"/>).
 ///
 /// Not thread-safe (wraps <see cref="Kokoro"/> / ORT). One instance per caller.
 /// </summary>
 public sealed class KokoroTts : IDisposable
 {
     private readonly Kokoro _kokoro;
-    private readonly string _dataDir;
-    private readonly Language _enUs;
-    private Language? _enGb;
+    private readonly KokoroPhonemizer _g2p;
 
     /// <param name="onnxDir">Directory holding kokoro.onnx and voices/.</param>
-    /// <param name="phonemizerDataDir">The espeak-ng-portable <c>data/</c> directory
-    /// (contains <c>en/</c>, <c>en-gb/</c>, …).</param>
-    public KokoroTts(string onnxDir, string phonemizerDataDir, ExecutionProvider ep,
+    /// <param name="phonemizerDataDir">The vernacula-phonemizer <c>data/</c> root, or null to
+    /// resolve it (VERNACULA_DATA_DIR, then the submodule — see <see cref="PhonemizerData"/>).</param>
+    public KokoroTts(string onnxDir, string? phonemizerDataDir, ExecutionProvider ep,
                      SessionLoadObserver? onLoad = null)
     {
+        _g2p = new KokoroPhonemizer(phonemizerDataDir);   // before the model: the cheaper failure first
         _kokoro = new Kokoro(onnxDir, ep, onLoad);
-        _dataDir = phonemizerDataDir;
-        _enUs = LanguageLoader.Load("en", Path.Combine(_dataDir, "en"));
     }
 
     /// <summary>Output sample rate (24 kHz).</summary>
@@ -65,7 +54,7 @@ public sealed class KokoroTts : IDisposable
     /// </summary>
     public KokoroSpeech SpeakAligned(string text, string voice, float speed = 1.0f, bool british = false)
     {
-        var (phonemes, groupSourceWords) = ToPhonemesWithSourceMap(text, british);
+        var (phonemes, groupSourceWords) = _g2p.Phonemize(text, british);
         var o = _kokoro.SynthesizeWithDurations(phonemes, voice, speed);
         if (o.Audio.Length == 0)
             return new KokoroSpeech([], []);
@@ -96,7 +85,7 @@ public sealed class KokoroTts : IDisposable
         var sourceWords = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
         var words = new List<KokoroWord>(sourceWords.Length);
 
-        if (runs.Count == groupSourceWords.Count && sourceWords.Length > 0)
+        if (groupSourceWords is not null && runs.Count == groupSourceWords.Count && sourceWords.Length > 0)
         {
             // Collect each source word's group span. A word's groups are contiguous and in
             // time order, so first start / last end gives its [start, end].
@@ -158,8 +147,7 @@ public sealed class KokoroTts : IDisposable
     }
 
     /// <summary>Inner phoneme-token count (excludes the 2 pad tokens) for <paramref name="text"/>.</summary>
-    public int CountTokens(string text, bool british = false)
-        => System.Math.Max(0, KokoroVocab.Encode(ToPhonemes(text, british)).Length - 2);
+    public int CountTokens(string text, bool british = false) => _g2p.CountTokens(text, british);
 
     private void SplitToTokenBudget(string chunk, bool british, List<string> output)
     {
@@ -224,48 +212,7 @@ public sealed class KokoroTts : IDisposable
     /// Text → Kokoro-alphabet phoneme string, without running the vocoder. Useful
     /// for inspection, caching, or feeding <see cref="Kokoro.Synthesize"/> directly.
     /// </summary>
-    public string ToPhonemes(string text, bool british = false)
-        => ToPhonemesWithSourceMap(text, british).Phonemes;
-
-    // Phonemize + render + punctuation re-injection, also returning one source-word index
-    // per output phoneme group. Render (per-char) and ReinjectPunctuation (clause join)
-    // preserve group order and count, so the map stays 1:1 with the final token runs.
-    private (string Phonemes, IReadOnlyList<int> GroupSourceWords) ToPhonemesWithSourceMap(string text, bool british)
-    {
-        var lang = british ? (_enGb ??= LanguageLoader.Load("en-gb", Path.Combine(_dataDir, "en-gb"))) : _enUs;
-        var (ipa, groupSourceWords) = Phonemize.RunWithSourceWords(text, lang);
-        var kok = KokoroFormat.Render(ipa, british);
-        return (ReinjectPunctuation(kok, text), groupSourceWords);
-    }
-
-    // The phonemizer collapses every clause/sentence punctuation mark to a single
-    // '\n' and drops the final one — but Kokoro's vocab carries punctuation tokens
-    // (',' '.' ';' …) that drive its prosodic pauses. Re-inject them by correlating
-    // the source text's clause punctuation (in order) with the '\n' breaks: the i-th
-    // break and the trailing position get the i-th source mark. Number-internal dots
-    // (e.g. "3.14", normalized to words upstream) produce no break and are excluded
-    // so the alignment holds. Defaults to a comma if a mark is somehow missing.
-    private static readonly Regex ClausePunctRe = new(@"[,;:!?…—]|(?<![0-9])\.(?![0-9])", RegexOptions.Compiled);
-
-    private static string ReinjectPunctuation(string kokoro, string sourceText)
-    {
-        var clauses = kokoro.Split('\n');
-        if (clauses.Length == 1 && !ClausePunctRe.IsMatch(sourceText))
-            return kokoro;
-
-        var marks = ClausePunctRe.Matches(sourceText);
-        var sb = new StringBuilder(kokoro.Length + clauses.Length);
-        for (var i = 0; i < clauses.Length; i++)
-        {
-            sb.Append(clauses[i]);
-            var mark = i < marks.Count ? marks[i].Value : (i < clauses.Length - 1 ? "," : "");
-            if (mark.Length == 1 && KokoroVocab.Contains(mark[0]))
-                sb.Append(mark);
-            if (i < clauses.Length - 1)
-                sb.Append(' ');
-        }
-        return sb.ToString();
-    }
+    public string ToPhonemes(string text, bool british = false) => _g2p.ToPhonemes(text, british);
 
     public void Dispose() => _kokoro.Dispose();
 }

--- a/src/Vernacula.Tts.Base/KokoroVocab.cs
+++ b/src/Vernacula.Tts.Base/KokoroVocab.cs
@@ -4,7 +4,7 @@ namespace Vernacula.Tts.Base;
 /// Phoneme → token-id map for hexgrad/Kokoro-82M (the model's <c>vocab</c>,
 /// 114 entries, ids sparse over 1..177; id 0 is the padding token used to
 /// bracket the sequence). Keys are single Kokoro-alphabet phoneme codepoints
-/// as produced by <c>Vernacula.Phonemizer.KokoroFormat.Render</c>.
+/// as produced by <see cref="KokoroFormat.Render"/>.
 ///
 /// GENERATED from <c>KModel.vocab</c> by
 /// <c>scripts/kokoro_export/export_voices.py</c>'s sibling vocab dump

--- a/src/Vernacula.Tts.Base/PhonemizerData.cs
+++ b/src/Vernacula.Tts.Base/PhonemizerData.cs
@@ -1,4 +1,4 @@
-namespace Vernacula.Tts.CLI;
+namespace Vernacula.Tts.Base;
 
 /// <summary>
 /// Locates the vernacula-phonemizer `data/` tree and hands it to the phonemizer.
@@ -6,11 +6,12 @@ namespace Vernacula.Tts.CLI;
 /// The phonemizer's own DataPath finds the tree by walking up from AppContext.BaseDirectory for an
 /// ancestor holding `data/core/phonology.jsonc` — which works when you run from inside the
 /// phonemizer repo, and does not work here: our build output is
-/// src/Vernacula.Tts.CLI/bin/&lt;cfg&gt;/net10.0, and this repo has no top-level `data/`. The tree
-/// lives one level in, under the submodule. So we resolve it ourselves and set
-/// VERNACULA_DATA_DIR, which DataPath honours ahead of the walk.
+/// src/&lt;project&gt;/bin/&lt;cfg&gt;/net10.0, and this repo has no top-level `data/`. The tree lives one
+/// level in, under the submodule. So we resolve it ourselves and set VERNACULA_DATA_DIR, which
+/// DataPath honours ahead of the walk. Shared by every consumer of the phonemizer here — the IPA
+/// path in Vernacula.Tts.CLI and the Kokoro frontend (<see cref="KokoroPhonemizer"/>).
 /// </summary>
-internal static class PhonemizerData
+public static class PhonemizerData
 {
     private const string Sentinel = "core/phonology.jsonc";
     private const string SubmoduleData = "external/vernacula-phonemizer/data";
@@ -39,13 +40,12 @@ internal static class PhonemizerData
 
     /// <summary>The same sentinel check DataPath uses — the file, not just a `data` directory, so
     /// an unrelated `data/` on the walk cannot match.</summary>
-    private static bool IsDataRoot(string dir) =>
+    public static bool IsDataRoot(string dir) =>
         File.Exists(Path.Combine(dir, Sentinel.Replace('/', Path.DirectorySeparatorChar)));
 
     public static string NotFoundMessage() =>
         "Could not locate the vernacula-phonemizer data tree (looked for "
         + $"{SubmoduleData}/{Sentinel} above \"{AppContext.BaseDirectory}\").\n"
         + "  If the submodule isn't checked out:  git submodule update --init external/vernacula-phonemizer\n"
-        + "  Otherwise point at it explicitly:    --data-dir <path to vernacula-phonemizer/data>\n"
-        + "  Or pass --ipa to skip phonemization and supply IPA directly.";
+        + "  Otherwise point at it explicitly:    --data-dir <path to vernacula-phonemizer/data>";
 }

--- a/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
+++ b/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Vernacula.Tts.Base</AssemblyName>
     <!--
       EP is passed by consuming projects (Vernacula.Tts.Backends.CLI, Vernacula.Tts.Avalonia,
-      and the ChatterboxSmoke test). Mirrors the pattern in Vernacula.Base —
+      Vernacula.Tts.CLI and the smoke tests). Mirrors the pattern in Vernacula.Base —
       PrivateAssets="all" keeps the package out of consumers' output; each
       consumer brings its own OnnxRuntime variant.
     -->
@@ -52,19 +52,16 @@
       <Private>true</Private>
       <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>
-    <!-- Kokoro G2P frontend: pure-C# espeak-ng port + KokoroFormat render target.
-         Vendored as a git submodule under external/ (data/ language files ship
-         with it). Used by KokoroTts to turn text into Kokoro phonemes.
+    <!-- The phonemizer: canonical IPA for the IPA-conditioned OmniVoice path (Vernacula.Tts.CLI) and,
+         rendered through KokoroFormat, Kokoro's G2P. Vendored as a git submodule under external/;
+         its data/ tree is located at runtime by PhonemizerData.
 
-         ⚠ PrivateAssets="all" — DO NOT DROP. This assembly is named Vernacula.Phonemizer, and so
-         is the SEPARATE, newer external/vernacula-phonemizer that Vernacula.Tts.CLI uses. When
-         both reach one output directory they are the same filename: the copy silently wins,
-         no warning, and whichever library lost fails at runtime with a TypeLoadException.
-         KokoroTts is the only thing in this repo that touches these types, so nothing needs the
-         reference transitively — the three projects that USE Kokoro carry their own direct
-         reference instead (Vernacula.Tts.Backends.CLI, Vernacula.Tts.Avalonia, tests/KokoroPerf). -->
-    <ProjectReference Include="..\..\external\espeak-ng-portable\csharp\src\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj"
-                      PrivateAssets="all" />
+         ⚠ Its Microsoft.ML.OnnxRuntime reference is a PLAIN (CPU) one, not PrivateAssets="all"
+         like the EP-selected package above, so it flows transitively into every consumer of this
+         project. A Cuda/DirectML consumer must outrank it with a direct ExcludeAssets="all"
+         reference or the CPU native library lands next to the GPU one and whichever copies last
+         wins — see Vernacula.Tts.CLI.csproj for the block and the explanation. -->
+    <ProjectReference Include="..\..\external\vernacula-phonemizer\csharp\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Vernacula.Tts.CLI/Program.cs
+++ b/src/Vernacula.Tts.CLI/Program.cs
@@ -287,7 +287,8 @@ internal static class Program
         {
             if (PhonemizerData.Resolve(dataDir) is not { } root)
             {
-                Console.Error.WriteLine(PhonemizerData.NotFoundMessage());
+                Console.Error.WriteLine(PhonemizerData.NotFoundMessage()
+                    + "\n  Or pass --ipa to skip phonemization and supply IPA directly.");
                 return 1;
             }
             if (verbose) Console.WriteLine($"phonemizer data: {root}");

--- a/tests/KokoroPerf/KokoroPerf.csproj
+++ b/tests/KokoroPerf/KokoroPerf.csproj
@@ -13,12 +13,12 @@
   <ItemGroup>
     <!-- .Gpu includes the CPU provider as fallback; covers both EP modes. -->
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.4" />
+    <!-- Outranks the plain CPU ORT that Vernacula.Phonemizer pulls in transitively; see
+         Vernacula.Tts.Base.csproj. -->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.4" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Kokoro's G2P frontend. Direct rather than transitive through Vernacula.Tts.Base — see the
-         PrivateAssets note on that project's reference to it. -->
-    <ProjectReference Include="..\..\external\espeak-ng-portable\csharp\src\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" />
     <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
       <Private>true</Private>
       <SetConfiguration>EP=Cuda</SetConfiguration>

--- a/tests/KokoroPerf/Program.cs
+++ b/tests/KokoroPerf/Program.cs
@@ -1,7 +1,7 @@
 // Kokoro TTS performance harness — latency / real-time-factor across providers.
 //
 //   dotnet run -c Release --project tests/KokoroPerf -- \
-//       --onnx-dir <dir> --data-dir <espeak data/> --ep cuda --iters 10
+//       --onnx-dir <dir> [--data-dir <vernacula-phonemizer data/>] --ep cuda --iters 10
 //
 // Reports session-load time and steady-state per-utterance latency + RTF
 // (audio_seconds / inference_seconds; higher = faster than real time) over a
@@ -13,7 +13,7 @@ using Vernacula.Tts.Base;
 using Vernacula.Base.Models;
 
 string onnxDir = "/home/chris/Programming/vernacula/scripts/kokoro_export/external/kokoro_onnx";
-string dataDir = "/home/chris/Programming/vernacula/external/espeak-ng-portable/data";
+string? dataDir = null;   // vernacula-phonemizer data/; null = resolve from the submodule
 var ep = ExecutionProvider.Cuda;
 var voice = "af_heart";
 var iters = 10;

--- a/tests/Vernacula.Tts.Tests/KokoroFormatTests.cs
+++ b/tests/Vernacula.Tts.Tests/KokoroFormatTests.cs
@@ -1,0 +1,54 @@
+using Vernacula.Tts.Base;
+using Xunit;
+
+namespace Vernacula.Tts.Tests;
+
+/// <summary>
+/// <see cref="KokoroFormat"/> over the IPA vernacula-phonemizer emits. The expected strings are what
+/// misaki's espeak post-processing gives the same words (docs/kokoro_vphon_investigation.md, Run 2).
+/// </summary>
+public class KokoroFormatTests
+{
+    [Theory]
+    // diphthongs, dark l, NURSE, detached punctuation
+    [InlineData("həlˈoᶷ wˈɝɫd . ðɪs ɪz ə tʰˈɛst .", "həlˈO wˈɜɹld. ðɪs ɪz ə tˈɛst.")]
+    // affricates with tie bars, flaps, aspiration
+    [InlineData("t͡ʃˈɝt͡ʃ d͡ʒˈʌd͡ʒ bˈʌt̬ən hˈɪd̬ən", "ʧˈɜɹʧ ʤˈʌʤ bˈʌTən hˈɪdən")]
+    // the five superscript offglides and the rhotic schwa
+    [InlineData("lˈeᶦzi bɹˈaᶷn aᶦ pʰˈɔᶦnt oᶷvɚ", "lˈAzi bɹˈWn I pˈYnt Ovəɹ")]
+    // en-us drops length marks; a palatal glide is dropped, not turned into j
+    [InlineData("fˈɑːks θˈɔːt jɚˈeᶦniʲəm", "fˈɑks θˈɔt jəɹˈAniəm")]
+    // ᵻ is a Kokoro token and survives; secondary stress survives
+    [InlineData("ɹᵻmˈɛmbɚ jˈɛstɚd̬ˌeᶦz", "ɹᵻmˈɛmbəɹ jˈɛstəɹdˌAz")]
+    // every clause mark attaches to the word before it
+    [InlineData("wˈeᶦt , hiː sˈɛd . ˈɪzənt ɪt ?", "wˈAt, hi sˈɛd. ˈɪzənt ɪt?")]
+    public void RendersAmerican(string ipa, string expected)
+        => Assert.Equal(expected, KokoroFormat.Render(ipa));
+
+    [Theory]
+    // GOAT is Q, length marks stay, SQUARE is ɛː, NEAR stays ɪə
+    [InlineData("həlˈəᶷ wˈɜːɫd . ðˈɛə hˈɪə", "həlˈQ wˈɜːld. ðˈɛː hˈɪə")]
+    [InlineData("ɡˈəᶷ hˈəᶷm nˈaᶷ !", "ɡˈQ hˈQm nˈW!")]
+    [InlineData("fˈaᶦə , ʃˈɛə , kjˈʊə .", "fˈIə, ʃˈɛː, kjˈʊə.")]
+    public void RendersBritish(string ipa, string expected)
+        => Assert.Equal(expected, KokoroFormat.Render(ipa, british: true));
+
+    [Theory]
+    [InlineData("mˈɪstɚ smˈɪθ ɚˈaᶦvd æt tʰˈɛn θˈɝd̬iː ˈeᶦ ˈɛm ˈɑːn tʰˈuːzdi , mˈɑːɹt͡ʃ θˈɝd , twˈɛnti twˈɛnti fˈɔːɹ .", false)]
+    [InlineData("jˈɛstədˌeᶦz wˈɛðə wˈɒz bˈɛtə ðæn tədˈeᶦz , wˈɒzənt ɪt ?", true)]
+    [InlineData("sˈɪŋɪŋ , θˈɪŋkɪŋ , lˈɛŋkθ , ðə kʰˈɪŋz ɹˈɪŋ .", false)]
+    public void EveryOutputCodepointIsInTheVocab(string ipa, bool british)
+    {
+        var ps = KokoroFormat.Render(ipa, british);
+        foreach (var ch in ps)
+            Assert.True(KokoroVocab.Contains(ch), $"'{ch}' (U+{(int)ch:X4}) is not a Kokoro token, in: {ps}");
+        Assert.Equal(ps.Length, KokoroVocab.Encode(ps).Length - 2);   // nothing was dropped
+    }
+
+    [Fact]
+    public void EmptyIsEmpty()
+    {
+        Assert.Equal("", KokoroFormat.Render(""));
+        Assert.Equal("", KokoroFormat.Render(null!));
+    }
+}

--- a/tests/Vernacula.Tts.Tests/KokoroPhonemizerTests.cs
+++ b/tests/Vernacula.Tts.Tests/KokoroPhonemizerTests.cs
@@ -1,0 +1,60 @@
+using Vernacula.Tts.Base;
+using Xunit;
+
+namespace Vernacula.Tts.Tests;
+
+/// <summary>
+/// The text → Kokoro-phonemes path and its phoneme-group → source-word map, through the real
+/// phonemizer. Needs the vernacula-phonemizer submodule's data/ tree; skips without it.
+/// </summary>
+public class KokoroPhonemizerTests
+{
+    private static KokoroPhonemizer? TryCreate()
+        => PhonemizerData.Resolve(null) is null ? null : new KokoroPhonemizer();
+
+    [Fact]
+    public void OneGroupPerSpokenWord_PunctuationAttached()
+    {
+        var g2p = TryCreate();
+        if (g2p is null) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+
+        var r = g2p.Phonemize("Hello world. This is a test, isn't it?");
+        // 8 source words → 8 groups; the three marks ride on their words, not as groups of their own.
+        var groups = r.Phonemes.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(8, groups.Length);
+        Assert.EndsWith(".", groups[1]);
+        Assert.EndsWith(",", groups[5]);
+        Assert.EndsWith("?", groups[7]);
+        Assert.NotNull(r.GroupSourceWords);
+        Assert.Equal(Enumerable.Range(0, 8), r.GroupSourceWords);
+        foreach (var ch in r.Phonemes)
+            Assert.True(ch == ' ' || KokoroVocab.Contains(ch), $"'{ch}' is not a Kokoro token");
+    }
+
+    [Fact]
+    public void ExpandedNumbersCollapseOntoTheirWrittenWord()
+    {
+        var g2p = TryCreate();
+        if (g2p is null) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+
+        // "$3.14" reads as several words; every one of them maps back to source word 4.
+        var r = g2p.Phonemize("I paid about it $3.14 yesterday.");
+        Assert.NotNull(r.GroupSourceWords);
+        var groups = r.Phonemes.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(groups.Length, r.GroupSourceWords!.Count);
+        var fromPrice = r.GroupSourceWords.Count(w => w == 4);
+        Assert.True(fromPrice >= 2, $"expected the price to read as several groups, map: {string.Join(",", r.GroupSourceWords)}");
+        Assert.Equal(5, r.GroupSourceWords[^1]);   // "yesterday." is the last word
+        Assert.True(r.GroupSourceWords.Zip(r.GroupSourceWords.Skip(1)).All(p => p.First <= p.Second), "map is monotone");
+    }
+
+    [Fact]
+    public void BritishUsesTheGbReading()
+    {
+        var g2p = TryCreate();
+        if (g2p is null) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+
+        Assert.Equal("ɡˈO hˈOm", g2p.ToPhonemes("go home"));
+        Assert.Equal("ɡˈQ hˈQm", g2p.ToPhonemes("go home", british: true));
+    }
+}


### PR DESCRIPTION
Kokoro phonemized through the pure-C# espeak-ng port in `external/espeak-ng-portable`, which is private and staying that way. vernacula-phonemizer is going public. This moves Kokoro's G2P onto it and removes the submodule, so CI needs one submodule, not two.

**What's new in `Vernacula.Tts.Base`**
- `KokoroFormat` — Kokoro's alphabet (misaki's espeak post-processing) re-keyed on what vernacula-phonemizer actually emits: superscript offglides (`oᶷ eᶦ aᶦ aᶷ ɔᶦ`, GB `əᶷ`), tie bars and aspiration (`d͡ʒ tʰ`), `t̬`/`d̬` flaps, `ɝ`, punctuation kept as its own token, en-GB `ɛə`.
- `KokoroPhonemizer` — text → Kokoro phonemes plus the phoneme-group → source-word map for the reader's word highlighting. Built from `PhonemizeTrace`'s input/IPA spans (better than the old engine's counting: `$3.14`'s three spoken words map to the one written one; `Mr. Smith`'s two tokens map to two words) and applied to the neural `PhonemizeAsync` reading when both agree on word count.
- `PhonemizerData` moved here from `Vernacula.Tts.CLI` — both consumers resolve the data tree the same way.
- `KokoroTts(onnxDir, phonemizerDataDir, …)` — the dir is now the vernacula-phonemizer `data/` root and may be null. The Backends CLI no longer requires `--data-dir`; the reader re-resolves a saved pre-migration path instead of failing at load.

**Parity** (docs/kokoro_vphon_investigation.md, Run 2): 77% word-exact against the old frontend over 14 probe sentences × 2 accents, and every difference is the phonemizer's reading, not the rendering — most move toward misaki's lexicon (`dˈɔɡ`, `mˈWntən`, `jəɹˈAniəm`), and two old bugs go away (en-GB SQUARE rendered `Aə`; "that the" run into one group). Every output codepoint is in `KokoroVocab` (tested).

**The CUDA runtime.** vernacula-phonemizer references the plain CPU ORT and it now flows through `Vernacula.Tts.Base` into everything. The three Cuda consumers of Kokoro (Backends.CLI, Avalonia, KokoroPerf) outrank it with a direct `ExcludeAssets="all"` reference — the trick `Vernacula.Tts.CLI` already used — and the shipped `libonnxruntime.so` was checked by checksum against the `.gpu.linux` package (Run 3).

**Verified locally:** solution builds (EP=Cpu, 0 errors); the workflow's exact steps after wiping test outputs: 22 / 55 (+4 skipped, 16 new tests) / 63 / 23 pass; `vernacula-tts-backends --backend kokoro` on CPU renders af_heart and bf_emma audio at ~5× real-time with the data dir auto-resolved.

Not in this PR: `$3.14` reads "three dollars fourteen" (old engine: "…and fourteen cents") — an upstream normalizer note; a by-ear check of the reader's highlighting with the new map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc
