### PR TITLE
fix(reader): the markdown view renders again

### DIFF
--- a/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
+++ b/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
@@ -25,7 +25,10 @@
     <PackageReference Include="Avalonia.Themes.Fluent"      Version="11.3.9" />
     <PackageReference Include="Avalonia.Fonts.Inter"        Version="11.3.9" />
     <PackageReference Include="CommunityToolkit.Mvvm"       Version="8.4.0" />
-    <PackageReference Include="Markdown.Avalonia"           Version="11.0.2" />
+    <!-- ⚠ 11.0.3 OR NEWER. In 11.0.2 the styling this attaches to a code span is an IBinding
+         implementation of its own, which Avalonia 11.3 rejects: any document containing `code`
+         logged "Unsupported IBinding implementation" and the whole markdown view rendered blank. -->
+    <PackageReference Include="Markdown.Avalonia"           Version="11.0.3" />
     <PackageReference Include="NAudio"                      Version="2.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
"Render markdown" showed an empty pane for any document containing a code span — which is most of them.

**It was not a parsing problem.** Plain text rendered; adding a single `` `code` `` span blanked the whole view, and Avalonia logged this on every update:

```
An error occurred binding 'Markdown' to 'Text':
'Unsupported IBinding implementation 'Markdown.Avalonia.Extensions.StaticBinding''
```

Markdown.Avalonia 11.0.2 attaches its code-span styling through an `IBinding` implementation of its own, which Avalonia 11.3 refuses. The render then fails and nothing is drawn — including the parts of the document that had nothing to do with code.

11.0.3 fixes it upstream, so the change is the version alone. Verified with a document covering headings, inline code, bold, italic, a link, a bullet list, a block quote and a fenced code block: everything renders, and the binding error count is zero. No `MarkdownStyleName` is needed — the default style already matches the dark theme (checked with and without; identical).

Notes:

- `Vernacula.Avalonia` also references Markdown.Avalonia 11.0.2, but its help window builds its own flow document (`MarkdownFlowBuilder`) and never uses `MarkdownScrollViewer`, so it is not affected and is left alone.
- Wider version check, for a separate branch rather than this one: Avalonia has a 12.1.2 (a major, needing its own migration), and ONNX Runtime 1.29, NAudio 3, Markdig 1.3.2, CommunityToolkit.Mvvm 8.4.2 are all available. Markdig in particular drives the markdown text extractor that karaoke alignment depends on, so it wants testing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc