### PR TITLE
review fixes: drop the device ORT ignores; env paths and base64 in pw-tts

### DIFF
--- a/web-demo/.gitignore
+++ b/web-demo/.gitignore
@@ -6,3 +6,4 @@ public/*.wasm
 public/vphon/
 public/vphon-data/
 build-smoke/
+.vite/

--- a/web-demo/src/inference/omnivoice.ts
+++ b/web-demo/src/inference/omnivoice.ts
@@ -145,7 +145,6 @@ export class OmniVoice {
   static async load(o: LoadOptions): Promise<OmniVoice> {
     const ORT = await getOrt();
     const ep = await pickExecutionProvider();
-    if (ep === "webgpu") await useMaxLimitsDevice();
     o.onProgress?.(`execution provider: ${ep}`);
 
     const opts: ort.InferenceSession.SessionOptions = {
@@ -297,14 +296,13 @@ export function voiceFor(voices: Voice[], lang: string, id?: string): Voice {
  * RTX 3090 at 16 steps: WebGPU/Chrome 177 ms per forward (~2.8 s per phrase) against 1295 ms on
  * 8-thread WASM (~20.7 s). Firefox's WebGPU was SLOWER than WASM and flat in sequence length, so
  * probing for an adapter is not enough on its own — the UI reports which path it got.
- */
-/**
- * Hand ORT a device built with the adapter's MAXIMUM limits.
  *
- * ⚠ WebGPU's `requestDevice()` grants DEFAULT limits — maxBufferSize 268 MB — however large the
- * adapter's maximum, and ORT takes the default. A model with any single tensor above that kills the
- * device with "Out of memory" on a GPU with tens of GB free. This build's largest tensor is 155 MB
- * so it clears the default, but that is luck rather than design, and it forecloses larger models.
+ * ⚠ THE DEVICE IS ORT'S, NOT OURS. An earlier version built a GPUDevice with the adapter's maximum
+ * limits and put it in `env.webgpu.device`; ORT-web 1.29's native WebGPU EP ignores that and
+ * creates its own — with the features it wants (shader-f16 where the adapter offers it) and
+ * DEFAULT limits, maxBufferSize 268 MB. Measured to be a no-op (docs/tts_speed_investigation.md,
+ * Run 8), so it is gone. The shipped build's largest tensor is 155 MB and fits; a build with a
+ * tensor over 268 MB needs the API to accept a device again.
  */
 /**
  * ⚠ A LOST DEVICE MUST SAY SO. Without this, a kernel fault or an out-of-memory kills the device
@@ -320,37 +318,4 @@ function reportOrtDevice(ORT: Ort, onProgress?: (d: string) => void): void {
   device.lost.then((info) => console.error(`WebGPU device lost: ${info.reason}: ${info.message}`));
 }
 
-interface AdapterLike {
-  limits: { maxBufferSize: number; maxStorageBufferBindingSize: number };
-  features: Set<string>;
-  requestDevice(d?: { requiredFeatures?: string[]; requiredLimits?: Record<string, number> }): Promise<unknown>;
-}
-
-/**
- * ⚠ MEASURED TO BE A NO-OP ON ORT-WEB 1.29 (docs/tts_speed_investigation.md, Run 8): the native
- * WebGPU EP creates its own device — with the features it wants and DEFAULT limits — and ignores
- * `env.webgpu.device`. It works because the largest tensor (155 MB) fits the default 268 MB. Kept
- * for the day the API accepts a device again; reportOrtDevice says what ORT actually got.
- */
-async function useMaxLimitsDevice(): Promise<void> {
-  try {
-    const gpu = (navigator as unknown as { gpu?: { requestAdapter(): Promise<AdapterLike | null> } }).gpu;
-    const adapter = await gpu?.requestAdapter();
-    if (!adapter) return;
-    // ⚠ FEATURES ARE OPT-IN TOO. A device we build ourselves has NO optional features unless
-    // asked: without `shader-f16` every fp16 kernel fails validation ("Invalid ComputePipeline
-    // MatMulNBits" and a cascade after it), which is how the fp16 build ran but produced garbage.
-    // ORT requests these itself when it creates the device; we must do the same when we do.
-    const wanted = ["shader-f16", "subgroups", "timestamp-query"];
-    const requiredFeatures = wanted.filter((f) => (adapter as unknown as { features: Set<string> }).features.has(f));
-    const device = await adapter.requestDevice({
-      requiredFeatures,
-      requiredLimits: {
-        maxBufferSize: adapter.limits.maxBufferSize,
-        maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,
-      },
-    });
-    ((await getOrt()).env.webgpu as unknown as { device?: unknown }).device = device;
-  } catch { /* fall back to ORT's own default-limits device */ }
-}
 

--- a/web-demo/tools/bench-webgpu.mjs
+++ b/web-demo/tools/bench-webgpu.mjs
@@ -1,5 +1,11 @@
 // Measure a transformer forward on the WebGPU EP, in headless Chrome.
 //
+// ⚠ PREFER tools/pw-bench.mjs. This harness measured 3.3 s per forward where the demo's own path
+// measured 1.1 s on the same machine, and its adapter reported different limits (2147 MB vs the
+// 4295 MB Run 8 recorded for Chrome/Dawn on the NVIDIA card): it does not reliably land on the
+// GPU the demo gets. pw-bench launches Chrome exactly as the demo's Playwright harness does and
+// matches the demo's numbers. docs/tts_speed_investigation.md, Run 6.
+//
 // ORT's WebGPU backend cannot be driven from Node (no navigator.gpu), so this serves a bench page
 // over localhost with the cross-origin-isolation headers ORT needs, launches headless Chrome at it,
 // and collects the timing the page posts back. Same model file the WASM bench uses, so the two

--- a/web-demo/tools/pw-tts.mjs
+++ b/web-demo/tools/pw-tts.mjs
@@ -7,7 +7,7 @@
  * deadline of its own instead of waiting for a timeout to expire on a page that will never post.
  *
  *   MODEL=<int4.onnx> EP=webgpu|wasm STEPS=32 TEXT="..." LANG_CODE=en DEADLINE=300 \
- *     node tools/pw-tts.mjs
+ *     [DECODER=<higgs_decoder.onnx> TOKENIZER=<tokenizer.json> OUT=<wav> PROFILE=1] node tools/pw-tts.mjs
  */
 import http from "node:http"; import fs from "node:fs"; import path from "node:path";
 import { chromium } from "playwright";
@@ -17,8 +17,8 @@ const MODEL = process.env.MODEL ?? "/mnt/data/omnivoice_ipa/onnx_web/omnivoice_t
 const NAME = MODEL.split("/").pop();
 const FILES = {
   [`/models/${NAME}`]: MODEL, [`/models/${NAME}.data`]: MODEL + ".data",
-  "/models/higgs_decoder.onnx": "/mnt/data/Programming/vernacula/scripts/omnivoice_export/onnx/higgs_decoder.onnx",
-  "/models/tokenizer.json": "/mnt/data/models/omnivoice/k2-fsa-OmniVoice/tokenizer.json",
+  "/models/higgs_decoder.onnx": process.env.DECODER ?? "/mnt/data/Programming/vernacula/scripts/omnivoice_export/onnx/higgs_decoder.onnx",
+  "/models/tokenizer.json": process.env.TOKENIZER ?? "/mnt/data/models/omnivoice/k2-fsa-OmniVoice/tokenizer.json",
 };
 const TEXT = process.env.TEXT ?? "The quick brown fox jumps over the lazy dog, and the weather today is remarkably pleasant.";
 const LANG = process.env.LANG_CODE ?? "en", STEPS = Number(process.env.STEPS ?? 32);
@@ -68,7 +68,8 @@ try {
   window.__result = { ok: true, ep: ov.backend.ep, targetTokens: r.targetTokens, seconds: a.length / r.sampleRate,
     generateMs: r.generateMs, transformerMs: r.transformerMs, hostMs: r.hostMs, peak, rms: Math.sqrt(sum / a.length),
     profile: prof.size ? [...prof.entries()].map(([k, v]) => ({ k, n: v.n, ms: v.ms })) : null,
-    wav: Array.from(new Uint8Array(new Float32Array(a).buffer)) };
+    // base64, not a JSON array of bytes: 7 s of audio is 2.8 MB of samples and 10 MB as digits.
+    wav: btoa(Array.from(new Uint8Array(new Float32Array(a).buffer), (b) => String.fromCharCode(b)).join("")) };
 } catch (e) { window.__result = { ok: false, error: String(e && e.stack || e) }; }
 </script>`;
 
@@ -109,7 +110,7 @@ while (Date.now() - T0 < DEADLINE) {
 }
 if (!r) { console.log(`${at()} DEADLINE (${DEADLINE / 1000}s) with no result — hung`); await finish(4); }
 if (!r.ok) { console.log(`${at()} FAILED: ${r.error}`); await finish(3); }
-const f32 = new Float32Array(new Uint8Array(r.wav).buffer);
+const f32 = new Float32Array(Uint8Array.from(Buffer.from(r.wav, "base64")).buffer);
 const wav = (s, sr) => { const b = Buffer.alloc(44 + s.length * 4); b.write("RIFF", 0); b.writeUInt32LE(36 + s.length * 4, 4); b.write("WAVEfmt ", 8); b.writeUInt32LE(16, 16); b.writeUInt16LE(3, 20); b.writeUInt16LE(1, 22); b.writeUInt32LE(sr, 24); b.writeUInt32LE(sr * 4, 28); b.writeUInt16LE(4, 32); b.writeUInt16LE(32, 34); b.write("data", 36); b.writeUInt32LE(s.length * 4, 40); Buffer.from(s.buffer).copy(b, 44); return b; };
 fs.writeFileSync(OUT, wav(f32, 24000));
 console.log(`${at()} ep=${r.ep} targetTokens=${r.targetTokens} audio=${r.seconds.toFixed(2)}s  generate ${(r.generateMs / 1000).toFixed(1)}s (transformer ${(r.transformerMs / 1000).toFixed(1)}s, host ${(r.hostMs / 1000).toFixed(1)}s)  peak=${r.peak.toFixed(3)} rms=${r.rms.toFixed(4)} -> ${OUT}`);


### PR DESCRIPTION
Review pass over #105.

- `useMaxLimitsDevice` created a GPUDevice on every load that ORT-web 1.29 never used (Run 8), and after #105 it also requested three features for nothing. Removed; the finding lives in the comment where the code was. Sanity-run on Chrome WebGPU: the demo still reports ORT's device features and renders.
- `pw-tts.mjs`: `DECODER`/`TOKENIZER` paths from the environment; audio returned as base64 instead of a 10 MB JSON array of bytes.
- `bench-webgpu.mjs`: header says it measured on the wrong adapter and points at `pw-bench.mjs`.
- `web-demo/.gitignore`: `.vite/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc