### PR TITLE
fix(reader): switching language selects that language's default voice

### DIFF
--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -467,21 +467,16 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         FileExists(OmniVoiceTokenizerJson) ? OmniVoiceTokenizerJson
         : DirExists(OmniVoiceOnnxDir) ? OmniVoiceIpaTts.LocateTokenizerJson(OmniVoiceOnnxDir) : null;
 
-    // Reload the library and re-pick: keep the selection when it is still a candidate for the
-    // language (and a keepId was given); otherwise the language's `default` entry, its donor's,
-    // any default, else the first candidate.
+    // Reload the library and re-pick: keep the selection when a keepId was given and it is still
+    // a candidate for the language; otherwise the candidates' `default` entry (the candidates are
+    // already one language tier, so that is the language's own default, or its donor's), else the
+    // first candidate.
     private void RefreshOmniVoiceVoices(string? keepId)
     {
         _allOmniVoiceVoices = StoredVoice.IsLibrary(OmniVoiceVoiceLib)
             ? SafeListVoices(OmniVoiceVoiceLib) : Array.Empty<StoredVoice.Info>();
         var candidates = VoiceCandidates();
-        var lang = (OmniVoiceLang ?? "").Trim();
-        var donor = LanguageCatalog.VoiceLangOf(lang);
-        bool IsDefaultFor(StoredVoice.Info v, string code) =>
-            v.IsDefault && string.Equals(v.Lang, code, StringComparison.OrdinalIgnoreCase);
         OmniVoiceVoice = (keepId is null ? null : candidates.FirstOrDefault(v => v.Id == keepId))
-            ?? candidates.FirstOrDefault(v => IsDefaultFor(v, lang))
-            ?? candidates.FirstOrDefault(v => IsDefaultFor(v, donor))
             ?? candidates.FirstOrDefault(v => v.IsDefault)
             ?? candidates.FirstOrDefault();
         OmniVoiceVoiceQuery = OmniVoiceVoice?.ToString() ?? "";

--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -420,7 +420,8 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     }
     partial void OnOmniVoiceLangChanged(string value)
     {
-        RefreshOmniVoiceVoices(OmniVoiceVoice?.Id);
+        // A new language gets its default voice, not whichever voice the last language left behind.
+        RefreshOmniVoiceVoices(keepId: null);
         PersistSettings();
         UpdatePrerequisiteStatus();
     }
@@ -467,13 +468,20 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         : DirExists(OmniVoiceOnnxDir) ? OmniVoiceIpaTts.LocateTokenizerJson(OmniVoiceOnnxDir) : null;
 
     // Reload the library and re-pick: keep the selection when it is still a candidate for the
-    // language; otherwise the language's `default` entry, else the first candidate.
+    // language (and a keepId was given); otherwise the language's `default` entry, its donor's,
+    // any default, else the first candidate.
     private void RefreshOmniVoiceVoices(string? keepId)
     {
         _allOmniVoiceVoices = StoredVoice.IsLibrary(OmniVoiceVoiceLib)
             ? SafeListVoices(OmniVoiceVoiceLib) : Array.Empty<StoredVoice.Info>();
         var candidates = VoiceCandidates();
-        OmniVoiceVoice = candidates.FirstOrDefault(v => v.Id == keepId)
+        var lang = (OmniVoiceLang ?? "").Trim();
+        var donor = LanguageCatalog.VoiceLangOf(lang);
+        bool IsDefaultFor(StoredVoice.Info v, string code) =>
+            v.IsDefault && string.Equals(v.Lang, code, StringComparison.OrdinalIgnoreCase);
+        OmniVoiceVoice = (keepId is null ? null : candidates.FirstOrDefault(v => v.Id == keepId))
+            ?? candidates.FirstOrDefault(v => IsDefaultFor(v, lang))
+            ?? candidates.FirstOrDefault(v => IsDefaultFor(v, donor))
             ?? candidates.FirstOrDefault(v => v.IsDefault)
             ?? candidates.FirstOrDefault();
         OmniVoiceVoiceQuery = OmniVoiceVoice?.ToString() ?? "";


### PR DESCRIPTION
On a language change the OmniVoice voice picker kept the current voice whenever it was still a candidate. Languages with no voices of their own (and no donor) fall back to the whole library, so the previous language's voice survived the switch. A language change now always re-picks: the language's own default voice, else its donor's default, else any default, else the first candidate. Library reloads and the settings load still keep the stored voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc