### PR TITLE
web-demo: Playwright harnesses for the speed work; report the device ORT builds

### DIFF
--- a/docs/tts_speed_investigation.md
+++ b/docs/tts_speed_investigation.md
@@ -113,7 +113,162 @@ on the GPU through CUDA and is ~10× faster than the browser's best path on the 
 **Where the 10× between CUDA and Chrome WebGPU goes.** Both are the same GPU. The C# path is
 fp32 with cuBLAS/cuDNN kernels and ORT's CUDA graph optimisations; the browser path is
 `MatMulNBits` int4 weights dequantised inside WGSL shaders, fp32 activations (no shader-f16),
-per-op dispatch through Dawn, and 64 forwards (2 CFG passes × 32 steps) each re-uploading the
-conditioning. Per forward: 34.8 s / 64 = 544 ms at S≈430 on WebGPU vs ~40 ms on CUDA. Run 8's
-177 ms at S=100 → 544 ms at S=430 says the WebGPU path scales roughly linearly with sequence
-length, i.e. attention and the dequant-matmuls dominate, not fixed overhead.
+per-op dispatch through Dawn, and 32 forwards (the CFG pair is batched as B=2 in one forward,
+in both implementations). Per forward: 34.8 s / 32 = 1.09 s at S≈430 on WebGPU vs ~87 ms on
+CUDA. (An earlier draft of this paragraph counted 64 forwards; the diffusion loop batches the
+pair — see diffusion.ts.)
+
+## Run 5 — 2026-09-05 ~12:20 — what can ORT's own fusion passes do to this graph?
+
+Goal 1× real time on Chrome WebGPU (from 0.25×). The budget: 32 forwards for 7 s of audio →
+≤220 ms per B=2 forward at S≈430; measured 1.09 s. The graph has 4,768 non-Constant nodes, every
+one a WebGPU dispatch, and Dawn's per-dispatch cost is 0.1–0.3 ms — so dispatch count alone could
+be most of the forward. First question, therefore: how many of those nodes fuse for free?
+
+`onnxruntime.transformers.optimizer` over the fp32 v7 graph (`onnx_base/…_v7.onnx`):
+
+    model_type=gpt2, no geometry:        7371 → 5727 nodes (29 s)
+      SimplifiedLayerNormalization 57, SkipSimplifiedLayerNormalization 56
+      removed: Cast 344, Mul 226, Add 169, Pow 113, ReduceMean 113, Sqrt 113, Div 113, Reshape 57
+    model_type=gpt2, num_heads=16, hidden_size=1024 (Qwen3-0.6B):  identical — no Attention,
+      MultiHeadAttention or RotaryEmbedding fusions
+    model_type=phi:  TypeError inside FusionOptions — not applicable to this export
+
+So the RMSNorms fuse (113 of them, ~14 nodes each — a third of the graph's dispatches), and
+nothing else does: Qwen3's q/k RMSNorm inside the attention block, GQA, and the boolean 4-D mask
+this export takes as an input match none of ORT's attention patterns. Fusing attention and rotary
+into GroupQueryAttention/RotaryEmbedding — both of which ORT-web 1.29's WebGPU bundle carries —
+would be hand graph surgery or a re-export through contrib ops. Deferred until the profile says
+whether dispatch count is actually the bottleneck.
+
+Building the RMSNorm-fused graph through the shipped recipe (int4 MatMulNBits block-32 →
+int8 per-row embedding) into `onnx_web/v7-fused/` for a like-for-like bench. Also noted: the
+Python tooling on this box is the system interpreter's onnxruntime 1.24.4 — there is no
+`export_venv` for this pipeline any more.
+
+## Run 6 — 2026-09-05 ~12:50 — the kernel profile of the real Chrome path
+
+ORT's WebGPU profiler (timestamp queries) hooked into the demo's own engine in `smoke-tts.mjs`
+(`PROFILE=1`; the module is the CDN one, so setting `env.webgpu.profiling` on it before
+`OmniVoice.load` reaches the session). Two dead ends first: `bench-webgpu.mjs` reported 0 kernels
+because its self-made device lacked `timestamp-query`, and — more important — it measured
+3.3 s per forward against the smoke's 1.09 s on what should be the same GPU: its adapter reports
+maxBufferSize 2147 MB where Run 8 recorded 4295 MB for Chrome/Dawn on the NVIDIA card, so that
+bench is not on the device the demo gets. Left as a known-bad tool for now; the smoke is the
+instrument.
+
+    generate 43.3s  (transformer 38.0s, host 3.5s)   [profiling costs ~3 s over Run 4's 40.2 s]
+    117,888 kernels, 15.4 s GPU time per generation → per forward: 3,684 kernels, 480 ms GPU,
+    1.19 s wall → 0.7 s per forward NOT in kernels
+
+    per forward, top kernels by GPU time:
+       403.9 ms    394×  MatMulNBits     ← 84% of GPU time
+        25.5 ms    114×  MatMul          (the attention QK/PV products)
+         9.1 ms    620×  Mul
+         8.0 ms    506×  Add
+         5.1 ms     60×  Where
+         4.7 ms    286×  Transpose
+         3.3 ms     56×  Softmax
+         2.6 ms    226×  Pow / Div / ReduceMean / Sqrt  (RMSNorm, ×4 kernels each)
+
+Two conclusions, both load-bearing:
+
+1. **60% of a forward is dispatch, not compute.** 3,684 dispatches at Dawn's ~0.19 ms each is
+   0.7 s — the "not in kernels" figure to within noise. Kernel count is the first lever, and the
+   RMSNorm fusion (Run 5) removes ~1,600 of the 3,684.
+2. **The matmuls are running at ~7% of the card.** 404 ms for ~1 TFLOP of int4 weight-matmul at
+   B·S = 860 tokens is ~2.5 TFLOPS on a 35-TFLOPS fp32 part; CUDA does the whole forward in
+   87 ms. ORT-web's `MatMulNBits` has a faster path for fp16 activations (packed math, the
+   DP4A/subgroup variants), which this fp32-activation build never reaches. fp16 activations are
+   the second lever — and the one with the precision question from the TF32 finding attached.
+
+Attention itself (MatMul + Softmax + Transpose ≈ 35 ms) is not the problem; fusing it would be
+worth doing only for its dispatch count.
+
+## Run 7 — 2026-09-05 ~13:20 — the fused build: 1,240 fewer dispatches bought 6%
+
+Same text, Chrome WebGPU, 32 steps, profiler on:
+
+    v7 (shipped):  generate 43.3s (transformer 38.0s)  per forward 3,684 kernels, 480 ms GPU, 1.19 s wall
+    v7-fused:      generate 41.1s (transformer 35.8s)  per forward 2,442 kernels, 462 ms GPU, 1.12 s wall
+                   LayerNormalization 114× 3.0 ms, SkipLayerNormalization 112× 2.5 ms — the
+                   fusion landed and the RMSNorm cost went from ~10 ms to ~5.5 ms per forward.
+
+So Run 6's conclusion 1 was WRONG in its arithmetic: removing a third of the dispatches removed
+~6% of the wall time, which puts Dawn's per-dispatch cost near 0.03 ms, not 0.19. The 0.66 s per
+forward that is not kernel time is something else: ORT's CPU-side work in wasm (the ~1,900
+Shape/Gather/Concat/Unsqueeze nodes run on the CPU, plus uniform packing and buffer management)
+and the per-step GPU→CPU readback of the [2,8,S,1025] fp32 logits (28 MB at S=430) with the sync
+it forces. Attention fusion and graph capture would still help, but they are the smaller lever;
+the readback and the MatMulNBits kernel (397 ms, unchanged) are the larger ones.
+
+The fp16 timing that followed hung: node waited on a page that never reported, and no Chrome
+process was alive — the browser died on the fp16 build. Diagnosed next with the one-forward
+logit tool, which reports the page's error instead of waiting.
+
+## Run 8 — 2026-09-05 ~14:10 — fp16: built, runs on WASM, cannot be measured on this adapter
+
+Tooling first, because it changed what was findable. The http+spawn harnesses report only at the
+end and hang silently on a dead page; three hours went to timeouts. Replaced for this work by
+`tools/pw-tts.mjs` (Playwright driving the system Chrome, headed on :0 with the same flags; the
+page's console, errors and progress stream live; a deadline instead of a timeout) and
+`tools/pw-bench.mjs` (the same, for N forwards with session options from env). The demo also now
+logs a lost WebGPU device to the console instead of hanging on the next run.
+
+The fp16 build (`v7-fused-f16/`, 424 MB: activations fp16 via ORT's converter, int4 weights and
+the int8 embedding untouched):
+
+- Runs on WASM in Node (993 ms/forward at S=64) — the graph is valid.
+- On WebGPU the session creates in 2 s and the first forward raises
+  `Error while parsing WGSL: 'f16' type used without 'f16' extension enabled`, then a cascade of
+  invalid pipelines, and the loop "completes" on whatever the failed kernels left behind.
+- The adapter here (Chrome 152, ANGLE/Vulkan, RTX 3090) offers `subgroups`,
+  `subgroup-size-control`, `timestamp-query`, `chromium-experimental-subgroup-matrix` — and NOT
+  `shader-f16`. ORT-web requests f16 itself when the adapter has it (`i("shader-f16")` in the
+  1.29 bundle), so the build should work on an adapter that offers it (Metal on a Mac, most
+  likely) and is untestable on this one.
+- ⚠ ORT-web 1.29 creates its own device and IGNORES `env.webgpu.device`: the device in use had
+  ORT's own feature set, not ours. `useMaxLimitsDevice` has been a no-op since the move to the
+  native WebGPU EP; it works because the largest tensor (155 MB) fits the default 268 MB limit.
+
+Like-for-like on the same 190-token text under the new harness (the library's default `en`
+voice, as the C# runs): fp32-fused **7.3 s of audio in 26.2 s, 0.28× real time, 694 ms per
+forward at S≈350**. (The 10 s/40 s figures earlier in this log were the smoke tool's longer
+voice; ratios agree.)
+
+## Run 9 — 2026-09-05 ~14:40 — readback, capture, static shapes: three suspects, three acquittals
+
+`pw-bench.mjs`, fused fp32 build, B=2, Chrome/Dawn on the RTX 3090:
+
+    S=350  dynamic graph                          647 ms/forward
+    S=350  + preferredOutputLocation: gpu-buffer  627 ms   → the 22 MB logits readback is ~20 ms
+    S=512  dynamic graph                         1083 ms
+    S=512  static graph, ORT offline BASIC       1124 ms   → the 2,300 CPU-side shape nodes cost nothing
+    S=512  static graph, ORT offline EXTENDED    2684 ms   ← EXTENDED inserts FusedMatMul (28×), which
+                                                            the WebGPU EP does not run; do not use it
+    enableGraphCapture                            refused: "not all compute graph nodes have been
+                                                  partitioned to the JsExecutionProvider", on the
+                                                  dynamic AND the static graph
+
+The static graph (`make_dim_param_fixed` two_b=2, seq=512, then ORT BASIC: 3,633 → 1,502 nodes,
+zero Shape ops) was built for capture and to test the CPU-shape-ops theory; it disproves the
+theory and does not unlock capture. Something ORT still places on the CPU; not chased further,
+because with dispatch count (Run 7), readback and shape ops all measured small, the non-kernel
+~0.25 s per forward is ORT-web's own per-kernel JS/Dawn bookkeeping, and capture is the only
+thing that attacks it.
+
+## Run 10 — 2026-09-05 ~14:50 — where this leaves the browser, and the one lever left
+
+Per forward at S≈350 on this GPU: ~400 ms is `MatMulNBits`, ~250 ms is everything else. The
+fast `MatMulNBits` paths in ORT-web (DP4A, subgroup-matrix) and the fp16 build all require
+`shader-f16`, which Chrome on this Linux/Vulkan adapter does not expose under any flag tried
+(`--enable-dawn-features=allow_unsafe_apis`, `WebGPUDeveloperFeatures`, `--use-angle=gl`). A
+Mac's Metal adapter, and most Windows/D3D12 ones, do expose it. So the fp16 build is the
+experiment — it just has to be run on a machine that can run it, and judged by ear there,
+because the TF32 finding says the diffusion loop may not tolerate 10-bit mantissas.
+
+Ceiling estimate for Chrome WebGPU with fp32 activations on this class of GPU: ~0.3× real time
+(fusion gets 0.25 → 0.28). With fp16 on an adapter that has it: unknown, plausibly 2× on the
+matmul share → ~0.5×. 1× needs the matmul kernel AND the per-kernel overhead to both halve, or a
+model with fewer steps — the distillation item in the shelved plan. 2.5× is the native-CUDA
+number and is not available through WebGPU as shipped.

--- a/web-demo/package-lock.json
+++ b/web-demo/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
         "esbuild": "^0.24.0",
+        "playwright": "^1.55.1",
         "puppeteer-core": "^25.9.0",
         "typescript": "^5.6.3",
         "vite": "^6.0.3"
@@ -2032,6 +2033,53 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.26",

--- a/web-demo/package.json
+++ b/web-demo/package.json
@@ -25,6 +25,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "esbuild": "^0.24.0",
+    "playwright": "^1.55.1",
     "puppeteer-core": "^25.9.0",
     "typescript": "^5.6.3",
     "vite": "^6.0.3"

--- a/web-demo/src/inference/omnivoice.ts
+++ b/web-demo/src/inference/omnivoice.ts
@@ -163,6 +163,7 @@ export class OmniVoice {
     }
     o.onProgress?.("creating transformer session");
     const transformer = await ORT.InferenceSession.create(tBytes, opts);
+    if (ep === "webgpu") reportOrtDevice(ORT, o.onProgress);
 
     o.onProgress?.("downloading decoder");
     const dBytes = await o.fetchBytes(o.decoderUrl, "decoder");
@@ -305,17 +306,45 @@ export function voiceFor(voices: Voice[], lang: string, id?: string): Voice {
  * device with "Out of memory" on a GPU with tens of GB free. This build's largest tensor is 155 MB
  * so it clears the default, but that is luck rather than design, and it forecloses larger models.
  */
-interface AdapterLike {
-  limits: { maxBufferSize: number; maxStorageBufferBindingSize: number };
-  requestDevice(d?: { requiredLimits?: Record<string, number> }): Promise<unknown>;
+/**
+ * ⚠ A LOST DEVICE MUST SAY SO. Without this, a kernel fault or an out-of-memory kills the device
+ * silently, the next session.run() never resolves, and the page shows a progress bar forever —
+ * which is how the fp16 experiment first failed. ORT exposes the device it built on
+ * `env.webgpu.device` once a session exists; hook its `lost` promise there, and say which
+ * features it has, because "does this adapter offer shader-f16" decides which builds can run.
+ */
+function reportOrtDevice(ORT: Ort, onProgress?: (d: string) => void): void {
+  const device = (ORT.env.webgpu as unknown as { device?: { features: Set<string>; lost: Promise<{ reason: string; message: string }> } }).device;
+  if (!device) return;
+  onProgress?.(`webgpu device features: ${[...device.features].sort().join(" ")}`);
+  device.lost.then((info) => console.error(`WebGPU device lost: ${info.reason}: ${info.message}`));
 }
 
+interface AdapterLike {
+  limits: { maxBufferSize: number; maxStorageBufferBindingSize: number };
+  features: Set<string>;
+  requestDevice(d?: { requiredFeatures?: string[]; requiredLimits?: Record<string, number> }): Promise<unknown>;
+}
+
+/**
+ * ⚠ MEASURED TO BE A NO-OP ON ORT-WEB 1.29 (docs/tts_speed_investigation.md, Run 8): the native
+ * WebGPU EP creates its own device — with the features it wants and DEFAULT limits — and ignores
+ * `env.webgpu.device`. It works because the largest tensor (155 MB) fits the default 268 MB. Kept
+ * for the day the API accepts a device again; reportOrtDevice says what ORT actually got.
+ */
 async function useMaxLimitsDevice(): Promise<void> {
   try {
     const gpu = (navigator as unknown as { gpu?: { requestAdapter(): Promise<AdapterLike | null> } }).gpu;
     const adapter = await gpu?.requestAdapter();
     if (!adapter) return;
+    // ⚠ FEATURES ARE OPT-IN TOO. A device we build ourselves has NO optional features unless
+    // asked: without `shader-f16` every fp16 kernel fails validation ("Invalid ComputePipeline
+    // MatMulNBits" and a cascade after it), which is how the fp16 build ran but produced garbage.
+    // ORT requests these itself when it creates the device; we must do the same when we do.
+    const wanted = ["shader-f16", "subgroups", "timestamp-query"];
+    const requiredFeatures = wanted.filter((f) => (adapter as unknown as { features: Set<string> }).features.has(f));
     const device = await adapter.requestDevice({
+      requiredFeatures,
       requiredLimits: {
         maxBufferSize: adapter.limits.maxBufferSize,
         maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,

--- a/web-demo/tools/bench-webgpu.mjs
+++ b/web-demo/tools/bench-webgpu.mjs
@@ -22,6 +22,10 @@ const STEPS = Number(process.argv[4] ?? 16);
 const WARM = Number(process.env.WARM ?? 3);
 const ITERS = Number(process.env.ITERS ?? 10);
 const RAISE = process.env.RAISE === "1" ? "true" : "false";
+// PROFILE=1: ORT's WebGPU kernel profiler — per-kernel GPU time from timestamp queries — so a
+// forward's wall time can be split into GPU kernel time and everything else (dispatch, readback,
+// host). That split is the difference between "fuse the graph" and "make the kernels faster".
+const PROFILE = process.env.PROFILE === "1" ? "true" : "false";
 const DIST = path.resolve("node_modules/onnxruntime-web/dist");
 const PORT = 8791;
 const DATA_NAME = MODEL.split("/").pop() + ".data";
@@ -32,7 +36,9 @@ const say = (o) => fetch("/result", {method:"POST", body: JSON.stringify(o)});
 try {
   if (!navigator.gpu) throw new Error("navigator.gpu absent");
   const ad = await navigator.gpu.requestAdapter();
-  const info = ad ? (ad.info ? \`\${ad.info.vendor} \${ad.info.architecture}\` : "adapter ok") : "no adapter";
+  const ai = ad ? (ad.info ?? (ad.requestAdapterInfo ? await ad.requestAdapterInfo() : null)) : null;
+  const info = ad ? (ai ? \`\${ai.vendor} \${ai.architecture} \${ai.device||""} \${ai.description||""}\` : "adapter ok")
+    + (ad.isFallbackAdapter ? " [FALLBACK/software]" : "") + " ts=" + ad.features.has("timestamp-query") : "no adapter";
   const lim = ad.limits;
   await say({note:"limits", maxBuffer: lim.maxBufferSize, maxStorageBinding: lim.maxStorageBufferBindingSize});
   // ⚠ WebGPU grants DEFAULT limits (maxBufferSize 268 MB) unless you ask for more, whatever the
@@ -40,14 +46,24 @@ try {
   // embedding, or 310 MB at fp16 -- kills the device with "Out of memory" on a card with 23 GB
   // free. Build the device ourselves with the adapter's maximum and hand it to ORT.
   const raise = ${RAISE};
-  const dev0 = await ad.requestDevice(raise ? { requiredLimits: {
+  // The profiler needs the device created WITH timestamp-query, or it reports nothing at all.
+  const feats = (${PROFILE} && ad.features.has("timestamp-query")) ? ["timestamp-query"] : [];
+  const dev0 = await ad.requestDevice(raise ? { requiredFeatures: feats, requiredLimits: {
       maxBufferSize: ad.limits.maxBufferSize,
-      maxStorageBufferBindingSize: ad.limits.maxStorageBufferBindingSize } } : undefined);
+      maxStorageBufferBindingSize: ad.limits.maxStorageBufferBindingSize } } : { requiredFeatures: feats });
   dev0.lost.then(i => say({ok:false, error: "GPU DEVICE LOST: reason=" + i.reason + " msg=" + i.message}));
   if (raise) ort.env.webgpu.device = dev0;
   await say({note:"device", maxBuffer: dev0.limits.maxBufferSize, raised: raise});
   ort.env.wasm.wasmPaths = "/dist/";
   ort.env.logLevel = "error";
+  // Profiling is configured BEFORE the session exists: the backend reads it at initialisation.
+  const prof = new Map();
+  if (${PROFILE}) {
+    ort.env.webgpu.profiling = { mode: "default", ondata: (d) => {
+      const e = prof.get(d.kernelType) ?? { n: 0, ms: 0 };
+      e.n++; e.ms += (d.endTime - d.startTime) / 1e6; prof.set(d.kernelType, e);
+    } };
+  }
   let t = performance.now();
   const sess = await ort.InferenceSession.create("/model.onnx", {
     executionProviders: ["webgpu"], graphOptimizationLevel: "all",
@@ -67,9 +83,12 @@ try {
   // and any downward drift across a longer series is the fixed overhead amortizing.
   const warm=[];
   for (let i=0;i<${WARM};i++){ t=performance.now(); await sess.run(feeds); warm.push(performance.now()-t); }
+  prof.clear(); let profRuns = 0;   // the warm-ups are not counted
   const times=[];
-  for (let i=0;i<${ITERS};i++){ t=performance.now(); await sess.run(feeds); times.push(performance.now()-t); }
-  say({ok:true, info, load, warm, times, S:${S}, steps:${STEPS}});
+  for (let i=0;i<${ITERS};i++){ t=performance.now(); await sess.run(feeds); times.push(performance.now()-t); profRuns++; }
+  if (${PROFILE}) ort.env.webgpu.profiling = { mode: "" };
+  say({ok:true, info, load, warm, times, S:${S}, steps:${STEPS},
+       profile: ${PROFILE} ? { runs: profRuns, kernels: [...prof.entries()].map(([k,v]) => ({ k, n: v.n, ms: v.ms })) } : null});
 } catch (e) {
   let d;
   try { d = JSON.stringify(e, Object.getOwnPropertyNames(Object(e))); } catch { d = ""; }
@@ -101,6 +120,14 @@ const server = http.createServer((req, res) => {
       console.log(`load: ${(r.load / 1000).toFixed(1)}s`);
       console.log(`forward @S=${r.S}: ${per.toFixed(0)} ms  (runs: ${r.times.map(x => x.toFixed(0)).join(", ")})`);
       console.log(`=> ${r.steps} steps ≈ ${(per * r.steps / 1000).toFixed(1)}s per generation`);
+      if (r.profile) {
+        const ks = r.profile.kernels.map(k => ({ ...k, n: k.n / r.profile.runs, ms: k.ms / r.profile.runs }))
+          .sort((a, b) => b.ms - a.ms);
+        const total = ks.reduce((a, k) => a + k.ms, 0), count = ks.reduce((a, k) => a + k.n, 0);
+        console.log(`profile: ${count.toFixed(0)} kernels/forward, ${total.toFixed(0)} ms GPU time/forward `
+          + `(wall ${per.toFixed(0)} ms → ${(per - total).toFixed(0)} ms not in kernels)`);
+        for (const k of ks.slice(0, 14)) console.log(`  ${k.ms.toFixed(1).padStart(8)} ms  ${String(k.n.toFixed(0)).padStart(5)}×  ${k.k}`);
+      }
       done(0);
     });
     return;

--- a/web-demo/tools/logit-diff.mjs
+++ b/web-demo/tools/logit-diff.mjs
@@ -12,6 +12,11 @@ process.on("exit",()=>{try{CHILD?.kill("SIGKILL");}catch{}});
 const PORT=8796;
 const MODEL = process.env.MODEL ?? "/mnt/data/omnivoice_ipa/onnx_web/omnivoice_transformer_ipa.int4.onnx";
 const NAME = MODEL.split("/").pop();
+// MODEL2: a DIFFERENT file for the WebGPU side (e.g. an fp16-activation build) against MODEL on
+// WASM as the fp32 reference. Same inputs, one forward — the kernel-level precision question,
+// asked before any listening test. Defaults to MODEL, i.e. the original wasm-vs-webgpu check.
+const MODEL2 = process.env.MODEL2 ?? MODEL;
+const NAME2 = MODEL2.split("/").pop();
 const S = Number(process.env.S ?? 120);
 const PAGE=`<!doctype html><meta charset=utf-8><body><script type="module">
 const say=(o)=>fetch("/r",{method:"POST",body:JSON.stringify(o)});
@@ -20,6 +25,8 @@ try{
   ort.env.wasm.wasmPaths="/ort/"; ort.env.logLevel="error";
   const model=await (await fetch("/m/${NAME}")).arrayBuffer();
   const data=new Uint8Array(await (await fetch("/m/${NAME}.data")).arrayBuffer());
+  const model2=await (await fetch("/m2/${NAME2}")).arrayBuffer();
+  const data2=new Uint8Array(await (await fetch("/m2/${NAME2}.data")).arrayBuffer());
   const B=1,C=8,S=${S};
   const ids=BigInt64Array.from({length:B*C*S},(_,i)=>BigInt((i*7+3)%1024));
   const am=Uint8Array.from({length:B*S},(_,i)=>i%2===0?1:0);
@@ -29,8 +36,8 @@ try{
                     attention_mask:new ort.Tensor("bool",at,[B,1,S,S])});
   const out={};
   for (const ep of ["wasm","webgpu"]) {
-    const s=await ort.InferenceSession.create(model,{executionProviders:[ep],graphOptimizationLevel:"all",
-      externalData:[{path:"${NAME}.data",data}]});
+    const s=await ort.InferenceSession.create(ep==="wasm"?model:model2,{executionProviders:[ep],graphOptimizationLevel:"all",
+      externalData:[{path:ep==="wasm"?"${NAME}.data":"${NAME2}.data",data:ep==="wasm"?data:data2}]});
     const r=await s.run(feeds());
     out[ep]=Array.from(r.logits.data);
   }
@@ -50,11 +57,13 @@ http.createServer((q,res)=>{
     res.writeHead(200,iso);res.end("ok");const r=JSON.parse(b);
     if(!r.ok){console.error("FAILED: "+r.error);done(3);}
     console.log(`  logits: ${r.len} values`);
+    console.log(`  wasm: ${NAME} (${MODEL})  vs  webgpu: ${NAME2} (${MODEL2})`);
     console.log(`  max |wasm-webgpu| = ${r.maxAbs.toFixed(4)}   mean = ${r.meanAbs.toFixed(5)}`);
     console.log(`  argmax agreement  = ${(r.argmaxAgree*100).toFixed(3)}%`);
     done(0);});return;}
   if(q.url==="/"){res.writeHead(200,{...iso,"Content-Type":"text/html"});return res.end(PAGE);}
   let f = q.url===`/m/${NAME}` ? MODEL : q.url===`/m/${NAME}.data` ? MODEL+".data"
+        : q.url===`/m2/${NAME2}` ? MODEL2 : q.url===`/m2/${NAME2}.data` ? MODEL2+".data"
         : q.url.startsWith("/ort/") ? path.join("node_modules/onnxruntime-web/dist",q.url.slice(5)) : null;
   if(f&&fs.existsSync(f)){const ct=/\.(js|mjs)$/.test(f)?"text/javascript":/\.wasm$/.test(f)?"application/wasm":"application/octet-stream";
     res.writeHead(200,{...iso,"Content-Type":ct});return fs.createReadStream(f).pipe(res);}

--- a/web-demo/tools/pw-bench.mjs
+++ b/web-demo/tools/pw-bench.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * One transformer forward, N times, in a real Chrome under Playwright — the per-forward instrument
+ * for kernel and overhead experiments. Session options come from SESSION_OPTS (JSON) so a knob can
+ * be A/B'd without editing anything:
+ *
+ *   MODEL=<.onnx> S=350 B=2 ITERS=6 SESSION_OPTS='{"enableGraphCapture":true}' node tools/pw-bench.mjs
+ *
+ * ⚠ bench-webgpu.mjs measured 3× slower than the demo on what should have been the same GPU; its
+ * adapter reported different limits. This one launches Chrome exactly as pw-tts.mjs does, which
+ * matches the demo's numbers.
+ */
+import http from "node:http"; import fs from "node:fs"; import path from "node:path";
+import { chromium } from "playwright";
+const PORT = 8798;
+const MODEL = process.env.MODEL ?? "/mnt/data/omnivoice_ipa/onnx_web/omnivoice_transformer_ipa.int4.onnx";
+const NAME = MODEL.split("/").pop();
+const S = Number(process.env.S ?? 350), B = Number(process.env.B ?? 2);
+const WARM = Number(process.env.WARM ?? 2), ITERS = Number(process.env.ITERS ?? 6);
+const OPTS = process.env.SESSION_OPTS ?? "{}", EP = process.env.EP ?? "webgpu";
+const DEADLINE = Number(process.env.DEADLINE ?? 240) * 1000;
+const FEATURES_ONLY = process.env.FEATURES_ONLY === "1";     // print the adapter's features and stop
+const EXTRA_FLAGS = (process.env.EXTRA_FLAGS ?? "").split(" ").filter(Boolean);
+const VERBOSE = process.env.VERBOSE === "1";                 // echo every console line (ORT placement logs)
+
+const PAGE = `<!doctype html><meta charset=utf-8><body><script type="module">
+const p = (m) => console.log("progress: " + m);
+try {
+  { const ad = await navigator.gpu?.requestAdapter(); p("adapter features: " + (ad ? [...ad.features].sort().join(" ") : "none"));
+    if (${FEATURES_ONLY}) { window.__result = { ok: true, warm: [0], times: [0] }; throw new Error("__stop"); } }
+  const ort = await import("https://cdn.jsdelivr.net/npm/onnxruntime-web@1.29.0/dist/ort.all.bundle.min.mjs");
+  ort.env.wasm.wasmPaths = "https://cdn.jsdelivr.net/npm/onnxruntime-web@1.29.0/dist/";
+  ort.env.logLevel = "error"; ort.env.wasm.numThreads = 8;
+  const model = await (await fetch("/m/${NAME}")).arrayBuffer();
+  const data = new Uint8Array(await (await fetch("/m/${NAME}.data")).arrayBuffer());
+  const extra = ${OPTS};
+  let t = performance.now();
+  const sess = await ort.InferenceSession.create(model, { executionProviders: [${JSON.stringify(EP)}], graphOptimizationLevel: "all",
+    externalData: [{ path: "${NAME}.data", data }], ...extra });
+  p("session " + ((performance.now() - t) / 1000).toFixed(1) + "s  opts=" + JSON.stringify(extra));
+  const B = ${B}, C = 8, S = ${S};
+  const ids = BigInt64Array.from({ length: B * C * S }, (_, i) => BigInt((i * 7 + 3) % 1024));
+  const am = Uint8Array.from({ length: B * S }, (_, i) => i % 2 === 0 ? 1 : 0);
+  const at = new Uint8Array(B * S * S).fill(1);
+  const feeds = () => ({ input_ids: new ort.Tensor("int64", ids, [B, C, S]), audio_mask: new ort.Tensor("bool", am, [B, S]),
+    attention_mask: new ort.Tensor("bool", at, [B, 1, S, S]) });
+  const warm = [], times = [];
+  for (let i = 0; i < ${WARM}; i++) { t = performance.now(); const r = await sess.run(feeds()); warm.push(performance.now() - t); r.logits.dispose?.(); }
+  for (let i = 0; i < ${ITERS}; i++) { t = performance.now(); const r = await sess.run(feeds()); times.push(performance.now() - t); r.logits.dispose?.(); }
+  window.__result = { ok: true, warm, times };
+} catch (e) { if (!String(e).includes("__stop")) window.__result = { ok: false, error: String(e && e.stack || e) }; }
+</script>`;
+const iso = { "Cross-Origin-Opener-Policy": "same-origin", "Cross-Origin-Embedder-Policy": "require-corp" };
+const server = http.createServer((req, res) => {
+  if (req.url === "/") { res.writeHead(200, { ...iso, "Content-Type": "text/html" }); return res.end(PAGE); }
+  const f = req.url === `/m/${NAME}` ? MODEL : req.url === `/m/${NAME}.data` ? MODEL + ".data" : null;
+  if (f && fs.existsSync(f)) { res.writeHead(200, { ...iso, "Content-Type": "application/octet-stream", "Content-Length": fs.statSync(f).size }); return fs.createReadStream(f).pipe(res); }
+  res.writeHead(404, iso); res.end();
+}).listen(PORT);
+const T0 = Date.now(); const at = () => `[${((Date.now() - T0) / 1000).toFixed(1)}s]`;
+const browser = await chromium.launch({ executablePath: process.env.CHROME || "/usr/bin/google-chrome", headless: false,
+  args: ["--no-sandbox", "--disable-gpu-sandbox", "--enable-unsafe-webgpu", "--no-first-run", "--no-default-browser-check",
+    "--disable-search-engine-choice-screen", "--noerrdialogs", "--ozone-platform=x11", "--enable-gpu", "--ignore-gpu-blocklist",
+    "--enable-features=Vulkan", "--use-angle=vulkan", ...EXTRA_FLAGS], env: { ...process.env, DISPLAY: process.env.DISPLAY || ":0" } });
+const page = await browser.newPage();
+page.on("console", (m) => { const t = m.text(); if (t.startsWith("progress: ")) console.log(`${at()} ${t.slice(10)}`); else if (VERBOSE) console.log(`${at()} ${m.type()}: ${t.slice(0, 300)}`); else if (m.type() === "error" && !/VerifyEachNode|404/.test(t)) console.log(`${at()} console.error: ${t.slice(0, 240)}`); });
+page.on("pageerror", (e) => console.log(`${at()} pageerror: ${String(e).slice(0, 240)}`));
+async function finish(code) { try { await browser.close(); } catch {} server.close(); process.exit(code); }
+await page.goto(`http://localhost:${PORT}/`);
+let r = null;
+while (Date.now() - T0 < DEADLINE) { r = await page.evaluate(() => window.__result ?? null).catch(() => null); if (r) break; await new Promise((f) => setTimeout(f, 500)); }
+if (!r) { console.log(`${at()} DEADLINE — hung`); await finish(4); }
+if (!r.ok) { console.log(`${at()} FAILED: ${r.error.slice(0, 400)}`); await finish(3); }
+const mean = r.times.reduce((a, x) => a + x, 0) / r.times.length;
+console.log(`${at()} S=${S} B=${B}  warm ${r.warm.map((x) => x.toFixed(0)).join(",")}  forward mean ${mean.toFixed(0)} ms  min ${Math.min(...r.times).toFixed(0)}  (${r.times.map((x) => x.toFixed(0)).join(", ")})`);
+await finish(0);

--- a/web-demo/tools/pw-tts.mjs
+++ b/web-demo/tools/pw-tts.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Drive the demo's engine in a REAL Chrome under Playwright and report as it goes.
+ *
+ * Replaces the http+spawn harness pattern (smoke-tts.mjs) for anything that can hang: this one
+ * sees the page's console and errors, prints progress the moment it happens, and gives up on a
+ * deadline of its own instead of waiting for a timeout to expire on a page that will never post.
+ *
+ *   MODEL=<int4.onnx> EP=webgpu|wasm STEPS=32 TEXT="..." LANG_CODE=en DEADLINE=300 \
+ *     node tools/pw-tts.mjs
+ */
+import http from "node:http"; import fs from "node:fs"; import path from "node:path";
+import { chromium } from "playwright";
+
+const PORT = 8797, PUB = path.resolve("public");
+const MODEL = process.env.MODEL ?? "/mnt/data/omnivoice_ipa/onnx_web/omnivoice_transformer_ipa.int4.onnx";
+const NAME = MODEL.split("/").pop();
+const FILES = {
+  [`/models/${NAME}`]: MODEL, [`/models/${NAME}.data`]: MODEL + ".data",
+  "/models/higgs_decoder.onnx": "/mnt/data/Programming/vernacula/scripts/omnivoice_export/onnx/higgs_decoder.onnx",
+  "/models/tokenizer.json": "/mnt/data/models/omnivoice/k2-fsa-OmniVoice/tokenizer.json",
+};
+const TEXT = process.env.TEXT ?? "The quick brown fox jumps over the lazy dog, and the weather today is remarkably pleasant.";
+const LANG = process.env.LANG_CODE ?? "en", STEPS = Number(process.env.STEPS ?? 32);
+const EP = process.env.EP ?? null, DEADLINE = Number(process.env.DEADLINE ?? 300) * 1000;
+const PROFILE = process.env.PROFILE === "1", OUT = process.env.OUT ?? "/tmp/pw_tts.wav";
+
+const PAGE = `<!doctype html><meta charset=utf-8><body><script type="module">
+const p = (m) => console.log("progress: " + m);
+try {
+  const m = await (await fetch("/vphon-data/_keys.json")).json();
+  const entry = m.languages[${JSON.stringify(LANG)}] ?? { dirs: [], core: [], exclude: [] };
+  const skip = new Set(entry.exclude ?? []);
+  const keys = [...m.engine, ...entry.dirs.flatMap((d) => m.dirs[d] ?? []), ...(entry.core ?? [])].filter((k) => !skip.has(k));
+  const bytes = new Map();
+  await Promise.all(keys.map(async k => { const r = await fetch("/vphon-data/"+k); bytes.set(k, new Uint8Array(await r.arrayBuffer())); }));
+  const vp = await import("/vphon/src/browser.js");
+  vp.setDataSource({ read:(k)=>{ const b=bytes.get(k); if(!b) throw new Error("missing key "+k); return b; } });
+  vp.setOrtLoader(()=>import("/ort/ort.wasm.bundle.min.mjs"));
+  const { phonemizeAsync } = await vp.loadEngine();
+  const ipa = (await phonemizeAsync(${JSON.stringify(TEXT)}, ${JSON.stringify(LANG)})).trim();
+  p("ipa: " + ipa);
+  const mod = await import("/app/omnivoice.js");
+  if (${JSON.stringify(EP)}) mod.setForcedEp(${JSON.stringify(EP)});
+  const prof = new Map();
+  if (${PROFILE}) {
+    const ortMod = await import("https://cdn.jsdelivr.net/npm/onnxruntime-web@1.29.0/dist/ort.all.bundle.min.mjs");
+    ortMod.env.webgpu.profiling = { mode: "default", ondata: (d) => {
+      const e = prof.get(d.kernelType) ?? { n: 0, ms: 0 }; e.n++; e.ms += (d.endTime - d.startTime) / 1e6; prof.set(d.kernelType, e); } };
+  }
+  { // diagnostics: what the adapter offers, and which device ORT ends up on
+    const ad = await navigator.gpu?.requestAdapter();
+    p("adapter features: " + (ad ? [...ad.features].join(" ") : "none"));
+  }
+  const t0 = performance.now();
+  const ov = await mod.OmniVoice.load({
+    transformerUrl: "/models/${NAME}", transformerDataUrl: "/models/${NAME}.data",
+    decoderUrl: "/models/higgs_decoder.onnx", tokenizerUrl: "/models/tokenizer.json",
+    voicesUrl: "/models/voices.jsonc", voiceCodesUrl: "/models/voice-codes.json",
+    fetchBytes: async (u) => (await fetch(u)).arrayBuffer(), onProgress: p,
+  });
+  p("load " + ((performance.now()-t0)/1000).toFixed(1) + "s ep=" + ov.backend.ep);
+  { const ortMod = await import("https://cdn.jsdelivr.net/npm/onnxruntime-web@1.29.0/dist/ort.all.bundle.min.mjs");
+    const d = ortMod.env.webgpu.device; p("ORT device features: " + (d ? [...d.features].join(" ") : "(no device exposed)")); }
+  const voice = mod.voiceFor(ov.voices, ${JSON.stringify(LANG)});
+  const r = await ov.synthesize(ipa, voice, { numStep: ${STEPS} }, (s, t) => { if (s === 1 || s % 8 === 0 || s === t) p("step " + s + "/" + t); });
+  const a = r.audio; let peak = 0, sum = 0; for (const v of a) { peak = Math.max(peak, Math.abs(v)); sum += v*v; }
+  window.__result = { ok: true, ep: ov.backend.ep, targetTokens: r.targetTokens, seconds: a.length / r.sampleRate,
+    generateMs: r.generateMs, transformerMs: r.transformerMs, hostMs: r.hostMs, peak, rms: Math.sqrt(sum / a.length),
+    profile: prof.size ? [...prof.entries()].map(([k, v]) => ({ k, n: v.n, ms: v.ms })) : null,
+    wav: Array.from(new Uint8Array(new Float32Array(a).buffer)) };
+} catch (e) { window.__result = { ok: false, error: String(e && e.stack || e) }; }
+</script>`;
+
+const iso = { "Cross-Origin-Opener-Policy": "same-origin", "Cross-Origin-Embedder-Policy": "require-corp" };
+const server = http.createServer((req, res) => {
+  if (req.url === "/") { res.writeHead(200, { ...iso, "Content-Type": "text/html" }); return res.end(PAGE); }
+  const f = FILES[req.url]
+    ?? (req.url.startsWith("/ort/") ? path.join("node_modules/onnxruntime-web/dist", req.url.slice(5))
+    :  req.url.startsWith("/app/") ? path.join("build-smoke", req.url.slice(5))
+    :  path.join(PUB, decodeURIComponent(req.url)));
+  if (fs.existsSync(f) && fs.statSync(f).isFile()) {
+    const ct = /\.(js|mjs)$/.test(f) ? "text/javascript" : /\.wasm$/.test(f) ? "application/wasm" : /\.json$/.test(f) ? "application/json" : "application/octet-stream";
+    res.writeHead(200, { ...iso, "Content-Type": ct, "Content-Length": fs.statSync(f).size });
+    return fs.createReadStream(f).pipe(res);
+  }
+  res.writeHead(404, iso); res.end();
+}).listen(PORT);
+
+const T0 = Date.now(); const at = () => `[${((Date.now() - T0) / 1000).toFixed(1)}s]`;
+const browser = await chromium.launch({
+  executablePath: process.env.CHROME || "/usr/bin/google-chrome", headless: false,
+  args: ["--no-sandbox", "--disable-gpu-sandbox", "--enable-unsafe-webgpu", "--no-first-run", "--no-default-browser-check",
+    "--disable-search-engine-choice-screen", "--noerrdialogs", "--ozone-platform=x11", "--enable-gpu",
+    "--ignore-gpu-blocklist", "--enable-features=Vulkan", "--use-angle=vulkan"],
+  env: { ...process.env, DISPLAY: process.env.DISPLAY || ":0" },
+});
+const page = await browser.newPage();
+page.on("console", (m) => { const t = m.text(); if (t.startsWith("progress: ")) console.log(`${at()} ${t.slice(10)}`); else if (m.type() === "error" || m.type() === "warning") console.log(`${at()} console.${m.type()}: ${t.slice(0, 300)}`); });
+page.on("pageerror", (e) => console.log(`${at()} pageerror: ${String(e).slice(0, 300)}`));
+page.on("crash", () => { console.log(`${at()} PAGE CRASHED`); finish(5); });
+async function finish(code) { try { await browser.close(); } catch {} server.close(); process.exit(code); }
+await page.goto(`http://localhost:${PORT}/`);
+let r = null;
+while (Date.now() - T0 < DEADLINE) {
+  r = await page.evaluate(() => window.__result ?? null).catch(() => null);
+  if (r) break;
+  await new Promise((f) => setTimeout(f, 1000));
+}
+if (!r) { console.log(`${at()} DEADLINE (${DEADLINE / 1000}s) with no result — hung`); await finish(4); }
+if (!r.ok) { console.log(`${at()} FAILED: ${r.error}`); await finish(3); }
+const f32 = new Float32Array(new Uint8Array(r.wav).buffer);
+const wav = (s, sr) => { const b = Buffer.alloc(44 + s.length * 4); b.write("RIFF", 0); b.writeUInt32LE(36 + s.length * 4, 4); b.write("WAVEfmt ", 8); b.writeUInt32LE(16, 16); b.writeUInt16LE(3, 20); b.writeUInt16LE(1, 22); b.writeUInt32LE(sr, 24); b.writeUInt32LE(sr * 4, 28); b.writeUInt16LE(4, 32); b.writeUInt16LE(32, 34); b.write("data", 36); b.writeUInt32LE(s.length * 4, 40); Buffer.from(s.buffer).copy(b, 44); return b; };
+fs.writeFileSync(OUT, wav(f32, 24000));
+console.log(`${at()} ep=${r.ep} targetTokens=${r.targetTokens} audio=${r.seconds.toFixed(2)}s  generate ${(r.generateMs / 1000).toFixed(1)}s (transformer ${(r.transformerMs / 1000).toFixed(1)}s, host ${(r.hostMs / 1000).toFixed(1)}s)  peak=${r.peak.toFixed(3)} rms=${r.rms.toFixed(4)} -> ${OUT}`);
+if (r.profile) {
+  const ks = r.profile.sort((a, b) => b.ms - a.ms), total = ks.reduce((a, k) => a + k.ms, 0), count = ks.reduce((a, k) => a + k.n, 0);
+  console.log(`  profile per forward: ${Math.round(count / STEPS)} kernels, ${(total / STEPS).toFixed(0)} ms GPU (wall ${(r.transformerMs / STEPS).toFixed(0)} ms)`);
+  for (const k of ks.slice(0, 8)) console.log(`    ${(k.ms / STEPS).toFixed(1).padStart(8)} ms  ${String(Math.round(k.n / STEPS)).padStart(5)}×  ${k.k}`);
+}
+await finish(0);

--- a/web-demo/tools/smoke-tts.mjs
+++ b/web-demo/tools/smoke-tts.mjs
@@ -52,6 +52,14 @@ try{
   if (${JSON.stringify(process.env.EP ?? null)}) mod.setForcedEp(${JSON.stringify(process.env.EP ?? null)});
   if (${JSON.stringify(process.env.GRAPH_OPT ?? null)}) mod.setGraphOpt(${JSON.stringify(process.env.GRAPH_OPT ?? null)});
   if (${JSON.stringify(process.env.DECODER_EP ?? null)}) mod.setDecoderEp(${JSON.stringify(process.env.DECODER_EP ?? null)});
+  const prof = new Map(); let forwards = 0;
+  if (${JSON.stringify(process.env.PROFILE === "1")}) {
+    const ortMod = await import("https://cdn.jsdelivr.net/npm/onnxruntime-web@1.29.0/dist/ort.all.bundle.min.mjs");
+    ortMod.env.webgpu.profiling = { mode: "default", ondata: (d) => {
+      const e = prof.get(d.kernelType) ?? { n: 0, ms: 0 };
+      e.n++; e.ms += (d.endTime - d.startTime) / 1e6; prof.set(d.kernelType, e);
+    } };
+  }
   const t0 = performance.now();
   const ov = await mod.OmniVoice.load({
     transformerUrl: "/models/${MODEL_NAME}",
@@ -61,7 +69,7 @@ try{
     voicesUrl: "/models/voices.jsonc",
     voiceCodesUrl: "/models/voice-codes.json",
     fetchBytes: async (u) => (await fetch(u)).arrayBuffer(),
-    onProgress: (d) => log.push("  " + d),
+    onProgress: (d) => { log.push("  " + d); fetch("/p", { method: "POST", body: d }); },
   });
   log.push("load: " + ((performance.now()-t0)/1000).toFixed(1) + "s   ep=" + ov.backend.ep);
 
@@ -72,13 +80,20 @@ try{
   say({ok:true, log, ipa, ep: ov.backend.ep,
        targetTokens: r.targetTokens, seconds: a.length/r.sampleRate,
        generateMs: r.generateMs, transformerMs: r.transformerMs, hostMs: r.hostMs,
+       profile: prof.size ? [...prof.entries()].map(([k,v]) => ({ k, n: v.n, ms: v.ms })) : null,
        peak, rms: Math.sqrt(sum/a.length),
        wav: Array.from(new Uint8Array(new Float32Array(a).buffer))});
 }catch(e){ say({ok:false, log, error:[String(e), e&&e.stack].join(" | ")}); }
 </script>`;
 
 const iso = {"Cross-Origin-Opener-Policy":"same-origin","Cross-Origin-Embedder-Policy":"require-corp"};
+const T0 = Date.now();
 http.createServer((req,res)=>{
+  if (req.method==="POST" && req.url==="/p") {
+    let b=""; req.on("data",c=>b+=c); req.on("end",()=>{ res.writeHead(200,iso); res.end("ok");
+      console.log(`  [${((Date.now()-T0)/1000).toFixed(1)}s] ${b}`); });
+    return;
+  }
   if (req.method==="POST" && req.url==="/r") {
     let b=""; req.on("data",c=>b+=c);
     req.on("end",()=>{ res.writeHead(200,iso); res.end("ok");
@@ -90,6 +105,15 @@ http.createServer((req,res)=>{
       console.log(`  ep=${r.ep}  targetTokens=${r.targetTokens}  audio=${r.seconds.toFixed(2)}s`);
       console.log(`  generate ${(r.generateMs/1000).toFixed(1)}s  (transformer ${(r.transformerMs/1000).toFixed(1)}s, host ${(r.hostMs/1000).toFixed(1)}s)`);
       console.log(`  peak=${r.peak.toFixed(4)} rms=${r.rms.toFixed(4)}  -> ${out}`);
+      if (r.profile) {
+        // Per generation; the transformer ran STEPS times (B=2 CFG pairs in one forward) plus the
+        // decoder once — so per-forward figures are per-generation / STEPS, near enough.
+        const ks = r.profile.sort((a, b) => b.ms - a.ms);
+        const total = ks.reduce((a, k) => a + k.ms, 0), count = ks.reduce((a, k) => a + k.n, 0);
+        console.log(`  profile: ${count} kernels, ${(total/1000).toFixed(1)}s GPU time per generation `
+          + `(transformer wall ${(r.transformerMs/1000).toFixed(1)}s → ${((r.transformerMs-total)/1000).toFixed(1)}s not in kernels); per forward ≈ ${(count/STEPS).toFixed(0)} kernels, ${(total/STEPS).toFixed(0)} ms`);
+        for (const k of ks.slice(0, 14)) console.log(`    ${(k.ms/STEPS).toFixed(1).padStart(8)} ms  ${String(Math.round(k.n/STEPS)).padStart(5)}×  ${k.k}`);
+      }
       done(0); });
     return;
   }


### PR DESCRIPTION
Tooling and one small demo change from the "can the browser reach 1× real time" investigation (`docs/tts_speed_investigation.md`, Runs 5–10). No served model changes.

**Instruments** — the existing http+spawn harnesses report only at the end and hang silently on a dead page; `bench-webgpu.mjs` measured on a different adapter than the demo gets.
- `tools/pw-tts.mjs` — the demo's engine in the system Chrome under Playwright: console, errors and progress stream live, a deadline instead of a timeout, optional kernel profile.
- `tools/pw-bench.mjs` — N forwards with session options from env (`SESSION_OPTS`), plus `EXTRA_FLAGS`, `FEATURES_ONLY`, `VERBOSE`.
- `logit-diff.mjs` gains `MODEL2`; `smoke-tts.mjs` repaired (manifest shape, voice library, streaming progress, `PROFILE`); `bench-webgpu.mjs` gains `PROFILE`.
- Playwright is a devDependency; it launches the installed Chrome, no browser download.

**Demo** — ORT-web 1.29 creates its own WebGPU device and ignores `env.webgpu.device`, so `useMaxLimitsDevice` has been a no-op (documented, kept). After the transformer session exists the demo reports that device's features in the progress log and hooks its `lost` promise, so a dead device surfaces as an error rather than a progress bar that never moves.

**What was measured** (fused fp32 int4 build, RTX 3090, Chrome/Dawn, per B=2 forward at S≈350: 647 ms):
- RMSNorm fusion via ORT's `gpt2` pass: 3,684 → 2,442 kernels, **6%** faster.
- Logits readback: ~20 ms. CPU-side shape nodes (a static-shape graph): ~0. Graph capture: refused (nodes remain on the CPU EP).
- `MatMulNBits` is 84% of GPU time; every fast path for it in ORT-web needs `shader-f16`, which this adapter does not expose under any flag. The fp16 build (`onnx_web/v7-fused-f16/`, local) is valid — it runs on WASM — and has to be judged on an adapter with f16 (Mac/Metal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc
