### PR TITLE
feat(reader): IPA annotation above each word, furigana style

### DIFF
--- a/docs/investigations/ipa_ruby_segmentation_investigation.md
+++ b/docs/investigations/ipa_ruby_segmentation_investigation.md
@@ -1,0 +1,182 @@
+# IPA ruby annotation: segmentation for scriptio continua
+
+Ruby (furigana-style) IPA over the reader's karaoke text works by attributing slices of the
+phonemizer's reading to written words (PR #110). That relies on written words existing — a
+whitespace split. Japanese, Chinese and Thai have no spaces, so the whole sentence is one "word"
+and the entire reading stacks over it. This log is the hunt for a segmentation the render can use.
+
+## Run 1 — 2026-09-05
+
+**Question.** Does the phonemizer trace already segment scriptio continua? If so, are the token
+spans good enough to place ruby over the right characters?
+
+**Command.** A probe test dumping `PhonemizeTrace` tokens (surface, InputSpan, IpaSpan) for
+ja/cmn/th/ko sample sentences.
+
+**Raw finding.**
+
+```
+=== ja traced=True tokens=5   私は日本語を勉強しています。
+    surf='私わ'      in=null  ipa='wätäɕiwä'
+    surf='日本語を'  in=null  ipa='niho̞ŋɡo̞o̞'
+    surf='勉強して'  in=null  ipa='be̞ŋkʲo̞ːꜜɕite̞'
+    surf='います'    in=null  ipa='imäsɯᵝ'
+    surf='。'        in=null  ipa=null
+
+=== ja traced=True tokens=4   東京都に住んでいます。
+    surf='東京都に'  in=[0,4)  ipa='to̞ːkʲo̞ːmijäko̞ni'
+    surf='住んで'    in=[4,7)  ipa='sɯᵝꜜnde̞'
+    surf='います'    in=[7,10) ipa='imäsɯᵝ'
+    surf='。'        in=[10,11) ipa=null
+
+=== cmn tokens=1              我喜欢学习中文。
+    surf='我喜欢学习中文' in=[0,7) ipa='wo˧˥ ɕi˨˩˦ xuan˥˥ ɕyɛ˧˥ ɕi˧˥ ʈ͡ʂoŋ˥˥ wuən˧˥'
+
+=== th tokens=1               ฉันเรียนภาษาไทย
+    surf='ฉันเรียนภาษาไทย' in=[0,15) ipa='t͡ɕʰˈa˩˩˦n rˈia˧n pʰˈaː˧saː˩˩˦tʰˌa˧j'
+
+=== ko tokens=3               저는 한국어를 공부합니다  (spaces already)
+    surf='저는' in=[0,2)  / '한국어를' in=[3,7) / '공부합니다' in=[8,13)
+```
+
+**What it implies.**
+
+1. Japanese IS segmented — into bunsetsu-like chunks (私は / 日本語を / 勉強して / います), which is
+   exactly the unit ruby wants. Korean already has spaces and needs nothing.
+2. **But the input spans can be absent for Japanese**: the first sentence reports `in=null` on every
+   token, the second reports spans on all of them. The difference is a normalizer rewrite — 私は →
+   私わ (the topic particle は read as わ). Provenance is dropped through that rewrite, and null
+   means "not known", never "identical". So segmentation is available but *placement* is not,
+   text-dependent.
+3. Chinese and Thai are NOT segmented: a whole clause is one token. Chinese is still tractable —
+   the reading has one space-delimited group per Han character (7 chars → 7 groups) — so a
+   per-character ruby is possible. Thai is not: 15 characters → 3 groups, no alignment.
+
+**Next step.** Two things to settle: how often ja loses provenance, and whether the token surface
+can substitute for a missing input span (it cannot be displayed as-is — 私わ is not what the reader
+typed).
+
+## Run 3 — 2026-09-05 (code review of PR #110, probe harness)
+
+**Command.** A throwaway xunit fact in `tests/Vernacula.Tts.Tests` calling
+`IpaAnnotator.Annotate(words, lang)` alongside `Phonemizer.PhonemizeTrace(string.Join(' ', words), lang)`
+and dumping both, over ~30 inputs (English abbreviations/currency/percent/fractions/hyphenation,
+fr, fr-CA, as, de, es, ru, ar, hi, ko, ja, zh, en-GB). File deleted afterwards.
+
+**Question.** Does the attribution hold on inputs beyond the five unit tests, and does the
+annotation always equal what the synthesizer will say?
+
+**Raw findings.**
+
+```
+Mr./Smith,/$3.14      -> mˈɪstɚ | smˈɪθ | θɹˈiː dˈɑːlɚz fˈɔːɹtˈiːn     correct
+100/km, 5%, 1/2, 3rd  -> all correct
+co-operate            -> kʰˈoᶷ ˈɑːpɚˌeᶦt  (stacked on the one word)     correct
+10:30/a.m./on/Jan./1st,/2020 -> correct
+"$" "3.14" (2 words)  -> <θɹˈiː> | <dˈɑːlɚz fˈɔːɹtˈiːn>                 WRONG, off by a word
+fr-CA aujourd'hui     -> annotation oʒuʁdɥˈi   vs reading oʒuʁd͡zɥˈi    WRONG, pre-rewrite reading
+ja こんにちは 世界      -> NULL   (matches Run 2: provenance dropped)
+zh 你好 世界           -> NULL   (probe artefact: no "zh" alias; the reader picks "cmn")
+```
+
+**What it implies.**
+
+1. The `Math.Min(lastWord + 1, lastInSpan)` distribution assumes emission order matches *written*
+   word order inside a shared input span. That holds for `Mr. Smith` and fails for a currency sign
+   written apart from its amount, where the sign is spoken last. The result is the "silently off by
+   a word" case the design says it withholds. A safer rule for a multi-word span with no per-token
+   input placement is to stack the whole group over the span's first word (or withhold the span).
+2. The `IpaSpan is null → string.Concat(tok.Emitted)` fallback re-introduces exactly what
+   `Trace.Stop` refuses to report: for the eight engines with a non-positional post-assembly
+   rewrite (fr-CA accent, `as` aspirate collapse) the displayed reading is the pre-rewrite one.
+   fr-CA is reproducible above and is a language the reader can pick.
+3. The zh null is a probe artefact — `LanguageCatalog` offers `cmn`, which Run 2 traced fine.
+
+**Next step.** Decide per case: stack-on-first-word for the inverted-order spans, and either drop
+the `Emitted` fallback or gate it on `trace.Rewrites` carrying no post-assembly entry.
+
+## Run 2 — 2026-09-05
+
+**Question.** How often does Japanese lose input-span provenance, and is there a safe fallback?
+Can Chinese be split per character?
+
+**Command.** Probe over 20 hand-written Japanese sentences (particles, numbers, katakana, mixed
+digits) and 8 Mandarin ones, reporting per sentence whether every token has an `InputSpan`, and
+whether the token surfaces preserve the input's length.
+
+**Raw finding.**
+
+```
+ja: 19/20 all-spans, 18/20 length-preserved
+
+ja spans=False lenPreserved=True   私は日本語を勉強しています。
+    fallback segments: 私は / 日本語を / 勉強して / います / 。
+    token surfaces   : 私わ / 日本語を / 勉強して / います / 。
+ja spans=True  lenPreserved=False  値段は3800円でした。      (surfLen 18 vs textLen 12)
+ja spans=True  lenPreserved=False  明日の会議は10時から始まります。 (surfLen 18 vs textLen 17)
+
+cmn surf='我喜欢学习中文' han=7 groups=7 match=True
+cmn surf='今天天气很好'   han=6 groups=6 match=True
+... 8/8 match
+```
+
+**What it implies.**
+
+1. Losing provenance is the exception, not the rule: 19 of 20. The one that loses it is the は→わ
+   particle rewrite, and it is length-preserving, so cumulative surface lengths reconstruct the
+   segments EXACTLY (私は / 日本語を / 勉強して / います / 。).
+2. The two sentences where lengths do NOT match are the ones with digits (3800円, 10時), where the
+   number expands — and both of those keep their spans. The two failure modes are disjoint, so
+   "spans, else cumulative length when the total matches" covers everything seen, and declines
+   rather than guesses when neither holds.
+3. Mandarin: one IPA group per Han character in all 8 sentences, so an all-Han run whose group
+   count equals its character count can be split per character — pinyin-over-hanzi, the exact
+   analogue of furigana.
+4. Thai remains unsegmentable here (15 characters, 3 groups, one token): its reading stays over the
+   whole run. Honest, and visibly different from the CJK case.
+
+**Decision.** Segment inside a whitespace word, not across it: tokens by input span, else by
+cumulative length when the total matches, else no split; then split an all-Han piece per character
+when its group count matches. Keeping the split *inside* the word means the display word list stays
+1:1 with the backend's aligned words, so karaoke timing still attaches by index — the pieces
+subdivide their word's own span by IPA weight instead.
+
+## Run 4 — 2026-09-05
+
+**Question.** Does the design from Run 2 hold when built and run: does a Japanese sentence render
+segmented, with the reader's own text preserved, and does the highlight follow the audio through
+the pieces?
+
+**Commands.** Unit tests over the annotator (16), then the reader driven on `:0` with the OmniVoice
+backend, language `ja`, voice `ja`, 16 diffusion steps; xdotool typed the text and clicked
+Synthesize, with frames captured every 0.32 s during playback.
+
+**Raw finding.**
+
+```
+東京都に住んでいます。   ->  東京都に / 住んで / います / 。
+                            to̞ːkʲo̞ːmijäko̞ni  sɯᵝꜜnde̞  imäsɯᵝ
+
+私は日本語を勉強しています。 (the sentence with NO input-span provenance)
+                        ->  私は / 日本語を / 勉強して / います / 。
+                            wätäɕiwä  niho̞ŋɡo̞o̞  be̞ŋkʲo̞ːꜜɕite̞  imäsɯᵝ
+
+playback frames:  f_3 -> 日本語を highlighted    f_6 -> 勉強して highlighted
+synthesis: 2.84 s of audio, 16 steps
+```
+
+**What it implies.**
+
+1. The reconstruction works where it matters. In 私は the token surface is 私わ, and the render
+   shows 私は — the reader's own characters — while the ruby above reads wätäɕiwä. That is exactly
+   the furigana relationship: the writing stays, the reading sits above it.
+2. Per-piece karaoke inside one aligned word behaves. The backend times that whole sentence as a
+   single word (no spaces to split on), and dividing its span by each piece's IPA weight moves the
+   highlight bunsetsu by bunsetsu. It is an estimate within the word, not a measurement — the same
+   caveat the OmniVoice word alignment already carries.
+3. xdotool cannot type CJK at speed (it produced 私ししししし… at 25 ms/key); 250 ms/key is reliable.
+   Recorded here only so the next UI check does not re-derive it.
+
+**Still open.** Thai and other unsegmented scripts keep one reading over the whole run — correct but
+not useful; segmenting them needs a dictionary the phonemizer does not carry. Korean already has
+spaces and needs nothing.

--- a/src/Vernacula.Tts.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Tts.Avalonia/Services/SettingsService.cs
@@ -70,6 +70,8 @@ public sealed class ReaderSettings
     public string VoicePath { get; set; } = "";
     public string OnnxBundleDir { get; set; } = "";
     public bool RenderMarkdown { get; set; } = false;
+    // IPA shown above each word in the karaoke view, furigana style.
+    public bool ShowIpaAnnotation { get; set; } = false;
 
     // TTS backend selection. TtsBackend stores the TtsBackendKind enum name
     // ("Chatterbox" / "Kokoro" / "OmniVoice").

--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -1058,8 +1058,10 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         if (!ShowIpaAnnotation)
         {
             foreach (var w in Words) w.SetRuby(null);
+            ReapplyCurrentHighlight();
             return;
         }
+        IpaAnnotationNotice = "";   // nothing to annotate is not a failure to annotate
         if (Words.Count == 0) return;
 
         var cts = new CancellationTokenSource();
@@ -1089,6 +1091,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                         {
                             if (token.IsCancellationRequested) return;
                             foreach (var w in Words) w.SetRuby(null);
+                            ReapplyCurrentHighlight();
                             // Its own line, not StatusMessage: this re-fires on every keystroke for
                             // a language that cannot be attributed, and it must not scribble over
                             // synthesis progress or a prerequisite error.
@@ -1101,6 +1104,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                         if (token.IsCancellationRequested) return;
                         IpaAnnotationNotice = "";
                         for (var i = 0; i < block.Count; i++) block[i].SetRuby(ipa[i]);
+                        ReapplyCurrentHighlight();
                     });
                 }
             }
@@ -1110,6 +1114,21 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                 Console.Error.WriteLine($"[IPA] annotation failed: {ex.Message}");
             }
         }, token);
+    }
+
+    /// <summary>
+    /// Put the highlight back on whichever half of the current word now draws it. Gaining pieces
+    /// moves it from the word to a piece and losing them moves it back; without this, turning the
+    /// annotation off mid-playback left the spoken word with no highlight at all until the audio
+    /// reached the next one, and an annotation arriving for the current word lit both.
+    /// </summary>
+    private void ReapplyCurrentHighlight()
+    {
+        if (_currentWordIndex < 0 || _currentWordIndex >= Words.Count) return;
+        var word = Words[_currentWordIndex];
+        word.IsCurrent = !word.HasPieces;
+        if (word.HasPieces) word.HighlightPieceAt(_playback.PositionSeconds);
+        else word.ClearPieceHighlight();
     }
 
     /// <summary>Index of the block whose output span contains <paramref name="offset"/>, or -1.</summary>

--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -134,6 +134,9 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     // across runs.
     [ObservableProperty] private bool _renderMarkdown;
 
+    // IPA above each word in the karaoke view, the way furigana sits above kanji. Persisted.
+    [ObservableProperty] private bool _showIpaAnnotation;
+
     // Status line below the synthesize button.
     [ObservableProperty] private string _statusMessage = "Ready.";
 
@@ -201,6 +204,9 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     // The structured (markdown-styled) karaoke view: blocks of words.
     public ObservableCollection<BlockItemViewModel> DisplayBlocks { get; } = new();
 
+    // Cancels the in-flight IPA annotation when the text, language, or toggle changes.
+    private CancellationTokenSource? _annotationCts;
+
     // How many streamed alignment words have had their timing attached so far.
     private int _streamWordCursor;
 
@@ -257,6 +263,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             VoicePath = _settings.Current.VoicePath;
             OnnxBundleDir = _settings.Current.OnnxBundleDir;
             RenderMarkdown = _settings.Current.RenderMarkdown;
+            ShowIpaAnnotation = _settings.Current.ShowIpaAnnotation;
             SelectedBackend = Enum.TryParse<TtsBackendKind>(_settings.Current.TtsBackend, out var b)
                 ? b : TtsBackendKind.Chatterbox;
             KokoroModelDir = _settings.Current.KokoroModelDir;
@@ -346,6 +353,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         _settings.Current.VoicePath = VoicePath;
         _settings.Current.OnnxBundleDir = OnnxBundleDir;
         _settings.Current.RenderMarkdown = RenderMarkdown;
+        _settings.Current.ShowIpaAnnotation = ShowIpaAnnotation;
         _settings.Current.TtsBackend = SelectedBackend.ToString();
         _settings.Current.PhonemizerDataDir = PhonemizerDataDir;
         _settings.Current.KokoroModelDir = KokoroModelDir;
@@ -374,17 +382,23 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         UpdatePrerequisiteStatus();
     }
     partial void OnRenderMarkdownChanged(bool value) => PersistSettings();
+    partial void OnShowIpaAnnotationChanged(bool value)
+    {
+        PersistSettings();
+        RefreshIpaAnnotation();
+    }
     // Live structured preview: rebuild the karaoke blocks as the source text changes
     // (skip during synthesis — the stream is filling the words and the box is disabled).
     partial void OnTextChanged(string value)
     {
-        if (!IsBusy) { BuildDisplayStructure(value); _streamWordCursor = 0; }
+        if (!IsBusy) { BuildDisplayStructure(value); _streamWordCursor = 0; RefreshIpaAnnotation(); }
     }
     partial void OnSelectedBackendChanged(TtsBackendKind value)
     {
         InvalidateSynthService();
         PersistSettings();
         UpdatePrerequisiteStatus();
+        RefreshIpaAnnotation();   // the reading language follows the backend
     }
     partial void OnKokoroModelDirChanged(string value)
     {
@@ -420,6 +434,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     }
     partial void OnOmniVoiceLangChanged(string value)
     {
+        RefreshIpaAnnotation();
         // A new language gets its default voice, not whichever voice the last language left behind.
         RefreshOmniVoiceVoices(keepId: null);
         PersistSettings();
@@ -536,6 +551,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     {
         PersistSettings();
         UpdatePrerequisiteStatus();
+        RefreshIpaAnnotation();   // bf_/bm_ voices read as en-GB
     }
     partial void OnKokoroSpeedChanged(float value) => PersistSettings();
 
@@ -992,6 +1008,85 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             current.Words.Add(w);
             Words.Add(w);
         }
+    }
+
+    // ── IPA annotation (furigana-style ruby text above each word) ──────
+
+    /// <summary>The language the annotation is read in: OmniVoice's picked language, Kokoro's
+    /// en/en-GB (its British voices are the bf_/bm_ ones), and en for Chatterbox, which is
+    /// English-only.</summary>
+    private string AnnotationLang => SelectedBackend switch
+    {
+        TtsBackendKind.OmniVoice => string.IsNullOrWhiteSpace(OmniVoiceLang) ? "en" : OmniVoiceLang.Trim(),
+        TtsBackendKind.Kokoro => KokoroVoice.StartsWith("bf_", StringComparison.Ordinal)
+            || KokoroVoice.StartsWith("bm_", StringComparison.Ordinal) ? "en-GB" : "en",
+        _ => "en",
+    };
+
+    /// <summary>
+    /// Recompute the ruby text over every word, or clear it when the option is off.
+    ///
+    /// Runs off the UI thread and per block: phonemizing a whole document takes long enough to
+    /// stutter typing, and a block is the largest unit whose reading is self-contained. Each call
+    /// cancels the one before it, so holding a key down does not queue a run per keystroke, and a
+    /// result that arrives after its text has changed is dropped rather than drawn over the new
+    /// words.
+    /// </summary>
+    private void RefreshIpaAnnotation()
+    {
+        _annotationCts?.Cancel();
+        _annotationCts = null;
+        if (!ShowIpaAnnotation)
+        {
+            foreach (var w in Words) w.Ipa = null;
+            return;
+        }
+        if (Words.Count == 0) return;
+
+        var cts = new CancellationTokenSource();
+        _annotationCts = cts;
+        var token = cts.Token;
+        var lang = AnnotationLang;
+        var dataDir = PhonemizerDataDir;
+        // Snapshot on the UI thread: the collections are rebuilt from under us on the next edit.
+        var blocks = DisplayBlocks.Select(b => b.Words.ToList()).ToList();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                // Settle first: typing rebuilds the words on every keystroke.
+                await Task.Delay(250, token).ConfigureAwait(false);
+                foreach (var block in blocks)
+                {
+                    token.ThrowIfCancellationRequested();
+                    var words = block.Select(w => w.Text).ToList();
+                    var ipa = IpaAnnotator.Annotate(words, lang, dataDir);
+                    if (ipa is null)
+                    {
+                        // The reading could not be attributed (unknown language, no data tree).
+                        // Say so once rather than drawing an annotation that may be off by a word.
+                        await Dispatcher.UIThread.InvokeAsync(() =>
+                        {
+                            if (token.IsCancellationRequested) return;
+                            foreach (var w in Words) w.Ipa = null;
+                            StatusMessage = $"IPA annotation unavailable for language \"{lang}\".";
+                        });
+                        return;
+                    }
+                    await Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        if (token.IsCancellationRequested) return;
+                        for (var i = 0; i < block.Count; i++) block[i].Ipa = ipa[i];
+                    });
+                }
+            }
+            catch (OperationCanceledException) { /* superseded by a newer edit */ }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[IPA] annotation failed: {ex.Message}");
+            }
+        }, token);
     }
 
     /// <summary>Index of the block whose output span contains <paramref name="offset"/>, or -1.</summary>

--- a/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/MainViewModel.cs
@@ -137,6 +137,14 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     // IPA above each word in the karaoke view, the way furigana sits above kanji. Persisted.
     [ObservableProperty] private bool _showIpaAnnotation;
 
+    // Why the annotation is blank, when it is. Shown under the checkbox rather than in
+    // StatusMessage, which belongs to synthesis and playback.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasIpaAnnotationNotice))]
+    private string _ipaAnnotationNotice = "";
+
+    public bool HasIpaAnnotationNotice => !string.IsNullOrEmpty(IpaAnnotationNotice);
+
     // Status line below the synthesize button.
     [ObservableProperty] private string _statusMessage = "Ready.";
 
@@ -232,7 +240,10 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         _playback.PlaybackStopped += _ =>
         {
             if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
+            {
                 Words[_currentWordIndex].IsCurrent = false;
+                Words[_currentWordIndex].ClearPieceHighlight();
+            }
             _currentWordIndex = -1;
             // Don't overwrite synthesis-in-progress status with "stopped".
             if (!IsBusy) StatusMessage = "Playback stopped.";
@@ -385,13 +396,14 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     partial void OnShowIpaAnnotationChanged(bool value)
     {
         PersistSettings();
+        if (!value) IpaAnnotationNotice = "";
         RefreshIpaAnnotation();
     }
     // Live structured preview: rebuild the karaoke blocks as the source text changes
     // (skip during synthesis — the stream is filling the words and the box is disabled).
     partial void OnTextChanged(string value)
     {
-        if (!IsBusy) { BuildDisplayStructure(value); _streamWordCursor = 0; RefreshIpaAnnotation(); }
+        if (!IsBusy) { BuildDisplayStructure(value); _streamWordCursor = 0; }
     }
     partial void OnSelectedBackendChanged(TtsBackendKind value)
     {
@@ -410,6 +422,7 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     partial void OnPhonemizerDataDirChanged(string value)
     {
         InvalidateSynthService();
+        RefreshIpaAnnotation();   // pointing at a valid data/ root fixes a blank annotation
         PersistSettings();
         UpdatePrerequisiteStatus();
     }
@@ -1008,6 +1021,11 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
             current.Words.Add(w);
             Words.Add(w);
         }
+
+        // The words are new objects, so any annotation on the old ones went with them. Rebuilding
+        // it here covers every caller -- editing the text AND starting a synthesis, which also
+        // rebuilds; the annotation used to vanish for the whole run that followed.
+        RefreshIpaAnnotation();
     }
 
     // ── IPA annotation (furigana-style ruby text above each word) ──────
@@ -1035,10 +1053,11 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     private void RefreshIpaAnnotation()
     {
         _annotationCts?.Cancel();
+        _annotationCts?.Dispose();
         _annotationCts = null;
         if (!ShowIpaAnnotation)
         {
-            foreach (var w in Words) w.Ipa = null;
+            foreach (var w in Words) w.SetRuby(null);
             return;
         }
         if (Words.Count == 0) return;
@@ -1069,15 +1088,19 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
                         await Dispatcher.UIThread.InvokeAsync(() =>
                         {
                             if (token.IsCancellationRequested) return;
-                            foreach (var w in Words) w.Ipa = null;
-                            StatusMessage = $"IPA annotation unavailable for language \"{lang}\".";
+                            foreach (var w in Words) w.SetRuby(null);
+                            // Its own line, not StatusMessage: this re-fires on every keystroke for
+                            // a language that cannot be attributed, and it must not scribble over
+                            // synthesis progress or a prerequisite error.
+                            IpaAnnotationNotice = $"No IPA annotation for language \"{lang}\".";
                         });
                         return;
                     }
                     await Dispatcher.UIThread.InvokeAsync(() =>
                     {
                         if (token.IsCancellationRequested) return;
-                        for (var i = 0; i < block.Count; i++) block[i].Ipa = ipa[i];
+                        IpaAnnotationNotice = "";
+                        for (var i = 0; i < block.Count; i++) block[i].SetRuby(ipa[i]);
                     });
                 }
             }
@@ -1150,10 +1173,17 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
         if (idx != _currentWordIndex)
         {
             if (_currentWordIndex >= 0 && _currentWordIndex < Words.Count)
+            {
                 Words[_currentWordIndex].IsCurrent = false;
+                Words[_currentWordIndex].ClearPieceHighlight();
+            }
             _currentWordIndex = idx;
-            if (idx >= 0 && idx < Words.Count) Words[idx].IsCurrent = true;
+            // A split word highlights piece by piece instead of all at once: lighting a whole
+            // Japanese sentence says nothing about where in it the voice has got to.
+            if (idx >= 0 && idx < Words.Count) Words[idx].IsCurrent = !Words[idx].HasPieces;
         }
+        // Every tick, not just on a word change: the piece moves within the word.
+        if (idx >= 0 && idx < Words.Count) Words[idx].HighlightPieceAt(posSec);
         // Use the live playback total — it grows as chunks append during
         // streaming, and matches _lastAlignment.AudioDurationSeconds once
         // synthesis finishes. (Reading _lastAlignment alone would show
@@ -1216,6 +1246,9 @@ public sealed partial class MainViewModel : ObservableObject, IDisposable
     {
         _synthCts?.Cancel();
         _synthCts?.Dispose();
+        // An annotation still in its debounce would post to a dispatcher that is shutting down.
+        _annotationCts?.Cancel();
+        _annotationCts?.Dispose();
         _playback.Dispose();
         _synthService?.Dispose();
     }

--- a/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Media;
+using Vernacula.Tts.Base;
 using Vernacula.Tts.Base.Markdown;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -50,7 +53,61 @@ public sealed partial class WordItemViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(HasIpa))]
     private string? _ipa;
 
-    public bool HasIpa => !string.IsNullOrEmpty(Ipa);
+    /// <summary>
+    /// The word's sub-parts, when it is written without spaces between its words (Japanese,
+    /// Chinese) and the phonemizer could say where the boundaries are. Empty for ordinary words,
+    /// which render as one piece of text with one reading above it.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasPieces))]
+    [NotifyPropertyChangedFor(nameof(HasIpa))]
+    private IReadOnlyList<RubyPieceViewModel> _pieces = Array.Empty<RubyPieceViewModel>();
+
+    public bool HasPieces => Pieces.Count > 0;
+
+    /// <summary>A split word's reading is drawn piece by piece, so the whole-word line is not.</summary>
+    public bool HasIpa => !HasPieces && !string.IsNullOrEmpty(Ipa);
+
+    /// <summary>Attach (or with null, clear) the annotation for this word.</summary>
+    public void SetRuby(WordRuby? ruby)
+    {
+        Ipa = ruby?.Ipa;
+        Pieces = ruby is null || ruby.Pieces.Count == 0
+            ? Array.Empty<RubyPieceViewModel>()
+            : ruby.Pieces.Select(p => new RubyPieceViewModel(this, p.Text, p.Ipa, p.Weight)).ToList();
+    }
+
+    /// <summary>
+    /// Light the piece being spoken at <paramref name="posSec"/>. The aligner times this word as a
+    /// whole -- a Japanese sentence with no spaces is one aligned word -- so its span is divided
+    /// among the pieces in proportion to how much speech each one's reading is worth, the same
+    /// weighting the duration model uses. That is an estimate within the word, not a measurement.
+    /// </summary>
+    public void HighlightPieceAt(double posSec)
+    {
+        if (!HasPieces) return;
+        var total = Pieces.Sum(p => p.Weight);
+        var span = EndSeconds - StartSeconds;
+        var current = -1;
+        if (total > 0 && span > 0)
+        {
+            var at = StartSeconds;
+            for (var i = 0; i < Pieces.Count; i++)
+            {
+                var end = at + span * Pieces[i].Weight / total;
+                if (posSec < end) { current = i; break; }
+                at = end;
+            }
+            if (current < 0 && posSec >= StartSeconds && posSec <= EndSeconds) current = Pieces.Count - 1;
+        }
+        for (var i = 0; i < Pieces.Count; i++) Pieces[i].IsCurrent = i == current;
+    }
+
+    /// <summary>Drop the piece highlight (the word is no longer the one being spoken).</summary>
+    public void ClearPieceHighlight()
+    {
+        foreach (var p in Pieces) p.IsCurrent = false;
+    }
 
     // ── Self-describing display properties (bound directly by the word button) ──
     public double FontSize => BlockKind == BlockKind.Heading
@@ -72,4 +129,27 @@ public sealed partial class WordItemViewModel : ObservableObject
 
     [RelayCommand]
     private void Click() => _onClicked?.Invoke(this);
+}
+
+/// <summary>
+/// One sub-part of a split word: the characters and their reading, plus whether it is the piece
+/// being spoken. Font sizes come from the owning word, so a piece inside a heading scales with it.
+/// </summary>
+public sealed partial class RubyPieceViewModel : ObservableObject
+{
+    public RubyPieceViewModel(WordItemViewModel word, string text, string ipa, double weight)
+    {
+        Word = word;
+        Text = text;
+        Ipa = ipa;
+        Weight = weight;
+    }
+
+    public WordItemViewModel Word { get; }
+    public string Text { get; }
+    public string Ipa { get; }
+    public double Weight { get; }
+    public bool HasIpa => !string.IsNullOrEmpty(Ipa);
+
+    [ObservableProperty] private bool _isCurrent;
 }

--- a/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
@@ -41,6 +41,17 @@ public sealed partial class WordItemViewModel : ObservableObject
 
     [ObservableProperty] private bool _isCurrent;
 
+    /// <summary>
+    /// The word's reading, shown small above it (furigana style) when IPA annotation is on.
+    /// Null or empty means nothing is drawn — punctuation has no reading, and the annotation is
+    /// cleared wholesale when the option is off or the text changes under it.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasIpa))]
+    private string? _ipa;
+
+    public bool HasIpa => !string.IsNullOrEmpty(Ipa);
+
     // ── Self-describing display properties (bound directly by the word button) ──
     public double FontSize => BlockKind == BlockKind.Heading
         ? HeadingLevel switch { 1 => 30, 2 => 24, 3 => 20, 4 => 18, _ => 16 }
@@ -49,6 +60,10 @@ public sealed partial class WordItemViewModel : ObservableObject
     public FontWeight FontWeight =>
         BlockKind == BlockKind.Heading || Style.HasFlag(InlineStyle.Bold)
             ? FontWeight.Bold : FontWeight.Normal;
+
+    /// <summary>Ruby size: small enough to read as an annotation, never so small it is unreadable
+    /// under a heading's larger body text.</summary>
+    public double IpaFontSize => Math.Max(10.0, FontSize * 0.6);
 
     public FontStyle FontStyle => Style.HasFlag(InlineStyle.Italic) ? FontStyle.Italic : FontStyle.Normal;
 

--- a/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
+++ b/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
@@ -86,18 +86,54 @@
                                                                  without one (punctuation) and
                                                                  the whole view with annotation
                                                                  off keep their normal height. -->
-                                                            <StackPanel Orientation="Vertical" Spacing="0">
-                                                                <TextBlock Text="{Binding Ipa}"
-                                                                           IsVisible="{Binding HasIpa}"
-                                                                           FontSize="{Binding IpaFontSize}"
-                                                                           FontWeight="Normal"
-                                                                           FontStyle="Normal"
-                                                                           Classes="ruby"
-                                                                           HorizontalAlignment="Center"
-                                                                           TextAlignment="Center" />
-                                                                <TextBlock Text="{Binding Text}"
-                                                                           HorizontalAlignment="Center" />
-                                                            </StackPanel>
+                                                            <Panel>
+                                                                <!-- Ordinary word: one reading over one word. -->
+                                                                <StackPanel Orientation="Vertical" Spacing="0"
+                                                                            IsVisible="{Binding !HasPieces}">
+                                                                    <TextBlock Text="{Binding Ipa}"
+                                                                               IsVisible="{Binding HasIpa}"
+                                                                               FontSize="{Binding IpaFontSize}"
+                                                                               FontWeight="Normal"
+                                                                               FontStyle="Normal"
+                                                                               Classes="ruby"
+                                                                               HorizontalAlignment="Center"
+                                                                               TextAlignment="Center" />
+                                                                    <TextBlock Text="{Binding Text}"
+                                                                               HorizontalAlignment="Center" />
+                                                                </StackPanel>
+                                                                <!-- Written without spaces (Japanese, Chinese):
+                                                                     the phonemizer's own segmentation is drawn
+                                                                     piece by piece, each with its own reading,
+                                                                     and the highlight moves through them. -->
+                                                                <ItemsControl ItemsSource="{Binding Pieces}"
+                                                                              IsVisible="{Binding HasPieces}">
+                                                                    <ItemsControl.ItemsPanel>
+                                                                        <ItemsPanelTemplate>
+                                                                            <WrapPanel Orientation="Horizontal" />
+                                                                        </ItemsPanelTemplate>
+                                                                    </ItemsControl.ItemsPanel>
+                                                                    <ItemsControl.ItemTemplate>
+                                                                        <DataTemplate x:DataType="vm:RubyPieceViewModel">
+                                                                            <Border Classes="piece"
+                                                                                    Classes.current="{Binding IsCurrent}">
+                                                                                <StackPanel Orientation="Vertical" Spacing="0">
+                                                                                    <TextBlock Text="{Binding Ipa}"
+                                                                                               IsVisible="{Binding HasIpa}"
+                                                                                               FontSize="{Binding Word.IpaFontSize}"
+                                                                                               FontWeight="Normal"
+                                                                                               FontStyle="Normal"
+                                                                                               Classes="ruby"
+                                                                                               HorizontalAlignment="Center"
+                                                                                               TextAlignment="Center" />
+                                                                                    <TextBlock Text="{Binding Text}"
+                                                                                               FontSize="{Binding Word.FontSize}"
+                                                                                               HorizontalAlignment="Center" />
+                                                                                </StackPanel>
+                                                                            </Border>
+                                                                        </DataTemplate>
+                                                                    </ItemsControl.ItemTemplate>
+                                                                </ItemsControl>
+                                                            </Panel>
                                                         </Button>
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>
@@ -286,6 +322,9 @@
             <CheckBox IsChecked="{Binding ShowIpaAnnotation}"
                       Content="IPA above each word"
                       ToolTip.Tip="Shows each word's phonemizer reading above it, the way furigana sits above kanji. Uses the current backend's language." />
+            <TextBlock Text="{Binding IpaAnnotationNotice}"
+                       IsVisible="{Binding HasIpaAnnotationNotice}"
+                       TextWrapping="Wrap" FontSize="11" Opacity="0.7" Margin="24,0,0,0" />
             <Button Content="Load text/markdown file…"
                     Command="{Binding PickTextFileCommand}"
                     IsEnabled="{Binding !IsBusy}"
@@ -376,6 +415,31 @@
             <Setter Property="Opacity" Value="0.62" />
             <Setter Property="Margin" Value="0,0,0,-1" />
             <Setter Property="Foreground" Value="#cde" />
+        </Style>
+
+        <!-- The ruby lights up with the word it annotates: dimmed text that stayed dim while its
+             word was highlighted read as if the annotation had stopped following the audio. -->
+        <Style Selector="Button.word.current TextBlock.ruby">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="Foreground" Value="#aef" />
+        </Style>
+
+        <!-- A piece of a split word. Segmentation is a claim about where the words are, so the
+             pieces are spaced apart enough to read as separate units without looking like a gap
+             in the sentence. -->
+        <Style Selector="Border.piece">
+            <Setter Property="Padding" Value="2,0" />
+            <Setter Property="Margin" Value="0,0,3,0" />
+            <Setter Property="CornerRadius" Value="3" />
+        </Style>
+        <Style Selector="Border.piece.current">
+            <Setter Property="Background" Value="#3355aadd" />
+        </Style>
+        <Style Selector="Border.piece.current TextBlock">
+            <Setter Property="Foreground" Value="#aef" />
+        </Style>
+        <Style Selector="Border.piece.current TextBlock.ruby">
+            <Setter Property="Opacity" Value="1" />
         </Style>
 
         <!-- Inline code: monospace + subtle chip. -->

--- a/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
+++ b/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
@@ -72,14 +72,33 @@
                                                              (heading size, bold/italic); the
                                                              code/link/current classes layer on. -->
                                                         <Button Command="{Binding ClickCommand}"
-                                                                Content="{Binding Text}"
                                                                 Classes="word"
                                                                 FontSize="{Binding FontSize}"
                                                                 FontWeight="{Binding FontWeight}"
                                                                 FontStyle="{Binding FontStyle}"
                                                                 Classes.code="{Binding IsCode}"
                                                                 Classes.link="{Binding IsLink}"
-                                                                Classes.current="{Binding IsCurrent}" />
+                                                                Classes.current="{Binding IsCurrent}">
+                                                            <!-- Ruby text: the word's IPA above
+                                                                 the word, furigana style. The
+                                                                 annotation row collapses when
+                                                                 there is no reading, so a word
+                                                                 without one (punctuation) and
+                                                                 the whole view with annotation
+                                                                 off keep their normal height. -->
+                                                            <StackPanel Orientation="Vertical" Spacing="0">
+                                                                <TextBlock Text="{Binding Ipa}"
+                                                                           IsVisible="{Binding HasIpa}"
+                                                                           FontSize="{Binding IpaFontSize}"
+                                                                           FontWeight="Normal"
+                                                                           FontStyle="Normal"
+                                                                           Classes="ruby"
+                                                                           HorizontalAlignment="Center"
+                                                                           TextAlignment="Center" />
+                                                                <TextBlock Text="{Binding Text}"
+                                                                           HorizontalAlignment="Center" />
+                                                            </StackPanel>
+                                                        </Button>
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>
                                             </ItemsControl>
@@ -264,6 +283,9 @@
             </StackPanel>
 
             <TextBlock Text="Text source" FontWeight="SemiBold" Margin="0,12,0,0" />
+            <CheckBox IsChecked="{Binding ShowIpaAnnotation}"
+                      Content="IPA above each word"
+                      ToolTip.Tip="Shows each word's phonemizer reading above it, the way furigana sits above kanji. Uses the current backend's language." />
             <Button Content="Load text/markdown file…"
                     Command="{Binding PickTextFileCommand}"
                     IsEnabled="{Binding !IsBusy}"
@@ -348,6 +370,14 @@
         <Style Selector="Button.word.current">
             <Setter Property="Foreground" Value="#aef" />
         </Style>
+        <!-- Ruby (IPA) line above a word: dimmer and lighter than the text it annotates, so the
+             written line still reads as the primary one. -->
+        <Style Selector="TextBlock.ruby">
+            <Setter Property="Opacity" Value="0.62" />
+            <Setter Property="Margin" Value="0,0,0,-1" />
+            <Setter Property="Foreground" Value="#cde" />
+        </Style>
+
         <!-- Inline code: monospace + subtle chip. -->
         <Style Selector="Button.word.code">
             <Setter Property="FontFamily" Value="Cascadia Code,Consolas,Menlo,monospace" />

--- a/src/Vernacula.Tts.Base/IpaAnnotator.cs
+++ b/src/Vernacula.Tts.Base/IpaAnnotator.cs
@@ -1,0 +1,84 @@
+using Vernacula.Phonemizer;
+
+namespace Vernacula.Tts.Base;
+
+/// <summary>
+/// Per-word IPA for display above the written text, furigana style.
+///
+/// The reading itself is the phonemizer's; what this adds is the attribution — which slice of the
+/// IPA belongs over which written word. That comes from the trace's two-way index (#1150): a
+/// token's <c>InputSpan</c> says which characters the reader typed, its <c>IpaSpan</c> which
+/// characters of the reading they became.
+///
+/// ⚠ THE WORDS ARE ANNOTATED AS ONE UTTERANCE, NOT ONE AT A TIME. Phonemizing each word alone
+/// would lose the context the normalizer needs — "Mr. Smith" and "$3.14" are read across word
+/// boundaries — so the words are rejoined with single spaces and traced in one pass, which also
+/// keeps the annotation consistent with what the synthesizer will say.
+/// </summary>
+public static class IpaAnnotator
+{
+    /// <summary>
+    /// One IPA string per entry of <paramref name="words"/>, or null when the reading cannot be
+    /// attributed. Entries may be empty (a word that produced no phonemes of its own, such as a
+    /// second written word folded into a preceding rewrite).
+    ///
+    /// Null is returned rather than a partial map: an annotation that is silently off by one word
+    /// is worse than none, and the trace withholds spans precisely when it cannot vouch for them.
+    /// </summary>
+    /// <param name="dataDir">The vernacula-phonemizer <c>data/</c> root, resolved as
+    /// <see cref="PhonemizerData.Resolve"/> does when null.</param>
+    public static IReadOnlyList<string>? Annotate(IReadOnlyList<string> words, string lang,
+        string? dataDir = null)
+    {
+        if (words.Count == 0) return Array.Empty<string>();
+        if (PhonemizerData.Resolve(dataDir) is null) return null;
+
+        var text = string.Join(' ', words);
+        PhonemeTrace trace;
+        try
+        {
+            // Registering the languages reads the data tree, so it can fail for the same reasons
+            // the reading can; both are "no annotation", never a crash in a display path.
+            Registry.EnsureLanguages();
+            trace = global::Vernacula.Phonemizer.Phonemizer.PhonemizeTrace(text, lang);
+        }
+        catch (Exception) { return null; }   // unknown language, unreadable data: no annotation
+        if (!trace.Traced) return null;
+
+        // Character offset -> index of the word containing it. The words were joined with single
+        // spaces, so this is exact rather than a re-split of the caller's text.
+        var wordAt = new int[text.Length];
+        var pos = 0;
+        for (var i = 0; i < words.Count; i++)
+        {
+            for (var k = 0; k < words[i].Length; k++) wordAt[pos + k] = i;
+            pos += words[i].Length;
+            if (pos < text.Length) wordAt[pos++] = i;   // the joining space belongs to the word before
+        }
+
+        var parts = new List<string>[words.Count];
+        (int Start, int End)? lastSpan = null;
+        var lastWord = -1;
+        foreach (var tok in trace.Tokens)
+        {
+            if (tok.InputSpan is not { } input || input.Start < 0 || input.Start >= text.Length) return null;
+            var ipa = tok.IpaSpan is { } span && span.Start >= 0 && span.End <= trace.Ipa.Length
+                ? trace.Ipa[span.Start..span.End]
+                : string.Concat(tok.Emitted);
+            // Tokens sharing one input span came from one normalizer rewrite. When the span covers
+            // several written words ("Mr. Smith" -> mister, Smith) each successive token takes the
+            // next word in it, so the annotation lands over the word it is reading; when it is one
+            // word ("$3.14" -> three, dollars, fourteen) they all stack over that word.
+            var lastInSpan = wordAt[Math.Min(input.End, text.Length) - 1];
+            var word = lastSpan == input ? Math.Min(lastWord + 1, lastInSpan) : wordAt[input.Start];
+            if (word < 0 || word >= words.Count) return null;
+            (parts[word] ??= new List<string>()).Add(ipa.Trim());
+            lastSpan = input; lastWord = word;
+        }
+
+        var result = new string[words.Count];
+        for (var i = 0; i < words.Count; i++)
+            result[i] = parts[i] is { } p ? string.Join(' ', p.Where(s => s.Length > 0)) : "";
+        return result;
+    }
+}

--- a/src/Vernacula.Tts.Base/IpaAnnotator.cs
+++ b/src/Vernacula.Tts.Base/IpaAnnotator.cs
@@ -123,10 +123,10 @@ public static class IpaAnnotator
                     return null;
                 }
                 var word = oneForOne ? first + (t - i0) : first;
-                // Where this token's own characters sit inside its word, for a sub-word piece.
-                var (ws, we) = oneForOne
-                    ? (Math.Max(spans[t].Start, wordStart[word]), Math.Min(spans[t].End, wordStart[word] + words[word].Length))
-                    : (Math.Max(input.Start, wordStart[word]), Math.Min(input.End, wordStart[word] + words[word].Length));
+                // Which characters of that word this reading covers. Every token in the group
+                // shares the one input span, so this is that span clipped to the word.
+                var ws = Math.Max(input.Start, wordStart[word]);
+                var we = Math.Min(input.End, wordStart[word] + words[word].Length);
                 (parts[word] ??= new List<Contribution>()).Add(new Contribution(ws, we, ipa.Trim()));
             }
             i0 = i1 + 1;
@@ -147,8 +147,14 @@ public static class IpaAnnotator
 
     /// <summary>
     /// The word's sub-pieces, or empty when it does not split. A word splits only when its tokens
-    /// cover DISTINCT, in-order, non-empty ranges of it -- "$3.14" is three readings of one range
-    /// and stays stacked, while 東京都に/住んで/います are three ranges and become three pieces.
+    /// cover DISTINCT, in-order ranges of it -- "$3.14" is three readings of one range and stays
+    /// stacked, while 東京都に/住んで/います are three ranges and become three pieces.
+    ///
+    /// ⚠ THE PIECES MUST SPELL THE WORD BACK, CHARACTER FOR CHARACTER. They replace the word in the
+    /// render, so a character no piece covers is a character the reader loses: Chinese punctuation
+    /// gets no token at all, and 我住在北京。 would have lost its 。 Characters between (or around)
+    /// the tokens become pieces with no reading, which is what they are.
+    ///
     /// A piece that is one all-Han run whose reading has exactly one group per character splits
     /// again, per character: that is pinyin over hanzi, the same annotation Chinese readers expect.
     /// </summary>
@@ -158,26 +164,30 @@ public static class IpaAnnotator
         // readers use, and splitting "hello," into two pieces would churn every English render.
         if (!word.Any(IsContinua)) return Array.Empty<RubyPiece>();
 
+        var wordEnd = wordStart + word.Length;
+        var pieces = new List<RubyPiece>(parts.Count);
         var cursor = wordStart;
         foreach (var c in parts)
         {
-            if (c.Start < cursor || c.End <= c.Start || c.End > wordStart + word.Length) return Array.Empty<RubyPiece>();
+            // Overlapping or out-of-order ranges are not a segmentation of anything; decline.
+            if (c.Start < cursor || c.End <= c.Start || c.End > wordEnd) return Array.Empty<RubyPiece>();
+            if (c.Start > cursor) AddPiece(text[cursor..c.Start], "");   // uncovered: punctuation
+            AddPiece(text[c.Start..c.End], c.Ipa);
             cursor = c.End;
         }
+        if (cursor < wordEnd) AddPiece(text[cursor..wordEnd], "");
+        // One piece is not a segmentation -- that is just the word, and it renders as one.
+        return pieces.Count > 1 ? pieces : Array.Empty<RubyPiece>();
 
-        var pieces = new List<RubyPiece>(parts.Count);
-        foreach (var c in parts)
+        void AddPiece(string slice, string ipa)
         {
-            var slice = text[c.Start..c.End];
-            var groups = c.Ipa.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var groups = ipa.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             if (slice.Length > 1 && groups.Length == slice.Length && slice.All(IsHan))
                 for (var k = 0; k < slice.Length; k++)
                     pieces.Add(new RubyPiece(slice[k].ToString(), groups[k], OmniVoiceDuration.TotalWeight(groups[k])));
             else
-                pieces.Add(new RubyPiece(slice, c.Ipa, OmniVoiceDuration.TotalWeight(c.Ipa)));
+                pieces.Add(new RubyPiece(slice, ipa, ipa.Length == 0 ? 0 : OmniVoiceDuration.TotalWeight(ipa)));
         }
-        // One piece is not a segmentation -- that is just the word, and it renders as one.
-        return pieces.Count > 1 ? pieces : Array.Empty<RubyPiece>();
     }
 
     /// <summary>Scripts written without spaces between words, where the render has to be segmented

--- a/src/Vernacula.Tts.Base/IpaAnnotator.cs
+++ b/src/Vernacula.Tts.Base/IpaAnnotator.cs
@@ -15,6 +15,16 @@ namespace Vernacula.Tts.Base;
 /// boundaries — so the words are rejoined with single spaces and traced in one pass, which also
 /// keeps the annotation consistent with what the synthesizer will say.
 /// </summary>
+/// <summary>One displayable sub-part of a word: a slice of the written text and the reading of
+/// that slice. <see cref="Weight"/> is its share of the word's spoken duration, so a highlight can
+/// move through the pieces of a word the aligner only timed as a whole.</summary>
+public sealed record RubyPiece(string Text, string Ipa, double Weight);
+
+/// <summary>A word's annotation: the whole reading, plus the pieces it splits into when the word
+/// is written without spaces (Japanese, Chinese) and the trace can say where the boundaries are.
+/// <see cref="Pieces"/> is empty for ordinary spaced words, which are their own single piece.</summary>
+public sealed record WordRuby(string Ipa, IReadOnlyList<RubyPiece> Pieces);
+
 public static class IpaAnnotator
 {
     /// <summary>
@@ -27,10 +37,10 @@ public static class IpaAnnotator
     /// </summary>
     /// <param name="dataDir">The vernacula-phonemizer <c>data/</c> root, resolved as
     /// <see cref="PhonemizerData.Resolve"/> does when null.</param>
-    public static IReadOnlyList<string>? Annotate(IReadOnlyList<string> words, string lang,
+    public static IReadOnlyList<WordRuby>? Annotate(IReadOnlyList<string> words, string lang,
         string? dataDir = null)
     {
-        if (words.Count == 0) return Array.Empty<string>();
+        if (words.Count == 0) return Array.Empty<WordRuby>();
         if (PhonemizerData.Resolve(dataDir) is null) return null;
 
         var text = string.Join(' ', words);
@@ -56,29 +66,164 @@ public static class IpaAnnotator
             if (pos < text.Length) wordAt[pos++] = i;   // the joining space belongs to the word before
         }
 
-        var parts = new List<string>[words.Count];
-        (int Start, int End)? lastSpan = null;
-        var lastWord = -1;
-        foreach (var tok in trace.Tokens)
+        // Japanese drops span provenance through some normalizer rewrites (は read as わ), and a
+        // word written without spaces is exactly where the boundaries matter most. When every span
+        // is missing but the token surfaces still account for the input character for character,
+        // the boundaries can be reconstructed from their lengths; when they cannot (a number that
+        // expands, say) this returns null and the caller declines rather than guesses.
+        var spans = InputSpans(trace, text);
+        if (spans is null) return null;
+
+        // Group the tokens by input span first. A span is the unit the normalizer rewrote, and
+        // only by looking at a whole group can we tell whether its tokens line up with the written
+        // words one for one -- which is what decides whether they may be distributed across them.
+        var wordStart = new int[words.Count];
+        for (int i = 0, at = 0; i < words.Count; i++) { wordStart[i] = at; at += words[i].Length + 1; }
+
+        var parts = new List<Contribution>[words.Count];
+        var i0 = 0;
+        while (i0 < trace.Tokens.Count)
         {
-            if (tok.InputSpan is not { } input || input.Start < 0 || input.Start >= text.Length) return null;
-            var ipa = tok.IpaSpan is { } span && span.Start >= 0 && span.End <= trace.Ipa.Length
-                ? trace.Ipa[span.Start..span.End]
-                : string.Concat(tok.Emitted);
-            // Tokens sharing one input span came from one normalizer rewrite. When the span covers
-            // several written words ("Mr. Smith" -> mister, Smith) each successive token takes the
-            // next word in it, so the annotation lands over the word it is reading; when it is one
-            // word ("$3.14" -> three, dollars, fourteen) they all stack over that word.
-            var lastInSpan = wordAt[Math.Min(input.End, text.Length) - 1];
-            var word = lastSpan == input ? Math.Min(lastWord + 1, lastInSpan) : wordAt[input.Start];
-            if (word < 0 || word >= words.Count) return null;
-            (parts[word] ??= new List<string>()).Add(ipa.Trim());
-            lastSpan = input; lastWord = word;
+            var input = spans[i0];
+            var i1 = i0;
+            while (i1 + 1 < trace.Tokens.Count && spans[i1 + 1] == input) i1++;
+
+            var first = wordAt[input.Start];
+            var last = wordAt[Math.Min(input.End, text.Length) - 1];
+            if (first < 0 || last >= words.Count || last < first) return null;
+
+            // One token per written word in the span ("Mr. Smith" -> mister, Smith): each token
+            // annotates its own word. Any other shape -- "$3.14" read as three words, or "$ 3.14"
+            // whose three tokens do not line up with its two written words -- is stacked over the
+            // span's first word instead. Distributing a group that does NOT correspond one for one
+            // puts the reading over the wrong word, which is worse than stacking it.
+            var oneForOne = i1 - i0 == last - first;
+            for (var t = i0; t <= i1; t++)
+            {
+                var tok = trace.Tokens[t];
+                string ipa;
+                if (tok.IpaSpan is { } span)
+                {
+                    if (span.Start < 0 || span.End > trace.Ipa.Length || span.End < span.Start) return null;
+                    ipa = trace.Ipa[span.Start..span.End];
+                }
+                else if (tok.Emitted.Count == 0)
+                {
+                    // No reading at all (punctuation). It still occupies characters of the word,
+                    // so it is recorded with an empty reading -- otherwise the pieces would not
+                    // spell the word back and the 。 would vanish from the render.
+                    ipa = "";
+                }
+                else
+                {
+                    // The span was withheld because a post-assembly rewrite moved the offsets, and
+                    // Emitted is what the token PRODUCED, not necessarily what the reading says
+                    // (fr-CA's accent, `as`'s aspirate collapse). Showing it would put a reading on
+                    // screen that the synthesizer will not speak.
+                    return null;
+                }
+                var word = oneForOne ? first + (t - i0) : first;
+                // Where this token's own characters sit inside its word, for a sub-word piece.
+                var (ws, we) = oneForOne
+                    ? (Math.Max(spans[t].Start, wordStart[word]), Math.Min(spans[t].End, wordStart[word] + words[word].Length))
+                    : (Math.Max(input.Start, wordStart[word]), Math.Min(input.End, wordStart[word] + words[word].Length));
+                (parts[word] ??= new List<Contribution>()).Add(new Contribution(ws, we, ipa.Trim()));
+            }
+            i0 = i1 + 1;
         }
 
-        var result = new string[words.Count];
+        var result = new WordRuby[words.Count];
         for (var i = 0; i < words.Count; i++)
-            result[i] = parts[i] is { } p ? string.Join(' ', p.Where(s => s.Length > 0)) : "";
+        {
+            var p = parts[i];
+            var ipa = p is null ? "" : string.Join(' ', p.Select(c => c.Ipa).Where(x => x.Length > 0));
+            result[i] = new WordRuby(ipa, p is null ? Array.Empty<RubyPiece>() : Pieces(p, text, wordStart[i], words[i]));
+        }
         return result;
+    }
+
+    /// <summary>One token's contribution: the characters of the word it covers, and their reading.</summary>
+    private readonly record struct Contribution(int Start, int End, string Ipa);
+
+    /// <summary>
+    /// The word's sub-pieces, or empty when it does not split. A word splits only when its tokens
+    /// cover DISTINCT, in-order, non-empty ranges of it -- "$3.14" is three readings of one range
+    /// and stays stacked, while 東京都に/住んで/います are three ranges and become three pieces.
+    /// A piece that is one all-Han run whose reading has exactly one group per character splits
+    /// again, per character: that is pinyin over hanzi, the same annotation Chinese readers expect.
+    /// </summary>
+    private static IReadOnlyList<RubyPiece> Pieces(List<Contribution> parts, string text, int wordStart, string word)
+    {
+        // Only scriptio continua is segmented. A spaced language already has the boundaries its
+        // readers use, and splitting "hello," into two pieces would churn every English render.
+        if (!word.Any(IsContinua)) return Array.Empty<RubyPiece>();
+
+        var cursor = wordStart;
+        foreach (var c in parts)
+        {
+            if (c.Start < cursor || c.End <= c.Start || c.End > wordStart + word.Length) return Array.Empty<RubyPiece>();
+            cursor = c.End;
+        }
+
+        var pieces = new List<RubyPiece>(parts.Count);
+        foreach (var c in parts)
+        {
+            var slice = text[c.Start..c.End];
+            var groups = c.Ipa.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (slice.Length > 1 && groups.Length == slice.Length && slice.All(IsHan))
+                for (var k = 0; k < slice.Length; k++)
+                    pieces.Add(new RubyPiece(slice[k].ToString(), groups[k], OmniVoiceDuration.TotalWeight(groups[k])));
+            else
+                pieces.Add(new RubyPiece(slice, c.Ipa, OmniVoiceDuration.TotalWeight(c.Ipa)));
+        }
+        // One piece is not a segmentation -- that is just the word, and it renders as one.
+        return pieces.Count > 1 ? pieces : Array.Empty<RubyPiece>();
+    }
+
+    /// <summary>Scripts written without spaces between words, where the render has to be segmented
+    /// before a per-word annotation means anything: Han, kana, Thai, Lao, Khmer and Myanmar.</summary>
+    private static bool IsContinua(char c) =>
+        IsHan(c)
+        || c is >= (char)0x3040 and <= (char)0x30FF      // hiragana + katakana
+        || c is >= (char)0x0E00 and <= (char)0x0EFF      // Thai, Lao
+        || c is >= (char)0x1000 and <= (char)0x109F      // Myanmar
+        || c is >= (char)0x1780 and <= (char)0x17FF;     // Khmer
+
+    /// <summary>CJK ideographs -- the characters that carry one syllable each in Chinese.</summary>
+    private static bool IsHan(char c) =>
+        c is >= (char)0x4E00 and <= (char)0x9FFF or >= (char)0x3400 and <= (char)0x4DBF;
+
+    /// <summary>
+    /// Each token's span into <paramref name="text"/>, or null when they cannot be established.
+    /// Reported spans are used as given. When every token is missing one, the surfaces are laid
+    /// back over the input by length -- valid only if they account for every non-space character,
+    /// which is what makes the length-preserving rewrites (は -> わ) recoverable and the
+    /// length-changing ones (3800 -> its reading) declined.
+    /// </summary>
+    private static (int Start, int End)[]? InputSpans(PhonemeTrace trace, string text)
+    {
+        var spans = new (int Start, int End)[trace.Tokens.Count];
+        var missing = 0;
+        for (var i = 0; i < trace.Tokens.Count; i++)
+        {
+            if (trace.Tokens[i].InputSpan is { } s
+                && s.Start >= 0 && s.End > s.Start && s.Start < text.Length)
+                spans[i] = (s.Start, Math.Min(s.End, text.Length));
+            else { missing++; spans[i] = (-1, -1); }
+        }
+        if (missing == 0) return spans;
+        if (missing != trace.Tokens.Count) return null;   // a partial map desyncs everything after the gap
+
+        var pos = 0;
+        for (var i = 0; i < trace.Tokens.Count; i++)
+        {
+            while (pos < text.Length && char.IsWhiteSpace(text[pos])) pos++;
+            var len = trace.Tokens[i].Surface.Length;
+            if (len <= 0 || pos + len > text.Length) return null;
+            spans[i] = (pos, pos + len);
+            pos += len;
+        }
+        while (pos < text.Length && char.IsWhiteSpace(text[pos])) pos++;
+        return pos == text.Length ? spans : null;   // surfaces must account for the whole input
     }
 }

--- a/tests/Vernacula.Tts.Tests/IpaAnnotatorTests.cs
+++ b/tests/Vernacula.Tts.Tests/IpaAnnotatorTests.cs
@@ -143,7 +143,11 @@ public class IpaAnnotatorTests
     [Fact]
     public void PiecesSpellTheWordBackExactly()
     {
+        // Including the characters no token covers: Chinese punctuation gets no token at all, and
+        // the pieces REPLACE the word in the render, so anything they drop is text the reader
+        // loses off the screen.
         foreach (var (word, lang) in new[] { ("東京都に住んでいます。", "ja"), ("我喜欢学习中文", "cmn"),
+                                             ("我住在北京。", "cmn"), ("「東京」に住んでいます", "ja"),
                                              ("私は日本語を勉強しています。", "ja") })
         {
             var pieces = Ruby(word, lang)[0].Pieces;

--- a/tests/Vernacula.Tts.Tests/IpaAnnotatorTests.cs
+++ b/tests/Vernacula.Tts.Tests/IpaAnnotatorTests.cs
@@ -1,0 +1,56 @@
+using Xunit;
+using Vernacula.Tts.Base;
+
+namespace Vernacula.Tts.Tests;
+
+public class IpaAnnotatorTests
+{
+    private static bool HavePhonemizer() => PhonemizerData.Resolve(null) is not null;
+
+    private static IReadOnlyList<string> Annotate(params string[] words)
+    {
+        if (!HavePhonemizer()) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+        var got = IpaAnnotator.Annotate(words, "en");
+        Assert.NotNull(got);
+        return got!;
+    }
+
+    [Fact]
+    public void OneEntryPerWord()
+    {
+        var ipa = Annotate("hello", "world");
+        Assert.Equal(2, ipa.Count);
+        Assert.All(ipa, s => Assert.NotEqual("", s));
+    }
+
+    [Fact]
+    public void AnnotationIsThatWordsReading()
+    {
+        // Each word's annotation is its own reading, not a slice of the neighbour's.
+        var ipa = Annotate("the", "cat", "sat");
+        Assert.Contains("æ", ipa[1]);
+        Assert.DoesNotContain("æ", ipa[0]);
+    }
+
+    [Fact]
+    public void ExpandedNumberStaysOverItsOwnWord()
+    {
+        // "$3.14" reads as several words but is written as one: all of it annotates that word,
+        // and the words around it keep their own readings.
+        var ipa = Annotate("costs", "$3.14", "today");
+        Assert.Equal(3, ipa.Count);
+        Assert.Contains(" ", ipa[1].Trim());          // several groups stacked over the one word
+        Assert.NotEqual("", ipa[2]);
+    }
+
+    [Fact]
+    public void EmptyInputIsEmptyNotNull()
+        => Assert.Empty(IpaAnnotator.Annotate(Array.Empty<string>(), "en")!);
+
+    [Fact]
+    public void UnknownLanguageDeclinesRatherThanThrowing()
+    {
+        if (!HavePhonemizer()) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+        Assert.Null(IpaAnnotator.Annotate(new[] { "hello" }, "zz-not-a-language"));
+    }
+}

--- a/tests/Vernacula.Tts.Tests/IpaAnnotatorTests.cs
+++ b/tests/Vernacula.Tts.Tests/IpaAnnotatorTests.cs
@@ -12,6 +12,14 @@ public class IpaAnnotatorTests
         if (!HavePhonemizer()) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
         var got = IpaAnnotator.Annotate(words, "en");
         Assert.NotNull(got);
+        return got!.Select(w => w.Ipa).ToList();
+    }
+
+    private static IReadOnlyList<WordRuby> Ruby(string word, string lang)
+    {
+        if (!HavePhonemizer()) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+        var got = IpaAnnotator.Annotate(new[] { word }, lang);
+        Assert.NotNull(got);
         return got!;
     }
 
@@ -41,6 +49,106 @@ public class IpaAnnotatorTests
         Assert.Equal(3, ipa.Count);
         Assert.Contains(" ", ipa[1].Trim());          // several groups stacked over the one word
         Assert.NotEqual("", ipa[2]);
+    }
+
+    [Fact]
+    public void SpanCoveringSeveralWordsIsNotDistributedUnlessItLinesUp()
+    {
+        // "$ 3.14" is one rewritten span whose three spoken tokens do not correspond one for one
+        // with its two written words. Handing them out in order put "three" over "$" and
+        // "dollars fourteen" over "3.14" -- a reading over the wrong word. The group stacks over
+        // the span's first word instead.
+        var ipa = Annotate("costs", "$", "3.14");
+        Assert.Equal(3, ipa.Count);
+        Assert.Contains("dˈɑːlɚz", ipa[1]);
+        Assert.Equal("", ipa[2]);
+    }
+
+    [Fact]
+    public void OneTokenPerWordInASpanStillFollowsTheWords()
+    {
+        // The shape that does line up: two tokens, two written words.
+        var ipa = Annotate("Mr.", "Smith");
+        Assert.Contains("mˈɪst", ipa[0]);
+        Assert.Contains("smˈɪθ", ipa[1]);
+    }
+
+    [Theory]
+    [InlineData("fr-CA")]   // applies an accent after assembly, so IpaSpan is withheld
+    [InlineData("as")]      // collapses a doubled aspirate, likewise
+    [InlineData("en")]
+    public void NeverShowsAReadingTheSynthesizerWillNotSay(string lang)
+    {
+        if (!HavePhonemizer()) Assert.Skip("vernacula-phonemizer data/ not found (submodule not checked out?).");
+        var words = new[] { "Bonjour", "le", "monde", "aujourd'hui" };
+        var ipa = IpaAnnotator.Annotate(words, lang);
+        if (ipa is null) return;   // withheld, which is the other allowed answer
+        var reading = global::Vernacula.Phonemizer.Phonemizer.Phonemize(string.Join(' ', words), lang);
+        foreach (var s in ipa.Select(w => w.Ipa).Where(s => s.Length > 0))
+            foreach (var group in s.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                Assert.Contains(group, reading);
+    }
+
+    // ── Scriptio continua: the render has to be segmented before ruby means anything ──
+
+    [Fact]
+    public void JapaneseSentenceSplitsIntoItsOwnUnits()
+    {
+        // One written "word" (no spaces) becomes the phonemizer's bunsetsu-like units, each with
+        // its own reading over its own characters.
+        var pieces = Ruby("東京都に住んでいます。", "ja")[0].Pieces;
+        Assert.Equal(new[] { "東京都に", "住んで", "います", "。" }, pieces.Select(p => p.Text));
+        Assert.Contains("sɯᵝ", pieces[1].Ipa);
+        Assert.All(pieces.Take(3), p => Assert.True(p.Weight > 0, "a spoken piece carries duration weight"));
+    }
+
+    [Fact]
+    public void JapaneseSplitsEvenWhenTheRewriteDropsProvenance()
+    {
+        // 私は -> 私わ loses every input span; the surfaces still account for the input character
+        // for character, so the boundaries are recoverable -- and the text shown stays the text
+        // the reader typed (私は), never the normalizer's rewrite (私わ).
+        var pieces = Ruby("私は日本語を勉強しています。", "ja")[0].Pieces;
+        Assert.Equal(new[] { "私は", "日本語を", "勉強して", "います", "。" }, pieces.Select(p => p.Text));
+    }
+
+    [Fact]
+    public void ChineseSplitsPerCharacter()
+    {
+        var pieces = Ruby("我喜欢学习中文", "cmn")[0].Pieces;
+        Assert.Equal(7, pieces.Count);
+        Assert.Equal("我", pieces[0].Text);
+        Assert.DoesNotContain(" ", pieces[0].Ipa.Trim());   // one syllable per character
+    }
+
+    [Fact]
+    public void UnsegmentableScriptStaysWhole()
+    {
+        // Thai has no token boundaries here: three groups for fifteen characters. Rather than
+        // invent a split, the whole run keeps one reading.
+        var ruby = Ruby("ฉันเรียนภาษาไทย", "th")[0];
+        Assert.Empty(ruby.Pieces);
+        Assert.NotEqual("", ruby.Ipa);
+    }
+
+    [Fact]
+    public void StackedReadingDoesNotBecomePieces()
+    {
+        // "$3.14" is three readings of ONE range, not three ranges: it must not be chopped up.
+        var ruby = Ruby("$3.14", "en")[0];
+        Assert.Empty(ruby.Pieces);
+        Assert.Contains("dˈɑːlɚz", ruby.Ipa);
+    }
+
+    [Fact]
+    public void PiecesSpellTheWordBackExactly()
+    {
+        foreach (var (word, lang) in new[] { ("東京都に住んでいます。", "ja"), ("我喜欢学习中文", "cmn"),
+                                             ("私は日本語を勉強しています。", "ja") })
+        {
+            var pieces = Ruby(word, lang)[0].Pieces;
+            Assert.Equal(word, string.Concat(pieces.Select(p => p.Text)));
+        }
     }
 
     [Fact]


### PR DESCRIPTION
The karaoke view can show each word's reading above it, small and dimmed, the way furigana sits above kanji. Off by default; the **IPA above each word** checkbox in the right pane persists with the other picker state.

```
 ðə  kwˈɪk  bɹˈaᶷn  fˈɑːks  d͡ʒˈʌmpt  oᶷvɚ  mˈɪstɚ  smˈɪθ   θɹˈiː dˈɑːlɚz fˈɔːɹtˈiːn
The quick  brown    fox    jumped   over   Mr.    Smith,        $3.14
```

The reading itself is the phonemizer's. What is new is the attribution — which slice of the IPA belongs over which written word — and it comes from the trace's two-way index (#1150): a token's `InputSpan` says which characters the reader typed, its `IpaSpan` which characters of the reading they became.

**Words are annotated a block at a time, as one utterance**, not one word at a time, so the normalizer keeps the context it reads across word boundaries. `Mr. Smith` annotates as `mˈɪstɚ` over "Mr." and `smˈɪθ` over "Smith"; `$3.14` stacks its three groups over the single written word. When the trace cannot vouch for the mapping, the annotation is withheld whole — one silently off by a word is worse than none.

The language follows the backend: OmniVoice's picked language, Kokoro's `en`/`en-GB` (its `bf_`/`bm_` voices), `en` for the English-only Chatterbox. Annotation runs off the UI thread, debounced, and each run cancels the last, so typing does not stutter and a late result never draws over words that have since changed.

Verified in the running app on English and French (the French reading follows the OmniVoice language picker), plus five unit tests over the attribution: one entry per word, each word's own reading, an expanded number staying over its own word, empty input, and an unknown language declining rather than throwing. Full suite green (68 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc