### PR TITLE
reader: OmniVoice-IPA as a third backend

### DIFF
--- a/src/Vernacula.Tts.Avalonia/Services/OmniVoiceSynthesisService.cs
+++ b/src/Vernacula.Tts.Avalonia/Services/OmniVoiceSynthesisService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Vernacula.Tts.App.Models;
+using Vernacula.Tts.Base;
+using Vernacula.Tts.Base.Markdown;
+using NAudio.Wave;
+using Vernacula.Base.Models;
+
+namespace Vernacula.Tts.App.Services;
+
+/// <summary>
+/// OmniVoice-IPA streaming backend: text → IPA (vernacula-phonemizer, any language) → the IPA
+/// fine-tune, in a stored voice from the web demo's library. Same per-chunk contract as the other
+/// backends; <see cref="TtsRequest.Voice"/> is a library voice id, <see cref="TtsRequest.Lang"/>
+/// the phonemizer language, <see cref="TtsRequest.NumStep"/> the diffusion steps.
+///
+/// Word timings are proportional estimates, not measurements — see <see cref="OmniVoiceIpaTts"/>.
+/// The 2.45 GB transformer loads lazily on the first call and is reused.
+/// </summary>
+public sealed class OmniVoiceSynthesisService : ITtsBackend
+{
+    private readonly string _onnxDir;
+    private readonly string? _tokenizerJson;
+    private readonly string? _phonemizerDataDir;
+    private readonly string _voiceLibDir;
+    private readonly ExecutionProvider _ep;
+
+    private OmniVoiceIpaTts? _tts;
+    private readonly object _gate = new();
+
+    public OmniVoiceSynthesisService(string onnxDir, string? tokenizerJson, string? phonemizerDataDir,
+                                     string voiceLibDir, ExecutionProvider ep = ExecutionProvider.Auto)
+    {
+        _onnxDir = onnxDir;
+        _tokenizerJson = tokenizerJson;
+        _phonemizerDataDir = phonemizerDataDir;
+        _voiceLibDir = voiceLibDir;
+        _ep = ep;
+    }
+
+    public int SampleRate => OmniVoiceIpaTts.SampleRate;
+
+    public async Task<SynthesisResult> SynthesizeStreamingAsync(
+        TtsRequest request,
+        Action<ChunkProducedEvent>? onChunkProduced = null,
+        Action<ProgressEvent>? onProgress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var lang = string.IsNullOrWhiteSpace(request.Lang) ? "en" : request.Lang!;
+
+        onProgress?.Invoke(new ProgressEvent("loading models"));
+        await Task.Run(EnsureLoaded, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var preparedText = MarkdownTextExtractor.Extract(request.Text).Text;
+        if (string.IsNullOrWhiteSpace(preparedText))
+            throw new InvalidOperationException("Text is empty after markdown extraction.");
+
+        return await Task.Run(() =>
+        {
+            var tts = _tts!;
+            // The voice is per request, the loaded model is not: swapping voices is a JSON read.
+            if (tts.Voice?.Id != request.Voice)
+                tts.Voice = StoredVoice.Load(_voiceLibDir, request.Voice)
+                    ?? throw new InvalidOperationException($"voice \"{request.Voice}\" not found in {_voiceLibDir}");
+
+            var chunks = tts.ChunkForSynthesis(preparedText, lang);
+            int totalChunks = chunks.Count;
+            onProgress?.Invoke(new ProgressEvent($"chunked into {totalChunks} pieces", null, totalChunks));
+
+            var chunkAudios = new float[totalChunks][];
+            var sidecarChunks = new List<ChunkRecord>(totalChunks);
+            var allWords = new List<AlignedWord>();
+            int sampleOffsetCursor = 0;
+
+            for (int idx = 0; idx < totalChunks; idx++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                onProgress?.Invoke(new ProgressEvent($"synthesizing ({request.NumStep} steps)", idx + 1, totalChunks));
+
+                string chunkText = chunks[idx];
+                var sp = tts.SpeakAligned(chunkText, lang, request.NumStep);
+                var wav = sp.Audio;
+
+                chunkAudios[idx] = wav;
+                double chunkStartSec = sampleOffsetCursor / (double)SampleRate;
+                double chunkEndSec = (sampleOffsetCursor + wav.Length) / (double)SampleRate;
+                sampleOffsetCursor += wav.Length;
+
+                var absWords = new List<AlignedWord>(sp.Words.Count);
+                foreach (var w in sp.Words)
+                {
+                    absWords.Add(new AlignedWord
+                    {
+                        Text = w.Text,
+                        StartSeconds = chunkStartSec + w.StartSec,
+                        EndSeconds = chunkStartSec + w.EndSec,
+                        ChunkIndex = idx,
+                    });
+                }
+                allWords.AddRange(absWords);
+                sidecarChunks.Add(new ChunkRecord
+                {
+                    Index = idx,
+                    AudioStartSeconds = chunkStartSec,
+                    AudioEndSeconds = chunkEndSec,
+                    Text = chunkText,
+                    WordCount = absWords.Count,
+                });
+
+                onProgress?.Invoke(new ProgressEvent($"chunk {idx + 1}/{totalChunks} ready", idx + 1, totalChunks));
+                onChunkProduced?.Invoke(new ChunkProducedEvent(
+                    idx, totalChunks, wav, chunkText, chunkStartSec, absWords));
+            }
+
+            int totalSamples = chunkAudios.Sum(c => c.Length);
+            var allSamples = new float[totalSamples];
+            int off = 0;
+            for (int i = 0; i < totalChunks; i++)
+            {
+                Array.Copy(chunkAudios[i], 0, allSamples, off, chunkAudios[i].Length);
+                off += chunkAudios[i].Length;
+            }
+            var fmt = WaveFormat.CreateIeeeFloatWaveFormat(SampleRate, 1);
+            using (var writer = new WaveFileWriter(request.OutWavPath, fmt))
+                writer.WriteSamples(allSamples, 0, allSamples.Length);
+
+            var sidecar = new AlignmentSidecar
+            {
+                AudioPath = request.OutWavPath,
+                SampleRate = SampleRate,
+                AudioDurationSeconds = totalSamples / (double)SampleRate,
+                Aligner = "omnivoice_ipa_proportional",
+                Chunks = sidecarChunks,
+                Words = allWords,
+            };
+            return new SynthesisResult(request.OutWavPath, sidecar);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private void EnsureLoaded()
+    {
+        if (_tts is not null) return;
+        lock (_gate)
+        {
+            _tts ??= new OmniVoiceIpaTts(_onnxDir, _tokenizerJson, _phonemizerDataDir, _ep);
+        }
+    }
+
+    public void Dispose() => _tts?.Dispose();
+}

--- a/src/Vernacula.Tts.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Tts.Avalonia/Services/SettingsService.cs
@@ -71,13 +71,22 @@ public sealed class ReaderSettings
     public string OnnxBundleDir { get; set; } = "";
     public bool RenderMarkdown { get; set; } = false;
 
-    // TTS backend selection + Kokoro config. TtsBackend stores the
-    // TtsBackendKind enum name ("Chatterbox" / "Kokoro").
+    // TTS backend selection. TtsBackend stores the TtsBackendKind enum name
+    // ("Chatterbox" / "Kokoro" / "OmniVoice").
     public string TtsBackend { get; set; } = "Chatterbox";
-    public string KokoroModelDir { get; set; } = "";
+    // vernacula-phonemizer data/ root, shared by Kokoro and OmniVoice. (Was KokoroDataDir
+    // when Kokoro was the only phonemizer user; that field is still read as a fallback.)
+    public string PhonemizerDataDir { get; set; } = "";
     public string KokoroDataDir { get; set; } = "";
+    public string KokoroModelDir { get; set; } = "";
     public string KokoroVoice { get; set; } = "";
     public float KokoroSpeed { get; set; } = 1.0f;
+    public string OmniVoiceOnnxDir { get; set; } = "";
+    public string OmniVoiceTokenizerJson { get; set; } = "";
+    public string OmniVoiceVoiceLib { get; set; } = "";
+    public string OmniVoiceLang { get; set; } = "en";
+    public string OmniVoiceVoice { get; set; } = "";
+    public int OmniVoiceNumStep { get; set; } = 32;
     // (Older settings.json files may contain a NfaBundleDir field —
     // System.Text.Json silently ignores unknown JSON properties, so the
     // old field is dropped harmlessly on load. New saves omit it.)

--- a/src/Vernacula.Tts.Avalonia/Services/TtsStreaming.cs
+++ b/src/Vernacula.Tts.Avalonia/Services/TtsStreaming.cs
@@ -14,6 +14,10 @@ public enum TtsBackendKind
 
     /// <summary>Kokoro-82M, named voice + speed, duration-based word alignment.</summary>
     Kokoro,
+
+    /// <summary>OmniVoice IPA fine-tune via vernacula-phonemizer: any of its languages, a stored
+    /// voice from the web demo's library, proportional (estimated) word alignment.</summary>
+    OmniVoice,
 }
 
 /// <summary>Final synthesis output: the written WAV path + the alignment sidecar.</summary>
@@ -39,10 +43,12 @@ public sealed record ProgressEvent(string Phase, int? ChunkIndex = null, int? To
 
 /// <summary>
 /// A backend-agnostic synthesis request. <see cref="Voice"/> is interpreted by the
-/// backend: a voice-WAV path for Chatterbox, a named voice (e.g. "af_heart") for Kokoro.
-/// <see cref="Speed"/> applies to Kokoro; Chatterbox ignores it.
+/// backend: a voice-WAV path for Chatterbox, a named voice (e.g. "af_heart") for Kokoro, a
+/// library voice id for OmniVoice. <see cref="Speed"/> applies to Kokoro; <see cref="Lang"/>
+/// (a vernacula-phonemizer code) and <see cref="NumStep"/> (diffusion steps) to OmniVoice.
 /// </summary>
-public sealed record TtsRequest(string Text, string OutWavPath, string Voice, float Speed = 1.0f);
+public sealed record TtsRequest(string Text, string OutWavPath, string Voice, float Speed = 1.0f,
+                                string? Lang = null, int NumStep = 32);
 
 /// <summary>
 /// A streaming TTS backend. Implementations lazily load their models on the first call

--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -42,22 +43,28 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
     [NotifyPropertyChangedFor(nameof(IsChatterbox))]
     [NotifyPropertyChangedFor(nameof(IsKokoro))]
+    [NotifyPropertyChangedFor(nameof(IsOmniVoice))]
+    [NotifyPropertyChangedFor(nameof(NeedsPhonemizer))]
     private TtsBackendKind _selectedBackend;
 
     public bool IsChatterbox => SelectedBackend == TtsBackendKind.Chatterbox;
     public bool IsKokoro => SelectedBackend == TtsBackendKind.Kokoro;
+    public bool IsOmniVoice => SelectedBackend == TtsBackendKind.OmniVoice;
+    /// <summary>Kokoro and OmniVoice both phonemize through vernacula-phonemizer.</summary>
+    public bool NeedsPhonemizer => IsKokoro || IsOmniVoice;
     public IReadOnlyList<TtsBackendKind> Backends { get; } =
-        new[] { TtsBackendKind.Chatterbox, TtsBackendKind.Kokoro };
+        new[] { TtsBackendKind.Chatterbox, TtsBackendKind.Kokoro, TtsBackendKind.OmniVoice };
 
-    // Kokoro config: model dir (kokoro.onnx + voices/), phonemizer data dir,
-    // named voice, and speed. Voices are discovered from the model dir.
+    // vernacula-phonemizer data/ root — shared by the two phonemizing backends.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _phonemizerDataDir = "";
+
+    // Kokoro config: model dir (kokoro.onnx + voices/), named voice, and speed.
+    // Voices are discovered from the model dir.
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
     private string _kokoroModelDir = "";
-
-    [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
-    private string _kokoroDataDir = "";
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
@@ -66,6 +73,34 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [ObservableProperty] private float _kokoroSpeed = 1.0f;
 
     public ObservableCollection<string> KokoroVoices { get; } = new();
+
+    // OmniVoice-IPA config: the ONNX dir (base transformer + codec + versioned diff), an
+    // optional explicit tokenizer.json (auto-located otherwise), the stored-voice library,
+    // the phonemizer language, the voice, and the diffusion step count.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _omniVoiceOnnxDir = "";
+
+    [ObservableProperty] private string _omniVoiceTokenizerJson = "";
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _omniVoiceVoiceLib = "";
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _omniVoiceLang = "en";
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private StoredVoice.Info? _omniVoiceVoice;
+
+    [ObservableProperty] private int _omniVoiceNumStep = 32;
+
+    /// <summary>The library's voices for <see cref="OmniVoiceLang"/> — or all of them when the
+    /// language has none, since any voice can read any language's IPA.</summary>
+    public ObservableCollection<StoredVoice.Info> OmniVoiceVoices { get; } = new();
+    private IReadOnlyList<StoredVoice.Info> _allOmniVoiceVoices = Array.Empty<StoredVoice.Info>();
 
     // Text input — either typed/pasted in the UI or loaded from a .md file.
     [ObservableProperty]
@@ -202,13 +237,25 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             SelectedBackend = Enum.TryParse<TtsBackendKind>(_settings.Current.TtsBackend, out var b)
                 ? b : TtsBackendKind.Chatterbox;
             KokoroModelDir = _settings.Current.KokoroModelDir;
-            // A saved dir that is not a phonemizer data root is a path from before the Kokoro
-            // frontend moved to vernacula-phonemizer; re-resolve rather than fail at load time.
-            KokoroDataDir = PhonemizerData.IsDataRoot(_settings.Current.KokoroDataDir ?? "")
-                ? _settings.Current.KokoroDataDir : (PhonemizerData.Resolve(null) ?? "");
+            // The saved root, else the pre-rename Kokoro one, else the submodule. A saved dir
+            // that is not a data root is a path from before the frontend moved to
+            // vernacula-phonemizer; re-resolve rather than fail at load time.
+            PhonemizerDataDir = PhonemizerData.IsDataRoot(_settings.Current.PhonemizerDataDir)
+                ? _settings.Current.PhonemizerDataDir
+                : PhonemizerData.IsDataRoot(_settings.Current.KokoroDataDir)
+                ? _settings.Current.KokoroDataDir
+                : (PhonemizerData.Resolve(null) ?? "");
             KokoroVoice = _settings.Current.KokoroVoice;
             KokoroSpeed = _settings.Current.KokoroSpeed > 0 ? _settings.Current.KokoroSpeed : 1.0f;
             RefreshKokoroVoices();
+            OmniVoiceOnnxDir = string.IsNullOrWhiteSpace(_settings.Current.OmniVoiceOnnxDir)
+                ? (Environment.GetEnvironmentVariable("OMNIVOICE_ONNX_DIR") ?? "") : _settings.Current.OmniVoiceOnnxDir;
+            OmniVoiceTokenizerJson = _settings.Current.OmniVoiceTokenizerJson ?? "";
+            OmniVoiceVoiceLib = StoredVoice.IsLibrary(_settings.Current.OmniVoiceVoiceLib)
+                ? _settings.Current.OmniVoiceVoiceLib : (StoredVoice.ResolveDefaultLibrary() ?? "");
+            OmniVoiceLang = string.IsNullOrWhiteSpace(_settings.Current.OmniVoiceLang) ? "en" : _settings.Current.OmniVoiceLang;
+            OmniVoiceNumStep = _settings.Current.OmniVoiceNumStep is > 0 and <= 64 ? _settings.Current.OmniVoiceNumStep : 32;
+            RefreshOmniVoiceVoices(_settings.Current.OmniVoiceVoice);
         }
         finally { _loadingSettings = false; }
         UpdatePrerequisiteStatus();
@@ -232,8 +279,19 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         {
             TtsBackendKind.Kokoro =>
                 !DirExists(KokoroModelDir) ? $"Kokoro model dir not found: {Describe(KokoroModelDir)}"
-                : !PhonemizerData.IsDataRoot(KokoroDataDir) ? $"vernacula-phonemizer data dir not found: {Describe(KokoroDataDir)}"
+                : !PhonemizerData.IsDataRoot(PhonemizerDataDir) ? $"vernacula-phonemizer data dir not found: {Describe(PhonemizerDataDir)}"
                 : string.IsNullOrWhiteSpace(KokoroVoice) ? "No Kokoro voice selected."
+                : null,
+            TtsBackendKind.OmniVoice =>
+                !DirExists(OmniVoiceOnnxDir) ? $"OmniVoice ONNX dir not found: {Describe(OmniVoiceOnnxDir)}"
+                : !FileExists(Path.Combine(OmniVoiceOnnxDir, IpaFineTune.DefaultDiffFile))
+                    ? $"IPA fine-tune diff not found: {Path.Combine(OmniVoiceOnnxDir, IpaFineTune.DefaultDiffFile)}"
+                : OmniVoiceTokenizerPath() is null
+                    ? "Qwen3 tokenizer.json not found (put it beside the graphs, set OMNIVOICE_MODEL_DIR, or pick it)."
+                : !PhonemizerData.IsDataRoot(PhonemizerDataDir) ? $"vernacula-phonemizer data dir not found: {Describe(PhonemizerDataDir)}"
+                : !StoredVoice.IsLibrary(OmniVoiceVoiceLib) ? $"Voice library not found: {Describe(OmniVoiceVoiceLib)}"
+                : OmniVoiceVoice is null ? "No OmniVoice voice selected."
+                : string.IsNullOrWhiteSpace(OmniVoiceLang) ? "No phonemizer language set."
                 : null,
             _ =>
                 !DirExists(OnnxBundleDir) ? $"ONNX bundle dir not found: {Describe(OnnxBundleDir)}"
@@ -263,10 +321,16 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         _settings.Current.OnnxBundleDir = OnnxBundleDir;
         _settings.Current.RenderMarkdown = RenderMarkdown;
         _settings.Current.TtsBackend = SelectedBackend.ToString();
+        _settings.Current.PhonemizerDataDir = PhonemizerDataDir;
         _settings.Current.KokoroModelDir = KokoroModelDir;
-        _settings.Current.KokoroDataDir = KokoroDataDir;
         _settings.Current.KokoroVoice = KokoroVoice;
         _settings.Current.KokoroSpeed = KokoroSpeed;
+        _settings.Current.OmniVoiceOnnxDir = OmniVoiceOnnxDir;
+        _settings.Current.OmniVoiceTokenizerJson = OmniVoiceTokenizerJson;
+        _settings.Current.OmniVoiceVoiceLib = OmniVoiceVoiceLib;
+        _settings.Current.OmniVoiceLang = OmniVoiceLang;
+        _settings.Current.OmniVoiceVoice = OmniVoiceVoice?.Id ?? "";
+        _settings.Current.OmniVoiceNumStep = OmniVoiceNumStep;
         _settings.Save();
     }
 
@@ -303,11 +367,75 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         PersistSettings();
         UpdatePrerequisiteStatus();
     }
-    partial void OnKokoroDataDirChanged(string value)
+    partial void OnPhonemizerDataDirChanged(string value)
     {
         InvalidateSynthService();
         PersistSettings();
         UpdatePrerequisiteStatus();
+    }
+    partial void OnOmniVoiceOnnxDirChanged(string value)
+    {
+        InvalidateSynthService();
+        PersistSettings();
+        UpdatePrerequisiteStatus();
+    }
+    partial void OnOmniVoiceTokenizerJsonChanged(string value)
+    {
+        InvalidateSynthService();
+        PersistSettings();
+        UpdatePrerequisiteStatus();
+    }
+    partial void OnOmniVoiceVoiceLibChanged(string value)
+    {
+        InvalidateSynthService();
+        RefreshOmniVoiceVoices(OmniVoiceVoice?.Id);
+        PersistSettings();
+        UpdatePrerequisiteStatus();
+    }
+    partial void OnOmniVoiceLangChanged(string value)
+    {
+        RefreshOmniVoiceVoices(OmniVoiceVoice?.Id);
+        PersistSettings();
+        UpdatePrerequisiteStatus();
+    }
+    partial void OnOmniVoiceVoiceChanged(StoredVoice.Info? value)
+    {
+        PersistSettings();
+        UpdatePrerequisiteStatus();
+    }
+    partial void OnOmniVoiceNumStepChanged(int value) => PersistSettings();
+
+    /// <summary>The tokenizer the OmniVoice backend will use: the picked file if set, else
+    /// what <see cref="OmniVoiceIpaTts.LocateTokenizerJson"/> finds. Null when neither exists.</summary>
+    private string? OmniVoiceTokenizerPath() =>
+        FileExists(OmniVoiceTokenizerJson) ? OmniVoiceTokenizerJson
+        : DirExists(OmniVoiceOnnxDir) ? OmniVoiceIpaTts.LocateTokenizerJson(OmniVoiceOnnxDir) : null;
+
+    // Voices for the current language from the library, keeping the selection when it is still
+    // listed; otherwise the language's `default` entry, else the first. A language with no voice
+    // of its own shows the whole library: the model reads IPA, so any voice can read any language.
+    private void RefreshOmniVoiceVoices(string? keepId)
+    {
+        _allOmniVoiceVoices = StoredVoice.IsLibrary(OmniVoiceVoiceLib)
+            ? SafeListVoices(OmniVoiceVoiceLib) : Array.Empty<StoredVoice.Info>();
+        var lang = (OmniVoiceLang ?? "").Trim();
+        var forLang = _allOmniVoiceVoices.Where(v => string.Equals(v.Lang, lang, StringComparison.OrdinalIgnoreCase)).ToList();
+        var shown = forLang.Count > 0 ? forLang : _allOmniVoiceVoices.ToList();
+        OmniVoiceVoices.Clear();
+        foreach (var v in shown) OmniVoiceVoices.Add(v);
+        OmniVoiceVoice = shown.FirstOrDefault(v => v.Id == keepId)
+            ?? shown.FirstOrDefault(v => v.IsDefault)
+            ?? shown.FirstOrDefault();
+
+        static IReadOnlyList<StoredVoice.Info> SafeListVoices(string dir)
+        {
+            try { return StoredVoice.ListVoices(dir); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[OmniVoice] voice library unreadable: {ex.Message}");
+                return Array.Empty<StoredVoice.Info>();
+            }
+        }
     }
     partial void OnKokoroVoiceChanged(string value)
     {
@@ -362,10 +490,32 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     }
 
     [RelayCommand]
-    private async Task PickKokoroDataDirAsync()
+    private async Task PickPhonemizerDataDirAsync()
     {
         var path = await PickFolderAsync("Pick the vernacula-phonemizer data/ directory");
-        if (path is not null) KokoroDataDir = path;
+        if (path is not null) PhonemizerDataDir = path;
+    }
+
+    [RelayCommand]
+    private async Task PickOmniVoiceOnnxDirAsync()
+    {
+        var path = await PickFolderAsync("Pick the OmniVoice ONNX directory (transformer + Higgs codec + ipa_diff)");
+        if (path is not null) OmniVoiceOnnxDir = path;
+    }
+
+    [RelayCommand]
+    private async Task PickOmniVoiceTokenizerAsync()
+    {
+        var path = await PickFileAsync("Pick the Qwen3 tokenizer.json",
+            new FilePickerFileType("tokenizer.json") { Patterns = new[] { "tokenizer.json", "*.json" } });
+        if (path is not null) OmniVoiceTokenizerJson = path;
+    }
+
+    [RelayCommand]
+    private async Task PickOmniVoiceVoiceLibAsync()
+    {
+        var path = await PickFolderAsync("Pick the voice library (voices.jsonc + voice-codes.json)");
+        if (path is not null) OmniVoiceVoiceLib = path;
     }
 
     [RelayCommand]
@@ -412,19 +562,25 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         {
             _synthService ??= SelectedBackend switch
             {
-                TtsBackendKind.Kokoro => new KokoroSynthesisService(KokoroModelDir, KokoroDataDir),
+                TtsBackendKind.Kokoro => new KokoroSynthesisService(KokoroModelDir, PhonemizerDataDir),
+                TtsBackendKind.OmniVoice => new OmniVoiceSynthesisService(OmniVoiceOnnxDir,
+                    FileExists(OmniVoiceTokenizerJson) ? OmniVoiceTokenizerJson : null, PhonemizerDataDir, OmniVoiceVoiceLib),
                 _ => new SynthesisService(OnnxBundleDir),
             };
 
             // ms precision avoids collisions when the user re-Synthesizes
             // (or clicks Play, below) twice in the same second.
             string outWav = Path.Combine(Path.GetTempPath(),
-                $"chatterbox_app_{DateTime.UtcNow:yyyyMMddHHmmss_fff}.wav");
+                $"vernacula_tts_{DateTime.UtcNow:yyyyMMddHHmmss_fff}.wav");
             bool streamingStarted = false;
 
-            var request = SelectedBackend == TtsBackendKind.Kokoro
-                ? new TtsRequest(Text, outWav, KokoroVoice, KokoroSpeed)
-                : new TtsRequest(Text, outWav, VoicePath);
+            var request = SelectedBackend switch
+            {
+                TtsBackendKind.Kokoro => new TtsRequest(Text, outWav, KokoroVoice, KokoroSpeed),
+                TtsBackendKind.OmniVoice => new TtsRequest(Text, outWav, OmniVoiceVoice!.Id,
+                    Lang: OmniVoiceLang.Trim(), NumStep: OmniVoiceNumStep),
+                _ => new TtsRequest(Text, outWav, VoicePath),
+            };
 
             var result = await _synthService.SynthesizeStreamingAsync(
                 request,
@@ -548,8 +704,16 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         {
             TtsBackendKind.Kokoro =>
                 DirExists(KokoroModelDir)
-                && DirExists(KokoroDataDir)
+                && DirExists(PhonemizerDataDir)
                 && !string.IsNullOrWhiteSpace(KokoroVoice),
+            TtsBackendKind.OmniVoice =>
+                DirExists(OmniVoiceOnnxDir)
+                && FileExists(Path.Combine(OmniVoiceOnnxDir, IpaFineTune.DefaultDiffFile))
+                && OmniVoiceTokenizerPath() is not null
+                && DirExists(PhonemizerDataDir)
+                && StoredVoice.IsLibrary(OmniVoiceVoiceLib)
+                && OmniVoiceVoice is not null
+                && !string.IsNullOrWhiteSpace(OmniVoiceLang),
             _ =>
                 FileExists(VoicePath)
                 && DirExists(OnnxBundleDir),

--- a/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
+++ b/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
@@ -132,6 +132,19 @@
                 </Grid>
             </StackPanel>
 
+            <!-- ── Phonemizer (Kokoro + OmniVoice) ─────────────────── -->
+            <StackPanel Spacing="10" IsVisible="{Binding NeedsPhonemizer}">
+                <TextBlock Text="Phonemizer data dir (vernacula-phonemizer/data)"
+                           FontWeight="SemiBold" Margin="0,8,0,0" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox Text="{Binding PhonemizerDataDir}" IsReadOnly="True"
+                             Watermark="No data dir picked" />
+                    <Button Grid.Column="1" Content="Pick…"
+                            Command="{Binding PickPhonemizerDataDirCommand}"
+                            IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
+                </Grid>
+            </StackPanel>
+
             <!-- ── Kokoro config ─────────────────────────────────── -->
             <StackPanel Spacing="10" IsVisible="{Binding IsKokoro}">
                 <TextBlock Text="Kokoro model dir (kokoro.onnx + voices/)"
@@ -141,16 +154,6 @@
                              Watermark="No model dir picked" />
                     <Button Grid.Column="1" Content="Pick…"
                             Command="{Binding PickKokoroModelDirCommand}"
-                            IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
-                </Grid>
-
-                <TextBlock Text="Phonemizer data dir (vernacula-phonemizer/data)"
-                           FontWeight="SemiBold" Margin="0,8,0,0" />
-                <Grid ColumnDefinitions="*,Auto">
-                    <TextBox Text="{Binding KokoroDataDir}" IsReadOnly="True"
-                             Watermark="No data dir picked" />
-                    <Button Grid.Column="1" Content="Pick…"
-                            Command="{Binding PickKokoroDataDirCommand}"
                             IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
                 </Grid>
 
@@ -164,6 +167,55 @@
                            FontWeight="SemiBold" Margin="0,8,0,0" />
                 <Slider Minimum="0.5" Maximum="2.0" Value="{Binding KokoroSpeed}"
                         IsEnabled="{Binding !IsBusy}" TickFrequency="0.1" />
+            </StackPanel>
+
+            <!-- ── OmniVoice-IPA config ──────────────────────────── -->
+            <StackPanel Spacing="10" IsVisible="{Binding IsOmniVoice}">
+                <TextBlock Text="OmniVoice ONNX dir (transformer + Higgs codec + ipa_diff)"
+                           FontWeight="SemiBold" Margin="0,8,0,0" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox Text="{Binding OmniVoiceOnnxDir}" IsReadOnly="True"
+                             Watermark="No ONNX dir picked" />
+                    <Button Grid.Column="1" Content="Pick…"
+                            Command="{Binding PickOmniVoiceOnnxDirCommand}"
+                            IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
+                </Grid>
+
+                <TextBlock Text="Qwen3 tokenizer.json (optional — auto-located)"
+                           FontWeight="SemiBold" Margin="0,8,0,0" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox Text="{Binding OmniVoiceTokenizerJson}" IsReadOnly="True"
+                             Watermark="Beside the graphs / OMNIVOICE_MODEL_DIR / HF cache" />
+                    <Button Grid.Column="1" Content="Pick…"
+                            Command="{Binding PickOmniVoiceTokenizerCommand}"
+                            IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
+                </Grid>
+
+                <TextBlock Text="Voice library (voices.jsonc + voice-codes.json)"
+                           FontWeight="SemiBold" Margin="0,8,0,0" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox Text="{Binding OmniVoiceVoiceLib}" IsReadOnly="True"
+                             Watermark="No library picked" />
+                    <Button Grid.Column="1" Content="Pick…"
+                            Command="{Binding PickOmniVoiceVoiceLibCommand}"
+                            IsEnabled="{Binding !IsBusy}" Margin="6,0,0,0" />
+                </Grid>
+
+                <TextBlock Text="Language (vernacula-phonemizer code: en, en-GB, cy, cmn, …)"
+                           FontWeight="SemiBold" Margin="0,8,0,0" />
+                <TextBox Text="{Binding OmniVoiceLang}" Watermark="en"
+                         IsEnabled="{Binding !IsBusy}" />
+
+                <TextBlock Text="Voice" FontWeight="SemiBold" Margin="0,8,0,0" />
+                <ComboBox ItemsSource="{Binding OmniVoiceVoices}"
+                          SelectedItem="{Binding OmniVoiceVoice}"
+                          IsEnabled="{Binding !IsBusy}"
+                          HorizontalAlignment="Stretch" />
+
+                <TextBlock Text="{Binding OmniVoiceNumStep, StringFormat='Diffusion steps: {0}'}"
+                           FontWeight="SemiBold" Margin="0,8,0,0" />
+                <Slider Minimum="8" Maximum="48" Value="{Binding OmniVoiceNumStep}"
+                        IsEnabled="{Binding !IsBusy}" TickFrequency="4" IsSnapToTickEnabled="True" />
             </StackPanel>
 
             <TextBlock Text="Text source" FontWeight="SemiBold" Margin="0,12,0,0" />

--- a/src/Vernacula.Tts.Base/IpaFineTune.cs
+++ b/src/Vernacula.Tts.Base/IpaFineTune.cs
@@ -1,13 +1,14 @@
-namespace Vernacula.Tts.CLI;
+namespace Vernacula.Tts.Base;
 
 /// <summary>
-/// Facts about the shipped OmniVoice IPA fine-tune that the CLI needs at runtime.
+/// Facts about the shipped OmniVoice IPA fine-tune that its consumers (Vernacula.Tts.CLI, the
+/// reader) need at runtime.
 ///
 /// These describe a FROZEN artifact (the v6 LoRA checkpoint), not a live configuration, which is
 /// why they are literals here rather than read from the training tree — the training tree lives on
 /// the machine that produced the checkpoint and is not part of a user install.
 /// </summary>
-internal static class IpaFineTune
+public static class IpaFineTune
 {
     /// <summary>Default diff filename inside --onnx-dir. Bump alongside the checkpoint; the
     /// version is in the name precisely so a stale diff cannot masquerade as current

--- a/src/Vernacula.Tts.Base/OmniVoiceAudioPost.cs
+++ b/src/Vernacula.Tts.Base/OmniVoiceAudioPost.cs
@@ -144,4 +144,26 @@ public static class OmniVoiceAudioPost
         Array.Copy(proc, 0, outArr, pad, proc.Length);
         return outArr;
     }
+
+    /// <summary>
+    /// The finishing chain in the order Python's <c>_post_process_audio</c> applies it: remove
+    /// silence → volume → fade-in/out + zero-pad. Volume: with a reference (<paramref name="refRms"/>
+    /// is its RMS before any boost), un-boost a reference that <see cref="OmniVoiceTts.EncodeReference"/>
+    /// boosted for being quiet; without one, peak-normalise to 0.5.
+    /// </summary>
+    public static float[] Finish(float[] audio, int sr, float? refRms)
+    {
+        audio = RemoveSilence(audio, sr, midSilMs: 500, leadSilMs: 100, trailSilMs: 100);
+        if (refRms is float rr)
+        {
+            if (rr < 0.1f) { float g = rr / 0.1f; for (int i = 0; i < audio.Length; i++) audio[i] *= g; }
+        }
+        else
+        {
+            float max = 0;
+            foreach (var v in audio) max = Math.Max(max, Math.Abs(v));
+            if (max >= 1e-6f) { float g = 0.5f / max; for (int i = 0; i < audio.Length; i++) audio[i] *= g; }
+        }
+        return FadeAndPad(audio, sr);
+    }
 }

--- a/src/Vernacula.Tts.Base/OmniVoiceIpaTts.cs
+++ b/src/Vernacula.Tts.Base/OmniVoiceIpaTts.cs
@@ -1,0 +1,204 @@
+using Vernacula.Base.Models;
+using Vernacula.Phonemizer;
+using Vernacula.Tts.Base.Markdown;
+
+namespace Vernacula.Tts.Base;
+
+/// <summary>One spoken word: its source text and [start, end) seconds in the audio.</summary>
+public sealed record OmniVoiceIpaWord(string Text, double StartSec, double EndSec);
+
+/// <summary>Result of <see cref="OmniVoiceIpaTts.SpeakAligned"/>: audio plus per-word timings.</summary>
+public sealed record OmniVoiceIpaSpeech(float[] Audio, IReadOnlyList<OmniVoiceIpaWord> Words);
+
+/// <summary>
+/// End-to-end IPA-native text-to-speech: text → canonical IPA (vernacula-phonemizer, any of its
+/// languages) → the OmniVoice IPA fine-tune → audio. The engine behind <c>vernacula-tts</c>, as a
+/// class the reader can drive chunk by chunk: the CLI's setup (tokenizer, the versioned diff, the
+/// phonemizer data tree), its conditioning (a stored voice's codes and IPA transcript, the IPA-side
+/// duration estimate) and its finishing chain, with a chunker and a word map on top.
+///
+/// ⚠ WORD TIMINGS HERE ARE ESTIMATED, NOT MEASURED. Chatterbox reads them off its cross-attention
+/// and Kokoro off its predicted durations; this model exposes neither, so each chunk's audio is
+/// divided among its words in proportion to their IPA script-weight (the same weight the duration
+/// estimator uses). Good enough to keep a highlight moving with the speech; not good enough to
+/// seek to a word. A forced aligner (Vernacula.Base.Alignment) would be the measured answer.
+///
+/// Not thread-safe (wraps ORT sessions). One instance per caller.
+/// </summary>
+public sealed class OmniVoiceIpaTts : IDisposable
+{
+    public const int SampleRate = OmniVoiceTts.SampleRate;
+
+    /// <summary>Audio tokens per chunk above which a paragraph is split on sentences. 25 tokens
+    /// ≈ 1 s; 750 ≈ 30 s. The CLI warns at 1500 that output degrades in one shot; half that keeps
+    /// each chunk well inside what the fine-tune saw (FLEURS read sentences, median 12 s).</summary>
+    public const int MaxChunkTokens = 750;
+
+    private readonly OmniVoiceTts _tts;
+
+    /// <summary>The reference voice. Null renders in auto mode — which the fine-tune handles badly
+    /// under ~5 s of text (noise rather than speech, deterministically), so the reader always
+    /// sets one.</summary>
+    public StoredVoice? Voice { get; set; }
+
+    /// <param name="onnxDir">Holds the base transformer, the Higgs codec graphs and (by default)
+    /// the versioned IPA diff.</param>
+    /// <param name="tokenizerJson">Qwen3 tokenizer.json; null resolves it via
+    /// <see cref="LocateTokenizerJson"/>.</param>
+    /// <param name="phonemizerDataDir">vernacula-phonemizer data/ root; null resolves it via
+    /// <see cref="PhonemizerData.Resolve"/>.</param>
+    /// <param name="diffPath">The IPA fine-tune diff; null means <see cref="IpaFineTune.DefaultDiffFile"/>
+    /// beside the graphs. There is no orthographic fallback here: without the diff the model reads
+    /// IPA as spelling and produces confident nonsense, so a missing diff throws.</param>
+    public OmniVoiceIpaTts(string onnxDir, string? tokenizerJson, string? phonemizerDataDir,
+                           ExecutionProvider ep, SessionLoadObserver? onLoad = null, string? diffPath = null)
+    {
+        if (PhonemizerData.Resolve(phonemizerDataDir) is null)
+            throw new DirectoryNotFoundException(PhonemizerData.NotFoundMessage());
+        Registry.EnsureLanguages();
+
+        tokenizerJson ??= LocateTokenizerJson(onnxDir)
+            ?? throw new FileNotFoundException("Qwen3 tokenizer.json not found: looked beside the graphs in "
+                + $"{onnxDir}, in OMNIVOICE_MODEL_DIR, and in the k2-fsa/OmniVoice HuggingFace cache.");
+        diffPath ??= Path.Combine(onnxDir, IpaFineTune.DefaultDiffFile);
+        if (!File.Exists(diffPath))
+            throw new FileNotFoundException($"IPA fine-tune diff not found: {diffPath}");
+
+        _tts = new OmniVoiceTts(onnxDir, tokenizerJson, ep, onLoad, transformerFile: null, diffPath);
+    }
+
+    /// <summary>tokenizer.json beside the graphs, else in OMNIVOICE_MODEL_DIR, else in the
+    /// k2-fsa/OmniVoice snapshot of the HuggingFace hub cache. Null when none exists.</summary>
+    public static string? LocateTokenizerJson(string onnxDir)
+    {
+        var beside = Path.Combine(onnxDir, "tokenizer.json");
+        if (File.Exists(beside)) return beside;
+        var modelDir = Environment.GetEnvironmentVariable("OMNIVOICE_MODEL_DIR");
+        if (!string.IsNullOrEmpty(modelDir) && File.Exists(Path.Combine(modelDir, "tokenizer.json")))
+            return Path.Combine(modelDir, "tokenizer.json");
+        var snapshots = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".cache", "huggingface", "hub", "models--k2-fsa--OmniVoice", "snapshots");
+        if (Directory.Exists(snapshots))
+            foreach (var snap in Directory.EnumerateDirectories(snapshots))
+                if (File.Exists(Path.Combine(snap, "tokenizer.json"))) return Path.Combine(snap, "tokenizer.json");
+        return null;
+    }
+
+    /// <summary>Text → canonical IPA in <paramref name="lang"/> (a vernacula-phonemizer code).
+    /// The best-output entry: languages with a neural model use it. Blocking, like
+    /// <see cref="KokoroPhonemizer"/> and for the same reason — every caller is off the UI thread.</summary>
+    public static string Phonemize(string text, string lang)
+        => global::Vernacula.Phonemizer.Phonemizer.PhonemizeAsync(text, lang).GetAwaiter().GetResult().Trim();
+
+    private string? CondRefIpa => Voice is null ? null : OmniVoiceTextPrep.AddPunctuation(Voice.RefIpa);
+    private int? RefTokens => Voice?.Codes.GetLength(1);
+
+    /// <summary>Estimated audio tokens for <paramref name="text"/> under the current voice.</summary>
+    public int EstimateTokens(string text, string lang)
+        => OmniVoiceDuration.EstimateTargetTokens(Phonemize(text, lang), CondRefIpa, RefTokens);
+
+    /// <summary>
+    /// Split <paramref name="text"/> into synthesis chunks: paragraph/char chunking first
+    /// (<see cref="ParagraphChunker"/>), then any chunk estimated over <see cref="MaxChunkTokens"/>
+    /// is packed from its sentences. All splits are at whitespace, so the concatenated word
+    /// sequence is unchanged and word timings stay 1:1 with the source text.
+    /// </summary>
+    public IReadOnlyList<string> ChunkForSynthesis(string text, string lang)
+    {
+        var pieces = new List<string>();
+        foreach (var chunk in ParagraphChunker.Chunk(text))
+        {
+            if (EstimateTokens(chunk, lang) <= MaxChunkTokens) { pieces.Add(chunk); continue; }
+            var buf = new List<string>();
+            var bufTokens = 0;
+            foreach (var raw in SentenceSplitRe.Split(chunk))
+            {
+                var s = raw.Trim();
+                if (s.Length == 0) continue;
+                var st = EstimateTokens(s, lang);
+                if (buf.Count > 0 && bufTokens + st > MaxChunkTokens)
+                {
+                    pieces.Add(string.Join(' ', buf)); buf.Clear(); bufTokens = 0;
+                }
+                buf.Add(s); bufTokens += st;
+            }
+            if (buf.Count > 0) pieces.Add(string.Join(' ', buf));
+        }
+        return pieces;
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex SentenceSplitRe =
+        new(@"(?<=[.!?…])\s+", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>Synthesize one chunk in the current voice and return audio plus estimated
+    /// per-word timings (see the class remarks).</summary>
+    public OmniVoiceIpaSpeech SpeakAligned(string text, string lang, int numStep = 32)
+    {
+        var trace = global::Vernacula.Phonemizer.Phonemizer.PhonemizeTrace(text, lang);
+        var ipa = Phonemize(text, lang);
+        if (string.IsNullOrWhiteSpace(ipa)) return new OmniVoiceIpaSpeech([], []);
+
+        // Duration is estimated on the IPA, not the orthography — both sides of the ratio must be
+        // the same representation, and IPA-on-both is the pacing the fine-tune was accepted with.
+        int target = OmniVoiceDuration.EstimateTargetTokens(ipa, CondRefIpa, RefTokens);
+        // lang: null is the IPA fine-tune's conditioning — the language never reaches the model.
+        var tokens = _tts.GenerateTokens(ipa, target, CondRefIpa, Voice?.Codes, lang: null, instruct: null,
+            new OmniVoiceTts.GenConfig(NumStep: numStep));
+        var audio = OmniVoiceAudioPost.Finish(_tts.DecodeTokens(tokens), SampleRate, Voice?.RefRms);
+
+        return new OmniVoiceIpaSpeech(audio, OmniVoiceIpaAlignment.Proportional(text, trace, audio.Length / (double)SampleRate));
+    }
+
+    public void Dispose() => _tts.Dispose();
+}
+
+/// <summary>
+/// The estimated word map: each whitespace-delimited source word gets a share of the chunk's
+/// duration proportional to the IPA script-weight of what it became. Separate from the engine so
+/// it can be tested without a model.
+/// </summary>
+public static class OmniVoiceIpaAlignment
+{
+    public static IReadOnlyList<OmniVoiceIpaWord> Proportional(string text, PhonemeTrace trace, double totalSec)
+    {
+        var sourceWords = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var weights = new double[sourceWords.Length];
+
+        // Character offset → index of the whitespace-delimited word containing it.
+        var wordAt = new int[text.Length];
+        var w = -1; var inWord = false;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (char.IsWhiteSpace(text[i])) { inWord = false; wordAt[i] = w + 1; continue; }
+            if (!inWord) { w++; inWord = true; }
+            wordAt[i] = w;
+        }
+
+        var mapped = trace.Traced;
+        if (mapped)
+        {
+            foreach (var tok in trace.Tokens)
+            {
+                if (tok.InputSpan is not { } input || tok.IpaSpan is not { } span
+                    || input.Start < 0 || input.Start >= text.Length) { mapped = false; break; }
+                var word = wordAt[input.Start];
+                if (word >= sourceWords.Length) { mapped = false; break; }
+                weights[word] += OmniVoiceDuration.TotalWeight(trace.Ipa[span.Start..span.End]);
+            }
+        }
+        if (!mapped)
+            for (var i = 0; i < weights.Length; i++) weights[i] = sourceWords[i].Length;
+
+        double sum = 0;
+        foreach (var x in weights) sum += x;
+        var words = new List<OmniVoiceIpaWord>(sourceWords.Length);
+        double cursor = 0;
+        for (var i = 0; i < sourceWords.Length; i++)
+        {
+            var dur = sum > 0 ? totalSec * weights[i] / sum : totalSec / Math.Max(1, sourceWords.Length);
+            words.Add(new OmniVoiceIpaWord(sourceWords[i], cursor, cursor + dur));
+            cursor += dur;
+        }
+        return words;
+    }
+}

--- a/src/Vernacula.Tts.Base/StoredVoice.cs
+++ b/src/Vernacula.Tts.Base/StoredVoice.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 
-namespace Vernacula.Tts.CLI;
+namespace Vernacula.Tts.Base;
 
 /// <summary>
 /// A reference voice that is already encoded — Higgs codec codes plus the IPA transcript they were
@@ -28,6 +28,52 @@ public sealed class StoredVoice
 
     private const int NumCodebooks = 8;
 
+    /// <summary>One library entry, without its codes — what a voice picker needs.</summary>
+    public sealed record Info(string Id, string Lang, string Label, bool IsDefault)
+    {
+        public override string ToString() => $"{Id} — {Label}";
+    }
+
+    private static readonly JsonDocumentOptions Jsonc =
+        new() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
+
+    /// <summary>True if <paramref name="dir"/> holds a voice library (both files present).</summary>
+    public static bool IsLibrary(string? dir) =>
+        !string.IsNullOrWhiteSpace(dir)
+        && File.Exists(Path.Combine(dir, "voices.jsonc")) && File.Exists(Path.Combine(dir, "voice-codes.json"));
+
+    /// <summary>
+    /// The web demo's library, found by walking up from the executable — the default for every
+    /// consumer, so the CLI, the reader and the browser render the SAME voice. Null when this is
+    /// not running inside the repo.
+    /// </summary>
+    public static string? ResolveDefaultLibrary()
+    {
+        for (var d = new DirectoryInfo(AppContext.BaseDirectory); d is not null; d = d.Parent)
+        {
+            var candidate = Path.Combine(d.FullName, "web-demo", "public", "models");
+            if (IsLibrary(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    /// <summary>Every voice in the library at <paramref name="dir"/>, in file order.</summary>
+    public static IReadOnlyList<Info> ListVoices(string dir)
+    {
+        string voicesPath = Path.Combine(dir, "voices.jsonc");
+        if (!File.Exists(voicesPath))
+            throw new FileNotFoundException($"voice library not found: {voicesPath}");
+        using var doc = JsonDocument.Parse(File.ReadAllText(voicesPath), Jsonc);
+        var list = new List<Info>();
+        foreach (var e in doc.RootElement.EnumerateArray())
+            list.Add(new Info(
+                e.GetProperty("id").GetString() ?? "",
+                e.GetProperty("lang").GetString() ?? "",
+                e.TryGetProperty("label", out var lb) ? lb.GetString() ?? "" : "",
+                e.TryGetProperty("default", out var df) && df.ValueKind == JsonValueKind.True));
+        return list;
+    }
+
     /// <summary>
     /// Load one voice by id. Returns null when <paramref name="voiceId"/> is "list", having printed
     /// the library — a lookup failure on 288 entries is otherwise a guessing game.
@@ -43,8 +89,7 @@ public sealed class StoredVoice
 
         // ⚠ voices.jsonc is JSONC — the comments in it carry the provenance of each voice and are
         // meant to stay. Skip them at parse time rather than asking the file to become JSON.
-        var opts = new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
-        using var voicesDoc = JsonDocument.Parse(File.ReadAllText(voicesPath), opts);
+        using var voicesDoc = JsonDocument.Parse(File.ReadAllText(voicesPath), Jsonc);
 
         if (voiceId == "list")
         {

--- a/src/Vernacula.Tts.CLI/Program.cs
+++ b/src/Vernacula.Tts.CLI/Program.cs
@@ -111,8 +111,7 @@ internal static class Program
         // ── Validate ──────────────────────────────────────────────────────────────────────────
         if (voiceId == "list")
         {
-            try { StoredVoice.Load(voiceLib ?? Path.Combine(AppContext.BaseDirectory,
-                      "..", "..", "..", "..", "..", "web-demo", "public", "models"), "list"); }
+            try { StoredVoice.Load(voiceLib ?? StoredVoice.ResolveDefaultLibrary() ?? "web-demo/public/models", "list"); }
             catch (Exception ex) { Console.Error.WriteLine(ex.Message); return 1; }
             return 0;
         }
@@ -322,8 +321,7 @@ internal static class Program
         {
             // Default to the web demo's library so the CLI and the browser render the SAME voice —
             // the point of the flag is to hear what a visitor hears, without a browser.
-            string libDir = voiceLib ?? Path.Combine(AppContext.BaseDirectory,
-                "..", "..", "..", "..", "..", "web-demo", "public", "models");
+            string libDir = voiceLib ?? StoredVoice.ResolveDefaultLibrary() ?? "web-demo/public/models";
             try { stored = StoredVoice.Load(libDir, voiceId); }
             catch (Exception ex) { Console.Error.WriteLine(ex.Message); return 1; }
             if (stored is null) return 0;                       // `--voice-id list` printed the library
@@ -450,11 +448,7 @@ internal static class Program
         }
         else if (post == "python")
         {
-            audio = OmniVoiceAudioPost.RemoveSilence(audio, OmniVoiceTts.SampleRate,
-                midSilMs: 500, leadSilMs: 100, trailSilMs: 100);
-            if (refRms is float rr) { if (rr < 0.1f) Scale(audio, rr / 0.1f); }
-            else Normalize(audio, 0.5f);
-            audio = OmniVoiceAudioPost.FadeAndPad(audio, OmniVoiceTts.SampleRate);
+            audio = OmniVoiceAudioPost.Finish(audio, OmniVoiceTts.SampleRate, refRms);
         }
         else { Console.Error.WriteLine($"--post must be \"python\" or \"demo\", not \"{post}\"."); return 2; }
 
@@ -483,11 +477,6 @@ internal static class Program
         foreach (var v in x) max = Math.Max(max, Math.Abs(v));
         if (max < 1e-6f) return;
         float g = peak / max;
-        for (int i = 0; i < x.Length; i++) x[i] *= g;
-    }
-
-    private static void Scale(float[] x, float g)
-    {
         for (int i = 0; i < x.Length; i++) x[i] *= g;
     }
 

--- a/tests/Vernacula.Tts.Tests/OmniVoiceIpaAlignmentTests.cs
+++ b/tests/Vernacula.Tts.Tests/OmniVoiceIpaAlignmentTests.cs
@@ -1,0 +1,66 @@
+using Vernacula.Tts.Base;
+using Xunit;
+
+namespace Vernacula.Tts.Tests;
+
+/// <summary>
+/// The reader's estimated word map for OmniVoice: one entry per whitespace-delimited source word,
+/// contiguous, covering the chunk, weighted by the IPA each word became (from the phonemizer's
+/// trace spans). Needs the vernacula-phonemizer submodule's data/ tree; skips without it.
+/// </summary>
+public class OmniVoiceIpaAlignmentTests
+{
+    private static bool HavePhonemizer()
+    {
+        if (PhonemizerData.Resolve(null) is null) return false;
+        Vernacula.Phonemizer.Registry.EnsureLanguages();
+        return true;
+    }
+
+    [Fact]
+    public void OneWordPerSourceWord_ContiguousAndCoveringTheChunk()
+    {
+        if (!HavePhonemizer()) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+
+        const string text = "The quick brown fox jumps over the lazy dog, doesn't it?";
+        var trace = Vernacula.Phonemizer.Phonemizer.PhonemizeTrace(text, "en");
+        var words = OmniVoiceIpaAlignment.Proportional(text, trace, totalSec: 4.0);
+
+        Assert.Equal(11, words.Count);
+        Assert.Equal(0.0, words[0].StartSec, 9);
+        Assert.Equal(4.0, words[^1].EndSec, 6);
+        for (var i = 1; i < words.Count; i++)
+            Assert.Equal(words[i - 1].EndSec, words[i].StartSec, 9);
+        // "jumps" (d͡ʒˈʌmps) should get more time than "the" (ðə); weights are IPA, not spelling.
+        double Dur(string w) => words.First(x => x.Text == w).EndSec - words.First(x => x.Text == w).StartSec;
+        Assert.True(Dur("jumps") > Dur("the"), $"jumps={Dur("jumps"):F3} the={Dur("the"):F3}");
+    }
+
+    [Fact]
+    public void ExpandedNumberWeightsItsWrittenWord()
+    {
+        if (!HavePhonemizer()) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+
+        const string text = "It cost $3.14 today.";
+        var trace = Vernacula.Phonemizer.Phonemizer.PhonemizeTrace(text, "en");
+        var words = OmniVoiceIpaAlignment.Proportional(text, trace, totalSec: 3.0);
+
+        Assert.Equal(4, words.Count);
+        // "$3.14" reads as three spoken words; it should own the largest share of the chunk.
+        var price = words[2];
+        Assert.Equal("$3.14", price.Text);
+        var priceDur = price.EndSec - price.StartSec;
+        foreach (var w in words.Where(w => w != price))
+            Assert.True(priceDur > w.EndSec - w.StartSec, $"{w.Text} outweighs the price");
+    }
+
+    [Fact]
+    public void UntracedFallsBackToCharacterLengths()
+    {
+        var trace = new Vernacula.Phonemizer.PhonemeTrace { Ipa = "", Traced = false };
+        var words = OmniVoiceIpaAlignment.Proportional("ab abcdef", trace, totalSec: 8.0);
+        Assert.Equal(2, words.Count);
+        Assert.Equal(2.0, words[0].EndSec, 6);
+        Assert.Equal(8.0, words[1].EndSec, 6);
+    }
+}


### PR DESCRIPTION
The reader synthesized with Chatterbox or Kokoro; the IPA fine-tune the web demo and `vernacula-tts` render with was CLI-only. This adds it as a third backend — any of vernacula-phonemizer's languages, in a stored voice from the web demo's library.

**`Vernacula.Tts.Base`**
- `OmniVoiceIpaTts` — the `vernacula-tts` engine as a class: tokenizer + versioned diff + phonemizer setup, a stored voice's codes and IPA transcript as conditioning, the IPA-side duration estimate, the Python-order finishing chain, a sentence packer for paragraphs over ~30 s of estimated audio, and an estimated word map.
- `OmniVoiceIpaAlignment` — the word map for karaoke highlighting: each source word's share of the chunk is proportional to the IPA script-weight of what it became, read off `PhonemizeTrace`'s input/IPA spans (the #1150 two-way index). **Estimated, not measured** — OmniVoice exposes neither attention (Chatterbox) nor durations (Kokoro) — and labelled `omnivoice_ipa_proportional` in the sidecar. A forced aligner from `Vernacula.Base.Alignment` would be the measured answer if the estimate isn't good enough by ear.
- `StoredVoice`, `IpaFineTune` moved here from `Vernacula.Tts.CLI`; `StoredVoice` gains `ListVoices`, `IsLibrary`, `ResolveDefaultLibrary` (the web demo's `models/`, found by walking up from the exe — the CLI's `../../../../..` path is gone).
- `OmniVoiceAudioPost.Finish` — the CLI's `--post python` chain, shared.

**`Vernacula.Tts.Avalonia`**
- `OmniVoiceSynthesisService`, `TtsBackendKind.OmniVoice`, `TtsRequest.Lang`/`NumStep`.
- Config panel: ONNX dir, optional `tokenizer.json` (auto-located beside the graphs → `OMNIVOICE_MODEL_DIR` → HF cache), voice library (defaults to the repo's), language code, voice (the library's voices for that language, or all of them if it has none — any voice can read any language's IPA), diffusion steps 8–48.
- The phonemizer data dir is one shared setting now (`PhonemizerDataDir`, migrated from `KokoroDataDir`), shown for both phonemizing backends.

**Verified:** engine class on CUDA — a two-paragraph text chunks into two pieces (7.1 s + 4.8 s) at ~1.8× real time in the library's `en` reference voice, 28 + 22 word timings matching the whitespace word count. Solution builds clean; Vernacula.Tts.Tests 58 passed + 4 skipped (3 new alignment tests). **The reader UI was compiled, not driven** — worth a click-through when you're at your desk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc
