### PR TITLE
fix: CUDA 13 detection, for both platforms and both cuDNN layouts

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,10 +13,9 @@ Vernacula runs on Linux, macOS, and Windows. The desktop app and CLI share the s
 > releases of this project used ONNX Runtime 1.24, which linked CUDA 12. If you are upgrading and
 > still have only CUDA 12, install the CUDA 13 runtime — or build with `-p:EP=Cpu`.
 >
-> ⚠ **Startup detection does not yet know about the major version**
-> ([#119](https://github.com/christopherthompson81/vernacula/issues/119)). A CUDA 12 machine still
-> reports CUDA as present and then runs on the CPU without saying why, so if GPU acceleration seems
-> to do nothing after upgrading, check your CUDA version first.
+> Startup detection knows about the major version: a CUDA 12 machine reports CUDA as unavailable
+> and says why, in the settings window and in `cuda_debug.txt`, rather than appearing to have GPU
+> support that never engages.
 
 Install FFmpeg on common Linux distros:
 

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -543,18 +543,21 @@ internal class ModelManagerService
             return;
         }
 
-        // ⚠ REMOVE BEFORE RE-ADDING. The loader honours registration order, which is why the probe
-        // returns an ordered list -- but AddDllDirectory only ever appends, so after a Re-check
-        // changed the ranking the directories registered at startup would still win. Undoing the
-        // previous registration is what makes the new order mean anything.
+        // ⚠ ADD FIRST, THEN REMOVE. AddDllDirectory only appends, so a re-check that changes the
+        // ranking has to drop the old registrations for the new order to mean anything -- but
+        // removing first leaves a window in which a session being created on another thread cannot
+        // resolve the CUDA DLLs at all, and it would fall back to the CPU because someone pressed
+        // Re-check. Adding the new set first means the directories are never unregistered.
         lock (_cudaDllCookies)
         {
-            foreach (var cookie in _cudaDllCookies)
-                if (cookie != IntPtr.Zero) RemoveDllDirectory(cookie);
+            var previous = _cudaDllCookies.ToList();
             _cudaDllCookies.Clear();
 
             foreach (var dir in HardwareInfo.GetWindowsCudaDllDirectories())
                 _cudaDllCookies.Add(AddDllDirectory(dir));
+
+            foreach (var cookie in previous)
+                if (cookie != IntPtr.Zero) RemoveDllDirectory(cookie);
         }
     }
 
@@ -598,13 +601,12 @@ internal class ModelManagerService
 
             if (!HardwareInfo.CanProbeCudaExecutionProvider())
             {
-                // The probe usually knows WHY -- a CUDA of the wrong major, a library present but
-                // off the loader path, no cuDNN at all. This is the path the settings window's
-                // Re-check drives, and a desktop user has no console to read the detail from, so it
-                // goes into the message and the log rather than only to stderr.
-                var note = HardwareInfo.CudaProbeNote;
-                var unavailableMessage = "CUDA execution is unavailable on this machine."
-                                       + (note is null ? "" : $" {note}");
+                // ⚠ THE SHARED MESSAGE, NOT A LOCAL ONE. This is the path the settings window's
+                // Re-check drives, and building its own string here meant the case with no probe
+                // note -- CUDA and cuDNN both present, no driver or no GPU visible to the process --
+                // reached the user as a bare "unavailable on this machine", with the explanation
+                // written for exactly that case unreachable from the UI.
+                var unavailableMessage = HardwareInfo.CudaUnavailableMessage();
                 File.WriteAllText(logPath, unavailableMessage);
                 return new CudaCheck(false, unavailableMessage, Ran: true);
             }

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -522,6 +522,13 @@ internal class ModelManagerService
     [DllImport("kernel32", CharSet = CharSet.Unicode, SetLastError = true)]
     private static extern IntPtr AddDllDirectory(string newDirectory);
 
+    [DllImport("kernel32", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool RemoveDllDirectory(IntPtr cookie);
+
+    /// <summary>Cookies from the last registration, so it can be undone before the next one.</summary>
+    private static readonly List<IntPtr> _cudaDllCookies = new();
+
     /// <summary>
     /// MSIX packaged apps use a restricted DLL search that excludes the system PATH.
     /// Explicitly register the directories that actually hold cudart, cublas, cudnn, etc.
@@ -536,8 +543,19 @@ internal class ModelManagerService
             return;
         }
 
-        foreach (var dir in HardwareInfo.GetWindowsCudaDllDirectories())
-            AddDllDirectory(dir);
+        // ⚠ REMOVE BEFORE RE-ADDING. The loader honours registration order, which is why the probe
+        // returns an ordered list -- but AddDllDirectory only ever appends, so after a Re-check
+        // changed the ranking the directories registered at startup would still win. Undoing the
+        // previous registration is what makes the new order mean anything.
+        lock (_cudaDllCookies)
+        {
+            foreach (var cookie in _cudaDllCookies)
+                if (cookie != IntPtr.Zero) RemoveDllDirectory(cookie);
+            _cudaDllCookies.Clear();
+
+            foreach (var dir in HardwareInfo.GetWindowsCudaDllDirectories())
+                _cudaDllCookies.Add(AddDllDirectory(dir));
+        }
     }
 
     /// <param name="Available">Whether a CUDA session was actually created.</param>

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -572,7 +572,13 @@ internal class ModelManagerService
 
             if (!HardwareInfo.CanProbeCudaExecutionProvider())
             {
-                const string unavailableMessage = "CUDA execution is unavailable on this machine.";
+                // The probe usually knows WHY -- a CUDA of the wrong major, a library present but
+                // off the loader path, no cuDNN at all. This is the path the settings window's
+                // Re-check drives, and a desktop user has no console to read the detail from, so it
+                // goes into the message and the log rather than only to stderr.
+                var note = HardwareInfo.CudaProbeNote;
+                var unavailableMessage = "CUDA execution is unavailable on this machine."
+                                       + (note is null ? "" : $" {note}");
                 File.WriteAllText(logPath, unavailableMessage);
                 return (false, unavailableMessage);
             }

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -593,9 +593,14 @@ internal class ModelManagerService
         }
         catch (Exception ex)
         {
-            string msg = $"CUDA check failed on {GetPlatformName()}.\nException: {ex.GetType().Name}\n{ex.Message}\n\nInner: {ex.InnerException?.Message}\n\nStack:\n{ex.StackTrace}";
-            File.WriteAllText(logPath, msg);
-            return (false, msg);
+            // ⚠ TWO AUDIENCES. The log gets everything; the caller gets a line a UI can show.
+            // Returning the dump meant a settings label whose first line was "CUDA check failed on
+            // Linux." -- the failure named, the reason buried under a stack trace.
+            string detail = $"CUDA check failed on {GetPlatformName()}.\nException: {ex.GetType().Name}\n{ex.Message}\n\nInner: {ex.InnerException?.Message}\n\nStack:\n{ex.StackTrace}";
+            File.WriteAllText(logPath, detail);
+            string summary = $"{ex.GetType().Name}: {ex.Message}"
+                           + (ex.InnerException is null ? "" : $" ({ex.InnerException.Message})");
+            return (false, summary);
         }
     }
 

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -540,7 +540,15 @@ internal class ModelManagerService
             AddDllDirectory(dir);
     }
 
-    public (bool Available, string Message) CheckCuda()
+    /// <param name="Available">Whether a CUDA session was actually created.</param>
+    /// <param name="Message">One line, suitable for a label. The full detail goes to the log.</param>
+    /// <param name="Ran">False when the check could not be attempted at all -- a missing model file,
+    /// say. ⚠ THE DIFFERENCE MATTERS TO THE UI: on first launch, before models are downloaded, this
+    /// returns false with a message about a missing preprocessor, and showing that as the reason
+    /// CUDA is unavailable sends someone to fix a CUDA install that was never broken.</param>
+    public record CudaCheck(bool Available, string Message, bool Ran);
+
+    public CudaCheck CheckCuda()
     {
         string logPath  = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -552,7 +560,7 @@ internal class ModelManagerService
         {
             string msg = $"{Config.PreprocessorFile} not found at: {modelFile}";
             File.WriteAllText(logPath, msg);
-            return (false, msg);
+            return new CudaCheck(false, msg, Ran: false);
         }
         try
         {
@@ -560,14 +568,14 @@ internal class ModelManagerService
             {
                 const string macOsMessage = "CUDA execution is not supported on macOS.";
                 File.WriteAllText(logPath, macOsMessage);
-                return (false, macOsMessage);
+                return new CudaCheck(false, macOsMessage, Ran: true);
             }
 
             if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
             {
                 string unsupportedMessage = $"CUDA execution is not supported on {RuntimeInformation.OSDescription}.";
                 File.WriteAllText(logPath, unsupportedMessage);
-                return (false, unsupportedMessage);
+                return new CudaCheck(false, unsupportedMessage, Ran: true);
             }
 
             if (!HardwareInfo.CanProbeCudaExecutionProvider())
@@ -580,7 +588,7 @@ internal class ModelManagerService
                 var unavailableMessage = "CUDA execution is unavailable on this machine."
                                        + (note is null ? "" : $" {note}");
                 File.WriteAllText(logPath, unavailableMessage);
-                return (false, unavailableMessage);
+                return new CudaCheck(false, unavailableMessage, Ran: true);
             }
 
             AddCudaToSearchPath();
@@ -589,7 +597,7 @@ internal class ModelManagerService
             using var session = new InferenceSession(modelFile, opts);
             string msg = $"CUDA OK on {GetPlatformName()}";
             File.WriteAllText(logPath, msg);
-            return (true, msg);
+            return new CudaCheck(true, msg, Ran: true);
         }
         catch (Exception ex)
         {
@@ -600,7 +608,7 @@ internal class ModelManagerService
             File.WriteAllText(logPath, detail);
             string summary = $"{ex.GetType().Name}: {ex.Message}"
                            + (ex.InnerException is null ? "" : $" ({ex.InnerException.Message})");
-            return (false, summary);
+            return new CudaCheck(false, summary, Ran: true);
         }
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
@@ -68,6 +68,10 @@ internal partial class MainViewModel : ObservableObject
         Progress = new ProgressViewModel(transcription, controlDb, settings, queue);
         Results  = new ResultsViewModel(export, settings);
 
+        // A hardware re-check can change which model bundle is active; the home screen's status
+        // text is computed from it, so it has to be recomputed too.
+        Settings.ModelSelectionChanged = () => Home.CheckModelsAsync();
+
         // ── Navigation wiring ─────────────────────────────────────────────────
 
         // Home → Config (new transcription dialog)

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -266,6 +266,20 @@ internal partial class SettingsViewModel : ObservableObject
     [ObservableProperty] private bool   _cudaToolkitInstalled = false;
     [ObservableProperty] private bool   _cudnnInstalled       = false;
     [ObservableProperty] private bool   _cudaEpWorking        = false;
+
+    /// <summary>
+    /// Why CUDA is unavailable, when the probe worked it out — a CUDA of the wrong major, a library
+    /// present but off the loader path, no cuDNN at all.
+    ///
+    /// ⚠ DELIBERATELY NOT LOCALISED. It names file paths and shell commands (`ldconfig`,
+    /// `/etc/ld.so.conf.d`), which do not translate, and it is the only thing standing between a
+    /// user whose GPU went quiet and a working install.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCudaProbeNote))]
+    private string _cudaProbeNote = "";
+
+    public bool HasCudaProbeNote => !string.IsNullOrEmpty(CudaProbeNote);
     [ObservableProperty] private bool   _isCheckingHardware   = false;
     [ObservableProperty] private string _batchCeilingText     = "";
 
@@ -663,6 +677,7 @@ internal partial class SettingsViewModel : ObservableObject
             (cudaOk, _)          = _modelMgr.CheckCuda();
         });
         CudaEpWorking = cudaOk;
+        CudaProbeNote = cudaOk ? "" : (HardwareInfo.CudaProbeNote ?? "");
         OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
         OnPropertyChanged(nameof(VibeVoiceAsrLabel));
         OnPropertyChanged(nameof(VibeVoiceAsrDescription));

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -668,78 +668,97 @@ internal partial class SettingsViewModel : ObservableObject
     private async Task RefreshHardwareAsync(bool force)
     {
         IsCheckingHardware = true;
-        var bf16Before = HardwareInfo.SupportsBf16Acceleration();
-        bool cudaOk = false;
-        string? cudaMessage = null;
-
-        await Task.Run(() =>
+        try
         {
-            var (totalMb, _)   = HardwareInfo.GetGpuMemoryMb();
-            GpuDetected        = totalMb > 0;
-            GpuVramText        = totalMb > 0
-                ? Loc.Instance.T("settings_hw_vram", new() { ["vram"] = $"{totalMb / 1024.0:F1}" })
-                : "";
+            bool cudaOk = false;
+            string? cudaMessage = null;
+            bool bf16Before = false, bf16After = false;
 
-            // Only when the user asked. Re-check means re-check -- someone has just installed
-            // cuDNN or run ldconfig -- but merely opening this window must not throw away a
-            // process-wide probe, which would re-run the whole scan for every model init after it.
-            if (force) HardwareInfo.InvalidateCudaProbes();
-            CudaToolkitInstalled = HardwareInfo.IsCudaToolkitInstalled();
-            CudnnInstalled       = HardwareInfo.IsCudnnInstalled();
-            (cudaOk, cudaMessage) = _modelMgr.CheckCuda();
-        });
-        CudaEpWorking = cudaOk;
-        // The probe's note when it has one; otherwise whatever CheckCuda said. The provider can
-        // fail AFTER the probe passes -- a swallowed load failure is exactly the case worth
-        // explaining -- and that message was being thrown away.
-        // ⚠ FIRST LINE ONLY. CheckCuda's failure message is a full exception dump -- message,
-        // inner exception and stack trace -- written to cuda_debug.txt on purpose. Rendering all of
-        // it into a 12px label is not a diagnostic, it is a wall.
-        CudaProbeNote = cudaOk
-            ? ""
-            : (HardwareInfo.CudaProbeNote ?? FirstLine(cudaMessage) ?? "");
-        OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
-        OnPropertyChanged(nameof(VibeVoiceAsrLabel));
-        OnPropertyChanged(nameof(VibeVoiceAsrDescription));
+            await Task.Run(() =>
+            {
+                // ⚠ ALL OF IT OFF THE UI THREAD, AND IN THIS ORDER. After an invalidation the caches
+                // are cold by construction, so every read below is a full probe -- on Windows a
+                // recursive walk of the CUDA, cuDNN and PATH roots, plus an NVML cycle. Reading before
+                // invalidating would also report the answers this refresh was meant to replace.
+                bf16Before = HardwareInfo.SupportsBf16Acceleration();
+                if (force) HardwareInfo.InvalidateCudaProbes();
 
-        // ⚠ AND WHAT DEPENDS ON IT. A forced refresh can flip SupportsBf16Acceleration, which
-        // decides which Granite bundle is active, so the model verdicts on this window were
-        // computed against an answer that may no longer hold. Re-checking hardware without
-        // re-checking models leaves the two disagreeing.
-        if (force && bf16Before != HardwareInfo.SupportsBf16Acceleration())
-        {
-            await CheckModelsAsync();
-            await CheckDiariZenModelsAsync();
-            await CheckVoxLinguaModelsAsync();
+                var (totalMb, _)   = HardwareInfo.GetGpuMemoryMb();
+                GpuDetected        = totalMb > 0;
+                GpuVramText        = totalMb > 0
+                    ? Loc.Instance.T("settings_hw_vram", new() { ["vram"] = $"{totalMb / 1024.0:F1}" })
+                    : "";
+
+                CudaToolkitInstalled = HardwareInfo.IsCudaToolkitInstalled();
+                CudnnInstalled       = HardwareInfo.IsCudnnInstalled();
+
+                var cudaCheck = _modelMgr.CheckCuda();
+                cudaOk = cudaCheck.Available;
+                // Only when the check actually ran: otherwise the message is about something else --
+                // on first launch, a model file that has not been downloaded yet -- and showing it here
+                // would blame CUDA for it.
+                cudaMessage = cudaCheck.Ran ? cudaCheck.Message : null;
+                bf16After = HardwareInfo.SupportsBf16Acceleration();
+            });
+            CudaEpWorking = cudaOk;
+            // The probe's note when it has one; otherwise whatever CheckCuda said. The provider can
+            // fail AFTER the probe passes -- a swallowed load failure is exactly the case worth
+            // explaining -- and that message was being thrown away.
+            // ⚠ FIRST LINE ONLY. CheckCuda's failure message is a full exception dump -- message,
+            // inner exception and stack trace -- written to cuda_debug.txt on purpose. Rendering all of
+            // it into a 12px label is not a diagnostic, it is a wall.
+            CudaProbeNote = cudaOk
+                ? ""
+                : (HardwareInfo.CudaProbeNote ?? FirstLine(cudaMessage) ?? "");
+            OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
+            OnPropertyChanged(nameof(VibeVoiceAsrLabel));
+            OnPropertyChanged(nameof(VibeVoiceAsrDescription));
+
+            // ⚠ AND WHAT DEPENDS ON IT. A forced refresh can flip SupportsBf16Acceleration, which
+            // decides which Granite bundle is active, so the model verdicts on this window were
+            // computed against an answer that may no longer hold. Re-checking hardware without
+            // re-checking models leaves the two disagreeing.
+            if (force && bf16Before != bf16After)
+            {
+                await CheckModelsAsync();
+                await CheckDiariZenModelsAsync();
+                await CheckVoxLinguaModelsAsync();
+            }
+
+            if (!CudaEpWorking && SelectedAsrBackend == AsrBackend.VibeVoice)
+                SelectedAsrBackend = AsrBackend.Parakeet;
+
+            // Batch ceiling — query free VRAM (accurate post-load figure)
+            var (_, freeMb) = HardwareInfo.GetGpuMemoryMb();
+            long batchFrames;
+            bool isFallback;
+            if (freeMb > 0)
+            {
+                double avail = freeMb - Config.VramSafetyMb;
+                long   frames = avail > 0
+                    ? (long)((avail - Config.VramInterceptMb) / Config.VramSlopePerSample)
+                    : Config.FallbackMaxFrames;
+                batchFrames = frames > 0 ? frames : Config.FallbackMaxFrames;
+                isFallback  = false;
+            }
+            else
+            {
+                batchFrames = Config.FallbackMaxFrames;
+                isFallback  = true;
+            }
+
+            _batchSecs       = batchFrames / (double)Config.SampleRate;
+            _batchIsFallback = isFallback;
+            ApplyBatchCeilingText();
+
         }
-
-        if (!CudaEpWorking && SelectedAsrBackend == AsrBackend.VibeVoice)
-            SelectedAsrBackend = AsrBackend.Parakeet;
-
-        // Batch ceiling — query free VRAM (accurate post-load figure)
-        var (_, freeMb) = HardwareInfo.GetGpuMemoryMb();
-        long batchFrames;
-        bool isFallback;
-        if (freeMb > 0)
+        finally
         {
-            double avail = freeMb - Config.VramSafetyMb;
-            long   frames = avail > 0
-                ? (long)((avail - Config.VramInterceptMb) / Config.VramSlopePerSample)
-                : Config.FallbackMaxFrames;
-            batchFrames = frames > 0 ? frames : Config.FallbackMaxFrames;
-            isFallback  = false;
+            // ⚠ finally: the model checks below can throw on IO, and a stuck flag hides
+            // the hardware rows behind "Checking…" and disables Re-check for the rest of
+            // the session.
+            IsCheckingHardware = false;
         }
-        else
-        {
-            batchFrames = Config.FallbackMaxFrames;
-            isFallback  = true;
-        }
-
-        _batchSecs       = batchFrames / (double)Config.SampleRate;
-        _batchIsFallback = isFallback;
-        ApplyBatchCeilingText();
-
-        IsCheckingHardware = false;
     }
 
     [RelayCommand]

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -687,7 +687,7 @@ internal partial class SettingsViewModel : ObservableObject
         {
             bool cudaOk = false;
             string? cudaMessage = null;
-            bool bf16Before = false, bf16After = false, bf16Known = false;
+            bool bf16Before = false, bf16After = false;
 
             // Collected off the UI thread, applied on it: these are bound properties, and raising
             // PropertyChanged from a thread-pool thread updates Avalonia bindings off the UI thread.
@@ -701,10 +701,13 @@ internal partial class SettingsViewModel : ObservableObject
                 // recursive walk of the CUDA, cuDNN and PATH roots, plus an NVML cycle. Reading
                 // before invalidating would report the answers this refresh was meant to replace.
                 //
-                // bf16 is sampled only if something has already asked for it: forcing it here on a
-                // cold cache would run the whole scan and throw the result away one line later.
-                bf16Known = HardwareInfo.IsBf16AnswerKnown;
-                bf16Before = bf16Known && HardwareInfo.SupportsBf16Acceleration();
+                // ⚠ SAMPLED, NOT SKIPPED. An earlier version only compared when something had
+                // already asked for this, to avoid forcing a cold probe -- but the model verdicts on
+                // this window come from ActiveRepos, which can be computed without ever forcing it
+                // (a non-Granite backend, or a BF16 directory that is not downloaded). Skipping the
+                // comparison then left those verdicts stale after a re-check that changed the
+                // answer. One probe is cheaper than that.
+                bf16Before = HardwareInfo.SupportsBf16Acceleration();
                 if (force) HardwareInfo.InvalidateCudaProbes();
 
                 (totalMb, _) = HardwareInfo.GetGpuMemoryMb();
@@ -713,13 +716,18 @@ internal partial class SettingsViewModel : ObservableObject
                 cudaPresent = HardwareInfo.IsCudaRuntimePresent;
                 cudnnPresent = HardwareInfo.IsCudnnPresent;
 
+                // Re-register from the refreshed probe even when the check then fails: CheckCuda
+                // only reaches AddCudaToSearchPath on its success path, so an unavailable result
+                // would otherwise leave the loader holding directories from a discarded answer.
+                if (force && OperatingSystem.IsWindows()) ModelManagerService.AddCudaToSearchPath();
+
                 var cudaCheck = _modelMgr.CheckCuda();
                 cudaOk = cudaCheck.Available;
                 // Only when the check actually ran: otherwise the message is about something else --
                 // on first launch, a model file that has not been downloaded yet -- and showing it
                 // here would blame CUDA for it.
                 cudaMessage = cudaCheck.Ran ? cudaCheck.Message : null;
-                bf16After = bf16Known && HardwareInfo.SupportsBf16Acceleration();
+                bf16After = HardwareInfo.SupportsBf16Acceleration();
             });
 
             GpuDetected          = totalMb > 0;
@@ -748,7 +756,7 @@ internal partial class SettingsViewModel : ObservableObject
             // decides which Granite bundle is active, so the model verdicts on this window were
             // computed against an answer that may no longer hold. Re-checking hardware without
             // re-checking models leaves the two disagreeing.
-            if (force && bf16Known && bf16Before != bf16After)
+            if (force && bf16Before != bf16After)
             {
                 await CheckModelsAsync();
                 await CheckDiariZenModelsAsync();

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -660,6 +660,7 @@ internal partial class SettingsViewModel : ObservableObject
     {
         IsCheckingHardware = true;
         bool cudaOk = false;
+        string? cudaMessage = null;
 
         await Task.Run(() =>
         {
@@ -674,10 +675,13 @@ internal partial class SettingsViewModel : ObservableObject
             HardwareInfo.InvalidateCudaProbes();
             CudaToolkitInstalled = HardwareInfo.IsCudaToolkitInstalled();
             CudnnInstalled       = HardwareInfo.IsCudnnInstalled();
-            (cudaOk, _)          = _modelMgr.CheckCuda();
+            (cudaOk, cudaMessage) = _modelMgr.CheckCuda();
         });
         CudaEpWorking = cudaOk;
-        CudaProbeNote = cudaOk ? "" : (HardwareInfo.CudaProbeNote ?? "");
+        // The probe's note when it has one; otherwise whatever CheckCuda said. The provider can
+        // fail AFTER the probe passes -- a swallowed load failure is exactly the case worth
+        // explaining -- and that message was being thrown away.
+        CudaProbeNote = cudaOk ? "" : (HardwareInfo.CudaProbeNote ?? cudaMessage ?? "");
         OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
         OnPropertyChanged(nameof(VibeVoiceAsrLabel));
         OnPropertyChanged(nameof(VibeVoiceAsrDescription));

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -668,6 +668,7 @@ internal partial class SettingsViewModel : ObservableObject
     private async Task RefreshHardwareAsync(bool force)
     {
         IsCheckingHardware = true;
+        var bf16Before = HardwareInfo.SupportsBf16Acceleration();
         bool cudaOk = false;
         string? cudaMessage = null;
 
@@ -700,6 +701,17 @@ internal partial class SettingsViewModel : ObservableObject
         OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
         OnPropertyChanged(nameof(VibeVoiceAsrLabel));
         OnPropertyChanged(nameof(VibeVoiceAsrDescription));
+
+        // ⚠ AND WHAT DEPENDS ON IT. A forced refresh can flip SupportsBf16Acceleration, which
+        // decides which Granite bundle is active, so the model verdicts on this window were
+        // computed against an answer that may no longer hold. Re-checking hardware without
+        // re-checking models leaves the two disagreeing.
+        if (force && bf16Before != HardwareInfo.SupportsBf16Acceleration())
+        {
+            await CheckModelsAsync();
+            await CheckDiariZenModelsAsync();
+            await CheckVoxLinguaModelsAsync();
+        }
 
         if (!CudaEpWorking && SelectedAsrBackend == AsrBackend.VibeVoice)
             SelectedAsrBackend = AsrBackend.Parakeet;

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -658,6 +658,12 @@ internal partial class SettingsViewModel : ObservableObject
     private static string? FirstLine(string? text) =>
         text is null ? null : text.Split('\n', 2)[0].Trim();
 
+    /// <summary>
+    /// Called when a hardware re-check changes which model bundle is active, so other views can
+    /// refresh what they latched. Set by MainViewModel, like the rest of the cross-view wiring.
+    /// </summary>
+    internal Func<Task>? ModelSelectionChanged { get; set; }
+
     /// <summary>The Re-check button: discards the cached probe and looks again.</summary>
     [RelayCommand]
     internal Task RecheckHardwareAsync() => RefreshHardwareAsync(force: true);
@@ -672,34 +678,45 @@ internal partial class SettingsViewModel : ObservableObject
         {
             bool cudaOk = false;
             string? cudaMessage = null;
-            bool bf16Before = false, bf16After = false;
+            bool bf16Before = false, bf16After = false, bf16Known = false;
+
+            // Collected off the UI thread, applied on it: these are bound properties, and raising
+            // PropertyChanged from a thread-pool thread updates Avalonia bindings off the UI thread.
+            long totalMb = 0;
+            bool cudaToolkit = false, cudnnFound = false;
 
             await Task.Run(() =>
             {
-                // ⚠ ALL OF IT OFF THE UI THREAD, AND IN THIS ORDER. After an invalidation the caches
-                // are cold by construction, so every read below is a full probe -- on Windows a
-                // recursive walk of the CUDA, cuDNN and PATH roots, plus an NVML cycle. Reading before
-                // invalidating would also report the answers this refresh was meant to replace.
-                bf16Before = HardwareInfo.SupportsBf16Acceleration();
+                // ⚠ THE HARDWARE WORK BELONGS HERE, AND IN THIS ORDER. After an invalidation the
+                // caches are cold by construction, so every read is a full probe -- on Windows a
+                // recursive walk of the CUDA, cuDNN and PATH roots, plus an NVML cycle. Reading
+                // before invalidating would report the answers this refresh was meant to replace.
+                //
+                // bf16 is sampled only if something has already asked for it: forcing it here on a
+                // cold cache would run the whole scan and throw the result away one line later.
+                bf16Known = HardwareInfo.IsBf16AnswerKnown;
+                bf16Before = bf16Known && HardwareInfo.SupportsBf16Acceleration();
                 if (force) HardwareInfo.InvalidateCudaProbes();
 
-                var (totalMb, _)   = HardwareInfo.GetGpuMemoryMb();
-                GpuDetected        = totalMb > 0;
-                GpuVramText        = totalMb > 0
-                    ? Loc.Instance.T("settings_hw_vram", new() { ["vram"] = $"{totalMb / 1024.0:F1}" })
-                    : "";
-
-                CudaToolkitInstalled = HardwareInfo.IsCudaToolkitInstalled();
-                CudnnInstalled       = HardwareInfo.IsCudnnInstalled();
+                (totalMb, _) = HardwareInfo.GetGpuMemoryMb();
+                cudaToolkit = HardwareInfo.IsCudaToolkitInstalled();
+                cudnnFound = HardwareInfo.IsCudnnInstalled();
 
                 var cudaCheck = _modelMgr.CheckCuda();
                 cudaOk = cudaCheck.Available;
                 // Only when the check actually ran: otherwise the message is about something else --
-                // on first launch, a model file that has not been downloaded yet -- and showing it here
-                // would blame CUDA for it.
+                // on first launch, a model file that has not been downloaded yet -- and showing it
+                // here would blame CUDA for it.
                 cudaMessage = cudaCheck.Ran ? cudaCheck.Message : null;
-                bf16After = HardwareInfo.SupportsBf16Acceleration();
+                bf16After = bf16Known && HardwareInfo.SupportsBf16Acceleration();
             });
+
+            GpuDetected          = totalMb > 0;
+            GpuVramText          = totalMb > 0
+                ? Loc.Instance.T("settings_hw_vram", new() { ["vram"] = $"{totalMb / 1024.0:F1}" })
+                : "";
+            CudaToolkitInstalled = cudaToolkit;
+            CudnnInstalled       = cudnnFound;
             CudaEpWorking = cudaOk;
             // The probe's note when it has one; otherwise whatever CheckCuda said. The provider can
             // fail AFTER the probe passes -- a swallowed load failure is exactly the case worth
@@ -718,11 +735,15 @@ internal partial class SettingsViewModel : ObservableObject
             // decides which Granite bundle is active, so the model verdicts on this window were
             // computed against an answer that may no longer hold. Re-checking hardware without
             // re-checking models leaves the two disagreeing.
-            if (force && bf16Before != bf16After)
+            if (force && bf16Known && bf16Before != bf16After)
             {
                 await CheckModelsAsync();
                 await CheckDiariZenModelsAsync();
                 await CheckVoxLinguaModelsAsync();
+                // And the views that latched the same answer: the home screen's model status is
+                // computed from the active bundle, and would otherwise disagree with this window
+                // until the app restarted.
+                if (ModelSelectionChanged is not null) await ModelSelectionChanged();
             }
 
             if (!CudaEpWorking && SelectedAsrBackend == AsrBackend.VibeVoice)

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -280,6 +280,15 @@ internal partial class SettingsViewModel : ObservableObject
     private string _cudaProbeNote = "";
 
     public bool HasCudaProbeNote => !string.IsNullOrEmpty(CudaProbeNote);
+
+    /// <summary>
+    /// Whether to offer the download links. ⚠ NOT SIMPLY THE NEGATION OF "installed". A CUDA that
+    /// is present but unreachable — the wrong major, or outside the loader path — needs an ldconfig
+    /// line or a different version, not another download; offering one beside a note saying the
+    /// library was found contradicts the note.
+    /// </summary>
+    [ObservableProperty] private bool _offerCudaDownload = true;
+    [ObservableProperty] private bool _offerCudnnDownload = true;
     [ObservableProperty] private bool   _isCheckingHardware   = false;
     [ObservableProperty] private string _batchCeilingText     = "";
 
@@ -683,7 +692,7 @@ internal partial class SettingsViewModel : ObservableObject
             // Collected off the UI thread, applied on it: these are bound properties, and raising
             // PropertyChanged from a thread-pool thread updates Avalonia bindings off the UI thread.
             long totalMb = 0;
-            bool cudaToolkit = false, cudnnFound = false;
+            bool cudaToolkit = false, cudnnFound = false, cudaPresent = false, cudnnPresent = false;
 
             await Task.Run(() =>
             {
@@ -701,6 +710,8 @@ internal partial class SettingsViewModel : ObservableObject
                 (totalMb, _) = HardwareInfo.GetGpuMemoryMb();
                 cudaToolkit = HardwareInfo.IsCudaToolkitInstalled();
                 cudnnFound = HardwareInfo.IsCudnnInstalled();
+                cudaPresent = HardwareInfo.IsCudaRuntimePresent;
+                cudnnPresent = HardwareInfo.IsCudnnPresent;
 
                 var cudaCheck = _modelMgr.CheckCuda();
                 cudaOk = cudaCheck.Available;
@@ -717,6 +728,8 @@ internal partial class SettingsViewModel : ObservableObject
                 : "";
             CudaToolkitInstalled = cudaToolkit;
             CudnnInstalled       = cudnnFound;
+            OfferCudaDownload    = !cudaToolkit && !cudaPresent;
+            OfferCudnnDownload   = !cudnnFound && !cudnnPresent;
             CudaEpWorking = cudaOk;
             // The probe's note when it has one; otherwise whatever CheckCuda said. The provider can
             // fail AFTER the probe passes -- a swallowed load failure is exactly the case worth

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -655,6 +655,9 @@ internal partial class SettingsViewModel : ObservableObject
                 ? Loc.Instance.T("settings_hw_vram", new() { ["vram"] = $"{totalMb / 1024.0:F1}" })
                 : "";
 
+            // Re-check means re-check: the probe caches for the life of the process, and this is
+            // the button someone presses right after installing cuDNN or running ldconfig.
+            HardwareInfo.InvalidateCudaProbes();
             CudaToolkitInstalled = HardwareInfo.IsCudaToolkitInstalled();
             CudnnInstalled       = HardwareInfo.IsCudnnInstalled();
             (cudaOk, _)          = _modelMgr.CheckCuda();

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -655,8 +655,17 @@ internal partial class SettingsViewModel : ObservableObject
 
     // ── Hardware checks ──────────────────────────────────────────────────────
 
+    private static string? FirstLine(string? text) =>
+        text is null ? null : text.Split('\n', 2)[0].Trim();
+
+    /// <summary>The Re-check button: discards the cached probe and looks again.</summary>
     [RelayCommand]
-    internal async Task RecheckHardwareAsync()
+    internal Task RecheckHardwareAsync() => RefreshHardwareAsync(force: true);
+
+    /// <param name="force">True only when the user asked. Opening the window reads what is already
+    /// known; throwing the probe away there would make every model init afterwards repeat the
+    /// scan.</param>
+    private async Task RefreshHardwareAsync(bool force)
     {
         IsCheckingHardware = true;
         bool cudaOk = false;
@@ -670,9 +679,10 @@ internal partial class SettingsViewModel : ObservableObject
                 ? Loc.Instance.T("settings_hw_vram", new() { ["vram"] = $"{totalMb / 1024.0:F1}" })
                 : "";
 
-            // Re-check means re-check: the probe caches for the life of the process, and this is
-            // the button someone presses right after installing cuDNN or running ldconfig.
-            HardwareInfo.InvalidateCudaProbes();
+            // Only when the user asked. Re-check means re-check -- someone has just installed
+            // cuDNN or run ldconfig -- but merely opening this window must not throw away a
+            // process-wide probe, which would re-run the whole scan for every model init after it.
+            if (force) HardwareInfo.InvalidateCudaProbes();
             CudaToolkitInstalled = HardwareInfo.IsCudaToolkitInstalled();
             CudnnInstalled       = HardwareInfo.IsCudnnInstalled();
             (cudaOk, cudaMessage) = _modelMgr.CheckCuda();
@@ -681,7 +691,12 @@ internal partial class SettingsViewModel : ObservableObject
         // The probe's note when it has one; otherwise whatever CheckCuda said. The provider can
         // fail AFTER the probe passes -- a swallowed load failure is exactly the case worth
         // explaining -- and that message was being thrown away.
-        CudaProbeNote = cudaOk ? "" : (HardwareInfo.CudaProbeNote ?? cudaMessage ?? "");
+        // ⚠ FIRST LINE ONLY. CheckCuda's failure message is a full exception dump -- message,
+        // inner exception and stack trace -- written to cuda_debug.txt on purpose. Rendering all of
+        // it into a 12px label is not a diagnostic, it is a wall.
+        CudaProbeNote = cudaOk
+            ? ""
+            : (HardwareInfo.CudaProbeNote ?? FirstLine(cudaMessage) ?? "");
         OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
         OnPropertyChanged(nameof(VibeVoiceAsrLabel));
         OnPropertyChanged(nameof(VibeVoiceAsrDescription));
@@ -1131,7 +1146,7 @@ internal partial class SettingsViewModel : ObservableObject
         var modelTask    = CheckModelsAsync();
         var diarizenTask = CheckDiariZenModelsAsync();
         var voxLinguaTask = CheckVoxLinguaModelsAsync();
-        var hardwareTask = RecheckHardwareAsync();
+        var hardwareTask = RefreshHardwareAsync(force: false);
         await Task.WhenAll(modelTask, diarizenTask, voxLinguaTask, hardwareTask);
 
         if (ModelsReady)

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -292,8 +292,8 @@
                                             Content="{Binding Source={x:Static local:Loc.Instance}, Path=[settings_hw_download_cuda]}"
                                             Classes="link-button"
                                             Command="{Binding OpenCudaDownloadPageCommand}"
-                                            IsVisible="{Binding CudaToolkitInstalled,
-                                                                 Converter={StaticResource InvBoolToVis}}" />
+                                            IsVisible="{Binding OfferCudaDownload,
+                                                                 Converter={StaticResource BoolToVis}}" />
                                 </Grid>
 
                                 <!-- cuDNN -->
@@ -316,8 +316,8 @@
                                             Content="{Binding Source={x:Static local:Loc.Instance}, Path=[settings_hw_download_cudnn]}"
                                             Classes="link-button"
                                             Command="{Binding OpenCudnnDownloadPageCommand}"
-                                            IsVisible="{Binding CudnnInstalled,
-                                                                 Converter={StaticResource InvBoolToVis}}" />
+                                            IsVisible="{Binding OfferCudnnDownload,
+                                                                 Converter={StaticResource BoolToVis}}" />
                                 </Grid>
 
                                 <!-- CUDA EP active -->

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -336,16 +336,18 @@
                                                Classes="check-label" />
                                 </Grid>
 
-                                <!-- What the probe found, when it found something. Untranslated on
-                                     purpose: it names paths and shell commands. -->
-                                <TextBlock Text="{Binding CudaProbeNote}"
-                                           IsVisible="{Binding HasCudaProbeNote}"
-                                           Foreground="{DynamicResource SubtextBrush}"
-                                           FontSize="12"
-                                           TextWrapping="Wrap"
-                                           Margin="22,0,0,6" />
-
                             </StackPanel>
+
+                            <!-- ⚠ OUTSIDE THE GpuDetected PANEL. Two of the causes this note
+                                 explains — no driver, no GPU visible to the process — are exactly
+                                 the ones that make GpuDetected false, so inside that panel the
+                                 explanation would be hidden precisely when it is needed. -->
+                            <TextBlock Text="{Binding CudaProbeNote}"
+                                       IsVisible="{Binding HasCudaProbeNote}"
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="12"
+                                       TextWrapping="Wrap"
+                                       Margin="22,4,0,6" />
 
                             <!-- No GPU message — shown when no acceleratable GPU is present -->
                             <TextBlock x:Name="NoGpuText"

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -336,6 +336,15 @@
                                                Classes="check-label" />
                                 </Grid>
 
+                                <!-- What the probe found, when it found something. Untranslated on
+                                     purpose: it names paths and shell commands. -->
+                                <TextBlock Text="{Binding CudaProbeNote}"
+                                           IsVisible="{Binding HasCudaProbeNote}"
+                                           Foreground="{DynamicResource SubtextBrush}"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Margin="22,0,0,6" />
+
                             </StackPanel>
 
                             <!-- No GPU message — shown when no acceleratable GPU is present -->

--- a/src/Vernacula.Base/DiariZenDiarizer.cs
+++ b/src/Vernacula.Base/DiariZenDiarizer.cs
@@ -1151,7 +1151,7 @@ public sealed class DiariZenDiarizer : IDisposable
             case ExecutionProvider.Cuda:
                 try { opts.AppendExecutionProvider_CUDA(0); }
                 catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException("CUDA EP not available."); }
+                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage()); }
                 break;
             case ExecutionProvider.DirectML:
                 try { opts.AppendExecutionProvider_DML(0); }

--- a/src/Vernacula.Base/DiariZenDiarizer.cs
+++ b/src/Vernacula.Base/DiariZenDiarizer.cs
@@ -1151,7 +1151,7 @@ public sealed class DiariZenDiarizer : IDisposable
             case ExecutionProvider.Cuda:
                 try { opts.AppendExecutionProvider_CUDA(0); }
                 catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage()); }
+                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
                 break;
             case ExecutionProvider.DirectML:
                 try { opts.AppendExecutionProvider_DML(0); }

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -194,10 +194,26 @@ public static class HardwareInfo
 
     private static CudaProbeResult Probe => Volatile.Read(ref _probe).Value;
 
-    private static CudaProbeResult RunProbe() =>
-        OperatingSystem.IsWindows() ? ProbeWindows()
-        : OperatingSystem.IsLinux() ? ProbeLinux()
-        : new CudaProbeResult(false, false, null, null, Array.Empty<string>());
+    private static CudaProbeResult RunProbe()
+    {
+        // ⚠ NOTHING ESCAPES. This class promises to answer rather than throw, and the Lazy would
+        // cache a thrown exception and rethrow it to every caller for the rest of the session --
+        // turning "no CUDA" at one unreadable directory into a hard failure at every model init.
+        try
+        {
+            return OperatingSystem.IsWindows() ? ProbeWindows()
+                 : OperatingSystem.IsLinux() ? ProbeLinux()
+                 : Unknown();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[HardwareInfo] CUDA probe failed: {ex.Message}");
+            return Unknown() with { RuntimeNote = $"The CUDA probe could not complete: {ex.Message}" };
+        }
+
+        static CudaProbeResult Unknown() =>
+            new(false, false, null, null, Array.Empty<string>());
+    }
 
     /// <summary>
     /// Linux: ask the dynamic loader, not the filesystem.
@@ -245,25 +261,30 @@ public static class HardwareInfo
         // Normalised on both sides: LD_LIBRARY_PATH is commonly written with a trailing slash while
         // the same directory arrives here from CUDA_PATH without one, and a raw string comparison
         // would then give exactly the circular advice this distinction exists to avoid.
-        var onLdPath = new HashSet<string>(
+        // Directories the loader already searches: LD_LIBRARY_PATH, and the system directories that
+        // are in the ldconfig cache by default. Telling someone to add /usr/lib/x86_64-linux-gnu to
+        // ld.so.conf.d is the same circular advice, just for the commoner install shape.
+        var alreadySearched = new HashSet<string>(
             (Environment.GetEnvironmentVariable("LD_LIBRARY_PATH") ?? "")
                 .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-                .Select(e => Normalise(e.Trim())),
+                .Select(e => Normalise(e.Trim()))
+                .Concat(new[] { "/usr/lib", "/usr/lib64", "/usr/lib/x86_64-linux-gnu",
+                                "/lib", "/lib64", "/lib/x86_64-linux-gnu" }.Select(Normalise)),
             StringComparer.Ordinal);
 
         foreach (var dir in GetLinuxCudaLibraryDirs())
         {
-            var hit = SafeGetFiles(dir, filePattern).FirstOrDefault();
+            var hit = SafeGetFiles(dir, filePattern).OrderBy(f => f, StringComparer.Ordinal).FirstOrDefault();
             if (hit is null) continue;
 
             // ⚠ DO NOT TELL SOMEONE TO ADD A DIRECTORY THAT IS ALREADY THERE. When the file turned
             // up in an LD_LIBRARY_PATH entry, the loader has already looked and failed, so the
             // cause is the library itself -- a missing dependency of its own, or the wrong
             // architecture -- and the ldconfig advice would send them in a circle.
-            return (Found: false, Note: onLdPath.Contains(Normalise(dir))
-                ? $"{label} was found at {hit}, in a directory that is already on LD_LIBRARY_PATH, "
-                  + "and still could not be loaded. One of its own dependencies is probably "
-                  + "missing, or it was built for a different architecture."
+            return (Found: false, Note: alreadySearched.Contains(Normalise(dir))
+                ? $"{label} was found at {hit}, in a directory the loader already searches, and "
+                  + "still could not be loaded. One of its own dependencies is probably missing, or "
+                  + "it was built for a different architecture."
                 : $"{label} was found at {hit} but the loader could not open it by name, so the "
                   + "CUDA execution provider cannot either. Add its directory to "
                   + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.",
@@ -726,14 +747,15 @@ public static class HardwareInfo
                 : NamesSomeOtherMajor(dir)        ? 3
                                                   : 2;
 
-            Add(cudartDirs);
-            Add(depDirs);
+            Add(cudartDirs.OrderBy(d => d, StringComparer.OrdinalIgnoreCase));
+            Add(depDirs.OrderBy(d => d, StringComparer.OrdinalIgnoreCase));
             // Beside our own runtime, these are unambiguous whatever else is installed; further
             // afield they are only safe when no other CUDA is present to confuse them with, because
             // curand64_10.dll carries that name under every major.
-            Add(unversioned.Where(BesideOurCuda));
-            if (!otherMajor) Add(unversioned);
-            Add(cudnnDirs.OrderBy(CudnnRank));
+            Add(unversioned.Where(BesideOurCuda).OrderBy(d => d, StringComparer.OrdinalIgnoreCase));
+            if (!otherMajor) Add(unversioned.OrderBy(d => d, StringComparer.OrdinalIgnoreCase));
+            // ThenBy: OrderBy is stable, so equal ranks would keep the set's arbitrary order.
+            Add(cudnnDirs.OrderBy(CudnnRank).ThenBy(d => d, StringComparer.OrdinalIgnoreCase));
         }
 
         var runtimeNote = runtime ? null

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -509,7 +509,18 @@ public static class HardwareInfo
         dirs.Add("/usr/lib/wsl/lib");
         dirs.Add("/usr/lib64");
 
-        return dirs.Where(Directory.Exists);
+        // Ordered, so the diagnostic is reproducible: which copy gets named decides whether the
+        // user is told to run ldconfig or to look at the library's own dependencies, and that must
+        // not change between runs. LD_LIBRARY_PATH first, because a hit there is the case with the
+        // more specific advice.
+        var ldEntries = (Environment.GetEnvironmentVariable("LD_LIBRARY_PATH") ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(e => Normalise(e.Trim()))
+            .ToHashSet(StringComparer.Ordinal);
+
+        return dirs.Where(Directory.Exists)
+                   .OrderBy(d => ldEntries.Contains(Normalise(d)) ? 0 : 1)
+                   .ThenBy(d => d, StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -737,21 +748,31 @@ public static class HardwareInfo
                 : $"No cuDNN was found. The CUDA execution provider needs cuDNN {RequiredCudnnMajor} "
                   + $"built for CUDA {RequiredCudaMajor}.";
 
+        // ⚠ PRESENT MEANS "THE RIGHT ONE IS HERE", NOT "SOMETHING IS HERE". Windows detection is
+        // by file name, so a library of the required major on disk is a usable one -- there is no
+        // Windows equivalent of the Linux "on disk but the loader cannot open it" gap. Reporting
+        // any CUDA as present suppressed the download link on exactly the machine this change is
+        // about: CUDA 12 only, note saying to install CUDA 13, and no way to get it.
         return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, dllDirs,
-                                   RuntimePresent: anyCudart, CudnnPresent: anyCudnn);
+                                   RuntimePresent: runtime, CudnnPresent: cudnn);
     }
 
     /// <summary>True when a path segment names the given CUDA major, as NVIDIA's standalone cuDNN
     /// tree does (…\CUDNN\v9.x\bin\13.0\).</summary>
     private static bool NamesMajor(string dir, int major) =>
         dir.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+           // NVIDIA writes its toolkit directories as v12.6, so the leading v has to come off or a
+           // cuDNN copied into CUDA 12.6's bin looks like it names nothing at all.
+           .Select(seg => seg.StartsWith('v') || seg.StartsWith('V') ? seg[1..] : seg)
            .Any(seg => seg == major.ToString()
                     || seg.StartsWith($"{major}.", StringComparison.Ordinal));
 
     /// <summary>True when a path segment names a CUDA major that is not the one we need — evidence
     /// that this directory belongs to another install, and should be tried last.</summary>
     private static bool NamesSomeOtherMajor(string dir) =>
-        Enumerable.Range(9, 12).Any(m => m != RequiredCudaMajor && NamesMajor(dir, m));
+        // From 10: cuDNN's own majors are 7-9, and a directory named for the cuDNN version (a
+        // C:\cudnn\9.3\bin) would otherwise be demoted for naming itself rather than a CUDA.
+        Enumerable.Range(10, 11).Any(m => m != RequiredCudaMajor && NamesMajor(dir, m));
 
     /// <summary>A directory in comparable form: absolute, with exactly one trailing separator, so
     /// two spellings of the same directory match and a prefix test lands on a path boundary.</summary>

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -165,15 +165,24 @@ public static class HardwareInfo
 
     private static CudaProbeResult? _probe;
 
+    /// <summary>Bumped by every invalidation, so a probe that began earlier does not publish its
+    /// answer over a newer one. Without it a Re-check could be undone by an in-flight probe and go
+    /// on reporting the pre-install state for the rest of the process.</summary>
+    private static int _probeGeneration;
+
     private static CudaProbeResult Probe
     {
         get
         {
             var current = Volatile.Read(ref _probe);
             if (current is not null) return current;
-            // A race recomputes rather than tearing: both writers publish an equivalent record.
+
+            var startedAt = Volatile.Read(ref _probeGeneration);
             var fresh = RunProbe();
-            Volatile.Write(ref _probe, fresh);
+            // Publish only if nothing invalidated while we were looking. Two probes of the same
+            // generation produce equivalent records, so either may win.
+            if (Volatile.Read(ref _probeGeneration) == startedAt)
+                Volatile.Write(ref _probe, fresh);
             return fresh;
         }
     }
@@ -220,23 +229,22 @@ public static class HardwareInfo
             return (true, null);
         }
 
-        foreach (var dir in GetLinuxCudaLibraryDirs())
+        // Every candidate across every directory, then decide: returning on the first directory
+        // that merely CONTAINS a match let one broken copy hide both a good copy further down and
+        // the "not on the loader path" diagnosis, which is the one with an actionable fix.
+        var candidates = GetLinuxCudaLibraryDirs().SelectMany(d => SafeGetFiles(d, filePattern)).ToList();
+        foreach (var file in candidates)
         {
-            var candidates = SafeGetFiles(dir, filePattern).ToList();
-            if (candidates.Count == 0) continue;
-
-            foreach (var file in candidates)
-            {
-                if (!NativeLibrary.TryLoad(file, out var byPath)) continue;
-                NativeLibrary.Free(byPath);
-                return (false, $"{label} was found at {file} but is not on the loader path, so the "
-                             + "CUDA execution provider cannot load it. Add its directory to "
-                             + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.");
-            }
-
-            return (false, $"{label} was found in {dir} but could not be loaded even by full path, "
-                         + "which usually means one of its own dependencies is missing.");
+            if (!NativeLibrary.TryLoad(file, out var byPath)) continue;
+            NativeLibrary.Free(byPath);
+            return (false, $"{label} was found at {file} but is not on the loader path, so the "
+                         + "CUDA execution provider cannot load it. Add its directory to "
+                         + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.");
         }
+
+        if (candidates.Count > 0)
+            return (false, $"{label} was found ({candidates[0]}) but could not be loaded, even by "
+                         + "full path, which usually means one of its own dependencies is missing.");
 
         return (false, absentNote);
     }
@@ -283,7 +291,10 @@ public static class HardwareInfo
     {
         get
         {
-            var notes = new[] { CudaRuntimeNote, CudnnNote }.Where(n => n is not null).ToArray();
+            // One snapshot: reading the two notes through their own properties could take them from
+            // different generations if a refresh landed between the reads.
+            var probe = Probe;
+            var notes = new[] { probe.RuntimeNote, probe.CudnnNote }.Where(n => n is not null).ToArray();
             return notes.Length == 0 ? null : string.Join(" ", notes);
         }
     }
@@ -312,7 +323,11 @@ public static class HardwareInfo
     /// open is exactly when someone presses it. (An LD_LIBRARY_PATH change still needs a restart:
     /// the loader read it at process start.)
     /// </summary>
-    public static void InvalidateCudaProbes() => Volatile.Write(ref _probe, null);
+    public static void InvalidateCudaProbes()
+    {
+        Interlocked.Increment(ref _probeGeneration);
+        Volatile.Write(ref _probe, null);
+    }
 
     /// <summary>
     /// True when the current machine appears capable of initializing CUDA execution:
@@ -562,7 +577,12 @@ public static class HardwareInfo
                     else if (name.StartsWith("cudnn", StringComparison.OrdinalIgnoreCase))
                     {
                         anyCudnn = true;
-                        cudnnDirs.Add(dir);
+                        // cudnn64_9.dll specifically, matching what Linux asks the loader for. A
+                        // cuDNN 8 copied into a CUDA 13 toolkit satisfies every path rule below and
+                        // still cannot be loaded by the provider, so accepting it would put the
+                        // wrong major on the DLL search path, which is what this exists to prevent.
+                        if (name.StartsWith("cudnn64_9", StringComparison.OrdinalIgnoreCase))
+                            cudnnDirs.Add(dir);
                     }
                     // cuFFT and cuRAND version independently of the CUDA major (CUDA 12 ships cuFFT
                     // 11, CUDA 13 ships 12), so they cannot identify a directory; these can.
@@ -595,8 +615,8 @@ public static class HardwareInfo
                 : $"No CUDA {RequiredCudaMajor} runtime was found.";
         var cudnnNote = cudnn ? null
             : anyCudnn
-                ? $"cuDNN was found, but not one belonging to a CUDA {RequiredCudaMajor} install, so "
-                  + "the CUDA execution provider cannot load it."
+                ? $"cuDNN was found, but not cuDNN 9 belonging to a CUDA {RequiredCudaMajor} "
+                  + "install, so the CUDA execution provider cannot load it."
                 : "No cuDNN was found. The CUDA execution provider needs cuDNN 9 built for CUDA "
                   + $"{RequiredCudaMajor}.";
 

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -567,11 +567,13 @@ public static class HardwareInfo
                                   | FileAttributes.System,
         };
 
-        var cudartDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var depDirs    = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var cudnnDirs  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var anyCudart  = false;
-        var anyCudnn   = false;
+        var cudartDirs   = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var depDirs      = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var unversioned  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var cudnnDirs    = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var anyCudart    = false;
+        var anyCudnn     = false;
+        var otherMajor   = false;
 
         foreach (var root in GetWindowsCudaSearchRoots())
         {
@@ -588,6 +590,8 @@ public static class HardwareInfo
                         anyCudart = true;
                         if (name.StartsWith($"cudart64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase))
                             cudartDirs.Add(dir);
+                        else
+                            otherMajor = true;   // another CUDA is installed alongside
                     }
                     else if (name.StartsWith("cudnn", StringComparison.OrdinalIgnoreCase))
                     {
@@ -607,6 +611,15 @@ public static class HardwareInfo
                     {
                         depDirs.Add(dir);
                     }
+                    // cuFFT and cuRAND keep their names across CUDA majors (curand64_10.dll under
+                    // both 12 and 13), so they identify a directory only when no other CUDA is
+                    // installed to confuse it with. The provider does load them, and a packaged app
+                    // cannot fall back on PATH, so they are worth having when they are unambiguous.
+                    else if (name.StartsWith("cufft", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith("curand", StringComparison.OrdinalIgnoreCase))
+                    {
+                        unversioned.Add(dir);
+                    }
                 }
             }
             catch { }
@@ -615,13 +628,28 @@ public static class HardwareInfo
         var runtime = cudartDirs.Count > 0;
         var cudnn = cudnnDirs.Count > 0;
 
-        // Only from an install we are actually going to use.
-        var dllDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        // Only from an install we are actually going to use, and in a deliberate order: a HashSet
+        // enumerates unpredictably, and AddDllDirectory order decides which of two cuDNNs the
+        // loader binds. Ours first, then cuDNN sitting with it, then anything else.
+        var dllDirs = new List<string>();
         if (runtime)
         {
-            foreach (var d in cudartDirs) dllDirs.Add(d);
-            foreach (var d in depDirs) dllDirs.Add(d);
-            foreach (var d in cudnnDirs) dllDirs.Add(d);
+            void Add(IEnumerable<string> dirs)
+            {
+                foreach (var d in dirs)
+                    if (!dllDirs.Contains(d, StringComparer.OrdinalIgnoreCase))
+                        dllDirs.Add(d);
+            }
+
+            bool BesideOurCuda(string dir) =>
+                cudartDirs.Any(c => c.StartsWith(dir, StringComparison.OrdinalIgnoreCase)
+                                 || dir.StartsWith(c, StringComparison.OrdinalIgnoreCase));
+
+            Add(cudartDirs);
+            Add(depDirs);
+            Add(cudnnDirs.Where(BesideOurCuda));
+            if (!otherMajor) Add(unversioned);
+            Add(cudnnDirs);
         }
 
         var runtimeNote = runtime ? null

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -161,12 +161,17 @@ public static class HardwareInfo
 
     /// <summary>What one look at the machine found. Computed together and published as a unit, so a
     /// reader never sees half of a refresh.</summary>
+    /// <param name="RuntimePresent">The runtime is on the machine, whether or not it can be used.
+    /// Distinguishing that from "absent" is what stops the UI offering a download link beside a note
+    /// saying the library is already installed and merely unreachable.</param>
     private sealed record CudaProbeResult(
         bool Runtime,
         bool Cudnn,
         string? RuntimeNote,
         string? CudnnNote,
-        IReadOnlyCollection<string> DllDirectories);
+        IReadOnlyCollection<string> DllDirectories,
+        bool RuntimePresent = false,
+        bool CudnnPresent = false);
 
     /// <summary>
     /// ⚠ A Lazy, NOT A HAND-ROLLED CACHE. CanProbeCudaExecutionProvider is asked at every
@@ -205,7 +210,7 @@ public static class HardwareInfo
     /// </summary>
     private static CudaProbeResult ProbeLinux()
     {
-        var (runtime, runtimeNote) = ProbeLinuxLibrary(
+        var (runtime, runtimeNote, runtimePresent) = ProbeLinuxLibrary(
             $"libcudart.so.{RequiredCudaMajor}",
             $"libcudart.so.{RequiredCudaMajor}*",
             $"CUDA {RequiredCudaMajor}",
@@ -213,23 +218,24 @@ public static class HardwareInfo
 
         // ⚠ THE SONAME, NOT THE BARE libcudnn.so. That one is the development symlink and on a
         // cuDNN 8 install it points at libcudnn.so.8, which the provider cannot use.
-        var (cudnn, cudnnNote) = ProbeLinuxLibrary(
+        var (cudnn, cudnnNote, cudnnPresent) = ProbeLinuxLibrary(
             $"libcudnn.so.{RequiredCudnnMajor}",
             $"libcudnn.so.{RequiredCudnnMajor}*",
             $"cuDNN {RequiredCudnnMajor}",
             $"No cuDNN {RequiredCudnnMajor} was found. The CUDA execution provider needs cuDNN "
             + $"{RequiredCudnnMajor} built for CUDA {RequiredCudaMajor}.");
 
-        return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, Array.Empty<string>());
+        return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, Array.Empty<string>(),
+                                   runtimePresent, cudnnPresent);
     }
 
-    private static (bool Found, string? Note) ProbeLinuxLibrary(
+    private static (bool Found, string? Note, bool Present) ProbeLinuxLibrary(
         string soname, string filePattern, string label, string absentNote)
     {
         if (NativeLibrary.TryLoad(soname, out var handle))
         {
             NativeLibrary.Free(handle);
-            return (true, null);
+            return (true, null, true);
         }
 
         // ⚠ LOOK, DO NOT LOAD. Loading a candidate by full path would register it under its
@@ -254,16 +260,17 @@ public static class HardwareInfo
             // up in an LD_LIBRARY_PATH entry, the loader has already looked and failed, so the
             // cause is the library itself -- a missing dependency of its own, or the wrong
             // architecture -- and the ldconfig advice would send them in a circle.
-            return (false, onLdPath.Contains(Normalise(dir))
+            return (Found: false, Note: onLdPath.Contains(Normalise(dir))
                 ? $"{label} was found at {hit}, in a directory that is already on LD_LIBRARY_PATH, "
                   + "and still could not be loaded. One of its own dependencies is probably "
                   + "missing, or it was built for a different architecture."
                 : $"{label} was found at {hit} but the loader could not open it by name, so the "
                   + "CUDA execution provider cannot either. Add its directory to "
-                  + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.");
+                  + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.",
+                Present: true);
         }
 
-        return (false, absentNote);
+        return (false, absentNote, false);
     }
 
     /// <summary>Returns the configured CUDA toolkit root for the current platform, or null if none is known.</summary>
@@ -435,6 +442,14 @@ public static class HardwareInfo
     /// because a CUDA installed mid-session changes this answer as well.
     /// </summary>
     public static bool SupportsBf16Acceleration() => Volatile.Read(ref _bf16Cache).Value;
+
+    /// <summary>The CUDA runtime is on this machine, even if it is the wrong major or cannot be
+    /// loaded. Offering a download link in that case tells the user to install what they have.</summary>
+    public static bool IsCudaRuntimePresent => Probe.RuntimePresent;
+
+    /// <summary>cuDNN is on this machine, even if it is not usable. See
+    /// <see cref="IsCudaRuntimePresent"/>.</summary>
+    public static bool IsCudnnPresent => Probe.CudnnPresent;
 
     /// <summary>Whether anything has asked for <see cref="SupportsBf16Acceleration"/> yet. Lets a
     /// caller find out whether the answer CHANGED without forcing the probe that computes it --
@@ -688,11 +703,26 @@ public static class HardwareInfo
                                         || d.StartsWith(c, StringComparison.OrdinalIgnoreCase));
             }
 
+            // ⚠ THE DIRECTORY NAME ORDERS cuDNN; IT DOES NOT DECIDE IT. NVIDIA's standalone package
+            // installs into per-CUDA subdirectories -- …\CUDNN\v9.x\bin\12.9\ AND …\bin\13.0\ --
+            // so both land in the set, neither sits beside our cudart, and enumeration order would
+            // hand the loader 12.9 first. That name is real evidence about which CUDA a cuDNN was
+            // built for; it is just not reliable enough to reject an install over (a cuDNN unzipped
+            // to C:\cudnn names nothing at all), which is why it ranks rather than filters.
+            int CudnnRank(string dir) =>
+                NamesMajor(dir, RequiredCudaMajor) ? 0
+                : BesideOurCuda(dir)              ? 1
+                : NamesSomeOtherMajor(dir)        ? 3
+                                                  : 2;
+
             Add(cudartDirs);
             Add(depDirs);
-            Add(cudnnDirs.Where(BesideOurCuda));
+            // Beside our own runtime, these are unambiguous whatever else is installed; further
+            // afield they are only safe when no other CUDA is present to confuse them with, because
+            // curand64_10.dll carries that name under every major.
+            Add(unversioned.Where(BesideOurCuda));
             if (!otherMajor) Add(unversioned);
-            Add(cudnnDirs);
+            Add(cudnnDirs.OrderBy(CudnnRank));
         }
 
         var runtimeNote = runtime ? null
@@ -707,8 +737,21 @@ public static class HardwareInfo
                 : $"No cuDNN was found. The CUDA execution provider needs cuDNN {RequiredCudnnMajor} "
                   + $"built for CUDA {RequiredCudaMajor}.";
 
-        return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, dllDirs);
+        return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, dllDirs,
+                                   RuntimePresent: anyCudart, CudnnPresent: anyCudnn);
     }
+
+    /// <summary>True when a path segment names the given CUDA major, as NVIDIA's standalone cuDNN
+    /// tree does (…\CUDNN\v9.x\bin\13.0\).</summary>
+    private static bool NamesMajor(string dir, int major) =>
+        dir.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+           .Any(seg => seg == major.ToString()
+                    || seg.StartsWith($"{major}.", StringComparison.Ordinal));
+
+    /// <summary>True when a path segment names a CUDA major that is not the one we need — evidence
+    /// that this directory belongs to another install, and should be tried last.</summary>
+    private static bool NamesSomeOtherMajor(string dir) =>
+        Enumerable.Range(9, 12).Any(m => m != RequiredCudaMajor && NamesMajor(dir, m));
 
     /// <summary>A directory in comparable form: absolute, with exactly one trailing separator, so
     /// two spellings of the same directory match and a prefix test lands on a path boundary.</summary>

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -236,10 +236,13 @@ public static class HardwareInfo
         // soname for the rest of the process, so the NEXT probe would find it by name and report
         // "installed" -- losing the ldconfig advice that the first probe correctly gave. The answer
         // has to mean the same thing every time the user presses Re-check.
+        // Normalised on both sides: LD_LIBRARY_PATH is commonly written with a trailing slash while
+        // the same directory arrives here from CUDA_PATH without one, and a raw string comparison
+        // would then give exactly the circular advice this distinction exists to avoid.
         var onLdPath = new HashSet<string>(
             (Environment.GetEnvironmentVariable("LD_LIBRARY_PATH") ?? "")
                 .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-                .Select(e => e.Trim()),
+                .Select(e => Normalise(e.Trim())),
             StringComparer.Ordinal);
 
         foreach (var dir in GetLinuxCudaLibraryDirs())
@@ -251,7 +254,7 @@ public static class HardwareInfo
             // up in an LD_LIBRARY_PATH entry, the loader has already looked and failed, so the
             // cause is the library itself -- a missing dependency of its own, or the wrong
             // architecture -- and the ldconfig advice would send them in a circle.
-            return (false, onLdPath.Contains(dir)
+            return (false, onLdPath.Contains(Normalise(dir))
                 ? $"{label} was found at {hit}, in a directory that is already on LD_LIBRARY_PATH, "
                   + "and still could not be loaded. One of its own dependencies is probably "
                   + "missing, or it was built for a different architecture."
@@ -318,15 +321,27 @@ public static class HardwareInfo
     /// the probe found. One place, because several call sites each threw their own version and only
     /// one of them said anything useful.
     /// </summary>
-    public static string CudaUnavailableMessage()
+    /// <param name="providerMissing">True when the ONNX Runtime binary has no CUDA provider entry
+    /// point at all, which is what an EntryPointNotFoundException means: a CPU-only build.
+    /// ⚠ THE PROBE'S NOTE IS IRRELEVANT THEN. No amount of installing CUDA or cuDNN puts a provider
+    /// into a binary that does not contain one, so leading with "no cuDNN found" sends that user
+    /// somewhere that cannot help them.</param>
+    public static string CudaUnavailableMessage(bool providerMissing = false)
     {
-        var note = CudaProbeNote;
-        // With a note, the probe knows what is wrong and says it. Without one, CUDA and cuDNN both
-        // checked out, so the major version is NOT the likely cause and must not lead.
+        // The platform question comes first: on macOS there is nothing to probe and nothing to say
+        // about majors. (Asking for the note here would also force a probe whose answer is unused.)
         if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
             return "The CUDA execution provider is not available on this platform; CUDA builds of "
                  + "ONNX Runtime exist for Windows and Linux only.";
 
+        if (providerMissing)
+            return "This build of ONNX Runtime has no CUDA execution provider in it: it is a "
+                 + "CPU-only build. Installing CUDA or cuDNN will not change that; the application "
+                 + "needs to be built with -p:EP=Cuda.";
+
+        // With a note, the probe knows what is wrong and says it. Without one, CUDA and cuDNN both
+        // checked out, so the major version is NOT the likely cause and must not lead.
+        var note = CudaProbeNote;
         return note is not null
             ? $"Could not initialise the CUDA execution provider. {note}"
             : "Could not initialise the CUDA execution provider. The CUDA "
@@ -665,9 +680,6 @@ public static class HardwareInfo
             // ⚠ ON PATH BOUNDARIES, NOT CHARACTERS. A bare StartsWith makes C:\cuda12\bin look
             // like it sits under C:\cuda, so a CUDA 12 cuDNN would be ordered ahead of the one
             // actually paired with our runtime -- the opposite of what this ordering is for.
-            static string Normalise(string dir) =>
-                Path.TrimEndingDirectorySeparator(Path.GetFullPath(dir)) + Path.DirectorySeparatorChar;
-
             bool BesideOurCuda(string dir)
             {
                 var d = Normalise(dir);
@@ -696,6 +708,14 @@ public static class HardwareInfo
                   + $"built for CUDA {RequiredCudaMajor}.";
 
         return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, dllDirs);
+    }
+
+    /// <summary>A directory in comparable form: absolute, with exactly one trailing separator, so
+    /// two spellings of the same directory match and a prefix test lands on a path boundary.</summary>
+    private static string Normalise(string dir)
+    {
+        try { return Path.TrimEndingDirectorySeparator(Path.GetFullPath(dir)) + Path.DirectorySeparatorChar; }
+        catch { return dir; }
     }
 
     private static IEnumerable<string> SafeGetFiles(string dir, string pattern)

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -307,6 +307,10 @@ public static class HardwareInfo
         var note = CudaProbeNote;
         // With a note, the probe knows what is wrong and says it. Without one, CUDA and cuDNN both
         // checked out, so the major version is NOT the likely cause and must not lead.
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
+            return "The CUDA execution provider is not available on this platform; CUDA builds of "
+                 + "ONNX Runtime exist for Windows and Linux only.";
+
         return note is not null
             ? $"Could not initialise the CUDA execution provider. {note}"
             : "Could not initialise the CUDA execution provider. The CUDA "
@@ -346,7 +350,10 @@ public static class HardwareInfo
         if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
             return false;
 
-        if (!IsCudaToolkitInstalled() || !IsCudnnInstalled())
+        // One snapshot: asking through the two properties could take the answers from either side
+        // of a Re-check landing between them.
+        var probe = Probe;
+        if (!probe.Runtime || !probe.Cudnn)
             return false;
 
         var (totalMb, _) = GetGpuMemoryMb();
@@ -393,7 +400,8 @@ public static class HardwareInfo
     /// Result is cached after the first call: the answer is fixed for the
     /// lifetime of the process (GPUs don't hot-swap), and the underlying
     /// NVML init/get/shutdown cycle is non-trivial when called repeatedly
-    /// from settings/UI flows.
+    /// from settings/UI flows. <see cref="InvalidateCudaProbes"/> clears it too,
+    /// because a CUDA installed mid-session changes this answer as well.
     /// </summary>
     public static bool SupportsBf16Acceleration() => Volatile.Read(ref _bf16Cache).Value;
 
@@ -587,14 +595,15 @@ public static class HardwareInfo
                         if (name.StartsWith($"cudnn64_{RequiredCudnnMajor}", StringComparison.OrdinalIgnoreCase))
                             cudnnDirs.Add(dir);
                     }
-                    // Everything else the provider loads. cuFFT and cuRAND version independently of
-                    // the CUDA major, so they cannot IDENTIFY an install -- but once we have decided
-                    // to use one, their directories still belong on the search path, which a
-                    // packaged app needs because its DLL search is restricted.
-                    else if (name.StartsWith("cublas", StringComparison.OrdinalIgnoreCase)
-                          || name.StartsWith("cufft", StringComparison.OrdinalIgnoreCase)
-                          || name.StartsWith("curand", StringComparison.OrdinalIgnoreCase)
-                          || name.StartsWith("nvrtc", StringComparison.OrdinalIgnoreCase))
+                    // ⚠ ONLY LIBRARIES THAT NAME THE MAJOR MAY IDENTIFY A DIRECTORY. cuFFT and
+                    // cuRAND version independently -- curand64_10.dll is called that under both
+                    // CUDA 12 and 13 -- so a directory known only by them could be CUDA 12's bin,
+                    // and adding it would let the provider bind CUDA 12's cuRAND beside a CUDA 13
+                    // cudart. In a stock toolkit they sit in the cudart directory anyway, which is
+                    // already on the list.
+                    else if (name.StartsWith($"cublas64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith($"cublasLt64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith($"nvrtc64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase))
                     {
                         depDirs.Add(dir);
                     }

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -163,29 +163,26 @@ public static class HardwareInfo
         string? CudnnNote,
         IReadOnlyCollection<string> DllDirectories);
 
-    private static CudaProbeResult? _probe;
+    /// <summary>
+    /// ⚠ A Lazy, NOT A HAND-ROLLED CACHE. CanProbeCudaExecutionProvider is asked at every
+    /// model-init site, and those run in parallel; on Windows the probe is a recursive walk of
+    /// every CUDA, cuDNN and PATH root. A check-then-run cache lets every caller that arrives
+    /// while it is empty run the whole walk. ExecutionAndPublication means one thread does it and
+    /// the others wait, and swapping the Lazy wholesale on invalidation keeps Re-check honest
+    /// without reintroducing that herd.
+    /// </summary>
+    private static Lazy<CudaProbeResult> _probe = NewProbe();
 
-    /// <summary>Bumped by every invalidation, so a probe that began earlier does not publish its
-    /// answer over a newer one. Without it a Re-check could be undone by an in-flight probe and go
-    /// on reporting the pre-install state for the rest of the process.</summary>
+    private static Lazy<CudaProbeResult> NewProbe() =>
+        new(RunProbe, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>Counts invalidations. Not needed for correctness now that each refresh is its own
+    /// Lazy, but it makes "the answer was actually thrown away" observable to a test.</summary>
+    internal static int ProbeGeneration => Volatile.Read(ref _probeGeneration);
+
     private static int _probeGeneration;
 
-    private static CudaProbeResult Probe
-    {
-        get
-        {
-            var current = Volatile.Read(ref _probe);
-            if (current is not null) return current;
-
-            var startedAt = Volatile.Read(ref _probeGeneration);
-            var fresh = RunProbe();
-            // Publish only if nothing invalidated while we were looking. Two probes of the same
-            // generation produce equivalent records, so either may win.
-            if (Volatile.Read(ref _probeGeneration) == startedAt)
-                Volatile.Write(ref _probe, fresh);
-            return fresh;
-        }
-    }
+    private static CudaProbeResult Probe => Volatile.Read(ref _probe).Value;
 
     private static CudaProbeResult RunProbe() =>
         OperatingSystem.IsWindows() ? ProbeWindows()
@@ -229,22 +226,17 @@ public static class HardwareInfo
             return (true, null);
         }
 
-        // Every candidate across every directory, then decide: returning on the first directory
-        // that merely CONTAINS a match let one broken copy hide both a good copy further down and
-        // the "not on the loader path" diagnosis, which is the one with an actionable fix.
+        // ⚠ LOOK, DO NOT LOAD. Loading a candidate by full path would register it under its
+        // soname for the rest of the process, so the NEXT probe would find it by name and report
+        // "installed" -- losing the ldconfig advice that the first probe correctly gave. The answer
+        // has to mean the same thing every time the user presses Re-check.
         var candidates = GetLinuxCudaLibraryDirs().SelectMany(d => SafeGetFiles(d, filePattern)).ToList();
-        foreach (var file in candidates)
-        {
-            if (!NativeLibrary.TryLoad(file, out var byPath)) continue;
-            NativeLibrary.Free(byPath);
-            return (false, $"{label} was found at {file} but is not on the loader path, so the "
-                         + "CUDA execution provider cannot load it. Add its directory to "
-                         + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.");
-        }
-
         if (candidates.Count > 0)
-            return (false, $"{label} was found ({candidates[0]}) but could not be loaded, even by "
-                         + "full path, which usually means one of its own dependencies is missing.");
+            return (false, $"{label} was found at {candidates[0]} but the loader could not open it "
+                         + "by name, so the CUDA execution provider cannot either. Add its "
+                         + "directory to /etc/ld.so.conf.d (then run ldconfig) or to "
+                         + "LD_LIBRARY_PATH; if it is already there, one of its own dependencies "
+                         + "is missing.");
 
         return (false, absentNote);
     }
@@ -326,7 +318,12 @@ public static class HardwareInfo
     public static void InvalidateCudaProbes()
     {
         Interlocked.Increment(ref _probeGeneration);
-        Volatile.Write(ref _probe, null);
+        Volatile.Write(ref _probe, NewProbe());
+        // ⚠ AND THE THINGS COMPUTED FROM IT. SupportsBf16Acceleration latches an answer derived
+        // from this probe, and it decides which model bundle is selected; leaving it behind meant a
+        // user could install CUDA, press Re-check, be told CUDA works, and still get the FP32
+        // bundle for the rest of the session.
+        Volatile.Write(ref _bf16Cache, NewBf16Cache());
     }
 
     /// <summary>
@@ -388,14 +385,16 @@ public static class HardwareInfo
     /// NVML init/get/shutdown cycle is non-trivial when called repeatedly
     /// from settings/UI flows.
     /// </summary>
-    public static bool SupportsBf16Acceleration() => _bf16Cache.Value;
+    public static bool SupportsBf16Acceleration() => Volatile.Read(ref _bf16Cache).Value;
 
-    private static readonly Lazy<bool> _bf16Cache = new(() =>
+    private static Lazy<bool> _bf16Cache = NewBf16Cache();
+
+    private static Lazy<bool> NewBf16Cache() => new(() =>
     {
         if (!CanProbeCudaExecutionProvider()) return false;
         var (major, _) = GetCudaComputeCapability();
         return major >= 8;
-    });
+    }, LazyThreadSafetyMode.ExecutionAndPublication);
 
     private static int NvmlInitPlatform() =>
         OperatingSystem.IsWindows() ? NvmlInitWindows() : NvmlInitLinux();
@@ -601,11 +600,17 @@ public static class HardwareInfo
         var usableCudnn = cudnnDirs.Where(d => NamesRequiredMajor(d) || toolkitRoots.Contains(ToolkitRootOf(d)))
                                    .ToList();
 
-        var dllDirs = new HashSet<string>(cudartDirs, StringComparer.OrdinalIgnoreCase);
-        foreach (var d in otherDeps) dllDirs.Add(d);
-        foreach (var d in usableCudnn) dllDirs.Add(d);
-
         var runtime = cudartDirs.Count > 0;
+
+        // Only from an install we are actually going to use: registering directories from a CUDA we
+        // have just rejected is how the wrong major reaches the search path.
+        var dllDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (runtime)
+        {
+            foreach (var d in cudartDirs) dllDirs.Add(d);
+            foreach (var d in otherDeps) dllDirs.Add(d);
+            foreach (var d in usableCudnn) dllDirs.Add(d);
+        }
         var cudnn = usableCudnn.Count > 0;
 
         var runtimeNote = runtime ? null

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -236,13 +236,29 @@ public static class HardwareInfo
         // soname for the rest of the process, so the NEXT probe would find it by name and report
         // "installed" -- losing the ldconfig advice that the first probe correctly gave. The answer
         // has to mean the same thing every time the user presses Re-check.
-        var candidates = GetLinuxCudaLibraryDirs().SelectMany(d => SafeGetFiles(d, filePattern)).ToList();
-        if (candidates.Count > 0)
-            return (false, $"{label} was found at {candidates[0]} but the loader could not open it "
-                         + "by name, so the CUDA execution provider cannot either. Add its "
-                         + "directory to /etc/ld.so.conf.d (then run ldconfig) or to "
-                         + "LD_LIBRARY_PATH; if it is already there, one of its own dependencies "
-                         + "is missing.");
+        var onLdPath = new HashSet<string>(
+            (Environment.GetEnvironmentVariable("LD_LIBRARY_PATH") ?? "")
+                .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+                .Select(e => e.Trim()),
+            StringComparer.Ordinal);
+
+        foreach (var dir in GetLinuxCudaLibraryDirs())
+        {
+            var hit = SafeGetFiles(dir, filePattern).FirstOrDefault();
+            if (hit is null) continue;
+
+            // ⚠ DO NOT TELL SOMEONE TO ADD A DIRECTORY THAT IS ALREADY THERE. When the file turned
+            // up in an LD_LIBRARY_PATH entry, the loader has already looked and failed, so the
+            // cause is the library itself -- a missing dependency of its own, or the wrong
+            // architecture -- and the ldconfig advice would send them in a circle.
+            return (false, onLdPath.Contains(dir)
+                ? $"{label} was found at {hit}, in a directory that is already on LD_LIBRARY_PATH, "
+                  + "and still could not be loaded. One of its own dependencies is probably "
+                  + "missing, or it was built for a different architecture."
+                : $"{label} was found at {hit} but the loader could not open it by name, so the "
+                  + "CUDA execution provider cannot either. Add its directory to "
+                  + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.");
+        }
 
         return (false, absentNote);
     }
@@ -404,6 +420,11 @@ public static class HardwareInfo
     /// because a CUDA installed mid-session changes this answer as well.
     /// </summary>
     public static bool SupportsBf16Acceleration() => Volatile.Read(ref _bf16Cache).Value;
+
+    /// <summary>Whether anything has asked for <see cref="SupportsBf16Acceleration"/> yet. Lets a
+    /// caller find out whether the answer CHANGED without forcing the probe that computes it --
+    /// which, on a cold cache, would run the whole scan only to throw it away.</summary>
+    public static bool IsBf16AnswerKnown => Volatile.Read(ref _bf16Cache).IsValueCreated;
 
     private static Lazy<bool> _bf16Cache = NewBf16Cache();
 
@@ -641,9 +662,19 @@ public static class HardwareInfo
                         dllDirs.Add(d);
             }
 
-            bool BesideOurCuda(string dir) =>
-                cudartDirs.Any(c => c.StartsWith(dir, StringComparison.OrdinalIgnoreCase)
-                                 || dir.StartsWith(c, StringComparison.OrdinalIgnoreCase));
+            // ⚠ ON PATH BOUNDARIES, NOT CHARACTERS. A bare StartsWith makes C:\cuda12\bin look
+            // like it sits under C:\cuda, so a CUDA 12 cuDNN would be ordered ahead of the one
+            // actually paired with our runtime -- the opposite of what this ordering is for.
+            static string Normalise(string dir) =>
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(dir)) + Path.DirectorySeparatorChar;
+
+            bool BesideOurCuda(string dir)
+            {
+                var d = Normalise(dir);
+                return cudartDirs.Select(Normalise)
+                                 .Any(c => c.StartsWith(d, StringComparison.OrdinalIgnoreCase)
+                                        || d.StartsWith(c, StringComparison.OrdinalIgnoreCase));
+            }
 
             Add(cudartDirs);
             Add(depDirs);

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -147,6 +147,11 @@ public static class HardwareInfo
     /// </summary>
     public const int RequiredCudaMajor = 13;
 
+    /// <summary>The cuDNN major the CUDA provider loads (libcudnn.so.9 / cudnn64_9.dll). Named for
+    /// the same reason as <see cref="RequiredCudaMajor"/>: when ONNX Runtime moves to cuDNN 10, a
+    /// literal 9 scattered through this file would report "no cuDNN" on a correct install.</summary>
+    public const int RequiredCudnnMajor = 9;
+
     /// <summary>
     /// True if the CUDA runtime this build needs can actually be loaded.
     /// </summary>
@@ -209,10 +214,11 @@ public static class HardwareInfo
         // ⚠ THE SONAME, NOT THE BARE libcudnn.so. That one is the development symlink and on a
         // cuDNN 8 install it points at libcudnn.so.8, which the provider cannot use.
         var (cudnn, cudnnNote) = ProbeLinuxLibrary(
-            "libcudnn.so.9",
-            "libcudnn.so.9*",
-            "cuDNN 9",
-            $"No cuDNN 9 was found. The CUDA execution provider needs cuDNN 9 built for CUDA {RequiredCudaMajor}.");
+            $"libcudnn.so.{RequiredCudnnMajor}",
+            $"libcudnn.so.{RequiredCudnnMajor}*",
+            $"cuDNN {RequiredCudnnMajor}",
+            $"No cuDNN {RequiredCudnnMajor} was found. The CUDA execution provider needs cuDNN "
+            + $"{RequiredCudnnMajor} built for CUDA {RequiredCudaMajor}.");
 
         return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, Array.Empty<string>());
     }
@@ -299,11 +305,15 @@ public static class HardwareInfo
     public static string CudaUnavailableMessage()
     {
         var note = CudaProbeNote;
-        return "Could not initialise the CUDA execution provider. This build links CUDA "
-            + $"{RequiredCudaMajor}, and an older CUDA runtime cannot load it, because the major "
-            + "version is part of the library name."
-            + (note is null ? " A missing driver, no visible GPU, or a CPU-only build of ONNX "
-                              + "Runtime will also report this." : $" {note}");
+        // With a note, the probe knows what is wrong and says it. Without one, CUDA and cuDNN both
+        // checked out, so the major version is NOT the likely cause and must not lead.
+        return note is not null
+            ? $"Could not initialise the CUDA execution provider. {note}"
+            : "Could not initialise the CUDA execution provider. The CUDA "
+              + $"{RequiredCudaMajor} runtime and cuDNN {RequiredCudnnMajor} were both found, so "
+              + "the likely causes are a missing or too-old driver, no GPU visible to this process "
+              + "(a container without the NVIDIA devices passed through, say), or a CPU-only build "
+              + "of ONNX Runtime.";
     }
 
     /// <summary>
@@ -517,21 +527,19 @@ public static class HardwareInfo
 
 
     /// <summary>
-    /// Windows: which directories hold a CUDA of the major this build needs, and whether cuDNN is
-    /// among them.
+    /// Windows: is there a CUDA of the major this build needs, and a cuDNN it can use?
     ///
-    /// ⚠ TWO cuDNN LAYOUTS ARE BOTH LEGITIMATE, AND A RULE THAT SUITS ONE BREAKS THE OTHER:
+    /// ⚠ THE MAJOR IS CHECKED ON cudart, WHICH CARRIES IT, AND NOT ON cuDNN, WHICH DOES NOT.
+    /// cudart64_13.dll names its CUDA; cudnn64_9.dll is called that whether it was built for CUDA
+    /// 12 or 13, so no rule over file names or directory layout can tell those apart. An earlier
+    /// attempt inferred it from the directory instead -- a cuDNN counted only if its path named the
+    /// CUDA version or it sat under the same toolkit as a matching cudart -- and that rejected the
+    /// commonest Windows install of all: unzip cuDNN to C:\cudnn and put it on PATH. Being strict
+    /// about something unknowable cost a working configuration and bought nothing.
     ///
-    ///   • NVIDIA's standalone tree, C:\Program Files\NVIDIA\CUDNN\v9.x\bin\13.0\, holds
-    ///     cudnn64_9.dll and nothing else. Requiring a cudart beside it drops this one.
-    ///   • The documented copy-into-the-toolkit install puts cudnn64_9.dll in &lt;toolkit&gt;\bin, while
-    ///     CUDA 13 puts its runtime DLLs in &lt;toolkit&gt;\bin\x64. Requiring the SAME directory as
-    ///     cudart drops this one.
-    ///
-    /// So a cuDNN directory qualifies when it names the CUDA version itself, or when it belongs to
-    /// a toolkit whose runtime is the major we need. Nothing else does -- a cuDNN left behind in an
-    /// older toolkit is not a cuDNN we can use, and its directory must not join the search path
-    /// either, since the provider would load the wrong major from it.
+    /// So cuDNN is answered the way Linux answers it: is a cuDNN of the required major there at
+    /// all. A cuDNN built for the wrong CUDA still gets past this and fails at provider init, on
+    /// both platforms, and that limit is real rather than papered over.
     /// </summary>
     private static CudaProbeResult ProbeWindows()
     {
@@ -552,7 +560,7 @@ public static class HardwareInfo
         };
 
         var cudartDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var otherDeps  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var depDirs    = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var cudnnDirs  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var anyCudart  = false;
         var anyCudnn   = false;
@@ -576,78 +584,50 @@ public static class HardwareInfo
                     else if (name.StartsWith("cudnn", StringComparison.OrdinalIgnoreCase))
                     {
                         anyCudnn = true;
-                        // cudnn64_9.dll specifically, matching what Linux asks the loader for. A
-                        // cuDNN 8 copied into a CUDA 13 toolkit satisfies every path rule below and
-                        // still cannot be loaded by the provider, so accepting it would put the
-                        // wrong major on the DLL search path, which is what this exists to prevent.
-                        if (name.StartsWith("cudnn64_9", StringComparison.OrdinalIgnoreCase))
+                        if (name.StartsWith($"cudnn64_{RequiredCudnnMajor}", StringComparison.OrdinalIgnoreCase))
                             cudnnDirs.Add(dir);
                     }
-                    // cuFFT and cuRAND version independently of the CUDA major (CUDA 12 ships cuFFT
-                    // 11, CUDA 13 ships 12), so they cannot identify a directory; these can.
-                    else if (name.StartsWith($"cublas64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase)
-                          || name.StartsWith($"cublasLt64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase)
-                          || name.StartsWith($"nvrtc64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase))
+                    // Everything else the provider loads. cuFFT and cuRAND version independently of
+                    // the CUDA major, so they cannot IDENTIFY an install -- but once we have decided
+                    // to use one, their directories still belong on the search path, which a
+                    // packaged app needs because its DLL search is restricted.
+                    else if (name.StartsWith("cublas", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith("cufft", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith("curand", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith("nvrtc", StringComparison.OrdinalIgnoreCase))
                     {
-                        otherDeps.Add(dir);
+                        depDirs.Add(dir);
                     }
                 }
             }
             catch { }
         }
 
-        var toolkitRoots = new HashSet<string>(cudartDirs.Select(ToolkitRootOf), StringComparer.OrdinalIgnoreCase);
-        var usableCudnn = cudnnDirs.Where(d => NamesRequiredMajor(d) || toolkitRoots.Contains(ToolkitRootOf(d)))
-                                   .ToList();
-
         var runtime = cudartDirs.Count > 0;
+        var cudnn = cudnnDirs.Count > 0;
 
-        // Only from an install we are actually going to use: registering directories from a CUDA we
-        // have just rejected is how the wrong major reaches the search path.
+        // Only from an install we are actually going to use.
         var dllDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (runtime)
         {
             foreach (var d in cudartDirs) dllDirs.Add(d);
-            foreach (var d in otherDeps) dllDirs.Add(d);
-            foreach (var d in usableCudnn) dllDirs.Add(d);
+            foreach (var d in depDirs) dllDirs.Add(d);
+            foreach (var d in cudnnDirs) dllDirs.Add(d);
         }
-        var cudnn = usableCudnn.Count > 0;
 
         var runtimeNote = runtime ? null
             : anyCudart
-                ? $"A CUDA runtime was found, but not CUDA {RequiredCudaMajor}, which this build links. "
-                  + $"Install the CUDA {RequiredCudaMajor} runtime."
+                ? $"A CUDA runtime was found, but not CUDA {RequiredCudaMajor}, which this build "
+                  + $"links. Install the CUDA {RequiredCudaMajor} runtime."
                 : $"No CUDA {RequiredCudaMajor} runtime was found.";
         var cudnnNote = cudnn ? null
             : anyCudnn
-                ? $"cuDNN was found, but not cuDNN 9 belonging to a CUDA {RequiredCudaMajor} "
-                  + "install, so the CUDA execution provider cannot load it."
-                : "No cuDNN was found. The CUDA execution provider needs cuDNN 9 built for CUDA "
-                  + $"{RequiredCudaMajor}.";
+                ? $"cuDNN was found, but not cuDNN {RequiredCudnnMajor}, which the CUDA execution "
+                  + "provider loads."
+                : $"No cuDNN was found. The CUDA execution provider needs cuDNN {RequiredCudnnMajor} "
+                  + $"built for CUDA {RequiredCudaMajor}.";
 
         return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, dllDirs);
-    }
-
-    /// <summary>True when a path segment names the CUDA version we need, as the standalone cuDNN
-    /// tree does (…\CUDNN\v9.x\bin\13.0\).</summary>
-    internal static bool NamesRequiredMajor(string dir) =>
-        dir.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-           .Any(seg => seg == RequiredCudaMajor.ToString()
-                    || seg.StartsWith($"{RequiredCudaMajor}.", StringComparison.Ordinal));
-
-    /// <summary>
-    /// The install a directory belongs to: the parent of its `bin`, so &lt;toolkit&gt;\bin and
-    /// &lt;toolkit&gt;\bin\x64 resolve to the same root and cuDNN copied into the toolkit is
-    /// recognised as belonging to the CUDA there.
-    /// </summary>
-    internal static string ToolkitRootOf(string dir)
-    {
-        for (var d = dir; !string.IsNullOrEmpty(d); d = Path.GetDirectoryName(d) ?? "")
-        {
-            if (string.Equals(Path.GetFileName(d), "bin", StringComparison.OrdinalIgnoreCase))
-                return Path.GetDirectoryName(d) ?? d;
-        }
-        return dir;
     }
 
     private static IEnumerable<string> SafeGetFiles(string dir, string pattern)

--- a/src/Vernacula.Base/HardwareInfo.cs
+++ b/src/Vernacula.Base/HardwareInfo.cs
@@ -137,23 +137,108 @@ public static class HardwareInfo
     // ── CUDA Toolkit ──────────────────────────────────────────────────────────
 
     /// <summary>
-    /// True if the platform's CUDA runtime library can be found.
+    /// The CUDA major version the bundled ONNX Runtime links against.
+    ///
+    /// ⚠ THE MAJOR IS PART OF THE ANSWER, NOT A DETAIL. ONNX Runtime moved from CUDA 12 to CUDA 13
+    /// at 1.27, and the two are not interchangeable: the provider names its dependencies with the
+    /// major in the library name (libcudart.so.13, cudart64_13.dll), so a machine with only CUDA 12
+    /// cannot load it. Answering "CUDA is installed" for any major meant the app tried CUDA, failed
+    /// to load the provider, had the failure swallowed, and ran on the CPU with the GPU idle.
     /// </summary>
-    public static bool IsCudaToolkitInstalled()
-    {
-        if (OperatingSystem.IsWindows())
-            return _windowsCudaScan.Value.HasCudart;
+    public const int RequiredCudaMajor = 13;
 
-        if (OperatingSystem.IsLinux())
+    /// <summary>
+    /// True if the CUDA runtime this build needs can actually be loaded.
+    /// </summary>
+    public static bool IsCudaToolkitInstalled() => Probe.Runtime;
+
+    // ── The probe ─────────────────────────────────────────────────────────────
+
+    /// <summary>What one look at the machine found. Computed together and published as a unit, so a
+    /// reader never sees half of a refresh.</summary>
+    private sealed record CudaProbeResult(
+        bool Runtime,
+        bool Cudnn,
+        string? RuntimeNote,
+        string? CudnnNote,
+        IReadOnlyCollection<string> DllDirectories);
+
+    private static CudaProbeResult? _probe;
+
+    private static CudaProbeResult Probe
+    {
+        get
         {
-            foreach (var dir in GetLinuxCudaLibraryDirs())
-            {
-                if (HasFile(dir, "libcudart.so") || HasFile(dir, "libcudart.so.*"))
-                    return true;
-            }
+            var current = Volatile.Read(ref _probe);
+            if (current is not null) return current;
+            // A race recomputes rather than tearing: both writers publish an equivalent record.
+            var fresh = RunProbe();
+            Volatile.Write(ref _probe, fresh);
+            return fresh;
+        }
+    }
+
+    private static CudaProbeResult RunProbe() =>
+        OperatingSystem.IsWindows() ? ProbeWindows()
+        : OperatingSystem.IsLinux() ? ProbeLinux()
+        : new CudaProbeResult(false, false, null, null, Array.Empty<string>());
+
+    /// <summary>
+    /// Linux: ask the dynamic loader, not the filesystem.
+    ///
+    /// ⚠ THE PROVIDER dlopens BY SONAME, so the only question that matters is whether the loader
+    /// can find the library. A side-by-side CUDA 13 that is not in the ldconfig cache or on
+    /// LD_LIBRARY_PATH is a file we can see and the provider cannot open; answering "installed" for
+    /// it lands us on the CPU with no explanation. Where that is the case we say so, because the
+    /// fix is one ldconfig line rather than an install.
+    /// </summary>
+    private static CudaProbeResult ProbeLinux()
+    {
+        var (runtime, runtimeNote) = ProbeLinuxLibrary(
+            $"libcudart.so.{RequiredCudaMajor}",
+            $"libcudart.so.{RequiredCudaMajor}*",
+            $"CUDA {RequiredCudaMajor}",
+            $"No CUDA {RequiredCudaMajor} runtime was found. This build links CUDA {RequiredCudaMajor}; an older CUDA cannot load it.");
+
+        // ⚠ THE SONAME, NOT THE BARE libcudnn.so. That one is the development symlink and on a
+        // cuDNN 8 install it points at libcudnn.so.8, which the provider cannot use.
+        var (cudnn, cudnnNote) = ProbeLinuxLibrary(
+            "libcudnn.so.9",
+            "libcudnn.so.9*",
+            "cuDNN 9",
+            $"No cuDNN 9 was found. The CUDA execution provider needs cuDNN 9 built for CUDA {RequiredCudaMajor}.");
+
+        return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, Array.Empty<string>());
+    }
+
+    private static (bool Found, string? Note) ProbeLinuxLibrary(
+        string soname, string filePattern, string label, string absentNote)
+    {
+        if (NativeLibrary.TryLoad(soname, out var handle))
+        {
+            NativeLibrary.Free(handle);
+            return (true, null);
         }
 
-        return false;
+        foreach (var dir in GetLinuxCudaLibraryDirs())
+        {
+            var candidates = SafeGetFiles(dir, filePattern).ToList();
+            if (candidates.Count == 0) continue;
+
+            foreach (var file in candidates)
+            {
+                if (!NativeLibrary.TryLoad(file, out var byPath)) continue;
+                NativeLibrary.Free(byPath);
+                return (false, $"{label} was found at {file} but is not on the loader path, so the "
+                             + "CUDA execution provider cannot load it. Add its directory to "
+                             + "/etc/ld.so.conf.d (then run ldconfig) or to LD_LIBRARY_PATH.");
+            }
+
+            return (false, $"{label} was found in {dir} but could not be loaded even by full path, "
+                         + "which usually means one of its own dependencies is missing.");
+        }
+
+        return (false, absentNote);
     }
 
     /// <summary>Returns the configured CUDA toolkit root for the current platform, or null if none is known.</summary>
@@ -181,24 +266,53 @@ public static class HardwareInfo
     // ── cuDNN ─────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// True if the platform's cuDNN runtime library can be found.
+    /// True if cuDNN can actually be loaded.
     /// </summary>
-    public static bool IsCudnnInstalled()
+    public static bool IsCudnnInstalled() => Probe.Cudnn;
+
+    /// <summary>Why the CUDA runtime could not be used, when the probe worked it out. Null when it
+    /// could. Readable by a UI, because a desktop app has no console to read stderr from.</summary>
+    public static string? CudaRuntimeNote => Probe.RuntimeNote;
+
+    /// <summary>Why cuDNN could not be used, when the probe worked it out. Kept apart from
+    /// <see cref="CudaRuntimeNote"/> so a cuDNN problem is never reported as the runtime's.</summary>
+    public static string? CudnnNote => Probe.CudnnNote;
+
+    /// <summary>Both notes, for a caller that just wants to say what is wrong.</summary>
+    public static string? CudaProbeNote
     {
-        if (OperatingSystem.IsWindows())
-            return _windowsCudaScan.Value.HasCudnn;
-
-        if (OperatingSystem.IsLinux())
+        get
         {
-            foreach (var dir in GetLinuxCudaLibraryDirs())
-            {
-                if (HasFile(dir, "libcudnn.so") || HasFile(dir, "libcudnn.so.*"))
-                    return true;
-            }
+            var notes = new[] { CudaRuntimeNote, CudnnNote }.Where(n => n is not null).ToArray();
+            return notes.Length == 0 ? null : string.Join(" ", notes);
         }
-
-        return false;
     }
+
+    /// <summary>
+    /// The explanation to give when the CUDA execution provider will not start, including whatever
+    /// the probe found. One place, because several call sites each threw their own version and only
+    /// one of them said anything useful.
+    /// </summary>
+    public static string CudaUnavailableMessage()
+    {
+        var note = CudaProbeNote;
+        return "Could not initialise the CUDA execution provider. This build links CUDA "
+            + $"{RequiredCudaMajor}, and an older CUDA runtime cannot load it, because the major "
+            + "version is part of the library name."
+            + (note is null ? " A missing driver, no visible GPU, or a CPU-only build of ONNX "
+                              + "Runtime will also report this." : $" {note}");
+    }
+
+    /// <summary>
+    /// Discard what the probe found, so the next question is asked afresh.
+    ///
+    /// ⚠ THE UI PROMISES THIS. The settings window's "Re-check" button, and the help text
+    /// describing it, say detection re-runs without restarting the application -- which a
+    /// process-lifetime cache silently broke. Installing cuDNN or running ldconfig while the app is
+    /// open is exactly when someone presses it. (An LD_LIBRARY_PATH change still needs a restart:
+    /// the loader read it at process start.)
+    /// </summary>
+    public static void InvalidateCudaProbes() => Volatile.Write(ref _probe, null);
 
     /// <summary>
     /// True when the current machine appears capable of initializing CUDA execution:
@@ -385,36 +499,34 @@ public static class HardwareInfo
     /// (roots to scan), these are the leaf directories to register with AddDllDirectory so an
     /// MSIX-packaged onnxruntime can locate the CUDA EP's dependencies at load time.
     /// </summary>
-    public static IReadOnlyCollection<string> GetWindowsCudaDllDirectories() =>
-        _windowsCudaScan.Value.DllDirectories;
+    public static IReadOnlyCollection<string> GetWindowsCudaDllDirectories() => Probe.DllDirectories;
+
 
     /// <summary>
-    /// Result of a single recursive scan of the Windows CUDA/cuDNN search roots:
-    /// whether the Toolkit runtime (cudart) and cuDNN are present, and the leaf
-    /// directories holding the runtime DLLs the CUDA execution provider needs.
+    /// Windows: which directories hold a CUDA of the major this build needs, and whether cuDNN is
+    /// among them.
+    ///
+    /// ⚠ TWO cuDNN LAYOUTS ARE BOTH LEGITIMATE, AND A RULE THAT SUITS ONE BREAKS THE OTHER:
+    ///
+    ///   • NVIDIA's standalone tree, C:\Program Files\NVIDIA\CUDNN\v9.x\bin\13.0\, holds
+    ///     cudnn64_9.dll and nothing else. Requiring a cudart beside it drops this one.
+    ///   • The documented copy-into-the-toolkit install puts cudnn64_9.dll in &lt;toolkit&gt;\bin, while
+    ///     CUDA 13 puts its runtime DLLs in &lt;toolkit&gt;\bin\x64. Requiring the SAME directory as
+    ///     cudart drops this one.
+    ///
+    /// So a cuDNN directory qualifies when it names the CUDA version itself, or when it belongs to
+    /// a toolkit whose runtime is the major we need. Nothing else does -- a cuDNN left behind in an
+    /// older toolkit is not a cuDNN we can use, and its directory must not join the search path
+    /// either, since the provider would load the wrong major from it.
     /// </summary>
-    private sealed record WindowsCudaScan(
-        bool HasCudart,
-        bool HasCudnn,
-        IReadOnlyCollection<string> DllDirectories);
-
-    // Toolkit / cuDNN presence is fixed for the lifetime of the process (installs don't
-    // appear or vanish mid-run), and CanProbeCudaExecutionProvider fans this query out
-    // across every ONNX model-init site — so the recursive scan is done once and cached,
-    // mirroring _bf16Cache below. A newly-installed CUDA is picked up on next launch.
-    private static readonly Lazy<WindowsCudaScan> _windowsCudaScan = new(ScanWindowsCuda);
-
-    private static WindowsCudaScan ScanWindowsCuda()
+    private static CudaProbeResult ProbeWindows()
     {
-        var dllDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (!OperatingSystem.IsWindows())
-            return new WindowsCudaScan(false, false, dllDirs);
+            return new CudaProbeResult(false, false, null, null, Array.Empty<string>());
 
-        // Bounded recursion: the DLLs sit at most ~2 levels below a search root
-        // (Toolkit bin\x64, cuDNN bin\<cuda>\). Capping depth + ignoring inaccessible
-        // and reparse-point dirs keeps an over-broad PATH root (e.g. one whose name merely
-        // contains "cuda") from triggering an unbounded walk or aborting on a single
-        // permission error mid-enumeration.
+        // Bounded recursion: the DLLs sit at most ~2 levels below a search root (Toolkit bin\x64,
+        // cuDNN bin\<cuda>). Capping depth and skipping inaccessible or reparse-point directories
+        // keeps an over-broad PATH root from triggering an unbounded walk.
         var options = new EnumerationOptions
         {
             RecurseSubdirectories = true,
@@ -425,7 +537,11 @@ public static class HardwareInfo
                                   | FileAttributes.System,
         };
 
-        bool hasCudart = false, hasCudnn = false;
+        var cudartDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var otherDeps  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var cudnnDirs  = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var anyCudart  = false;
+        var anyCudnn   = false;
 
         foreach (var root in GetWindowsCudaSearchRoots())
         {
@@ -434,27 +550,85 @@ public static class HardwareInfo
                 foreach (var file in Directory.EnumerateFiles(root, "*.dll", options))
                 {
                     var name = Path.GetFileName(file);
-                    bool isCudart = name.StartsWith("cudart64_", StringComparison.OrdinalIgnoreCase);
-                    bool isCudnn  = name.StartsWith("cudnn",     StringComparison.OrdinalIgnoreCase);
-                    bool isCudaDep = isCudart || isCudnn
-                        || name.StartsWith("cublas", StringComparison.OrdinalIgnoreCase)
-                        || name.StartsWith("cufft",  StringComparison.OrdinalIgnoreCase)
-                        || name.StartsWith("nvrtc",  StringComparison.OrdinalIgnoreCase);
+                    var dir = Path.GetDirectoryName(file);
+                    if (string.IsNullOrEmpty(dir)) continue;
 
-                    if (isCudart) hasCudart = true;
-                    if (isCudnn)  hasCudnn  = true;
-                    if (isCudaDep)
+                    if (name.StartsWith("cudart64_", StringComparison.OrdinalIgnoreCase))
                     {
-                        var dir = Path.GetDirectoryName(file);
-                        if (!string.IsNullOrEmpty(dir))
-                            dllDirs.Add(dir);
+                        anyCudart = true;
+                        if (name.StartsWith($"cudart64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase))
+                            cudartDirs.Add(dir);
+                    }
+                    else if (name.StartsWith("cudnn", StringComparison.OrdinalIgnoreCase))
+                    {
+                        anyCudnn = true;
+                        cudnnDirs.Add(dir);
+                    }
+                    // cuFFT and cuRAND version independently of the CUDA major (CUDA 12 ships cuFFT
+                    // 11, CUDA 13 ships 12), so they cannot identify a directory; these can.
+                    else if (name.StartsWith($"cublas64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith($"cublasLt64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase)
+                          || name.StartsWith($"nvrtc64_{RequiredCudaMajor}", StringComparison.OrdinalIgnoreCase))
+                    {
+                        otherDeps.Add(dir);
                     }
                 }
             }
             catch { }
         }
 
-        return new WindowsCudaScan(hasCudart, hasCudnn, dllDirs);
+        var toolkitRoots = new HashSet<string>(cudartDirs.Select(ToolkitRootOf), StringComparer.OrdinalIgnoreCase);
+        var usableCudnn = cudnnDirs.Where(d => NamesRequiredMajor(d) || toolkitRoots.Contains(ToolkitRootOf(d)))
+                                   .ToList();
+
+        var dllDirs = new HashSet<string>(cudartDirs, StringComparer.OrdinalIgnoreCase);
+        foreach (var d in otherDeps) dllDirs.Add(d);
+        foreach (var d in usableCudnn) dllDirs.Add(d);
+
+        var runtime = cudartDirs.Count > 0;
+        var cudnn = usableCudnn.Count > 0;
+
+        var runtimeNote = runtime ? null
+            : anyCudart
+                ? $"A CUDA runtime was found, but not CUDA {RequiredCudaMajor}, which this build links. "
+                  + $"Install the CUDA {RequiredCudaMajor} runtime."
+                : $"No CUDA {RequiredCudaMajor} runtime was found.";
+        var cudnnNote = cudnn ? null
+            : anyCudnn
+                ? $"cuDNN was found, but not one belonging to a CUDA {RequiredCudaMajor} install, so "
+                  + "the CUDA execution provider cannot load it."
+                : "No cuDNN was found. The CUDA execution provider needs cuDNN 9 built for CUDA "
+                  + $"{RequiredCudaMajor}.";
+
+        return new CudaProbeResult(runtime, cudnn, runtimeNote, cudnnNote, dllDirs);
+    }
+
+    /// <summary>True when a path segment names the CUDA version we need, as the standalone cuDNN
+    /// tree does (…\CUDNN\v9.x\bin\13.0\).</summary>
+    internal static bool NamesRequiredMajor(string dir) =>
+        dir.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+           .Any(seg => seg == RequiredCudaMajor.ToString()
+                    || seg.StartsWith($"{RequiredCudaMajor}.", StringComparison.Ordinal));
+
+    /// <summary>
+    /// The install a directory belongs to: the parent of its `bin`, so &lt;toolkit&gt;\bin and
+    /// &lt;toolkit&gt;\bin\x64 resolve to the same root and cuDNN copied into the toolkit is
+    /// recognised as belonging to the CUDA there.
+    /// </summary>
+    internal static string ToolkitRootOf(string dir)
+    {
+        for (var d = dir; !string.IsNullOrEmpty(d); d = Path.GetDirectoryName(d) ?? "")
+        {
+            if (string.Equals(Path.GetFileName(d), "bin", StringComparison.OrdinalIgnoreCase))
+                return Path.GetDirectoryName(d) ?? d;
+        }
+        return dir;
+    }
+
+    private static IEnumerable<string> SafeGetFiles(string dir, string pattern)
+    {
+        try { return Directory.Exists(dir) ? Directory.GetFiles(dir, pattern) : Array.Empty<string>(); }
+        catch { return Array.Empty<string>(); }
     }
 
     private static IEnumerable<string> SafeGetDirectories(string parent, string pattern)
@@ -468,15 +642,4 @@ public static class HardwareInfo
         catch { return Array.Empty<string>(); }
     }
 
-    private static bool HasFile(string dir, string pattern)
-    {
-        try
-        {
-            return Directory.Exists(dir) && Directory.GetFiles(dir, pattern).Length > 0;
-        }
-        catch
-        {
-            return false;
-        }
-    }
 }

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -75,7 +75,9 @@ public static class OrtSessionBuilder
                 catch (Exception ex)
                 {
                     throw new InvalidOperationException(
-                        "CUDA EP not available in the current ONNX Runtime build.", ex);
+                        HardwareInfo.CudaUnavailableMessage()
+                        + " Run on the CPU instead with the application's Cpu execution-provider "
+                        + "setting, or build with -p:EP=Cpu.", ex);
                 }
                 break;
 

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -72,6 +72,14 @@ public static class OrtSessionBuilder
                     AppendCuda(opts, disableTf32);
                     usedCuda = true;
                 }
+                // ⚠ BEFORE THE BROAD CATCH. EntryPointNotFoundException means the binary has no
+                // CUDA provider in it, and it would otherwise be handed the probe's note -- telling
+                // someone to install cuDNN when nothing they install can add a provider.
+                catch (EntryPointNotFoundException ex)
+                {
+                    throw new InvalidOperationException(
+                        HardwareInfo.CudaUnavailableMessage(providerMissing: true), ex);
+                }
                 catch (Exception ex)
                 {
                     throw new InvalidOperationException(

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -69,7 +69,7 @@ public sealed class SortformerStreamer : IDisposable
             case ExecutionProvider.Cuda:
                 try { opts.AppendExecutionProvider_CUDA(0); }
                 catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage()); }
+                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
                 break;
             case ExecutionProvider.DirectML:
                 try { opts.AppendExecutionProvider_DML(0); }

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -69,7 +69,7 @@ public sealed class SortformerStreamer : IDisposable
             case ExecutionProvider.Cuda:
                 try { opts.AppendExecutionProvider_CUDA(0); }
                 catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException("CUDA EP not available in current OnnxRuntime build."); }
+                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage()); }
                 break;
             case ExecutionProvider.DirectML:
                 try { opts.AppendExecutionProvider_DML(0); }

--- a/src/Vernacula.Base/VoxLinguaLid.cs
+++ b/src/Vernacula.Base/VoxLinguaLid.cs
@@ -303,7 +303,7 @@ public sealed class VoxLinguaLid : IDisposable
             case ExecutionProvider.Cuda:
                 try { opts.AppendExecutionProvider_CUDA(0); }
                 catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException("CUDA EP not available."); }
+                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage()); }
                 break;
             case ExecutionProvider.DirectML:
                 try { opts.AppendExecutionProvider_DML(0); }

--- a/src/Vernacula.Base/VoxLinguaLid.cs
+++ b/src/Vernacula.Base/VoxLinguaLid.cs
@@ -303,7 +303,7 @@ public sealed class VoxLinguaLid : IDisposable
             case ExecutionProvider.Cuda:
                 try { opts.AppendExecutionProvider_CUDA(0); }
                 catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage()); }
+                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
                 break;
             case ExecutionProvider.DirectML:
                 try { opts.AppendExecutionProvider_DML(0); }

--- a/tests/Vernacula.Tests/CudaDetectionTests.cs
+++ b/tests/Vernacula.Tests/CudaDetectionTests.cs
@@ -4,53 +4,18 @@ using Vernacula.Base;
 namespace Vernacula.Tests;
 
 /// <summary>
-/// The path rules behind Windows CUDA detection. They exist because two cuDNN layouts are both
-/// legitimate and a rule that suits one breaks the other — which is exactly how earlier attempts
-/// at this failed, each time on the layout the previous fix had not considered.
+/// What CUDA detection promises: an answer about the major this build actually links, and a reason
+/// whenever the answer is no.
 /// </summary>
 public class CudaDetectionTests
 {
-    private static string P(params string[] parts) => string.Join(System.IO.Path.DirectorySeparatorChar, parts);
-
     [Fact]
-    public void StandaloneCudnnTreeNamesTheCudaVersionInItsPath()
+    public void TheRequiredMajorsAreWhatOnnxRuntime129Links()
     {
-        // C:\Program Files\NVIDIA\CUDNN\v9.10\bin\13.0\ — holds cudnn64_9.dll and nothing else, so
-        // a rule that wants a cudart beside it would drop the whole install.
-        Assert.True(HardwareInfo.NamesRequiredMajor(P("C:", "Program Files", "NVIDIA", "CUDNN", "v9.10", "bin", "13.0")));
-        Assert.True(HardwareInfo.NamesRequiredMajor(P("opt", "cudnn", "13")));
-    }
-
-    [Fact]
-    public void ACudnnTreeForAnotherCudaIsNotOurs()
-    {
-        Assert.False(HardwareInfo.NamesRequiredMajor(P("C:", "Program Files", "NVIDIA", "CUDNN", "v9.10", "bin", "12.8")));
-        Assert.False(HardwareInfo.NamesRequiredMajor(P("C:", "Program Files", "NVIDIA", "CUDNN", "v9.10", "bin")));
-    }
-
-    [Fact]
-    public void ToolkitBinAndItsX64SubdirectoryAreTheSameInstall()
-    {
-        // The other legitimate layout: cuDNN copied into <toolkit>\bin, while CUDA 13 keeps its
-        // runtime DLLs in <toolkit>\bin\x64. A rule requiring the same directory drops this one.
-        var toolkit = P("C:", "Program Files", "NVIDIA GPU Computing Toolkit", "CUDA", "v13.0");
-        Assert.Equal(toolkit, HardwareInfo.ToolkitRootOf(P(toolkit, "bin")));
-        Assert.Equal(toolkit, HardwareInfo.ToolkitRootOf(P(toolkit, "bin", "x64")));
-    }
-
-    [Fact]
-    public void SeparateToolkitsDoNotShareARoot()
-    {
-        var v13 = P("C:", "CUDA", "v13.0", "bin", "x64");
-        var v12 = P("C:", "CUDA", "v12.8", "bin");
-        Assert.NotEqual(HardwareInfo.ToolkitRootOf(v13), HardwareInfo.ToolkitRootOf(v12));
-    }
-
-    [Fact]
-    public void ADirectoryWithNoBinSegmentIsItsOwnRoot()
-    {
-        var loose = P("C:", "some", "place");
-        Assert.Equal(loose, HardwareInfo.ToolkitRootOf(loose));
+        // The provider names these in its own dependencies: libcudart.so.13 and libcudnn.so.9.
+        // If a future runtime moves either, these constants are the one place to change.
+        Assert.Equal(13, HardwareInfo.RequiredCudaMajor);
+        Assert.Equal(9, HardwareInfo.RequiredCudnnMajor);
     }
 
     [Fact]
@@ -60,24 +25,36 @@ public class CudaDetectionTests
         if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
             Assert.Skip("CUDA detection only applies to Windows and Linux.");
 
-        // Whatever this machine has, the invariant holds: a false answer carries a reason, and a
-        // true one does not need one. This is what a settings window shows the user.
         HardwareInfo.InvalidateCudaProbes();
         var runtime = HardwareInfo.IsCudaToolkitInstalled();
         var cudnn = HardwareInfo.IsCudnnInstalled();
 
+        // A "no" always carries a reason a user can act on; a "yes" needs none.
         Assert.Equal(runtime, HardwareInfo.CudaRuntimeNote is null);
         Assert.Equal(cudnn, HardwareInfo.CudnnNote is null);
-        Assert.Contains($"CUDA {HardwareInfo.RequiredCudaMajor}", HardwareInfo.CudaUnavailableMessage());
     }
 
     [Fact]
-    public void ACudnnFromAnotherMajorDoesNotQualify()
+    public void TheMessageLeadsWithWhateverTheProbeFound()
     {
-        // Windows accepted any cudnn*.dll while Linux insisted on cuDNN 9. A cuDNN 8 copied into a
-        // CUDA 13 toolkit satisfies every path rule, so the major has to be checked on the name.
-        Assert.True(HardwareInfo.NamesRequiredMajor(P("opt", "cudnn", "13.0")));
-        Assert.False(HardwareInfo.NamesRequiredMajor(P("opt", "cudnn", "8")));
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
+            Assert.Skip("CUDA detection only applies to Windows and Linux.");
+
+        HardwareInfo.InvalidateCudaProbes();
+        var message = HardwareInfo.CudaUnavailableMessage();
+        var note = HardwareInfo.CudaProbeNote;
+
+        if (note is not null)
+        {
+            Assert.Contains(note, message);
+        }
+        else
+        {
+            // Both halves checked out, so the major version is not the likely cause and must not be
+            // blamed: the message should point at the driver, the GPU, or the build instead.
+            Assert.Contains("driver", message);
+            Assert.DoesNotContain("older CUDA runtime cannot load it", message);
+        }
     }
 
     [Fact]

--- a/tests/Vernacula.Tests/CudaDetectionTests.cs
+++ b/tests/Vernacula.Tests/CudaDetectionTests.cs
@@ -1,0 +1,77 @@
+using Xunit;
+using Vernacula.Base;
+
+namespace Vernacula.Tests;
+
+/// <summary>
+/// The path rules behind Windows CUDA detection. They exist because two cuDNN layouts are both
+/// legitimate and a rule that suits one breaks the other — which is exactly how earlier attempts
+/// at this failed, each time on the layout the previous fix had not considered.
+/// </summary>
+public class CudaDetectionTests
+{
+    private static string P(params string[] parts) => string.Join(System.IO.Path.DirectorySeparatorChar, parts);
+
+    [Fact]
+    public void StandaloneCudnnTreeNamesTheCudaVersionInItsPath()
+    {
+        // C:\Program Files\NVIDIA\CUDNN\v9.10\bin\13.0\ — holds cudnn64_9.dll and nothing else, so
+        // a rule that wants a cudart beside it would drop the whole install.
+        Assert.True(HardwareInfo.NamesRequiredMajor(P("C:", "Program Files", "NVIDIA", "CUDNN", "v9.10", "bin", "13.0")));
+        Assert.True(HardwareInfo.NamesRequiredMajor(P("opt", "cudnn", "13")));
+    }
+
+    [Fact]
+    public void ACudnnTreeForAnotherCudaIsNotOurs()
+    {
+        Assert.False(HardwareInfo.NamesRequiredMajor(P("C:", "Program Files", "NVIDIA", "CUDNN", "v9.10", "bin", "12.8")));
+        Assert.False(HardwareInfo.NamesRequiredMajor(P("C:", "Program Files", "NVIDIA", "CUDNN", "v9.10", "bin")));
+    }
+
+    [Fact]
+    public void ToolkitBinAndItsX64SubdirectoryAreTheSameInstall()
+    {
+        // The other legitimate layout: cuDNN copied into <toolkit>\bin, while CUDA 13 keeps its
+        // runtime DLLs in <toolkit>\bin\x64. A rule requiring the same directory drops this one.
+        var toolkit = P("C:", "Program Files", "NVIDIA GPU Computing Toolkit", "CUDA", "v13.0");
+        Assert.Equal(toolkit, HardwareInfo.ToolkitRootOf(P(toolkit, "bin")));
+        Assert.Equal(toolkit, HardwareInfo.ToolkitRootOf(P(toolkit, "bin", "x64")));
+    }
+
+    [Fact]
+    public void SeparateToolkitsDoNotShareARoot()
+    {
+        var v13 = P("C:", "CUDA", "v13.0", "bin", "x64");
+        var v12 = P("C:", "CUDA", "v12.8", "bin");
+        Assert.NotEqual(HardwareInfo.ToolkitRootOf(v13), HardwareInfo.ToolkitRootOf(v12));
+    }
+
+    [Fact]
+    public void ADirectoryWithNoBinSegmentIsItsOwnRoot()
+    {
+        var loose = P("C:", "some", "place");
+        Assert.Equal(loose, HardwareInfo.ToolkitRootOf(loose));
+    }
+
+    [Fact]
+    public void TheProbeAnswersAndSaysWhyWhenItSaysNo()
+    {
+        // Whatever this machine has, the invariant holds: a false answer carries a reason, and a
+        // true one does not need one. This is what a settings window shows the user.
+        HardwareInfo.InvalidateCudaProbes();
+        var runtime = HardwareInfo.IsCudaToolkitInstalled();
+        var cudnn = HardwareInfo.IsCudnnInstalled();
+
+        Assert.Equal(runtime, HardwareInfo.CudaRuntimeNote is null);
+        Assert.Equal(cudnn, HardwareInfo.CudnnNote is null);
+        Assert.Contains($"CUDA {HardwareInfo.RequiredCudaMajor}", HardwareInfo.CudaUnavailableMessage());
+    }
+
+    [Fact]
+    public void InvalidatingMakesTheNextAnswerFresh()
+    {
+        var before = HardwareInfo.IsCudaToolkitInstalled();
+        HardwareInfo.InvalidateCudaProbes();
+        Assert.Equal(before, HardwareInfo.IsCudaToolkitInstalled());   // same machine, same answer
+    }
+}

--- a/tests/Vernacula.Tests/CudaDetectionTests.cs
+++ b/tests/Vernacula.Tests/CudaDetectionTests.cs
@@ -58,6 +58,21 @@ public class CudaDetectionTests
     }
 
     [Fact]
+    public void ADownloadIsOnlyOfferedForSomethingActuallyMissing()
+    {
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
+            Assert.Skip("CUDA detection only applies to Windows and Linux.");
+
+        HardwareInfo.InvalidateCudaProbes();
+
+        // "Present" is the weaker claim, so a usable install is necessarily present. The gap
+        // between them — present but unusable — is where a download link would contradict the note
+        // telling the user the library is already there.
+        if (HardwareInfo.IsCudaToolkitInstalled()) Assert.True(HardwareInfo.IsCudaRuntimePresent);
+        if (HardwareInfo.IsCudnnInstalled()) Assert.True(HardwareInfo.IsCudnnPresent);
+    }
+
+    [Fact]
     public void InvalidatingReallyThrowsTheAnswerAway()
     {
         // Asserting only that the answer is stable would pass for a cache that never refreshes at

--- a/tests/Vernacula.Tests/CudaDetectionTests.cs
+++ b/tests/Vernacula.Tests/CudaDetectionTests.cs
@@ -56,6 +56,10 @@ public class CudaDetectionTests
     [Fact]
     public void TheProbeAnswersAndSaysWhyWhenItSaysNo()
     {
+        // Only Windows and Linux are probed at all; elsewhere there is nothing to explain.
+        if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux())
+            Assert.Skip("CUDA detection only applies to Windows and Linux.");
+
         // Whatever this machine has, the invariant holds: a false answer carries a reason, and a
         // true one does not need one. This is what a settings window shows the user.
         HardwareInfo.InvalidateCudaProbes();
@@ -65,6 +69,15 @@ public class CudaDetectionTests
         Assert.Equal(runtime, HardwareInfo.CudaRuntimeNote is null);
         Assert.Equal(cudnn, HardwareInfo.CudnnNote is null);
         Assert.Contains($"CUDA {HardwareInfo.RequiredCudaMajor}", HardwareInfo.CudaUnavailableMessage());
+    }
+
+    [Fact]
+    public void ACudnnFromAnotherMajorDoesNotQualify()
+    {
+        // Windows accepted any cudnn*.dll while Linux insisted on cuDNN 9. A cuDNN 8 copied into a
+        // CUDA 13 toolkit satisfies every path rule, so the major has to be checked on the name.
+        Assert.True(HardwareInfo.NamesRequiredMajor(P("opt", "cudnn", "13.0")));
+        Assert.False(HardwareInfo.NamesRequiredMajor(P("opt", "cudnn", "8")));
     }
 
     [Fact]

--- a/tests/Vernacula.Tests/CudaDetectionTests.cs
+++ b/tests/Vernacula.Tests/CudaDetectionTests.cs
@@ -53,7 +53,7 @@ public class CudaDetectionTests
             // Both halves checked out, so the major version is not the likely cause and must not be
             // blamed: the message should point at the driver, the GPU, or the build instead.
             Assert.Contains("driver", message);
-            Assert.DoesNotContain("older CUDA runtime cannot load it", message);
+            Assert.DoesNotContain("cannot load it", message);   // the major must not be blamed here
         }
     }
 

--- a/tests/Vernacula.Tests/CudaDetectionTests.cs
+++ b/tests/Vernacula.Tests/CudaDetectionTests.cs
@@ -81,10 +81,16 @@ public class CudaDetectionTests
     }
 
     [Fact]
-    public void InvalidatingMakesTheNextAnswerFresh()
+    public void InvalidatingReallyThrowsTheAnswerAway()
     {
+        // Asserting only that the answer is stable would pass for a cache that never refreshes at
+        // all, which is the bug this exists to prevent: Re-check has to re-check.
         var before = HardwareInfo.IsCudaToolkitInstalled();
+        var generation = HardwareInfo.ProbeGeneration;
+
         HardwareInfo.InvalidateCudaProbes();
+
+        Assert.True(HardwareInfo.ProbeGeneration > generation, "invalidation must discard the cached probe");
         Assert.Equal(before, HardwareInfo.IsCudaToolkitInstalled());   // same machine, same answer
     }
 }

--- a/tests/Vernacula.Tests/CudaDetectionTests.cs
+++ b/tests/Vernacula.Tests/CudaDetectionTests.cs
@@ -7,6 +7,12 @@ namespace Vernacula.Tests;
 /// What CUDA detection promises: an answer about the major this build actually links, and a reason
 /// whenever the answer is no.
 /// </summary>
+/// <remarks>
+/// ⚠ NOT IN PARALLEL WITH ANYTHING. These call InvalidateCudaProbes, which swaps caches shared by
+/// the whole assembly; another test reading SupportsBf16Acceleration at the same moment would see
+/// one being torn down.
+/// </remarks>
+[Collection("CudaProbe")]
 public class CudaDetectionTests
 {
     [Fact]


### PR DESCRIPTION
Closes #119.

ONNX Runtime 1.29 (#118) links CUDA 13, and nothing in startup detection knew it. A CUDA 12 machine reported CUDA present, the provider failed to load, `OrtSessionBuilder` swallowed the failure, and the app ran on the CPU with nothing said. Three attempts to fix this inside the dependency bump drew review findings — two of them regressions — so it was split out to be done on its own.

## The major is checked where it is knowable

`cudart64_13.dll` / `libcudart.so.13` name their CUDA, so that is what detection keys on. **`cudnn64_9.dll` does not** — it is called that whether it was built for CUDA 12 or 13, and no rule over file names or directory layout can tell them apart. An earlier draft of this PR inferred it from the directory (a cuDNN counted only if its path named the CUDA version, or it sat under the same toolkit as a matching cudart), which rejected the commonest Windows install there is: unzip cuDNN to `C:\cudnn` and put it on PATH. Being strict about something unknowable cost a working configuration and bought nothing.

So cuDNN is answered the same way on both platforms — is a cuDNN of the required major present — and the residual limit is stated rather than papered over: a cuDNN built for the wrong CUDA gets past detection and fails at provider init.

## Linux asks the loader, not the filesystem

The provider `dlopen`s by soname, so the question is whether the loader can open `libcudart.so.13`. A side-by-side CUDA 13 that is not in the ldconfig cache or on `LD_LIBRARY_PATH` is a file we can see and the provider cannot — and answering "installed" for it is what lands the user on the CPU with no explanation. Where that is the case, the probe says so, because the fix is one `ldconfig` line.

It looks rather than loads: loading a candidate by full path would register it under its soname for the life of the process, so the *next* Re-check would find it by name and quietly drop the advice the first one gave.

## The reason reaches the user

A desktop app has no console, so the note is a property the settings window binds and `cuda_debug.txt` records — a CUDA of the wrong major, a library present but off the loader path, no cuDNN at all. The runtime reason and the cuDNN reason are kept apart, so a cuDNN problem is never reported as the runtime's, and the four strict-mode failure sites share one message instead of three of them throwing a bare "CUDA EP not available". Where the probe has nothing to say — both halves present, provider still failing — the message points at the driver, an invisible GPU, or a CPU-only build instead of blaming the major version.

`CheckCuda` now returns a summary for the label and writes the full exception dump to the log, rather than handing a stack trace to a 12px `TextBlock`.

## Caching that Re-check can actually clear

One probe, computed under a `Lazy` with `ExecutionAndPublication` so five parallel model-init sites do not each run the Windows directory walk, and swapped wholesale on invalidation. Only the Re-check button invalidates — opening the settings window reads what is known. Invalidation also clears `SupportsBf16Acceleration`, which is derived from it and decides which model bundle loads; when that answer changes, the model verdicts are recomputed so the window cannot show two disagreeing states.

## Verification

Solution builds clean; 26 tests in `Vernacula.Tests`, 138 + 4 skipped in `Vernacula.Tts.Tests`. On this machine (CUDA 13.3 on the loader path, cuDNN 9): both detected, no notes, which is the correct answer.

**Not verifiable here:** the Windows paths. This box is Linux. The Windows probe is straightforward now — find `cudart64_13.dll`, find `cudnn64_9.dll`, collect the directories of libraries that name the major — but it has not been run on Windows, and that is worth doing before trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc



## What is verified, and what is not

Ten review rounds. Worth being precise about which half of this has actually been executed.

**Verified on this machine (Linux, CUDA 12.8 + 13.3, cuDNN 9, RTX 3090):** the runtime and cuDNN probes, the notes they produce, the messages every failure path builds, cache invalidation, and that a correct install reports correctly with no spurious note. 27 tests in `Vernacula.Tests`, 138 + 4 skipped in `Vernacula.Tts.Tests`, solution builds clean.

**Not executed anywhere:** the Windows probe, the DLL search-path registration, and the settings-window rendering. The Windows logic is simple — find `cudart64_13.dll`, find `cudnn64_9.dll`, collect the directories of libraries that name the major, order them — but it has been written and revised entirely by reading, and the last four review rounds found real logic gaps in it each time. Someone should run it on Windows with a CUDA 12 + CUDA 13 machine before it is trusted; the failure mode if it is wrong is the one it exists to fix, a silent fall back to CPU.

Remaining known gap, recorded on #119: pressing Re-check during a Granite Speech model load can flip the active bundle between component loads.
