### PR TITLE
fix(reader): closing the window no longer ends in an unhandled D-Bus error

### DIFF
--- a/src/Vernacula.Tts.Avalonia/App.axaml.cs
+++ b/src/Vernacula.Tts.Avalonia/App.axaml.cs
@@ -18,6 +18,10 @@ public sealed class App : Application
             {
                 DataContext = new MainViewModel(),
             };
+            // Let Program know the dispatcher is on its way out, so a D-Bus disconnect racing
+            // the teardown is treated as a clean exit rather than an unhandled crash.
+            desktop.ShutdownRequested += (_, _) => Program.BeginShutdown();
+            desktop.Exit += (_, _) => Program.BeginShutdown();
         }
         base.OnFrameworkInitializationCompleted();
     }

--- a/src/Vernacula.Tts.Avalonia/App.axaml.cs
+++ b/src/Vernacula.Tts.Avalonia/App.axaml.cs
@@ -19,9 +19,10 @@ public sealed class App : Application
                 DataContext = new MainViewModel(),
             };
             // Let Program know the dispatcher is on its way out, so a D-Bus disconnect racing
-            // the teardown is treated as a clean exit rather than an unhandled crash.
-            desktop.ShutdownRequested += (_, _) => Program.BeginShutdown();
-            desktop.Exit += (_, _) => Program.BeginShutdown();
+            // the teardown is treated as a clean exit rather than an unhandled crash. Only Exit
+            // counts: a shutdown *request* can be cancelled, and the guard must not stay armed
+            // while the app carries on running.
+            desktop.Exit += (_, e) => Program.BeginShutdown(e.ApplicationExitCode);
         }
         base.OnFrameworkInitializationCompleted();
     }

--- a/src/Vernacula.Tts.Avalonia/Program.cs
+++ b/src/Vernacula.Tts.Avalonia/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Avalonia;
 
 namespace Vernacula.Tts.App;
@@ -11,12 +12,19 @@ namespace Vernacula.Tts.App;
 internal static class Program
 {
     private static volatile bool s_shuttingDown;
+    private static volatile int s_exitCode;
 
     /// <summary>
-    /// Called when the desktop lifetime starts closing down. After this point the dispatcher
-    /// stops accepting work, so anything still trying to marshal to the UI thread will fail.
+    /// Called when the desktop lifetime is actually exiting -- not merely when a shutdown is
+    /// requested, since such a request can still be cancelled and the app go on running. After
+    /// this point the dispatcher stops accepting work, so anything still trying to marshal to
+    /// the UI thread will fail.
     /// </summary>
-    internal static void BeginShutdown() => s_shuttingDown = true;
+    internal static void BeginShutdown(int exitCode)
+    {
+        s_exitCode = exitCode;
+        s_shuttingDown = true;
+    }
 
     [System.STAThread]
     public static int Main(string[] args)
@@ -33,10 +41,13 @@ internal static class Program
         {
             if (!s_shuttingDown || e.ExceptionObject is not Exception ex || !IsDBusTeardown(ex)) return;
             Console.Error.WriteLine($"[shutdown] ignoring D-Bus teardown error: {ex.GetType().Name}: {ex.Message}");
-            Environment.Exit(0);
+            // Exit with the code the run had already settled on: a failing run must not be
+            // reported as a success just because teardown raised on the way out.
+            Environment.Exit(s_exitCode);
         };
 
         var exitCode = BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        s_exitCode = exitCode;
         // The UI is gone and the exit code is settled; leave before any background teardown
         // (D-Bus readers, ONNX session finalizers) can raise on a thread we do not own.
         Console.Out.Flush();
@@ -44,12 +55,15 @@ internal static class Program
         return exitCode;
     }
 
+    /// <summary>True when <paramref name="ex"/>, or anything it wraps, was raised inside the
+    /// D-Bus stack. Aggregates are flattened: one disconnect can fault several observers at once,
+    /// and the D-Bus one need not be first.</summary>
     private static bool IsDBusTeardown(Exception ex)
     {
-        for (var e = ex; e is not null; e = e.InnerException)
-            if (e.StackTrace?.Contains("Tmds.DBus", StringComparison.Ordinal) == true)
-                return true;
-        return false;
+        if (ex.StackTrace?.Contains("Tmds.DBus", StringComparison.Ordinal) == true) return true;
+        if (ex is AggregateException agg)
+            return agg.Flatten().InnerExceptions.Any(IsDBusTeardown);
+        return ex.InnerException is { } inner && IsDBusTeardown(inner);
     }
 
     public static AppBuilder BuildAvaloniaApp()

--- a/src/Vernacula.Tts.Avalonia/Program.cs
+++ b/src/Vernacula.Tts.Avalonia/Program.cs
@@ -1,16 +1,56 @@
+using System;
 using Avalonia;
 
 namespace Vernacula.Tts.App;
 
 /// <summary>
 /// Avalonia entry point. The actual UI lives in <see cref="App"/>;
-/// this is just the static AppBuilder boilerplate.
+/// this is just the static AppBuilder boilerplate, plus the guard that keeps a
+/// shutdown-time D-Bus race from turning a normal window close into a crash.
 /// </summary>
 internal static class Program
 {
+    private static volatile bool s_shuttingDown;
+
+    /// <summary>
+    /// Called when the desktop lifetime starts closing down. After this point the dispatcher
+    /// stops accepting work, so anything still trying to marshal to the UI thread will fail.
+    /// </summary>
+    internal static void BeginShutdown() => s_shuttingDown = true;
+
     [System.STAThread]
     public static int Main(string[] args)
-        => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    {
+        // Avalonia's FreeDesktop backend keeps a D-Bus connection whose signal observers were
+        // subscribed on the UI thread. When that connection drops during exit it reports the
+        // disconnect to each observer through the captured (Avalonia) synchronization context;
+        // with the dispatcher already shutting down, the Send is cancelled and the resulting
+        // TaskCanceledException is rethrown on a thread pool thread, where nothing can catch it.
+        // The app is done at that point, so treat it as a clean exit -- but only for exceptions
+        // that actually came through the D-Bus stack, and only once shutdown has begun, so real
+        // faults are still reported.
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+        {
+            if (!s_shuttingDown || e.ExceptionObject is not Exception ex || !IsDBusTeardown(ex)) return;
+            Console.Error.WriteLine($"[shutdown] ignoring D-Bus teardown error: {ex.GetType().Name}: {ex.Message}");
+            Environment.Exit(0);
+        };
+
+        var exitCode = BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        // The UI is gone and the exit code is settled; leave before any background teardown
+        // (D-Bus readers, ONNX session finalizers) can raise on a thread we do not own.
+        Console.Out.Flush();
+        Environment.Exit(exitCode);
+        return exitCode;
+    }
+
+    private static bool IsDBusTeardown(Exception ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+            if (e.StackTrace?.Contains("Tmds.DBus", StringComparison.Ordinal) == true)
+                return true;
+        return false;
+    }
 
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()


### PR DESCRIPTION
Closing the reader could end with `Unhandled exception. System.Threading.Tasks.TaskCanceledException` and a non-zero exit code.

Avalonia's FreeDesktop backend keeps a D-Bus connection whose signal observers were subscribed on the UI thread. When the connection drops during exit it reports the disconnect to each observer through the captured synchronization context. The dispatcher is already shutting down, so the `Send` is cancelled, and the resulting exception is rethrown on a thread pool thread where nothing can catch it.

Two changes, both in the entry point:

- `Main` calls `Environment.Exit` as soon as the lifetime loop returns, so background teardown has no window in which to raise.
- An unhandled exception is treated as a clean exit **only** when shutdown has begun *and* the exception passed through the D-Bus stack. Everything else still terminates with its trace.

Verified with a standalone harness running the same handler:

| case | exit | output |
| --- | --- | --- |
| cancellation with a Tmds.DBus frame, after shutdown | 0 | one `[shutdown] ignoring` line |
| same exception, different stack | 134 | unhandled, full trace |
| Tmds.DBus frame, before shutdown began | 134 | unhandled, full trace |

Three open/close cycles of the app exit 0. The original race did not reproduce here in a short session, so the guard is written to cover it rather than to depend on hitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc