### PR TITLE
fix(reader): the karaoke line no longer ripples word by word

### DIFF
--- a/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
@@ -49,9 +49,7 @@ public sealed partial class WordItemViewModel : ObservableObject
     /// Null or empty means nothing is drawn — punctuation has no reading, and the annotation is
     /// cleared wholesale when the option is off or the text changes under it.
     /// </summary>
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(HasIpa))]
-    private string? _ipa;
+    [ObservableProperty] private string? _ipa;
 
     /// <summary>
     /// The word's sub-parts, when it is written without spaces between its words (Japanese,
@@ -60,7 +58,6 @@ public sealed partial class WordItemViewModel : ObservableObject
     /// </summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasPieces))]
-    [NotifyPropertyChangedFor(nameof(HasIpa))]
     private IReadOnlyList<RubyPieceViewModel> _pieces = Array.Empty<RubyPieceViewModel>();
 
     public bool HasPieces => Pieces.Count > 0;
@@ -77,9 +74,6 @@ public sealed partial class WordItemViewModel : ObservableObject
     /// </summary>
     public FlowDirection PieceFlowDirection =>
         TextDirection.StrongDirectionOf(Text) == true ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
-
-    /// <summary>A split word's reading is drawn piece by piece, so the whole-word line is not.</summary>
-    public bool HasIpa => !HasPieces && !string.IsNullOrEmpty(Ipa);
 
     /// <summary>Attach (or with null, clear) the annotation for this word.</summary>
     public void SetRuby(WordRuby? ruby)
@@ -139,19 +133,34 @@ public sealed partial class WordItemViewModel : ObservableObject
     public double IpaFontSize => Math.Max(10.0, FontSize * 0.6);
 
     /// <summary>
+    /// How tall a line box is, as a multiple of its font size.
+    ///
+    /// ⚠ GENEROUS ON PURPOSE, AND IT HAS TO BE. Avalonia only centres a run in the box while the
+    /// box is taller than the run's natural height; ask for less and it clamps the box and pins the
+    /// baseline to the ascent, leaving the descent to spill out below — over the row beneath, since
+    /// a TextBlock does not clip. Devanagari and Thai fallbacks run to about 1.5 em before their
+    /// line gap, and a mixed run takes the tallest ascent and deepest descent of any font in it, so
+    /// the factor has to clear that. IPA needs the room anyway: it stacks tie bars and tone letters
+    /// above the letters and marks below them.
+    /// </summary>
+    private const double LineBox = 1.7;
+
+    /// <summary>
     /// A fixed line box for the word, so every word in a line sits on the same baseline.
     ///
     /// ⚠ EACH WORD IS ITS OWN CONTROL, so nothing aligns them for us. Left to size themselves they
-    /// do not agree: IPA and many scripts fall back to different fonts glyph by glyph, and a
-    /// fallback's ascent and descent are its own, so "d͡ʒˈʌmps" measures taller than "ðə" and the
-    /// words beneath them ride up and down by a few pixels. Fixing the line heights takes the
-    /// fallback's metrics out of the layout.
+    /// do not agree: IPA and many scripts fall back font by font, and a fallback's ascent and
+    /// descent are its own, so "d͡ʒˈʌmps" measures taller than "ðə" and the word beneath it rides
+    /// down. A fixed box takes that out of the LAYOUT — the box no longer grows, so no word moves
+    /// its neighbours. It does not make every font sit identically inside the box: Avalonia centres
+    /// the run there, so fonts of different ascent/descent asymmetry still place their glyphs a
+    /// little differently. That is why the ruby line also names a font that covers IPA outright,
+    /// rather than relying on the box alone.
     /// </summary>
-    public double LineHeight => Math.Ceiling(FontSize * 1.4);
+    public double LineHeight => Math.Ceiling(FontSize * LineBox);
 
-    /// <summary>The ruby line's fixed height. Generous, because IPA stacks marks above and below
-    /// the letters — tie bars, length marks, superscript offglides, tone letters.</summary>
-    public double IpaLineHeight => Math.Ceiling(IpaFontSize * 1.7);
+    /// <summary>The ruby line's fixed height, on the same reasoning.</summary>
+    public double IpaLineHeight => Math.Ceiling(IpaFontSize * LineBox);
 
     public FontStyle FontStyle => Style.HasFlag(InlineStyle.Italic) ? FontStyle.Italic : FontStyle.Normal;
 
@@ -180,7 +189,6 @@ public sealed partial class RubyPieceViewModel : ObservableObject
     public string Text { get; }
     public string Ipa { get; }
     public double Weight { get; }
-    public bool HasIpa => !string.IsNullOrEmpty(Ipa);
 
     [ObservableProperty] private bool _isCurrent;
 }

--- a/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
+++ b/src/Vernacula.Tts.Avalonia/ViewModels/WordItemViewModel.cs
@@ -65,6 +65,10 @@ public sealed partial class WordItemViewModel : ObservableObject
 
     public bool HasPieces => Pieces.Count > 0;
 
+    /// <summary>Whether this word reserves the ruby line. True once an annotation has been attached
+    /// — with the annotation off there is no row at all, and no space held for one.</summary>
+    [ObservableProperty] private bool _hasRubyRow;
+
     /// <summary>
     /// Which way this word's own pieces are laid out. The block's direction mirrors everything
     /// inside it, which is right for the words but not for the pieces of a word from the other
@@ -80,6 +84,9 @@ public sealed partial class WordItemViewModel : ObservableObject
     /// <summary>Attach (or with null, clear) the annotation for this word.</summary>
     public void SetRuby(WordRuby? ruby)
     {
+        // The row is reserved for every annotated word, including one with no reading of its own
+        // (punctuation): a word that skipped the row would sit higher than the rest of its line.
+        HasRubyRow = ruby is not null;
         Ipa = ruby?.Ipa;
         Pieces = ruby is null || ruby.Pieces.Count == 0
             ? Array.Empty<RubyPieceViewModel>()
@@ -130,6 +137,21 @@ public sealed partial class WordItemViewModel : ObservableObject
     /// <summary>Ruby size: small enough to read as an annotation, never so small it is unreadable
     /// under a heading's larger body text.</summary>
     public double IpaFontSize => Math.Max(10.0, FontSize * 0.6);
+
+    /// <summary>
+    /// A fixed line box for the word, so every word in a line sits on the same baseline.
+    ///
+    /// ⚠ EACH WORD IS ITS OWN CONTROL, so nothing aligns them for us. Left to size themselves they
+    /// do not agree: IPA and many scripts fall back to different fonts glyph by glyph, and a
+    /// fallback's ascent and descent are its own, so "d͡ʒˈʌmps" measures taller than "ðə" and the
+    /// words beneath them ride up and down by a few pixels. Fixing the line heights takes the
+    /// fallback's metrics out of the layout.
+    /// </summary>
+    public double LineHeight => Math.Ceiling(FontSize * 1.4);
+
+    /// <summary>The ruby line's fixed height. Generous, because IPA stacks marks above and below
+    /// the letters — tie bars, length marks, superscript offglides, tone letters.</summary>
+    public double IpaLineHeight => Math.Ceiling(IpaFontSize * 1.7);
 
     public FontStyle FontStyle => Style.HasFlag(InlineStyle.Italic) ? FontStyle.Italic : FontStyle.Normal;
 

--- a/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
+++ b/src/Vernacula.Tts.Avalonia/Views/MainWindow.axaml
@@ -103,7 +103,9 @@
                                                                          left to right over a word that
                                                                          does not. -->
                                                                     <TextBlock Text="{Binding Ipa}"
-                                                                               IsVisible="{Binding HasIpa}"
+                                                                               IsVisible="{Binding HasRubyRow}"
+                                                                               Height="{Binding IpaLineHeight}"
+                                                                               LineHeight="{Binding IpaLineHeight}"
                                                                                FontSize="{Binding IpaFontSize}"
                                                                                FontWeight="Normal"
                                                                                FontStyle="Normal"
@@ -112,6 +114,7 @@
                                                                                HorizontalAlignment="Center"
                                                                                TextAlignment="Center" />
                                                                     <TextBlock Text="{Binding Text}"
+                                                                               LineHeight="{Binding LineHeight}"
                                                                                HorizontalAlignment="Center" />
                                                                 </StackPanel>
                                                                 <!-- Written without spaces (Japanese, Chinese):
@@ -132,7 +135,9 @@
                                                                                     Classes.current="{Binding IsCurrent}">
                                                                                 <StackPanel Orientation="Vertical" Spacing="0">
                                                                                     <TextBlock Text="{Binding Ipa}"
-                                                                                               IsVisible="{Binding HasIpa}"
+                                                                                               IsVisible="{Binding Word.HasRubyRow}"
+                                                                                               Height="{Binding Word.IpaLineHeight}"
+                                                                                               LineHeight="{Binding Word.IpaLineHeight}"
                                                                                                FontSize="{Binding Word.IpaFontSize}"
                                                                                                FontWeight="Normal"
                                                                                                FontStyle="Normal"
@@ -142,6 +147,7 @@
                                                                                                TextAlignment="Center" />
                                                                                     <TextBlock Text="{Binding Text}"
                                                                                                FontSize="{Binding Word.FontSize}"
+                                                                                               LineHeight="{Binding Word.LineHeight}"
                                                                                                HorizontalAlignment="Center" />
                                                                                 </StackPanel>
                                                                             </Border>
@@ -431,6 +437,13 @@
             <Setter Property="Opacity" Value="0.62" />
             <Setter Property="Margin" Value="0,0,0,-1" />
             <Setter Property="Foreground" Value="#cde" />
+            <!-- ⚠ ONE FONT FOR THE WHOLE RUBY LINE. The UI font has no tie bar, superscript
+                 offglide, tone letter or downstep mark, so each reading fell back per string to
+                 whatever font did — and a fallback brings its own ascent, so "bɹˈaᶷn" sat lower
+                 than "kwˈɪk" and the line rippled. These families cover the IPA the phonemizer
+                 emits; the first one present is used for every reading alike. -->
+            <Setter Property="FontFamily"
+                    Value="Charis SIL, Doulos SIL, Gentium Plus, DejaVu Sans, Segoe UI, Arial Unicode MS, sans-serif" />
         </Style>
 
         <!-- The ruby lights up with the word it annotates: dimmed text that stayed dim while its


### PR DESCRIPTION
Words sat a few pixels above or below their neighbours, and the IPA above them rippled with them.

Two causes, both because each word is its own control, so nothing aligns them the way a single text layout would:

**Per-string font fallback.** The UI font has no tie bar, superscript offglide, tone letter or downstep mark, so each reading fell back to whatever font did have them — and a fallback brings its own ascent and descent. `bɹˈaᶷn` and `oᶷvɚ` measured taller and sat lower than `kwˈɪk`. The ruby line now names fonts that cover the IPA the phonemizer emits (Charis SIL, Doulos SIL, Gentium Plus, DejaVu Sans, Segoe UI, Arial Unicode MS), so every reading is set in the same one. The word line is left alone deliberately — that is the user's own text, in whatever script, and forcing a family there would break CJK and Indic rendering.

**Content-sized line boxes.** The word and ruby text each sized to its own content, so a taller fallback pushed its word down. Both heights are now fixed from the font size, which takes the fallback's metrics out of the layout. An annotated word with no reading of its own (punctuation) reserves the row instead of skipping it and riding up.

With the annotation off, no row is reserved and the layout is unchanged.

Verified in the running app on the pangram, on Japanese (the segmented-pieces template) and on Persian (RTL): both rows sit flat. 135 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc