### PR TITLE
web-demo: WebGPU has been dead since the proxy change; tie proxy to the WASM path

### DIFF
--- a/docs/tts_speed_investigation.md
+++ b/docs/tts_speed_investigation.md
@@ -1,0 +1,119 @@
+# OmniVoice-IPA speed: reader vs web demo — investigation log
+
+The question: the reader (Vernacula.Tts.Avalonia, C# + ONNX Runtime) seems to generate much
+faster than the web demo (browser, onnxruntime-web). Is it, and by how much, and why?
+
+Same utterance for every run — two sentences, 170 IPA chars, 190 target tokens (7.06 s), the
+library's `en` reference voice (83 codes), 32 diffusion steps. Machine: RTX 3090, i7-10700K
+(8 physical / 16 logical cores).
+
+## Run 1 — 2026-09-05 ~10:40 — the C# engine, CUDA and CPU
+
+`OmniVoiceIpaTts` (what the reader drives), fp32 base + v7 diff, via the scratch harness.
+
+    ep=Cuda load=3775ms
+      run0: 7.06s audio in 3874ms  (1.82x RT)     ← first call: CUDA kernel warm-up
+      run1: 7.06s audio in 2690ms  (2.62x RT)
+      run2: 7.06s audio in 2861ms  (2.47x RT)
+
+    ep=Cpu  load=6119ms
+      run0: 7.06s audio in 67608ms  (0.10x RT)    ← partly contended by Run 2's first attempt
+      run1: 7.06s audio in 53533ms  (0.13x RT)
+
+So the C# engine on CUDA is ~2.5× faster than real time; the same engine on the CPU, fp32 on 16
+threads, is ~8× slower than real time. Twenty-fold between the two, from the execution provider
+alone — the reader defaults to `EP=Cuda`, which is why it feels fast.
+
+## Run 2 — 2026-09-05 ~10:50 — one WASM transformer forward, 8 threads, S=350
+
+`tools/bench-wasm.mjs` on the int4 web build (the same wasm ORT the browser runs, in Node; only
+the thread count differs). S=350 ≈ text 170 + ref 83 + target 190 minus the pieces that share
+positions — close enough to the browser's real sequence for this utterance.
+
+    first attempt, while Run 1's CPU pass was still running:  7910 ms  → 253 s / generation
+    uncontended:                                               3965 ms  → 127 s / generation
+                                                               (runs: 3933, 3974, 3987)
+
+The contended number is the one a user with a busy machine gets, and it is the kind of number
+that makes the demo look broken. Uncontended, 32 forwards is ~127 s for 7 s of audio: ~0.06× real
+time — roughly half the speed of the C# CPU path, which runs fp32 with native kernels against
+int4 weights that WASM has to dequantize on the fly, and with 16 threads to WASM's 8.
+
+## Run 3 — 2026-09-05 — the browser itself, headless Firefox, full generation
+
+`tools/smoke-tts.mjs` serves the demo's own pipeline with COOP/COEP (so threads are on) and
+drives it in headless Firefox. First attempt failed in the tool, not the demo: `_keys.json`
+became a `{engine, dirs, languages, foreign}` manifest when per-language data loading landed and
+the tool still read it as a flat list. Fixed to resolve the language's keys the way
+`phonemizer.ts` does.
+
+Second attempt failed the same way one layer down: the tool's `voicesUrl` was the pre-library
+`voices.json`, and the transpiled engine it serves from `build-smoke/` was a Sep 1 copy that
+predates `voice-codes.json`. Rebuilt `build-smoke/` from the current `src/inference/*.ts` (tsc,
+`.ts` imports rewritten to `.js`) and pointed the tool at `voices.jsonc` + `voice-codes.json`.
+Third attempt's chain died after its first run because `pkill -f "firefox --headless"` matched
+the shell running it. Four defects in a tool that had not been run since the day it was written —
+worth knowing before trusting any "smoke" that is not in CI.
+
+    firefox, WASM (forced), 8 threads, COOP/COEP on:
+      ep=wasm  targetTokens=266  audio=10.09s
+      generate 181.8s  (transformer 174.9s, host 5.1s)        → 0.055x real time
+
+⚠ targetTokens is 266 here against 190 in the C# runs: the tool picks the language's voice with
+its own `voiceFor` default rather than the library's `default` entry, so a different reference
+length drove the duration estimate. The per-forward cost is what matters and it agrees with Run 2's
+extrapolation (174.9 s / 64 forwards = 2.7 s at S≈430 vs 3.97 s at S=350 in Node — the browser's
+transformer share is in the same band). The audio is 10 s rather than 7 s; the ratio holds either
+way.
+
+## Run 4 — 2026-09-05 ~11:30 — WebGPU: broken since the threading change, then measured
+
+Both WebGPU runs failed before the first forward:
+
+    [webgpu] DataCloneError: Failed to execute 'postMessage' on 'Worker': GPUDevice object
+    could not be cloned.  →  Error: no available backend found.
+
+Cause: 21c65d1 ("8 WASM threads and run the session off the main thread") set
+`ort.env.wasm.proxy = true` unconditionally. In proxy mode ORT posts its `env` to a worker, and
+`useMaxLimitsDevice` had put a GPUDevice in `env.webgpu.device` — a GPUDevice cannot cross a
+worker boundary. `pickExecutionProvider` chooses WebGPU whenever an adapter exists and there is
+no fallback to WASM on session failure, so from that commit **the deployed demo could not
+generate at all on Chrome, or on any Firefox with WebGPU enabled**. That is what "it doesn't
+happen with WebGPU on the demo" was. Nothing measured it because the smoke tool that exercises
+WebGPU had itself been broken (Run 3) since before the change.
+
+Fix: the EP is decided in ortInit.ts, before ORT is configured, and `proxy` follows it — on for
+WASM (which needs the worker to keep the tab responsive), off for WebGPU (whose work is
+asynchronous on the GPU anyway). Then:
+
+    chrome / webgpu (Dawn, RTX 3090), decoder on wasm:
+      ep=webgpu  targetTokens=266  audio=10.09s
+      generate 40.2s  (transformer 34.8s, host 3.5s)      → 0.25x real time
+
+    firefox / webgpu: killed after the transformer session came up — Runs 6 and 8 established
+    Firefox's WebGPU is flat at ~3 s per forward whatever the work (≈190 s here), and no one
+    deploys to it.
+
+## The table
+
+Same two sentences, 32 steps, one `en` reference voice (the browser tool picked a longer
+reference, hence 10.09 s of audio to the C# runs' 7.06 s — compare rates, not totals).
+
+| path | audio | wall | × real time |
+|---|---|---|---|
+| C# engine, CUDA fp32 (the reader's default)      | 7.06 s | 2.7–2.9 s | **2.5×** |
+| browser, Chrome WebGPU, int4                      | 10.09 s | 40.2 s | 0.25× |
+| C# engine, CPU fp32, 16 threads                   | 7.06 s | 54–68 s | 0.12× |
+| browser, Firefox WASM, int4, 8 threads            | 10.09 s | 181.8 s | 0.055× |
+
+So: confirmed, and by more than it looks like from the reader — the reader runs the fp32 model
+on the GPU through CUDA and is ~10× faster than the browser's best path on the same GPU, and
+~45× faster than the browser path most visitors actually get.
+
+**Where the 10× between CUDA and Chrome WebGPU goes.** Both are the same GPU. The C# path is
+fp32 with cuBLAS/cuDNN kernels and ORT's CUDA graph optimisations; the browser path is
+`MatMulNBits` int4 weights dequantised inside WGSL shaders, fp32 activations (no shader-f16),
+per-op dispatch through Dawn, and 64 forwards (2 CFG passes × 32 steps) each re-uploading the
+conditioning. Per forward: 34.8 s / 64 = 544 ms at S≈430 on WebGPU vs ~40 ms on CUDA. Run 8's
+177 ms at S=100 → 544 ms at S=430 says the WebGPU path scales roughly linearly with sequence
+length, i.e. attention and the dequant-matmuls dominate, not fixed overhead.

--- a/web-demo/src/inference/omnivoice.ts
+++ b/web-demo/src/inference/omnivoice.ts
@@ -12,7 +12,7 @@
  * almost exclusively. Shipping precomputed reference codes fixes that AND drops 654 MB.
  */
 import type * as ort from "onnxruntime-web";
-import { getOrt, type Ort } from "./ortInit.ts";
+import { getOrt, type Ort, pickExecutionProvider, type Ep } from "./ortInit.ts";
 import { Qwen3Tokenizer } from "./qwen3Tokenizer.ts";
 import { addPunctuation, prepare, NUM_CODEBOOKS } from "./textPrep.ts";
 import { estimateTargetTokens } from "./duration.ts";
@@ -50,11 +50,12 @@ export interface Voice {
   sex?: "M" | "F";
 }
 
-export interface Backend { ep: "webgpu" | "wasm"; }
+export interface Backend { ep: Ep; }
 
 /** Force an execution provider (tests/debugging). Unset = auto. */
-export let forcedEp: "webgpu" | "wasm" | undefined;
-export function setForcedEp(ep: "webgpu" | "wasm" | undefined) { forcedEp = ep; }
+// The EP choice lives in ortInit.ts, because ORT's proxy setting depends on it and must be made
+// before the first session; re-exported so the smoke tools keep their hooks.
+export { forcedEp, setForcedEp, pickExecutionProvider } from "./ortInit.ts";
 
 /**
  * Execution provider for the DECODER only.
@@ -73,8 +74,8 @@ export function setForcedEp(ep: "webgpu" | "wasm" | undefined) { forcedEp = ep; 
  * The cost is negligible: the transformer runs 64 times per generation (32 steps x 2 CFG passes)
  * and the decoder once, so this buys correctness for about 1 s out of 20.
  */
-export let decoderEp: "webgpu" | "wasm" | undefined = "wasm";
-export function setDecoderEp(ep: "webgpu" | "wasm" | undefined) { decoderEp = ep; }
+export let decoderEp: Ep | undefined = "wasm";
+export function setDecoderEp(ep: Ep | undefined) { decoderEp = ep; }
 
 /** Graph optimization level override (tests/debugging). Fusions change numerics, and this loop is
  *  precision-sensitive — the C# CUDA path disables TF32 for the same reason. */
@@ -143,7 +144,7 @@ export class OmniVoice {
 
   static async load(o: LoadOptions): Promise<OmniVoice> {
     const ORT = await getOrt();
-    const ep = forcedEp ?? await pickExecutionProvider();
+    const ep = await pickExecutionProvider();
     if (ep === "webgpu") await useMaxLimitsDevice();
     o.onProgress?.(`execution provider: ${ep}`);
 
@@ -324,10 +325,3 @@ async function useMaxLimitsDevice(): Promise<void> {
   } catch { /* fall back to ORT's own default-limits device */ }
 }
 
-export async function pickExecutionProvider(): Promise<"webgpu" | "wasm"> {
-  try {
-    const gpu = (navigator as unknown as { gpu?: { requestAdapter(): Promise<unknown> } }).gpu;
-    if (gpu && (await gpu.requestAdapter())) return "webgpu";
-  } catch { /* fall through to wasm */ }
-  return "wasm";
-}

--- a/web-demo/src/inference/ortInit.ts
+++ b/web-demo/src/inference/ortInit.ts
@@ -62,6 +62,26 @@ export const threadingUnavailableReason: string | null =
     : "single-threaded — WASM threads need SharedArrayBuffer, so a cross-origin-isolated page "
       + "(COOP/COEP) served from a secure context. Generation is several times slower without them.";
 
+/**
+ * Which execution provider the TTS session will use: WebGPU where an adapter exists, WASM
+ * otherwise. Decided HERE, before ORT is configured, because one ORT setting depends on it (below).
+ * The difference is not cosmetic — measured on an RTX 3090 at 16 steps: WebGPU/Chrome 177 ms per
+ * forward (~2.8 s per phrase) against 1295 ms on 8-thread WASM (~20.7 s).
+ */
+export type Ep = "webgpu" | "wasm";
+export let forcedEp: Ep | undefined;
+/** Test hook: override the adapter probe. Must be called before the first getOrt(). */
+export function setForcedEp(ep: Ep | undefined) { forcedEp = ep; }
+
+export async function pickExecutionProvider(): Promise<Ep> {
+  if (forcedEp) return forcedEp;
+  try {
+    const gpu = (navigator as unknown as { gpu?: { requestAdapter(): Promise<unknown> } }).gpu;
+    if (gpu && (await gpu.requestAdapter())) return "webgpu";
+  } catch { /* fall through to wasm */ }
+  return "wasm";
+}
+
 let cached: Promise<Ort> | undefined;
 
 /** The ORT module, loaded once. Await this instead of importing onnxruntime-web directly. */
@@ -72,11 +92,19 @@ export function getOrt(): Promise<Ort> {
     ort.env.wasm.wasmPaths = BASE;
     ort.env.logLevel = "warning";
     ort.env.wasm.numThreads = wasmThreads();
-    // ⚠ RUN THE WASM IN A WORKER. Without this the session executes on the MAIN thread, so a
-    // generation freezes the page for its whole duration and Firefox raises "this tab is slowing
-    // Firefox down" — which is true, and which no amount of threading fixes, because the threads
-    // ORT spawns still join back on a blocked main thread. `proxy` moves the session itself off it.
-    ort.env.wasm.proxy = true;
+    // ⚠ RUN THE WASM IN A WORKER — BUT ONLY ON THE WASM PATH. Without `proxy` a WASM session
+    // executes on the MAIN thread, so a generation freezes the page for its whole duration and
+    // Firefox raises "this tab is slowing Firefox down" — true, and no amount of threading fixes
+    // it, because the threads ORT spawns still join back on a blocked main thread.
+    //
+    // ⚠ AND `proxy` MUST BE OFF FOR WEBGPU. In proxy mode ORT posts its `env` to the worker, and
+    // the GPUDevice that useMaxLimitsDevice puts in `env.webgpu.device` cannot be cloned:
+    // `DataCloneError: GPUDevice object could not be cloned` → "no available backend found" →
+    // the demo could not generate at all on any browser with a WebGPU adapter (Chrome, and
+    // Firefox with dom.webgpu.enabled) from the commit that turned proxy on until this one. The
+    // GPU does its work asynchronously, so the WebGPU path does not need the worker to keep the
+    // tab responsive; only the CPU path does.
+    ort.env.wasm.proxy = (await pickExecutionProvider()) === "wasm";
     return ort;
   })();
   return cached;

--- a/web-demo/tools/smoke-tts.mjs
+++ b/web-demo/tools/smoke-tts.mjs
@@ -31,7 +31,13 @@ const say=(o)=>fetch("/r",{method:"POST",body:JSON.stringify(o)});
 const log=[];
 try{
   // 1. phonemize, through the upstream seams
-  const keys = await (await fetch("/vphon-data/_keys.json")).json();
+  // The manifest is the demo's: the engine set plus, per language, its dirs (looked up in
+  // dirs) and core files, minus its excludes (src/inference/phonemizer.ts). Fetch the engine
+  // and this run's language.
+  const m = await (await fetch("/vphon-data/_keys.json")).json();
+  const entry = m.languages[${JSON.stringify(LANG)}] ?? { dirs: [], core: [], exclude: [] };
+  const skip = new Set(entry.exclude ?? []);
+  const keys = [...m.engine, ...entry.dirs.flatMap((d) => m.dirs[d] ?? []), ...(entry.core ?? [])].filter((k) => !skip.has(k));
   const bytes = new Map();
   await Promise.all(keys.map(async k => { const r = await fetch("/vphon-data/"+k); bytes.set(k, new Uint8Array(await r.arrayBuffer())); }));
   const vp = await import("/vphon/src/browser.js");
@@ -52,7 +58,8 @@ try{
     transformerDataUrl: "/models/${MODEL_NAME}.data",
     decoderUrl: "/models/higgs_decoder.onnx",
     tokenizerUrl: "/models/tokenizer.json",
-    voicesUrl: "/models/voices.json",
+    voicesUrl: "/models/voices.jsonc",
+    voiceCodesUrl: "/models/voice-codes.json",
     fetchBytes: async (u) => (await fetch(u)).arrayBuffer(),
     onProgress: (d) => log.push("  " + d),
   });


### PR DESCRIPTION
**Found while timing the reader against the demo.** Since 21c65d1 (8 WASM threads + `ort.env.wasm.proxy = true`), every browser with a WebGPU adapter — Chrome, and Firefox with `dom.webgpu.enabled` — failed at session creation:

```
[webgpu] DataCloneError: Failed to execute 'postMessage' on 'Worker': GPUDevice object could not be cloned.
Error: no available backend found.
```

In proxy mode ORT posts its `env` to a worker; the `GPUDevice` that `useMaxLimitsDevice` puts in `env.webgpu.device` can't cross that boundary. `pickExecutionProvider` chooses WebGPU whenever an adapter exists and there's no fallback, so the deployed demo has had **no working generation on Chrome at all** since that commit. The smoke tool that would have caught it was itself broken.

**Fix:** the EP is decided in `ortInit.ts` before ORT is configured, and `proxy` follows it — on for WASM (the worker is what keeps the tab responsive), off for WebGPU (the GPU works asynchronously anyway).

**Measured after the fix** (same two sentences, 32 steps; `docs/tts_speed_investigation.md`):

| path | audio | wall | × real time |
|---|---|---|---|
| C# engine, CUDA fp32 (the reader) | 7.06 s | 2.7–2.9 s | **2.5×** |
| browser, Chrome WebGPU, int4 | 10.09 s | 40.2 s | 0.25× |
| C# engine, CPU fp32, 16 threads | 7.06 s | 54–68 s | 0.12× |
| browser, Firefox WASM, 8 threads | 10.09 s | 181.8 s | 0.055× |

Also: the browser smoke tool had rotted in four places since Sep 1 (phonemizer manifest shape, `voices.jsonc` + `voice-codes.json`, a stale `build-smoke/`, a process kill that matched its own shell). It runs again; `build-smoke/` stays untracked and is rebuilt with the tsc one-liner noted in the log.

`tsc` clean. **Needs a Netlify redeploy** to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc
