### PR TITLE
deps: fix two high-severity advisories, and stop hiding them

### DIFF
--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -14,7 +14,6 @@
 
   <PropertyGroup>
     <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <ItemGroup>
@@ -60,6 +59,11 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.9" />
     <PackageReference Include="Markdig" Version="0.34.0" />
+    <!-- ⚠ TRANSITIVE PIN, NOT A FEATURE. Avalonia 11.3.9 resolves Tmds.DBus.Protocol
+         0.21.2, which carries a high-severity advisory (GHSA-xrw6-gwf8-vvr9); 0.21.3 is the
+         patched release on that line. Drop this line once Avalonia itself resolves 0.21.3
+         or later. -->
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.9" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.9" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.9" />
@@ -68,7 +72,7 @@
     <PackageReference Include="FFmpeg.AutoGen" Version="6.1.0.1" />
 
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="SoundTouch.Net" Version="2.1.2" />
     <PackageReference Include="ClosedXML" Version="0.104.1" />

--- a/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
+++ b/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
@@ -14,13 +14,17 @@
 
   <PropertyGroup>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <!-- Avalonia 11.3 + Fluent theme + Markdown rendering, mirroring
        Vernacula.Avalonia's stack so a future merge is mechanical. -->
   <ItemGroup>
     <PackageReference Include="Avalonia"                    Version="11.3.9" />
+    <!-- ⚠ TRANSITIVE PIN, NOT A FEATURE. Avalonia 11.3.9 resolves Tmds.DBus.Protocol
+         0.21.2, which carries a high-severity advisory (GHSA-xrw6-gwf8-vvr9); 0.21.3 is the
+         patched release on that line. Drop this line once Avalonia itself resolves 0.21.3
+         or later. -->
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageReference Include="Avalonia.Desktop"            Version="11.3.9" />
     <PackageReference Include="Avalonia.Themes.Fluent"      Version="11.3.9" />
     <PackageReference Include="Avalonia.Fonts.Inter"        Version="11.3.9" />


### PR DESCRIPTION
Both apps carried vulnerable transitive packages, and neither reported it — the csprojs set `NuGetAudit=false`, so the warnings surfaced only from a test project that didn't.

| package | resolved | advisory | fix |
| --- | --- | --- | --- |
| Tmds.DBus.Protocol | 0.21.2 | [GHSA-xrw6-gwf8-vvr9](https://github.com/advisories/GHSA-xrw6-gwf8-vvr9) (high) | pin 0.21.3 |
| SQLitePCLRaw.lib.e_sqlite3 | 2.1.10 | [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (high) | Microsoft.Data.Sqlite 9.0.4 → 10.0.11 |

`Tmds.DBus.Protocol` comes from Avalonia 11.3.9, which resolves 0.21.2; 0.21.3 is the patched release on that same line, so it is pinned directly in both apps with a comment saying to drop the pin once Avalonia resolves it itself. `SQLitePCLRaw` comes in through Microsoft.Data.Sqlite in the ASR app, and the bump resolves a fixed native bundle.

**`NuGetAudit` is back on in both apps.** That is the part that keeps this from going quiet again — it was switched off with no recorded reason, and it is why two high-severity advisories sat invisible at build time.

Verification: `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages in any project; both test suites pass (138 + 22); the reader opens and closes cleanly; the ASR app loads its SQLite job list and shuts down over three consecutive runs.

Two things seen while testing, both pre-existing and left for follow-ups:

- The ASR app hits the same D-Bus teardown exception the reader had in #109 (it logs `[UNHANDLED] TaskCanceledException` on exit) — the guard added there was never applied to it.
- One of its shutdowns segfaulted once (exit 139) and did not reproduce in three further runs on the same build; worth watching rather than chasing on this evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc