### PR TITLE
fix(build): stop building every referenced project twice

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,10 +58,18 @@
        regard to case, so a reference written `EP=directml` would still pin the child to 1.24.4
        while slipping past a case-sensitive check. EP can also be overridden through Properties or
        AdditionalProperties just as well as SetConfiguration, the last of which is the mechanism
-       this very file uses above. -->
+       this very file uses above. All three arms match EP=DIRECTML rather than the bare word, so a
+       genuine configuration name that happens to contain it (DirectMLDebug) is not rejected.
+
+       ⚠ ONE HOLE REMAINS, DELIBERATELY UNGUARDED. Under a DirectML parent this target is off, and
+       the propagation it relies on rides on AdditionalProperties, which UndefineProperties or
+       GlobalPropertiesToRemove on a reference can strip. Such a reference would silently unpin the
+       child back to 1.29.0 and surface as an API-version throw at the first session. None exists;
+       guarding it needs a second target for the DirectML case, which is not worth carrying until
+       something wants it. -->
   <Target Name="RejectUnguardedDirectMlReference"
           Condition="'$(EP)' != 'DirectML'">
-    <Error Condition="$([System.String]::Copy('%(ProjectReference.SetConfiguration)').ToUpperInvariant().Contains('DIRECTML'))
+    <Error Condition="$([System.String]::Copy('%(ProjectReference.SetConfiguration)').ToUpperInvariant().Contains('EP=DIRECTML'))
                    OR $([System.String]::Copy('%(ProjectReference.Properties)').ToUpperInvariant().Contains('EP=DIRECTML'))
                    OR $([System.String]::Copy('%(ProjectReference.AdditionalProperties)').ToUpperInvariant().Contains('EP=DIRECTML'))"
            Text="%(ProjectReference.Identity) overrides its execution provider to DirectML while this project builds as EP=$(EP). The referenced project would resolve a different ONNX Runtime version than the native shipped beside it. Widen the OnnxRuntimeVersion propagation in Directory.Build.props to cover this case before adding such a reference." />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,12 +34,30 @@
        reference overriding EP could otherwise pair a 1.24.4 native with a 1.29 managed assembly.
        (In a SOLUTION build MSBuild pins every project to the solution's configuration and ignores
        SetConfiguration entirely, so nothing diverges there; the hazard is a direct project build.)
-       Everyday Cuda and Cpu builds now add no properties, and build each project once. -->
+       Everyday Cuda and Cpu builds now add no properties, and build each project once.
+
+       ⚠ TWO THINGS THIS DOES NOT COVER, both enforced or recorded rather than left to be
+       rediscovered:
+         - A reference overriding TO DirectML from a Cuda or Cpu parent would diverge with no
+           propagation to correct it. No such reference exists, and the target below fails the
+           build if one is added, rather than letting it surface as an API-version throw at the
+           first session.
+         - A DirectML solution build still builds each referenced project twice, because it still
+           passes the property. That is the same race, confined to the one EP CI does not run;
+           -m:1 is the workaround. Recorded on #121. -->
   <ItemDefinitionGroup Condition="'$(EP)' == 'DirectML'">
     <ProjectReference>
       <AdditionalProperties>OnnxRuntimeVersion=$(OnnxRuntimeVersion)</AdditionalProperties>
     </ProjectReference>
   </ItemDefinitionGroup>
+
+  <!-- The other half of the scoping above: the propagation keys on the PARENT's EP, so a reference
+       that overrides a child TO DirectML would be unguarded. Rather than trust a comment, fail. -->
+  <Target Name="RejectUnguardedDirectMlReference" BeforeTargets="BeforeBuild"
+          Condition="'$(EP)' != 'DirectML'">
+    <Error Condition="$([System.String]::Copy('%(ProjectReference.SetConfiguration)').Contains('DirectML'))"
+           Text="%(ProjectReference.Identity) overrides its execution provider to DirectML while this project builds as EP=$(EP). The referenced project would resolve a different ONNX Runtime version than the native shipped beside it. Widen the OnnxRuntimeVersion propagation in Directory.Build.props to cover this case before adding such a reference." />
+  </Target>
 
   <!-- ⚠ AN UNRECOGNISED EP SILENTLY GIVES YOU THE CPU. Every package group is conditioned on a
        spelling, and a value matching none of them selects no GPU package: the build succeeds and

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,13 +23,19 @@
     <OnnxRuntimeVersion Condition="'$(OnnxRuntimeVersion)' == ''">1.29.0</OnnxRuntimeVersion>
   </PropertyGroup>
 
-  <!-- ⚠ A REFERENCED PROJECT MUST USE THE REFERENCING PROJECT'S VERSION. Eight projects override
-       EP on a ProjectReference, and SetConfiguration really does override EP in the inner build
-       (verified by having the inner build report it). Without this the referenced library would
-       evaluate this property from a DIFFERENT EP and compile against a different managed assembly
-       than the one shipped beside it. Passing the resolved version down keeps one output directory
-       to one version. -->
-  <ItemDefinitionGroup>
+  <!-- ⚠ ONLY WHERE THE VERSION CAN ACTUALLY DIVERGE, BECAUSE THIS COSTS A SECOND BUILD.
+       AdditionalProperties on a ProjectReference gives the referenced build a different global
+       property set from the solution-level build of the same project, so MSBuild builds it twice
+       into the same directory, and under -m the two writes race on deps.json. That was roughly
+       half of CI runs (#121).
+
+       It is only needed when a reference can compute a different version than its parent, which
+       happens for DirectML alone: that is the one EP whose ONNX Runtime version differs, and a
+       reference overriding EP could otherwise pair a 1.24.4 native with a 1.29 managed assembly.
+       (In a SOLUTION build MSBuild pins every project to the solution's configuration and ignores
+       SetConfiguration entirely, so nothing diverges there; the hazard is a direct project build.)
+       Everyday Cuda and Cpu builds now add no properties, and build each project once. -->
+  <ItemDefinitionGroup Condition="'$(EP)' == 'DirectML'">
     <ProjectReference>
       <AdditionalProperties>OnnxRuntimeVersion=$(OnnxRuntimeVersion)</AdditionalProperties>
     </ProjectReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project InitialTargets="RejectUnknownExecutionProvider;RejectDirectMlOffWindows;RejectCudaOffX64">
+<Project InitialTargets="RejectUnknownExecutionProvider;RejectDirectMlOffWindows;RejectCudaOffX64;RejectUnguardedDirectMlReference">
 
   <!--
     Repo-wide build guards. Kept here rather than copied into each csproj so a new project cannot
@@ -52,10 +52,18 @@
   </ItemDefinitionGroup>
 
   <!-- The other half of the scoping above: the propagation keys on the PARENT's EP, so a reference
-       that overrides a child TO DirectML would be unguarded. Rather than trust a comment, fail. -->
-  <Target Name="RejectUnguardedDirectMlReference" BeforeTargets="BeforeBuild"
+       that overrides a child TO DirectML would be unguarded. Rather than trust a comment, fail.
+
+       ⚠ CASE-INSENSITIVE, AND ACROSS ALL THREE WAYS TO SET IT. MSBuild compares conditions without
+       regard to case, so a reference written `EP=directml` would still pin the child to 1.24.4
+       while slipping past a case-sensitive check. EP can also be overridden through Properties or
+       AdditionalProperties just as well as SetConfiguration, the last of which is the mechanism
+       this very file uses above. -->
+  <Target Name="RejectUnguardedDirectMlReference"
           Condition="'$(EP)' != 'DirectML'">
-    <Error Condition="$([System.String]::Copy('%(ProjectReference.SetConfiguration)').Contains('DirectML'))"
+    <Error Condition="$([System.String]::Copy('%(ProjectReference.SetConfiguration)').ToUpperInvariant().Contains('DIRECTML'))
+                   OR $([System.String]::Copy('%(ProjectReference.Properties)').ToUpperInvariant().Contains('EP=DIRECTML'))
+                   OR $([System.String]::Copy('%(ProjectReference.AdditionalProperties)').ToUpperInvariant().Contains('EP=DIRECTML'))"
            Text="%(ProjectReference.Identity) overrides its execution provider to DirectML while this project builds as EP=$(EP). The referenced project would resolve a different ONNX Runtime version than the native shipped beside it. Widen the OnnxRuntimeVersion propagation in Directory.Build.props to cover this case before adding such a reference." />
   </Target>
 


### PR DESCRIPTION
Closes #121.

CI failed on roughly half of runs, always identically: two MSBuild processes writing `Vernacula.Base.deps.json` at the same time. **The cause was mine, from #118.**

## What was happening

Propagating `OnnxRuntimeVersion` through `AdditionalProperties` on *every* `ProjectReference` gives the referenced build a different global property set than the solution-level build of the same project. MSBuild treats that as a separate configuration and builds the project again — into the same output directory. Measured on `main`, by having each build report itself:

| | times `Vernacula.Base` is built |
| --- | --- |
| with the propagation | **2** |
| without it | **1** |

Both builds print an identical property set and an identical output path (`EP=Cpu Platform=x64 Config=Release TFM=net10.0 Ort=1.29.0 Out=bin/x64/Release/net10.0/`), so nothing separates their writes — under `-m` they race, and about half the time one loses.

## The fix

The propagation is only needed where a reference can compute a *different* version than its parent, and that is DirectML alone: the one EP whose ONNX Runtime version differs (1.24.4 against 1.29.0), where a reference overriding `EP` could pair a 1.24.4 native with a 1.29 managed assembly. It is scoped to that EP now, so everyday Cuda and Cpu builds add no properties and build each project once.

## A correction to #118

While tracing this I found that a claim in #118 is wrong in the case that matters most. I verified there that `<SetConfiguration>EP=Cuda</SetConfiguration>` really does override `EP` in the inner build — true, but only for a **direct project build**. In a **solution** build MSBuild pins every project to the solution's configuration and ignores `SetConfiguration` entirely, so those eight EP overrides do not take effect and no version can diverge. That is why scoping the propagation is safe: the case it protects is the direct project build, which is exactly where `SetConfiguration` does apply.

## Verification

- `Vernacula.Base` builds **once** under `-p:EP=Cpu` and once under `-p:EP=Cuda` (was twice).
- Three consecutive CI-shaped builds (`dotnet build Vernacula.slnx -p:EP=Cpu`, Debug, parallel) succeed.
- Both suites pass: 27 and 138 + 4 skipped.

The same race also explains a share of the local "file is being used by another process" failures that get blamed on a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc