### PR TITLE
reader: picking the tokenizer re-queries the Synthesize button

### DIFF
--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -81,7 +81,12 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
     private string _omniVoiceOnnxDir = "";
 
-    [ObservableProperty] private string _omniVoiceTokenizerJson = "";
+    // ⚠ This one gates the button too: the tokenizer is auto-located from the ONNX dir, so when it
+    // is NOT found there it is the LAST thing the user picks -- and without this attribute the
+    // button's CanExecute was never re-queried after that pick, so it stayed greyed out.
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]
+    private string _omniVoiceTokenizerJson = "";
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SynthesizeCommand))]


### PR DESCRIPTION
`OmniVoiceTokenizerJson` lacked `NotifyCanExecuteChangedFor(SynthesizeCommand)`. The tokenizer is auto-located from the ONNX dir, so when it isn't there it's the last thing the user picks — and the button never re-evaluated after that pick, so it stayed greyed out with every prerequisite satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc