### PR TITLE
deps: CommunityToolkit.Mvvm 8.4.2, and drop an unused package reference

### DIFF
--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -59,13 +59,12 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.9" />
-    <PackageReference Include="Markdown.Avalonia" Version="11.0.2" />
     <PackageReference Include="Markdig" Version="0.34.0" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.9" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.9" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.9" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.9" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="FFmpeg.AutoGen" Version="6.1.0.1" />
 
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />

--- a/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
+++ b/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Avalonia.Desktop"            Version="11.3.9" />
     <PackageReference Include="Avalonia.Themes.Fluent"      Version="11.3.9" />
     <PackageReference Include="Avalonia.Fonts.Inter"        Version="11.3.9" />
-    <PackageReference Include="CommunityToolkit.Mvvm"       Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm"       Version="8.4.2" />
     <!-- ⚠ 11.0.3 OR NEWER. In 11.0.2 the styling this attaches to a code span is an IBinding
          implementation of its own, which Avalonia 11.3 rejects: any document containing `code`
          logged "Unsupported IBinding implementation" and the whole markdown view rendered blank. -->


### PR DESCRIPTION
Housekeeping ahead of the real dependency work.

- **Dropped `Markdown.Avalonia` from `Vernacula.Avalonia`.** It was referenced but never used: the help window builds its own flow document from Markdig and native Avalonia types, and nothing there mentions `MarkdownScrollViewer` or the package's namespaces. The reader is now its only consumer, so the version floor documented there covers the whole story.
- **CommunityToolkit.Mvvm 8.4.0 → 8.4.2** in both apps (patch).

Solution builds clean, 138 tests pass.

Found while checking, and going out as the next PR rather than buried here: two **high-severity advisories** in transitive packages affect both apps — `Tmds.DBus.Protocol` 0.21.2 (fixed in 0.21.3) and `SQLitePCLRaw.lib.e_sqlite3` 2.1.10 via Microsoft.Data.Sqlite (fixed after 2.1.11). Those now come before the version-currency work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc