### PR TITLE
fix(reader): stored voices are not un-boosted, so quiet languages play quiet

### DIFF
--- a/src/Vernacula.Tts.Avalonia/Services/OmniVoiceSynthesisService.cs
+++ b/src/Vernacula.Tts.Avalonia/Services/OmniVoiceSynthesisService.cs
@@ -71,6 +71,9 @@ public sealed class OmniVoiceSynthesisService : ITtsBackend
             int totalChunks = chunks.Count;
             onProgress?.Invoke(new ProgressEvent($"chunked into {totalChunks} pieces", null, totalChunks));
 
+            // One leveler for the whole document: the chunks are concatenated, so each one must
+            // not be normalised to the same peak on its own or the level pumps between them.
+            var leveler = new OmniVoiceAudioPost.StoredVoiceLeveler();
             var chunkAudios = new float[totalChunks][];
             var sidecarChunks = new List<ChunkRecord>(totalChunks);
             var allWords = new List<AlignedWord>();
@@ -82,7 +85,7 @@ public sealed class OmniVoiceSynthesisService : ITtsBackend
                 onProgress?.Invoke(new ProgressEvent($"synthesizing ({request.NumStep} steps)", idx + 1, totalChunks));
 
                 string chunkText = chunks[idx];
-                var sp = tts.SpeakAligned(chunkText, lang, request.NumStep);
+                var sp = tts.SpeakAligned(chunkText, lang, request.NumStep, leveler);
                 var wav = sp.Audio;
 
                 chunkAudios[idx] = wav;

--- a/src/Vernacula.Tts.Base/OmniVoiceAudioPost.cs
+++ b/src/Vernacula.Tts.Base/OmniVoiceAudioPost.cs
@@ -145,6 +145,40 @@ public static class OmniVoiceAudioPost
         return outArr;
     }
 
+    /// <summary>Scale so the loudest sample sits at <paramref name="peak"/>. Silence is left alone.</summary>
+    public static void Normalize(float[] x, float peak)
+    {
+        float max = 0;
+        foreach (var v in x) max = Math.Max(max, Math.Abs(v));
+        if (max < 1e-6f) return;
+        float g = peak / max;
+        for (int i = 0; i < x.Length; i++) x[i] *= g;
+    }
+
+    /// <summary>
+    /// The finishing chain for a STORED voice — the demo's, and the only correct one for a
+    /// reference we did not boost.
+    ///
+    /// ⚠ PYTHON'S VOLUME STEP UN-BOOSTS A REFERENCE THAT WAS BOOSTED AT ENCODE TIME. The stored
+    /// voices never were: they carry the source clip's own level, and the corpus spans rms
+    /// 0.0017–0.099, a 58× spread. Applying the un-boost to them undoes something that never
+    /// happened, so a quiet source plays quiet — af (rms 0.0148) came out at 15% of level — and at
+    /// the very quiet end it drops the whole utterance below the silence threshold, where
+    /// <see cref="RemoveSilence"/> deletes it outright.
+    ///
+    /// Hence: normalise BEFORE silence removal, and again AFTER the fade — the fine-tune emits a
+    /// leading transient inside the first 0.1 s, and normalising only before the fade lets that
+    /// transient take the headroom which the fade then removes.
+    /// </summary>
+    public static float[] FinishStoredVoice(float[] audio, int sr)
+    {
+        Normalize(audio, 0.5f);
+        audio = RemoveSilence(audio, sr, midSilMs: 500, leadSilMs: 100, trailSilMs: 100);
+        audio = FadeAndPad(audio, sr);
+        Normalize(audio, 0.5f);
+        return audio;
+    }
+
     /// <summary>
     /// The finishing chain in the order Python's <c>_post_process_audio</c> applies it: remove
     /// silence → volume → fade-in/out + zero-pad. Volume: with a reference (<paramref name="refRms"/>
@@ -160,9 +194,7 @@ public static class OmniVoiceAudioPost
         }
         else
         {
-            float max = 0;
-            foreach (var v in audio) max = Math.Max(max, Math.Abs(v));
-            if (max >= 1e-6f) { float g = 0.5f / max; for (int i = 0; i < audio.Length; i++) audio[i] *= g; }
+            Normalize(audio, 0.5f);
         }
         return FadeAndPad(audio, sr);
     }

--- a/src/Vernacula.Tts.Base/OmniVoiceAudioPost.cs
+++ b/src/Vernacula.Tts.Base/OmniVoiceAudioPost.cs
@@ -145,14 +145,47 @@ public static class OmniVoiceAudioPost
         return outArr;
     }
 
-    /// <summary>Scale so the loudest sample sits at <paramref name="peak"/>. Silence is left alone.</summary>
+    /// <summary>Scale IN PLACE so the loudest sample sits at <paramref name="peak"/>. Silence is
+    /// left alone.</summary>
     public static void Normalize(float[] x, float peak)
     {
-        float max = 0;
-        foreach (var v in x) max = Math.Max(max, Math.Abs(v));
+        float max = Peak(x);
         if (max < 1e-6f) return;
         float g = peak / max;
         for (int i = 0; i < x.Length; i++) x[i] *= g;
+    }
+
+    /// <summary>Loudest absolute sample, or 0 for an empty or silent buffer.</summary>
+    public static float Peak(float[] a)
+    {
+        float m = 0;
+        foreach (var v in a) m = Math.Max(m, Math.Abs(v));
+        return m;
+    }
+
+    /// <summary>
+    /// Keeps one document's chunks at consistent loudness. A document is synthesized chunk by
+    /// chunk and the pieces are concatenated, so normalising each chunk to the same peak on its own
+    /// would pump: a chunk whose loudest moment is a soft syllable would come out as loud as one
+    /// containing a shouted word. The first chunk sets the level and the rest keep their loudness
+    /// relative to it, which is what the old constant-gain chain did for free.
+    ///
+    /// A leveler is for ONE document. <see cref="OmniVoiceAudioPost.FinishStoredVoice"/> without
+    /// one is the single-utterance case (the CLI, the demo) and normalises outright.
+    /// </summary>
+    public sealed class StoredVoiceLeveler
+    {
+        private float _firstPeak;
+
+        /// <summary>The target peak for a chunk whose decoded peak was <paramref name="rawPeak"/>.
+        /// The first chunk anchors at 0.5; a later chunk that was twice as loud would want 1.0 and
+        /// is capped short of full scale rather than clipped.</summary>
+        internal float TargetFor(float rawPeak)
+        {
+            if (_firstPeak <= 0) _firstPeak = rawPeak;
+            if (_firstPeak <= 0) return 0.5f;
+            return Math.Min(0.95f, 0.5f * rawPeak / _firstPeak);
+        }
     }
 
     /// <summary>
@@ -169,13 +202,19 @@ public static class OmniVoiceAudioPost
     /// Hence: normalise BEFORE silence removal, and again AFTER the fade — the fine-tune emits a
     /// leading transient inside the first 0.1 s, and normalising only before the fade lets that
     /// transient take the headroom which the fade then removes.
+    ///
+    /// The input array is not modified; the caller keeps its decoded audio.
     /// </summary>
-    public static float[] FinishStoredVoice(float[] audio, int sr)
+    /// <param name="leveler">Optional, and shared across one document's chunks so they stay at
+    /// consistent loudness relative to each other. Null finishes a single utterance on its own.</param>
+    public static float[] FinishStoredVoice(float[] audio, int sr, StoredVoiceLeveler? leveler = null)
     {
+        var target = leveler?.TargetFor(Peak(audio)) ?? 0.5f;
+        audio = (float[])audio.Clone();
         Normalize(audio, 0.5f);
         audio = RemoveSilence(audio, sr, midSilMs: 500, leadSilMs: 100, trailSilMs: 100);
         audio = FadeAndPad(audio, sr);
-        Normalize(audio, 0.5f);
+        Normalize(audio, target);
         return audio;
     }
 

--- a/src/Vernacula.Tts.Base/OmniVoiceIpaTts.cs
+++ b/src/Vernacula.Tts.Base/OmniVoiceIpaTts.cs
@@ -144,7 +144,12 @@ public sealed class OmniVoiceIpaTts : IDisposable
         // lang: null is the IPA fine-tune's conditioning — the language never reaches the model.
         var tokens = _tts.GenerateTokens(ipa, target, CondRefIpa, Voice?.Codes, lang: null, instruct: null,
             new OmniVoiceTts.GenConfig(NumStep: numStep));
-        var audio = OmniVoiceAudioPost.Finish(_tts.DecodeTokens(tokens), SampleRate, Voice?.RefRms);
+        // A stored voice was never boosted at encode time, so Python's un-boost would just make a
+        // quiet source quieter; an encoded reference WAS boosted and needs it undone.
+        var decoded = _tts.DecodeTokens(tokens);
+        var audio = Voice is null
+            ? OmniVoiceAudioPost.Finish(decoded, SampleRate, refRms: null)
+            : OmniVoiceAudioPost.FinishStoredVoice(decoded, SampleRate);
 
         return new OmniVoiceIpaSpeech(audio, OmniVoiceIpaAlignment.Proportional(text, trace, audio.Length / (double)SampleRate));
     }

--- a/src/Vernacula.Tts.Base/OmniVoiceIpaTts.cs
+++ b/src/Vernacula.Tts.Base/OmniVoiceIpaTts.cs
@@ -132,7 +132,10 @@ public sealed class OmniVoiceIpaTts : IDisposable
 
     /// <summary>Synthesize one chunk in the current voice and return audio plus estimated
     /// per-word timings (see the class remarks).</summary>
-    public OmniVoiceIpaSpeech SpeakAligned(string text, string lang, int numStep = 32)
+    /// <param name="leveler">Shared across the chunks of one document so their loudness stays
+    /// consistent; null finishes this chunk as a single utterance.</param>
+    public OmniVoiceIpaSpeech SpeakAligned(string text, string lang, int numStep = 32,
+        OmniVoiceAudioPost.StoredVoiceLeveler? leveler = null)
     {
         var trace = global::Vernacula.Phonemizer.Phonemizer.PhonemizeTrace(text, lang);
         var ipa = Phonemize(text, lang);
@@ -149,7 +152,7 @@ public sealed class OmniVoiceIpaTts : IDisposable
         var decoded = _tts.DecodeTokens(tokens);
         var audio = Voice is null
             ? OmniVoiceAudioPost.Finish(decoded, SampleRate, refRms: null)
-            : OmniVoiceAudioPost.FinishStoredVoice(decoded, SampleRate);
+            : OmniVoiceAudioPost.FinishStoredVoice(decoded, SampleRate, leveler);
 
         return new OmniVoiceIpaSpeech(audio, OmniVoiceIpaAlignment.Proportional(text, trace, audio.Length / (double)SampleRate));
     }

--- a/src/Vernacula.Tts.CLI/Program.cs
+++ b/src/Vernacula.Tts.CLI/Program.cs
@@ -437,14 +437,7 @@ internal static class Program
         // fine — 91 of 318 clips in the first sweep, all of them FLEURS, whose audio is simply quiet.
         if (post == "demo")
         {
-            // Normalise BEFORE silence removal, and again after the fade: the fine-tune emits a
-            // leading transient inside the first 0.1 s, so normalising only before the fade lets that
-            // transient take the headroom and the fade then removes it.
-            Normalize(audio, 0.5f);
-            audio = OmniVoiceAudioPost.RemoveSilence(audio, OmniVoiceTts.SampleRate,
-                midSilMs: 500, leadSilMs: 100, trailSilMs: 100);
-            audio = OmniVoiceAudioPost.FadeAndPad(audio, OmniVoiceTts.SampleRate);
-            Normalize(audio, 0.5f);
+            audio = OmniVoiceAudioPost.FinishStoredVoice(audio, OmniVoiceTts.SampleRate);
         }
         else if (post == "python")
         {
@@ -469,15 +462,6 @@ internal static class Program
         var (samples, sr, ch) = AudioUtils.ReadAudio(path);
         float[] mono = ch > 1 ? AudioUtils.DownmixToMono(samples, ch) : samples;
         return AudioUtils.ResampleMono(mono, sr, OmniVoiceTts.SampleRate);
-    }
-
-    private static void Normalize(float[] x, float peak)
-    {
-        float max = 0;
-        foreach (var v in x) max = Math.Max(max, Math.Abs(v));
-        if (max < 1e-6f) return;
-        float g = peak / max;
-        for (int i = 0; i < x.Length; i++) x[i] *= g;
     }
 
     private static float Rms(float[] x)

--- a/tests/Vernacula.Tts.Tests/OmniVoiceAudioPostTests.cs
+++ b/tests/Vernacula.Tts.Tests/OmniVoiceAudioPostTests.cs
@@ -40,6 +40,39 @@ public class OmniVoiceAudioPostTests
     }
 
     [Fact]
+    public void ChunksOfOneDocumentKeepTheirLoudnessRelativeToEachOther()
+    {
+        // A document is synthesized in chunks and concatenated. Normalising each to 0.5 on its own
+        // makes a soft chunk as loud as a shouted one -- audible pumping mid-paragraph. With one
+        // leveler, the first chunk anchors the level and a half-as-loud chunk stays half as loud.
+        var leveler = new OmniVoiceAudioPost.StoredVoiceLeveler();
+        var first = OmniVoiceAudioPost.FinishStoredVoice(Tone(0.4f), Sr, leveler);
+        var softer = OmniVoiceAudioPost.FinishStoredVoice(Tone(0.2f), Sr, leveler);
+        Assert.Equal(0.5f, Peak(first), 2);
+        Assert.Equal(0.25f, Peak(softer), 2);
+    }
+
+    [Fact]
+    public void ALouderLaterChunkIsHeldShortOfFullScale()
+    {
+        var leveler = new OmniVoiceAudioPost.StoredVoiceLeveler();
+        OmniVoiceAudioPost.FinishStoredVoice(Tone(0.2f), Sr, leveler);
+        var louder = OmniVoiceAudioPost.FinishStoredVoice(Tone(0.9f), Sr, leveler);
+        Assert.True(Peak(louder) <= 0.95f, $"peak {Peak(louder)} must stay short of clipping");
+        Assert.True(Peak(louder) > 0.5f, "and still be louder than the anchor chunk");
+    }
+
+    [Fact]
+    public void TheDecodedAudioIsNotModified()
+    {
+        // Both chains leave the caller's buffer alone, so raw decoder output stays raw.
+        var raw = Tone(0.3f);
+        var before = (float[])raw.Clone();
+        OmniVoiceAudioPost.FinishStoredVoice(raw, Sr);
+        Assert.Equal(before, raw);
+    }
+
+    [Fact]
     public void PythonChainStillUnBoostsAnEncodedReference()
     {
         // Unchanged for a reference WE boosted at encode time: that boost still has to come off.

--- a/tests/Vernacula.Tts.Tests/OmniVoiceAudioPostTests.cs
+++ b/tests/Vernacula.Tts.Tests/OmniVoiceAudioPostTests.cs
@@ -1,0 +1,56 @@
+using Xunit;
+using Vernacula.Tts.Base;
+
+namespace Vernacula.Tts.Tests;
+
+/// <summary>
+/// Which finishing chain a render gets is a loudness decision, and the wrong one is audible: a
+/// stored voice carries its source clip's own level (the corpus spans rms 0.0017-0.099), so
+/// Python's un-boost -- which exists to undo a boost applied at encode time -- makes quiet voices
+/// quieter still.
+/// </summary>
+public class OmniVoiceAudioPostTests
+{
+    private const int Sr = 24000;
+
+    /// <summary>Half a second of tone at a given peak, loud enough never to read as silence.</summary>
+    private static float[] Tone(float peak)
+    {
+        var a = new float[Sr / 2];
+        for (var i = 0; i < a.Length; i++) a[i] = peak * MathF.Sin(2 * MathF.PI * 220 * i / Sr);
+        return a;
+    }
+
+    private static float Peak(float[] a)
+    {
+        float m = 0;
+        foreach (var v in a) m = MathF.Max(m, MathF.Abs(v));
+        return m;
+    }
+
+    [Fact]
+    public void StoredVoiceChainNormalizesRegardlessOfHowQuietTheReferenceWas()
+    {
+        // af's reference is rms 0.0148. Under the un-boost that was 15% of level; the render is
+        // now normalised, so a quiet source voice is as loud as a loud one.
+        var quiet = OmniVoiceAudioPost.FinishStoredVoice(Tone(0.05f), Sr);
+        var loud = OmniVoiceAudioPost.FinishStoredVoice(Tone(0.9f), Sr);
+        Assert.Equal(0.5f, Peak(quiet), 2);
+        Assert.Equal(0.5f, Peak(loud), 2);
+    }
+
+    [Fact]
+    public void PythonChainStillUnBoostsAnEncodedReference()
+    {
+        // Unchanged for a reference WE boosted at encode time: that boost still has to come off.
+        var got = OmniVoiceAudioPost.Finish(Tone(0.5f), Sr, refRms: 0.05f);
+        Assert.True(Peak(got) < 0.3f, $"expected the un-boost to attenuate, got peak {Peak(got)}");
+    }
+
+    [Fact]
+    public void PythonChainWithoutAReferencePeakNormalizes()
+    {
+        var got = OmniVoiceAudioPost.Finish(Tone(0.05f), Sr, refRms: null);
+        Assert.Equal(0.5f, Peak(got), 2);
+    }
+}


### PR DESCRIPTION
`af — af · FEMALE · 8.0s` played far quieter than other languages in the reader.

Rendering from a stored voice ran Python's post-chain. Its volume step exists to undo a boost applied when a reference is encoded — and the stored voices were never boosted. They carry their source clip's own level, and the corpus spans rms 0.0017–0.099, a 58× spread, so the step attenuated every stored voice by `refRms / 0.1`:

| voice | refRms | old gain |
| --- | --- | --- |
| af | 0.0148 | **0.148** (−16.6 dB) |
| en | 0.0278 | 0.278 |
| ja | 0.0612 | 0.612 |
| cmn | 0.1105 | 1.0 (untouched) |

So af was 16.6 dB below cmn on the same sentence. At the very quiet end it is worse than quiet: the un-boost drops the utterance below the −50 dBFS silence threshold and `RemoveSilence` deletes it outright.

The web demo hit this and deviated from Python deliberately; the CLI carries the same chain behind `--post demo`. Rather than add a third copy, that chain moves into `OmniVoiceAudioPost.FinishStoredVoice` (normalise → remove silence → fade+pad → normalise again, the second pass because the fine-tune emits a leading transient inside the first 0.1 s). The reader uses it whenever it renders a stored voice; an encoded reference WAV still gets Python's chain, where the un-boost undoes something real. The CLI now calls the shared method and its local copy is gone.

Measured from the running app, same text, 16 diffusion steps:

```
af   dur 3.48s  rms 0.0672  peak 0.500
cmn  dur 2.88s  rms 0.0676  peak 0.500
ja   dur 3.18s  rms 0.0941  peak 0.500
```

Three unit tests pin the chain choice: a stored voice normalises no matter how quiet its reference, an encoded reference is still un-boosted, and no reference at all still peak-normalises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc