### PR TITLE
chore(deps): Markdig 0.34.0 -> 1.3.2

### DIFF
--- a/docs/investigations/dependency_upgrade_investigation.md
+++ b/docs/investigations/dependency_upgrade_investigation.md
@@ -98,25 +98,53 @@ Every alert form tested diverges — `[!NOTE]`, `[!WARNING]`, and unknown kinds
 such as `[!FOO]`, which 1.x also strips. Plain quotes and `> [not an alert]`
 are unchanged.
 
+**Scope — top-level alerts only.** Markdig's `AlertParser` fires on a
+top-level quote. An alert indented under a list item is unchanged from 0.34.0:
+`- item one\n  > [!NOTE]\n  > body` still extracts as
+`item one\n\n[!NOTE] body` on both versions. GitHub *does* render that as an
+alert, so the two disagree, and a README whose install steps carry a
+`> [!WARNING]` under a numbered step still has the marker spoken while an
+identical marker two paragraphs earlier at top level is stripped. Pinned by a
+test rather than worked around: a future Markdig that closes the gap would
+shift offsets again, silently, for exactly the reason this run exists. Two
+related forms, measured and consistent with the above: `> [!NOTE] trailing`
+on one line is not an alert on either version (spec-correct), and a `> >`
+alert nested inside an alert is not stripped (`AllowNestedAlerts` off).
+
+An alert with an empty body (`> [!NOTE]` alone) is a third asymmetry: on
+1.3.2 it yields no text *and no `BlockSpan`*, where 0.34.0 gave one quote
+block containing `[!NOTE]`. The speech outcome is right, but a blockquote in
+the source now contributes nothing to the block index. Also pinned.
+
 **Implication.** The new behaviour is the one we want: the synthesizer no
-longer speaks "bracket bang NOTE bracket" when reading a README. But it moves
+longer speaks "bracket bang NOTE bracket" when reading a top-level alert. But it moves
 every output offset after an alert by the marker's length, so it is a
 behaviour change to land deliberately, not a silent one — and it is exactly
 the kind of thing that should be frozen by a test, since neither the build nor
 the 24 existing tests noticed. Nine tests added in
 `MarkdownTextExtractorTests.cs` (marker stripped for each of the five GitHub
-kinds and for an unknown kind; the quote block spans only the body; following
-text is not shifted; non-alert brackets survive). Seven of the nine fail
-against 0.34.0, which is the check that they pin the change rather than
-restate the parser.
+kinds and for an unknown kind; the block is still a `QuoteBlock` — which is
+what keeps the extractor's `case QuoteBlock` arm matching it — spanning
+exactly the body; following text is not shifted; non-alert brackets survive;
+and the two asymmetries above). Seven of the original nine fail against
+0.34.0, which is the check that they pin the change rather than restate the
+parser. The two that pass on both earn their place differently: one guards
+against over-broad future alert recognition, the other against `AlertBlock`
+being reparented away from `QuoteBlock`.
 
 **Method note for the next bump.** Diffing a corpus of what the code already
 handles only proves the old behaviour is intact. Ask separately what the new
 version *added* — for a Markdig-style bundle, diff the extension list of the
 built pipeline between versions, and write corpus cases for whatever appears.
-`MaximumNestingDepth`, `CjkFriendlyEmphasis`, `AllowDomainWithoutPeriod`,
-`AllowNestedAlerts` and `InferColumnWidthsFromSeparator` are also new in 1.x
-but are opt-in and verified off.
+`CjkFriendlyEmphasis`, `AllowDomainWithoutPeriod`, `AllowNestedAlerts` and
+`InferColumnWidthsFromSeparator` are also new in 1.x, and are opt-in and
+verified off. `MaximumNestingDepth` is new but *not* off — it defaults to 128.
+It is harmless for a different reason: 0.34.0 had the same limit as a
+hardcoded constant, and 1.x only made it configurable. Measured on both
+versions, 100 nested `>` parses and 130 throws the identical
+`ArgumentException`. Worth stating precisely, since this paragraph is the
+recipe for the next bump: "new option" and "changed behaviour" are not the
+same question.
 
 ## Open, not caused by any bump — `SourceStart` is wrong inside container continuation lines
 

--- a/docs/investigations/dependency_upgrade_investigation.md
+++ b/docs/investigations/dependency_upgrade_investigation.md
@@ -1,0 +1,53 @@
+# Dependency upgrade investigation
+
+A running log of the upgrade queue: what each bump was validated against, and
+what the raw output said. Entries are chronological.
+
+## Run 1 — 2026-09-05 — Markdig 0.34.0 → 1.3.2
+
+**Question.** The karaoke view maps highlight positions through
+`TextRange.OutputStart/OutputLength` and `SourceStart/SourceLength` from
+`MarkdownTextExtractor`. A major-version bump of the parser could shift source
+spans (block start offsets, inline delimiter inclusion) without failing a
+single test, because the 24 existing tests assert invariants on constructs they
+name rather than on a broad corpus. Does 1.3.2 produce the same extraction as
+0.34.0?
+
+**First finding, before running anything.** The pin comment in
+`Vernacula.Tts.Base.csproj` justified the version by "cf. Markdown.Avalonia →
+Markdig". That is wrong. `project.assets.json` shows Markdown.Avalonia 11.0.3
+pulling only its own sub-packages plus ColorTextBlock/ColorDocument, Avalonia,
+HtmlAgilityPack and Avalonia.AvaloniaEdit — no Markdig. It parses markdown with
+its own engine. The only Markdig in the graph is ours, from
+`Vernacula.Tts.Base` and `Vernacula.Avalonia`. The two pins still need to match
+each other, so the constraint survives; only the stated reason changed.
+
+**Command.** A throwaway console harness in the scratchpad referencing
+`Vernacula.Tts.Base` (with `ImportDirectoryBuildProps=false` so it doesn't
+inherit the EP guards), dumping `Text` plus every collection property of
+`MarkdownExtractionResult` — `Ranges` and `Blocks` — with full record
+formatting, over a corpus exercising: ATX and setext headings, bold/italic,
+inline code, links, backtick and tilde fences, an indented code block, tight
+and nested lists, an ordered list, a blockquote, a pipe table, a footnote
+reference and definition, an image, a two-space hard break, a raw HTML block,
+an autolink, an entity, a backslash escape, and a thematic break. Run once on
+`chore/markdig-1.3.2`, then `git stash` back to 0.34.0 and run again.
+
+```
+dotnet run --project <harness> -p:EP=Cpu -c Release -- corpus.md
+diff out-0.34.0.txt out-1.3.2.txt
+```
+
+**Raw finding.** `IDENTICAL` — byte-for-byte, text and every span. Notable
+values that held across both: inline code's source span covers the backticks
+while the output omits them (`OutputLength = 11, SourceLength = 13`), the link
+range covers the label only and skips the destination (source jumps 78→104
+across the URL), and fenced/indented code and table cells contribute no output
+text at all.
+
+**Implication.** No span-semantics change to absorb; the bump is a
+straight version change. The gap the exercise did expose was documentary, not
+behavioural, so the pin comment is corrected in the same branch. Nothing here
+argues for new tests — the corpus asserts equivalence between two versions, not
+a property worth freezing, and the 24 existing tests already cover the
+constructs by name.

--- a/docs/investigations/dependency_upgrade_investigation.md
+++ b/docs/investigations/dependency_upgrade_investigation.md
@@ -111,7 +111,7 @@ related forms, measured and consistent with the above: `> [!NOTE] trailing`
 on one line is not an alert on either version (spec-correct), and a `> >`
 alert nested inside an alert is not stripped (`AllowNestedAlerts` off).
 
-An alert with an empty body (`> [!NOTE]` alone) is a third asymmetry: on
+An alert with an empty body (`> [!NOTE]` alone) is the second asymmetry: on
 1.3.2 it yields no text *and no `BlockSpan`*, where 0.34.0 gave one quote
 block containing `[!NOTE]`. The speech outcome is right, but a blockquote in
 the source now contributes nothing to the block index. Also pinned.
@@ -121,16 +121,17 @@ longer speaks "bracket bang NOTE bracket" when reading a top-level alert. But it
 every output offset after an alert by the marker's length, so it is a
 behaviour change to land deliberately, not a silent one — and it is exactly
 the kind of thing that should be frozen by a test, since neither the build nor
-the 24 existing tests noticed. Nine tests added in
+the 24 existing tests noticed. Eleven tests added in
 `MarkdownTextExtractorTests.cs` (marker stripped for each of the five GitHub
 kinds and for an unknown kind; the block is still a `QuoteBlock` — which is
 what keeps the extractor's `case QuoteBlock` arm matching it — spanning
 exactly the body; following text is not shifted; non-alert brackets survive;
-and the two asymmetries above). Seven of the original nine fail against
-0.34.0, which is the check that they pin the change rather than restate the
-parser. The two that pass on both earn their place differently: one guards
-against over-broad future alert recognition, the other against `AlertBlock`
-being reparented away from `QuoteBlock`.
+and the two asymmetries above). Nine of the eleven fail against 0.34.0, which
+is the check that they pin the change rather than restate the parser. The two
+that pass on both are deliberately version-invariant: one guards against
+over-broad future alert recognition, the other pins the list-nesting gap
+described above, which is unchanged between the versions and is exactly what
+would notice a future Markdig closing it.
 
 **Method note for the next bump.** Diffing a corpus of what the code already
 handles only proves the old behaviour is intact. Ask separately what the new

--- a/docs/investigations/dependency_upgrade_investigation.md
+++ b/docs/investigations/dependency_upgrade_investigation.md
@@ -38,16 +38,93 @@ dotnet run --project <harness> -p:EP=Cpu -c Release -- corpus.md
 diff out-0.34.0.txt out-1.3.2.txt
 ```
 
-**Raw finding.** `IDENTICAL` — byte-for-byte, text and every span. Notable
+**Raw finding (superseded — see Run 2, which found this conclusion too
+narrow).** `IDENTICAL` — byte-for-byte, text and every span. Notable
 values that held across both: inline code's source span covers the backticks
 while the output omits them (`OutputLength = 11, SourceLength = 13`), the link
 range covers the label only and skips the destination (source jumps 78→104
 across the URL), and fenced/indented code and table cells contribute no output
 text at all.
 
-**Implication.** No span-semantics change to absorb; the bump is a
-straight version change. The gap the exercise did expose was documentary, not
-behavioural, so the pin comment is corrected in the same branch. Nothing here
-argues for new tests — the corpus asserts equivalence between two versions, not
-a property worth freezing, and the 24 existing tests already cover the
-constructs by name.
+**Implication (wrong — see Run 2).** Read at the time as "no span-semantics
+change to absorb; the bump is a straight version change", and as an argument
+that no new tests were needed. Both conclusions were drawn from a corpus that
+did not contain the one construct that moved. The corpus was written from the
+list of constructs the extractor already handles, which is exactly the wrong
+generator for a question about *new* parser behaviour: an extension added in
+1.x recognizes syntax that 0.34.0 saw as something else, so the construct at
+risk is by definition one the old version had no concept of.
+
+The documentary finding above stands: the pin comment is corrected in the same
+branch.
+
+## Run 2 — 2026-09-05 — the same bump, corpus extended to constructs 1.x newly recognizes
+
+**Question.** Run 1 asked "does the same input parse the same way", and got
+yes. The question it failed to ask: **did `UseAdvancedExtensions()` pick up new
+extensions in 1.x?** Both consumers call it bare —
+`MarkdownTextExtractor.cs:108` and `MarkdownFlowBuilder.cs:20` — so any
+extension added to that bundle is opted into silently.
+
+**Command.** A corpus of GitHub alert blockquotes through the same harness, on
+both versions:
+
+```
+> [!NOTE]
+> Useful information that users should know.
+
+> [!WARNING]
+> Careful.
+
+> plain quote
+> second line
+
+> [!FOO]
+> unknown kind
+```
+
+**Raw finding.** Not identical. Markdig 1.x adds `AlertExtension` to
+`UseAdvancedExtensions()`; `AlertBlock` subclasses `QuoteBlock` and consumes
+the `[!KIND]` marker into the block rather than leaving it as a
+`LiteralInline`.
+
+| | 0.34.0 | 1.3.2 |
+|---|---|---|
+| `Text` (first alert) | `[!NOTE] Useful information that users should know.` | `Useful information that users should know.` |
+| `Ranges` over the corpus | 11 | 5 |
+| first `BlockSpan` length | 50 | 42 |
+
+Every alert form tested diverges — `[!NOTE]`, `[!WARNING]`, and unknown kinds
+such as `[!FOO]`, which 1.x also strips. Plain quotes and `> [not an alert]`
+are unchanged.
+
+**Implication.** The new behaviour is the one we want: the synthesizer no
+longer speaks "bracket bang NOTE bracket" when reading a README. But it moves
+every output offset after an alert by the marker's length, so it is a
+behaviour change to land deliberately, not a silent one — and it is exactly
+the kind of thing that should be frozen by a test, since neither the build nor
+the 24 existing tests noticed. Nine tests added in
+`MarkdownTextExtractorTests.cs` (marker stripped for each of the five GitHub
+kinds and for an unknown kind; the quote block spans only the body; following
+text is not shifted; non-alert brackets survive). Seven of the nine fail
+against 0.34.0, which is the check that they pin the change rather than
+restate the parser.
+
+**Method note for the next bump.** Diffing a corpus of what the code already
+handles only proves the old behaviour is intact. Ask separately what the new
+version *added* — for a Markdig-style bundle, diff the extension list of the
+built pipeline between versions, and write corpus cases for whatever appears.
+`MaximumNestingDepth`, `CjkFriendlyEmphasis`, `AllowDomainWithoutPeriod`,
+`AllowNestedAlerts` and `InferColumnWidthsFromSeparator` are also new in 1.x
+but are opt-in and verified off.
+
+## Open, not caused by any bump — `SourceStart` is wrong inside container continuation lines
+
+Surfaced while reading Run 2's output. `TextRange.SourceStart` is documented as
+a character offset into the original markdown, and is that for paragraphs. For
+a literal on a continuation line of a blockquote or list it is an offset into
+Markdig's re-assembled container content instead. In the Run 2 corpus,
+`plain quote` reports `SourceStart = 0` — document offset 0 is the `>` of the
+first alert — and `second line` reports 12, both offsets into
+`"plain quote\nsecond line"`. Identical on 0.34.0 and 1.3.2, so it predates
+this work; filed separately.

--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -58,7 +58,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.3.9" />
-    <PackageReference Include="Markdig" Version="0.34.0" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
     <!-- ⚠ TRANSITIVE PIN, NOT A FEATURE. Avalonia 11.3.9 resolves Tmds.DBus.Protocol
          0.21.2, which carries a high-severity advisory (GHSA-xrw6-gwf8-vvr9); 0.21.3 is the
          patched release on that line. Drop this line once Avalonia itself resolves 0.21.3

--- a/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
+++ b/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
@@ -37,11 +37,12 @@
     <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 
-  <!-- Markdig: markdown AST for MarkdownTextExtractor. Matches the version
-       Vernacula.Avalonia is already on so two copies don't end up in a
-       composite app (cf. Markdown.Avalonia → Markdig). -->
+  <!-- Markdig: markdown AST for MarkdownTextExtractor. Kept in step with the
+       pin in Vernacula.Avalonia (MarkdownFlowBuilder) so a composite app
+       resolves one copy. Markdown.Avalonia is not involved — it parses
+       markdown with its own engine and pulls no Markdig of its own. -->
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.34.0" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
   </ItemGroup>
 
   <!-- ONNX protobuf: read the base transformer graph (initializer external-data

--- a/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Vernacula.Tts.Base.Markdown;
 using Xunit;
 
@@ -138,14 +137,42 @@ public class MarkdownTextExtractorTests
         Assert.Equal("Body of the alert.", r.Text);
     }
 
+    // AlertBlock subclasses QuoteBlock, so the `case QuoteBlock` arm in the
+    // extractor still matches it. If a future Markdig reparents it the block
+    // would fall through to `default: return false` and vanish from the output
+    // entirely — this is the test that localizes that.
     [Fact]
-    public void Alert_quote_stays_one_quote_block_spanning_only_the_body()
+    public void Alert_is_still_a_quote_block_spanning_exactly_the_body()
     {
         var r = MarkdownTextExtractor.Extract("> [!NOTE]\n> Body of the alert.");
         var block = Assert.Single(r.Blocks);
         Assert.Equal(BlockKind.Quote, block.Kind);
-        Assert.Equal(0, block.OutputStart);
-        Assert.Equal(r.Text.Length, block.OutputLength);
+        Assert.Equal("Body of the alert.",
+                     r.Text[block.OutputStart..(block.OutputStart + block.OutputLength)]);
+    }
+
+    // Markdig's AlertParser only fires on a top-level quote, so an alert
+    // indented under a list item keeps its marker and is spoken. GitHub does
+    // render these as alerts, so the two disagree; pinned rather than fixed,
+    // because a future Markdig closing the gap would shift output offsets
+    // again and this is what would notice.
+    [Fact]
+    public void Alert_nested_in_a_list_item_keeps_its_marker()
+    {
+        var r = MarkdownTextExtractor.Extract("- item one\n  > [!NOTE]\n  > Nested alert body.");
+        Assert.Equal("item one\n\n[!NOTE] Nested alert body.", r.Text);
+    }
+
+    // An alert whose body is empty contributes no text and, unlike a plain
+    // `>` quote, no BlockSpan either — the marker was the only content and it
+    // is consumed into the block. Consumers walking Blocks to mirror document
+    // structure see one fewer quote than the source has.
+    [Fact]
+    public void Alert_with_an_empty_body_contributes_no_text_and_no_block()
+    {
+        var r = MarkdownTextExtractor.Extract("> [!NOTE]");
+        Assert.Equal("", r.Text);
+        Assert.Empty(r.Blocks);
     }
 
     [Fact]

--- a/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
@@ -163,10 +163,12 @@ public class MarkdownTextExtractorTests
         Assert.Equal("item one\n\n[!NOTE] Nested alert body.", r.Text);
     }
 
-    // An alert whose body is empty contributes no text and, unlike a plain
-    // `>` quote, no BlockSpan either — the marker was the only content and it
-    // is consumed into the block. Consumers walking Blocks to mirror document
-    // structure see one fewer quote than the source has.
+    // An alert whose body is empty contributes no text and no BlockSpan,
+    // where 0.34.0 gave one quote block containing the marker: the marker was
+    // the only content, and it is now consumed into the block. Consumers
+    // walking Blocks to mirror document structure see one fewer quote than
+    // the source has. (An empty *plain* quote also yields no block, on both
+    // versions — the contrast here is against 0.34.0 on this same input.)
     [Fact]
     public void Alert_with_an_empty_body_contributes_no_text_and_no_block()
     {

--- a/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Vernacula.Tts.Base.Markdown;
 using Xunit;
 
@@ -109,6 +110,58 @@ public class MarkdownTextExtractorTests
     {
         var r = MarkdownTextExtractor.Extract("> quoted text here");
         Assert.Equal("quoted text here", r.Text);
+    }
+
+    // GitHub alert blockquotes. Markdig 1.x recognizes these (AlertExtension,
+    // pulled in by UseAdvancedExtensions) and consumes the "[!KIND]" marker
+    // into the block instead of leaving it as a literal, so the marker no
+    // longer reaches the synthesizer. Under 0.34.0 the TTS read it aloud.
+    // These tests pin the stripping: it moves every following output offset,
+    // and the karaoke view aligns against those offsets.
+
+    [Theory]
+    [InlineData("NOTE")]
+    [InlineData("TIP")]
+    [InlineData("IMPORTANT")]
+    [InlineData("WARNING")]
+    [InlineData("CAUTION")]
+    public void Alert_quote_drops_the_kind_marker(string kind)
+    {
+        var r = MarkdownTextExtractor.Extract($"> [!{kind}]\n> Body of the alert.");
+        Assert.Equal("Body of the alert.", r.Text);
+    }
+
+    [Fact]
+    public void Alert_marker_is_dropped_for_an_unknown_kind_too()
+    {
+        var r = MarkdownTextExtractor.Extract("> [!FOO]\n> Body of the alert.");
+        Assert.Equal("Body of the alert.", r.Text);
+    }
+
+    [Fact]
+    public void Alert_quote_stays_one_quote_block_spanning_only_the_body()
+    {
+        var r = MarkdownTextExtractor.Extract("> [!NOTE]\n> Body of the alert.");
+        var block = Assert.Single(r.Blocks);
+        Assert.Equal(BlockKind.Quote, block.Kind);
+        Assert.Equal(0, block.OutputStart);
+        Assert.Equal(r.Text.Length, block.OutputLength);
+    }
+
+    [Fact]
+    public void Text_after_an_alert_is_not_shifted_by_the_marker()
+    {
+        var r = MarkdownTextExtractor.Extract("> [!NOTE]\n> Heed this.\n\nAfter the alert.");
+        Assert.Equal("Heed this.\n\nAfter the alert.", r.Text);
+        Assert.Equal(r.Text.IndexOf("After", StringComparison.Ordinal),
+                     r.Blocks[^1].OutputStart);
+    }
+
+    [Fact]
+    public void Bracketed_text_that_is_not_an_alert_marker_is_kept()
+    {
+        var r = MarkdownTextExtractor.Extract("> [not an alert]\n> Body.");
+        Assert.Equal("[not an alert] Body.", r.Text);
     }
 
     // ── Skipped constructs ────────────────────────────────────────────


### PR DESCRIPTION
Next in the upgrade queue after #122.

## What changed

Both Markdig pins (`Vernacula.Tts.Base`, `Vernacula.Avalonia`) go from 0.34.0 to 1.3.2.

**This is not a behaviour-neutral bump.** `UseAdvancedExtensions()` — which both consumers call bare — gained `AlertExtension` in Markdig 1.x. `AlertBlock` subclasses `QuoteBlock` and consumes the `[!KIND]` marker into the block instead of leaving it as a literal, so a GitHub alert blockquote extracts differently:

| | 0.34.0 | 1.3.2 |
|---|---|---|
| `Text` | `[!NOTE] Useful information that users should know.` | `Useful information that users should know.` |
| `Blocks[0].OutputLength` | 50 | 42 |

The new behaviour is the one we want — the synthesizer no longer reads "bracket bang NOTE bracket" aloud — but it shifts every output offset after an alert by the marker's length, and the karaoke view aligns against those offsets. So it is landed deliberately and pinned by tests rather than absorbed silently. Eleven tests in `MarkdownTextExtractorTests.cs` cover the five GitHub kinds, an unknown kind, the block identity and span, non-shifting of following text, non-alert brackets, and the two asymmetries below; **nine of the eleven fail against 0.34.0**, which is the check that they pin the change rather than restate the parser. The two that pass on both are deliberately version-invariant: one guards against over-broad future alert recognition, the other pins the list-nesting gap below.

### The stripping is top-level only

Markdig's `AlertParser` fires on a top-level quote. An alert indented under a list item is unchanged from 0.34.0 — `- item one\n  > [!NOTE]\n  > body` still extracts as `item one\n\n[!NOTE] body`. GitHub renders that as an alert, so the two disagree: a README whose install steps carry a `> [!WARNING]` under a numbered step still has the marker spoken, while an identical marker two paragraphs earlier at top level is stripped. Pinned by a test rather than worked around, since a future Markdig closing the gap would shift offsets again for exactly the reason this investigation exists.

An empty-bodied `> [!NOTE]` is the second asymmetry: it now yields no text *and no `BlockSpan`*, where 0.34.0 gave a quote block containing the marker. Speech outcome right, block index one short. Also pinned.

`MarkdownFlowBuilder` needs no change: its `QuoteBlock` arm still matches `AlertBlock`. A `> [!NOTE]` in help content renders as a generic quote rather than showing the literal marker. No live regression — no repo markdown uses alert syntax today.

## How this was found (and what I got wrong first)

My first pass diffed the extractor's full output over a corpus of ATX/setext headings, emphasis, inline code, links, fences, indented code, lists, quotes, tables, footnotes, images, hard breaks, raw HTML, autolinks, entities, escapes and thematic breaks — and got byte-identical output. I concluded the bump was behaviour-neutral. **That corpus was built from the constructs the extractor already handles, which is the wrong generator for a question about a new parser version:** an extension added in 1.x recognizes syntax the old version had no concept of, so the construct at risk is by definition one the corpus wouldn't contain. Review caught it. The right check — diff the *extension list of the built pipeline* between versions, then write cases for whatever appears — is recorded as a method note for the next bump.

Full write-up, including the retracted Run 1 conclusion, in `docs/investigations/dependency_upgrade_investigation.md`.

## Drive-by comment fix

The pin comment claimed the version was matched to `Markdown.Avalonia → Markdig`. The restore graph shows Markdown.Avalonia 11.0.3 pulls no Markdig at all — it parses with its own engine, and the only Markdig in the graph is ours. The two pins still need to match *each other*; only the stated reason was wrong.

## Also filed

#124 — `TextRange.SourceStart` is wrong for literals on container continuation lines. Pre-existing, identical on both versions, found while reading the alert output. Not addressed here.

## Verification

- Solution builds clean, no new warnings.
- 27 + 63 + 149 + 23 tests pass (4 skipped in `Vernacula.Tts.Tests` — OmniVoice parity captures, skipped on `main` too).
- Both pins resolve to exactly 1.3.2 (no float, no downgrade); no vulnerable packages.
- 1.3.2 adds a `net10.0` asset with zero package dependencies; the repo is net10.0 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc
