### PR TITLE
fix(markdown): record literal source spans in document coordinates

### DIFF
--- a/docs/investigations/markdown_source_span_investigation.md
+++ b/docs/investigations/markdown_source_span_investigation.md
@@ -1,0 +1,99 @@
+# Markdown source-span investigation (#124)
+
+`TextRange.SourceStart` is documented as a character offset into the original
+markdown. For literals on a container's continuation lines it was an offset
+into a different string entirely. This log covers finding the real cause and
+measuring the blast radius.
+
+## Run 1 — 2026-09-05 — where does the wrong offset come from?
+
+**Question.** `MarkdownTextExtractor` recorded `srcStart = lit.Content.Start`.
+`LiteralInline.Content` is a `StringSlice`, and a slice carries the buffer it
+points into. Is that buffer always the original document?
+
+**Command.** A probe over Markdig 1.3.2 printing, for every `LiteralInline`:
+the slice text, `ReferenceEquals(slice.Text, markdown)`, the document
+substring at the slice offsets, and the same at `lit.Span` offsets.
+
+**Raw finding.** `sameBuf` is `False` for exactly the shapes in the bug
+report, and in those the slice offsets point at unrelated text while
+`lit.Span` is right:
+
+```
+=== > plain quote\n> second line
+  lit=plain quote   sameBuf=False  slice[0,11]="> plain quo"   span[2,11]="plain quote"
+  lit=second line   sameBuf=False  slice[12,11]="e\n> second"  span[16,11]="second line"
+=== - item one\ncontinued lazily
+  lit=item one          sameBuf=False slice[0,8]="- item o"        span[2,8]="item one"
+  lit=continued lazily  sameBuf=False slice[9,16]="e\ncontinued lazi" span[11,16]="continued lazily"
+```
+
+`sameBuf=True` for ordinary paragraphs, where slice and span agree.
+
+**Implication.** Markdig re-assembles a container's lines into a fresh buffer
+and slices *that*; `slice.Start` is an offset into the re-assembled content.
+`lit.Span` is in document coordinates unconditionally. The fix is to read the
+position from the span. Note `CodeInline` was already doing this
+(`code.Span.Start`) — the literal case was the outlier.
+
+## Run 2 — 2026-09-05 — does the span hold up on the awkward inputs?
+
+**Question.** Before switching, is `lit.Span` correct everywhere, and does its
+length still match the emitted text?
+
+**Command.** The same probe over escapes, HTML entities, hard breaks, CJK,
+astral-plane emoji, CRLF documents, emphasis spanning a line break, and
+quotes/lists containing all of the above.
+
+**Raw finding.** Span offsets correct in every case. Lengths match the output
+except for backslash escapes, where the span is one character wider:
+
+```
+  lit=*not italic   slice[8,11]="*not italic"   span[7,12]="\*not italic"  [len slice=11 span=12]
+```
+
+**Implication.** That widening is right, and the record's own doc comment
+already allows it — output is a *subsequence* of the source slice, not an
+equal-length one, the same way inline code's span covers its backticks. So
+`SourceLength` moves from "however long the output happened to be" to the
+span's real extent, which is strictly more accurate.
+
+## Run 3 — 2026-09-05 — blast radius, on real documents
+
+**Question.** How much of the index was actually wrong, and does the fix
+close it?
+
+**Command.** Walk every range of all 425 tracked markdown files (excluding
+`external/`), slice the source at `SourceStart..+SourceLength`, and require it
+to contain the output text. Whitespace-normalized, because inline code turns
+an internal line break into a space.
+
+```
+git ls-files '*.md' | grep -v '^external/'
+```
+
+**Raw finding.**
+
+| | files with a bad range | bad ranges | total ranges |
+|---|---|---|---|
+| before | 410 / 425 | 19,894 | 50,397 |
+| after | 1 / 425 | 1 | 50,397 |
+
+**Implication.** This was not an edge case — 96% of the repo's own markdown
+had a broken index, because any document long enough to contain one quote or
+one wrapped list item has them. It went unnoticed because nothing downstream
+of `SourceStart` fails loudly; the karaoke highlight just lands on the wrong
+source text.
+
+The single remaining case is not a defect: an inline code span inside a block
+quote, whose document extent legitimately includes the `> ` continuation
+marker that the output drops. The check can't express "subsequence" without
+re-implementing the extractor, so it stays as a known-good outlier rather than
+a weakened assertion.
+
+**Test note.** The pre-existing tests asserted `Assert.Contains(outSlice,
+srcSlice)` on one construct each, which passes by luck whenever the wrong
+offset still lands inside a long enough source slice. The new theory asserts
+the same property across the container shapes that were broken, and three
+`[Fact]`s pin the bug report's exact offsets (16, not 12; 2, not 0; 13, not
+0). 13 of the 17 new cases fail against the unfixed extractor.

--- a/docs/investigations/markdown_source_span_investigation.md
+++ b/docs/investigations/markdown_source_span_investigation.md
@@ -97,3 +97,48 @@ offset still lands inside a long enough source slice. The new theory asserts
 the same property across the container shapes that were broken, and three
 `[Fact]`s pin the bug report's exact offsets (16, not 12; 2, not 0; 13, not
 0). 13 of the 17 new cases fail against the unfixed extractor.
+
+## Run 4 — 2026-09-05 — review follow-up: the output side of the same index
+
+**Question.** Review pointed out that the new invariant test slices
+`r.Text.Substring(range.OutputStart, range.OutputLength)` without asserting
+output bounds first. Can a recorded range overrun `Text`?
+
+**Command.** Probe documents whose last literal is followed by markup that
+emits nothing.
+
+**Raw finding.** Yes, and it predates this work:
+
+```
+"hello ![img](/x.png)"  → Text="hello" (5), last range Output[0,6]   OVERRUN
+"text <span>"           → Text="text"  (4), last range Output[0,5]   OVERRUN
+```
+
+`Run` trims trailing whitespace off the builder but never shortens the last
+range, so anything dropped at the tail — an image, an inline tag — leaves a
+range pointing past the end. A consumer walking the index to slice `Text`
+gets an `ArgumentOutOfRangeException`, not a wrong highlight.
+
+**Blast radius: latent, not live.** Across the same 425 files: **0** overrunning
+ranges before *and* after. No document in this repo ends that way. The shape
+that triggers it is ordinary though — a README whose last line is a badge —
+and the invariant test was one `[InlineData]` away from dying with a throw
+instead of a readable assert. Fixed at the source (`TrimRangesToOutput`) rather
+than only asserted around, with three such inputs added to the theory.
+
+**Two more from the same review, both pre-existing and neither fixed here:**
+
+- A synthesized inline can carry a *degenerate* span: `"+-\n[1]"` produces a
+  literal whose `Span` has `End < Start`. `SourceStartOf`'s clamp turns that
+  into a harmless in-bounds zero-length entry. The extractor comment claimed
+  `lit.Span` was in document coordinates "in every case"; that overstated it,
+  and the comment now says what the bounds check is actually for.
+- `lit.Span` is off by one for tab-led heading text — `"# \tabc"` records
+  `"\tab"` for output `"abc"`. Identical on both versions, needs a tab
+  immediately after the heading marker, and correcting it would mean
+  second-guessing Markdig's own position. Left alone, recorded here.
+
+`CodeInline` was the last path still writing raw span arithmetic, and the
+source of the single surviving bad range repo-wide; it now goes through the
+same helper, so "every recorded range is sliceable" is total rather than
+per-case.

--- a/docs/investigations/markdown_source_span_investigation.md
+++ b/docs/investigations/markdown_source_span_investigation.md
@@ -81,9 +81,17 @@ git ls-files '*.md' | grep -v '^external/'
 
 **Implication.** This was not an edge case — 96% of the repo's own markdown
 had a broken index, because any document long enough to contain one quote or
-one wrapped list item has them. It went unnoticed because nothing downstream
-of `SourceStart` fails loudly; the karaoke highlight just lands on the wrong
-source text.
+one wrapped list item has them.
+
+**Why nobody noticed, stated accurately:** `TextRange.SourceStart` and
+`SourceLength` have *no consumer in the tree*. The only reader of `Ranges` is
+`FindStyle` in `MainViewModel`, which uses `Style` and compares `OutputStart`
+/`OutputLength` only. The source index is being built ahead of forced
+alignment, so none of the 19,894 wrong entries was ever rendered. An earlier
+draft of this note said the karaoke highlight "lands on the wrong source
+text"; that overstated it — the highlight does not read these fields yet.
+The fix is therefore low-risk rather than urgent, which is worth saying in
+that direction: it corrects the index before anything depends on it.
 
 The single remaining case is not a defect: an inline code span inside a block
 quote, whose document extent legitimately includes the `> ` continuation
@@ -96,7 +104,8 @@ srcSlice)` on one construct each, which passes by luck whenever the wrong
 offset still lands inside a long enough source slice. The new theory asserts
 the same property across the container shapes that were broken, and three
 `[Fact]`s pin the bug report's exact offsets (16, not 12; 2, not 0; 13, not
-0). 13 of the 17 new cases fail against the unfixed extractor.
+0). After the additions in Runs 4 and 5, 17 of the 21 new cases fail against
+the unfixed extractor.
 
 ## Run 4 — 2026-09-05 — review follow-up: the output side of the same index
 
@@ -138,7 +147,37 @@ than only asserted around, with three such inputs added to the theory.
   immediately after the heading marker, and correcting it would mean
   second-guessing Markdig's own position. Left alone, recorded here.
 
-`CodeInline` was the last path still writing raw span arithmetic, and the
-source of the single surviving bad range repo-wide; it now goes through the
-same helper, so "every recorded range is sliceable" is total rather than
-per-case.
+`CodeInline` was the last path still writing raw span arithmetic; it now goes
+through the same helper, so "every recorded range is sliceable" is total
+rather than per-case. To be precise about what that buys: the reroute is
+provably a no-op on real input (code-inline ranges are byte-identical across
+all 425 files), and it does *not* fix the one surviving bad range, which is
+correct as recorded. It closes the last path that could produce an
+unsliceable one.
+
+## Run 5 — 2026-09-05 — review round two: the same overrun in the block index
+
+**Question.** `TrimRangesToOutput` clamps `_ranges`. `_blocks` is built from
+the same builder offsets and documented in the same output-text terms
+("spans are in output order"). Does it overrun on the same inputs?
+
+**Raw finding.** Yes, on all of them:
+
+```
+"hello ![img](/x.png)"  → Text="hello" (5)   Paragraph[0,6]  OVERRUN
+"> quoted ![badge](/b)" → Text="quoted"(6)   Quote[0,7]      OVERRUN
+"a *b ![x](y)*"         → Text="a b"   (3)   Paragraph[0,4]  OVERRUN
+```
+
+**Implication.** Same defect, same shapes, one list over. Latent for the same
+reason and one step further removed — the only consumer, `FindBlockIndex`,
+does a containment lookup and never slices `Text`. Fixed alongside rather than
+left as the twin of a bug fixed inches away, and the invariant test now walks
+`Blocks` as well as `Ranges`.
+
+`TrimBlocksToOutput` walks the whole list instead of stopping at the first
+entry that fits. The ranges version can stop early because both `_ranges.Add`
+calls sit immediately after an append to `_sb`, which is only truncated after
+the walk — so output order is monotonic by construction. Block spans are
+recorded as their blocks complete, which is a weaker guarantee, and the list
+is short enough that relying on it buys nothing.

--- a/src/Vernacula.Tts.Base/Markdown/MarkdownTextExtractor.cs
+++ b/src/Vernacula.Tts.Base/Markdown/MarkdownTextExtractor.cs
@@ -159,6 +159,25 @@ public sealed class MarkdownTextExtractor
         }
     }
 
+    // Same clamp for the block index. Walks the whole list rather than
+    // stopping at the first entry that fits: block spans are built as their
+    // blocks complete, and that is a weaker ordering guarantee than the
+    // ranges have.
+    private void TrimBlocksToOutput(int outputLength)
+    {
+        for (int i = _blocks.Count - 1; i >= 0; i--)
+        {
+            var b = _blocks[i];
+            if (b.OutputStart + b.OutputLength <= outputLength) continue;
+            if (b.OutputStart >= outputLength)
+            {
+                _blocks.RemoveAt(i);
+                continue;
+            }
+            _blocks[i] = b with { OutputLength = outputLength - b.OutputStart };
+        }
+    }
+
     private MarkdownExtractionResult Run(string markdown)
     {
         _source = markdown;
@@ -176,8 +195,11 @@ public sealed class MarkdownTextExtractor
         // whose output span already ran past the text: the literal "hello "
         // in "hello ![img](/x.png)" records 6 characters, but Text is
         // "hello". Clamp so every entry is sliceable against Text — a
-        // consumer walking the index has no other way to know.
+        // consumer walking the index has no other way to know. BlockSpan is
+        // documented in the same output-text terms and overruns on the same
+        // inputs, so it gets the same treatment.
         TrimRangesToOutput(_sb.Length);
+        TrimBlocksToOutput(_sb.Length);
         return new MarkdownExtractionResult(_sb.ToString(), _ranges, _blocks);
     }
 

--- a/src/Vernacula.Tts.Base/Markdown/MarkdownTextExtractor.cs
+++ b/src/Vernacula.Tts.Base/Markdown/MarkdownTextExtractor.cs
@@ -118,8 +118,33 @@ public sealed class MarkdownTextExtractor
         return extractor.Run(markdown);
     }
 
+    // The markdown being extracted, for bounds-checking recorded source spans.
+    private string _source = string.Empty;
+
+    // Document-coordinate start/length for an inline's source span, clamped to
+    // the document. The span may legitimately be longer than the emitted text
+    // (a backslash escape emits one character for two source ones), which the
+    // TextRange contract allows: output is a subsequence of the source slice.
+    private int SourceStartOf(SourceSpan span, int outLen, out int srcLen)
+    {
+        int start = span.Start;
+        srcLen = span.End - span.Start + 1;
+        if (start < 0 || start > _source.Length)
+        {
+            // Defensive: an inline with no usable position. Record an empty
+            // span at a valid offset rather than one a consumer would throw
+            // on when it slices the source.
+            srcLen = 0;
+            return Math.Clamp(start, 0, _source.Length);
+        }
+        if (srcLen < outLen) srcLen = outLen;
+        if (start + srcLen > _source.Length) srcLen = _source.Length - start;
+        return start;
+    }
+
     private MarkdownExtractionResult Run(string markdown)
     {
+        _source = markdown;
         var doc = MarkdownParser.Parse(markdown, Pipeline);
         bool first = true;
         foreach (var block in doc)
@@ -240,13 +265,25 @@ public sealed class MarkdownTextExtractor
             case LiteralInline lit:
                 // Literal text: copy the slice verbatim AND record a range
                 // entry pointing back to the source span.
+                //
+                // The source position comes from lit.Span, NOT from the
+                // slice. LiteralInline.Content is a slice over whatever
+                // buffer Markdig assembled the inline from, and for a
+                // continuation line of a container — the second line of a
+                // block quote, a lazily continued list item — that buffer is
+                // the container's re-joined content, not the original
+                // document. slice.Start is an offset into that buffer and
+                // means nothing here; lit.Span is in document coordinates in
+                // every case (verified across quotes, lazy list
+                // continuations, nested quotes, escapes, entities, CRLF and
+                // multi-line emphasis).
                 var slice = lit.Content;
-                if (slice.Length <= 0) return;
-                int srcStart = slice.Start;
-                int srcLen = slice.End - slice.Start + 1;
+                int outLen = slice.End - slice.Start + 1;
+                if (outLen <= 0) return;
                 int outStart = _sb.Length;
                 _sb.Append(slice.AsSpan());
-                _ranges.Add(new TextRange(outStart, srcLen, srcStart, srcLen, _style));
+                int srcStart = SourceStartOf(lit.Span, outLen, out int srcLen);
+                _ranges.Add(new TextRange(outStart, outLen, srcStart, srcLen, _style));
                 break;
 
             case CodeInline code:

--- a/src/Vernacula.Tts.Base/Markdown/MarkdownTextExtractor.cs
+++ b/src/Vernacula.Tts.Base/Markdown/MarkdownTextExtractor.cs
@@ -138,8 +138,25 @@ public sealed class MarkdownTextExtractor
             return Math.Clamp(start, 0, _source.Length);
         }
         if (srcLen < outLen) srcLen = outLen;
-        if (start + srcLen > _source.Length) srcLen = _source.Length - start;
+        if (srcLen > _source.Length - start) srcLen = _source.Length - start;
         return start;
+    }
+
+    // Drop or shorten range entries that extend past the final output text.
+    // Ranges are appended in output order, so only the tail can be affected.
+    private void TrimRangesToOutput(int outputLength)
+    {
+        for (int i = _ranges.Count - 1; i >= 0; i--)
+        {
+            var r = _ranges[i];
+            if (r.OutputStart + r.OutputLength <= outputLength) break;
+            if (r.OutputStart >= outputLength)
+            {
+                _ranges.RemoveAt(i);
+                continue;
+            }
+            _ranges[i] = r with { OutputLength = outputLength - r.OutputStart };
+        }
     }
 
     private MarkdownExtractionResult Run(string markdown)
@@ -154,6 +171,13 @@ public sealed class MarkdownTextExtractor
         }
         // Trim trailing whitespace the block-separator logic may have appended.
         while (_sb.Length > 0 && char.IsWhiteSpace(_sb[^1])) _sb.Length--;
+        // The trim can cut into the last range, and dropped trailing markup
+        // (a README ending in a badge image, a stray inline tag) leaves one
+        // whose output span already ran past the text: the literal "hello "
+        // in "hello ![img](/x.png)" records 6 characters, but Text is
+        // "hello". Clamp so every entry is sliceable against Text — a
+        // consumer walking the index has no other way to know.
+        TrimRangesToOutput(_sb.Length);
         return new MarkdownExtractionResult(_sb.ToString(), _ranges, _blocks);
     }
 
@@ -273,10 +297,13 @@ public sealed class MarkdownTextExtractor
                 // block quote, a lazily continued list item — that buffer is
                 // the container's re-joined content, not the original
                 // document. slice.Start is an offset into that buffer and
-                // means nothing here; lit.Span is in document coordinates in
-                // every case (verified across quotes, lazy list
-                // continuations, nested quotes, escapes, entities, CRLF and
-                // multi-line emphasis).
+                // means nothing here; lit.Span is in document coordinates for
+                // every shape observed (quotes, lazy list continuations,
+                // nested quotes, escapes, entities, CRLF, multi-line
+                // emphasis, alerts, tables, footnotes, BOM, CR-only). Not
+                // unconditionally, though — a synthesized inline can carry a
+                // degenerate span, which is why SourceStartOf bounds-checks
+                // rather than trusting it.
                 var slice = lit.Content;
                 int outLen = slice.End - slice.Start + 1;
                 if (outLen <= 0) return;
@@ -296,8 +323,9 @@ public sealed class MarkdownTextExtractor
                 // points at the full delimited extent, so record the
                 // full delim range — close-enough for forced alignment
                 // which works at word granularity.
+                int codeSrcStart = SourceStartOf(code.Span, code.Content.Length, out int codeSrcLen);
                 _ranges.Add(new TextRange(codeOutStart, code.Content.Length,
-                    code.Span.Start, code.Span.End - code.Span.Start + 1, _style | InlineStyle.Code));
+                    codeSrcStart, codeSrcLen, _style | InlineStyle.Code));
                 break;
 
             case LinkInline link when !link.IsImage:

--- a/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
@@ -285,6 +285,14 @@ public class MarkdownTextExtractorTests
             string srcSlice = src.Substring(range.SourceStart, range.SourceLength);
             Assert.Contains(outSlice, srcSlice, StringComparison.Ordinal);
         }
+
+        // BlockSpan is documented in the same output-text terms and overruns
+        // on the same inputs, so it carries the same invariant.
+        foreach (var block in r.Blocks)
+        {
+            Assert.InRange(block.OutputStart, 0, r.Text.Length);
+            Assert.InRange(block.OutputStart + block.OutputLength, 0, r.Text.Length);
+        }
     }
 
     // The three shapes from the bug report, pinned at exact offsets. Before
@@ -337,6 +345,9 @@ public class MarkdownTextExtractorTests
         var last = r.Ranges[^1];
         Assert.Equal(r.Text.Length, last.OutputStart + last.OutputLength);
         Assert.Equal("hello", r.Text.Substring(last.OutputStart, last.OutputLength));
+
+        var block = Assert.Single(r.Blocks);
+        Assert.Equal("hello", r.Text.Substring(block.OutputStart, block.OutputLength));
     }
 
     // A backslash escape emits one character for two source ones, so the

--- a/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Vernacula.Tts.Base.Markdown;
 using Xunit;
 
@@ -238,6 +240,97 @@ public class MarkdownTextExtractorTests
     }
 
     // ── Source-range index ────────────────────────────────────────────
+
+    // Every recorded range must be in bounds and its source slice must
+    // actually contain the output it claims to represent. The older tests
+    // spot-check one construct each; this walks a battery of documents,
+    // including the container shapes where the index used to point at
+    // unrelated text (see the LiteralInline case in the extractor).
+    //
+    // "Contains" rather than "equals" because the contract allows a source
+    // slice wider than the output: a backslash escape emits one character
+    // for two source ones, and inline code's span covers its backticks.
+    [Theory]
+    [InlineData("Hello world.")]
+    [InlineData("> plain quote\n> second line")]
+    [InlineData("- item one\ncontinued lazily")]
+    [InlineData("This [is not][nope] a link.")]
+    [InlineData("> level one\n> > level two\n> back to one")]
+    [InlineData("- a\n  - nested\n    continued\n- b")]
+    [InlineData("> quote with `code`\n> and **bold** text")]
+    [InlineData("escape \\*not italic\\* done")]
+    [InlineData("*emph across\nlines* end")]
+    [InlineData("> [!NOTE]\n> Alert body here.")]
+    [InlineData("1. step one\n   > [!WARNING]\n   > careful\n2. step two")]
+    [InlineData("para one\n\n> quoted\n\n- listed\n\n# heading")]
+    [InlineData("CRLF quote:\r\n> line one\r\n> line two")]
+    public void Every_range_maps_to_source_that_contains_its_output(string src)
+    {
+        var r = MarkdownTextExtractor.Extract(src);
+        Assert.NotEmpty(r.Ranges);
+        foreach (var range in r.Ranges)
+        {
+            Assert.InRange(range.SourceStart, 0, src.Length);
+            Assert.InRange(range.SourceStart + range.SourceLength, 0, src.Length);
+            string outSlice = r.Text.Substring(range.OutputStart, range.OutputLength);
+            string srcSlice = src.Substring(range.SourceStart, range.SourceLength);
+            Assert.Contains(outSlice, srcSlice, StringComparison.Ordinal);
+        }
+    }
+
+    // The three shapes from the bug report, pinned at exact offsets. Before
+    // the fix these read LiteralInline.Content.Start, an offset into the
+    // buffer Markdig re-assembles for a container's continuation lines rather
+    // than into the document, so each pointed at unrelated text.
+
+    [Fact]
+    public void Quote_continuation_line_maps_to_its_real_document_offset()
+    {
+        const string src = "> plain quote\n> second line";
+        var r = MarkdownTextExtractor.Extract(src);
+        var second = r.Ranges[^1];
+        Assert.Equal("second line", r.Text.Substring(second.OutputStart, second.OutputLength));
+        Assert.Equal(16, second.SourceStart);   // was 12, an offset into "plain quote\nsecond line"
+        Assert.Equal("second line", src.Substring(second.SourceStart, second.SourceLength));
+    }
+
+    [Fact]
+    public void Lazily_continued_list_item_maps_to_its_real_document_offset()
+    {
+        const string src = "- item one\ncontinued lazily";
+        var r = MarkdownTextExtractor.Extract(src);
+        Assert.Equal(2, r.Ranges[0].SourceStart);    // was 0, pointing at "- item o"
+        Assert.Equal("item one", src.Substring(r.Ranges[0].SourceStart, r.Ranges[0].SourceLength));
+        Assert.Equal("continued lazily",
+                     src.Substring(r.Ranges[^1].SourceStart, r.Ranges[^1].SourceLength));
+    }
+
+    [Fact]
+    public void Unresolved_reference_link_bracket_maps_to_its_real_document_offset()
+    {
+        const string src = "This [is not][nope] a link.";
+        var r = MarkdownTextExtractor.Extract(src);
+        var bracket = r.Ranges.Single(t => r.Text.Substring(t.OutputStart, t.OutputLength) == "[");
+        Assert.Equal(13, bracket.SourceStart);   // was 0, pointing at "T"
+        Assert.Equal("[", src.Substring(bracket.SourceStart, bracket.SourceLength));
+    }
+
+    // A backslash escape emits one character for two source ones, so the
+    // source span is legitimately wider than the output. Pinned because the
+    // fix changed SourceLength from "however long the output was" to the
+    // span's real extent, and the documented contract is subsequence, not
+    // equality.
+    [Fact]
+    public void Escaped_character_keeps_the_wider_source_span()
+    {
+        const string src = "escape \\*not italic\\* done";
+        var r = MarkdownTextExtractor.Extract(src);
+        var escaped = r.Ranges.Single(t =>
+            r.Text.Substring(t.OutputStart, t.OutputLength).StartsWith("*not", StringComparison.Ordinal));
+        Assert.Equal("*not italic", r.Text.Substring(escaped.OutputStart, escaped.OutputLength));
+        Assert.Equal("\\*not italic", src.Substring(escaped.SourceStart, escaped.SourceLength));
+        Assert.True(escaped.SourceLength > escaped.OutputLength);
+    }
 
     [Fact]
     public void Plain_paragraph_range_points_back_to_source()

--- a/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
+++ b/tests/Vernacula.Tts.Tests/MarkdownTextExtractorTests.cs
@@ -264,12 +264,21 @@ public class MarkdownTextExtractorTests
     [InlineData("1. step one\n   > [!WARNING]\n   > careful\n2. step two")]
     [InlineData("para one\n\n> quoted\n\n- listed\n\n# heading")]
     [InlineData("CRLF quote:\r\n> line one\r\n> line two")]
+    // Trailing markup that emits nothing: the last literal's output span used
+    // to run past Text once the trailing whitespace was trimmed.
+    [InlineData("hello ![img](/x.png)")]
+    [InlineData("text <span>")]
+    [InlineData("> quoted ![badge](/b.svg)")]
     public void Every_range_maps_to_source_that_contains_its_output(string src)
     {
         var r = MarkdownTextExtractor.Extract(src);
         Assert.NotEmpty(r.Ranges);
         foreach (var range in r.Ranges)
         {
+            // Output bounds first: a range that overruns Text would make the
+            // Substring below throw instead of failing readably.
+            Assert.InRange(range.OutputStart, 0, r.Text.Length);
+            Assert.InRange(range.OutputStart + range.OutputLength, 0, r.Text.Length);
             Assert.InRange(range.SourceStart, 0, src.Length);
             Assert.InRange(range.SourceStart + range.SourceLength, 0, src.Length);
             string outSlice = r.Text.Substring(range.OutputStart, range.OutputLength);
@@ -313,6 +322,21 @@ public class MarkdownTextExtractorTests
         var bracket = r.Ranges.Single(t => r.Text.Substring(t.OutputStart, t.OutputLength) == "[");
         Assert.Equal(13, bracket.SourceStart);   // was 0, pointing at "T"
         Assert.Equal("[", src.Substring(bracket.SourceStart, bracket.SourceLength));
+    }
+
+    // Trailing markup that contributes no text (an image, an inline tag) left
+    // the preceding literal's output span running past Text, because the
+    // trailing-whitespace trim shortens the text without shortening the range.
+    // A consumer walking the index to slice Text got an out-of-range throw.
+    [Fact]
+    public void Range_is_clamped_when_trailing_markup_is_dropped()
+    {
+        const string src = "hello ![img](/x.png)";
+        var r = MarkdownTextExtractor.Extract(src);
+        Assert.Equal("hello", r.Text);
+        var last = r.Ranges[^1];
+        Assert.Equal(r.Text.Length, last.OutputStart + last.OutputLength);
+        Assert.Equal("hello", r.Text.Substring(last.OutputStart, last.OutputLength));
     }
 
     // A backslash escape emits one character for two source ones, so the


### PR DESCRIPTION
Closes #124.

## The bug

`TextRange.SourceStart` is documented as a character offset into the original markdown. It was read from `LiteralInline.Content.Start` — and a `StringSlice` carries the buffer it points into. For a container's continuation lines (the second line of a block quote, a lazily continued list item) Markdig re-assembles those lines into a fresh buffer and slices *that*, so the recorded offset addressed a string the caller never sees.

```
> plain quote
> second line
```

`second line` reported `SourceStart = 12`, an offset into `"plain quote\nsecond line"`. The document has it at 16.

`lit.Span` is in document coordinates unconditionally — verified across quotes, lazy list continuations, nested quotes, escapes, entities, hard breaks, CJK, astral-plane emoji, CRLF and emphasis spanning a line break. `CodeInline` was already using `code.Span`; the literal case was the outlier. One-line cause, one-line fix.

## Blast radius

Not an edge case. Walking every range of all 425 tracked markdown files and requiring the source slice to contain the output it claims to represent:

| | files with a bad range | bad ranges | total ranges |
|---|---|---|---|
| before | **410 / 425** | **19,894** | 50,397 |
| after | 1 / 425 | 1 | 50,397 |

Any document long enough to contain one block quote or one wrapped list item had them.

**Why nobody noticed — stated accurately:** `TextRange.SourceStart`/`SourceLength` have *no consumer in the tree*. The only reader of `Ranges` is `FindStyle` in `MainViewModel`, which uses `Style` and the output offsets. The source index is being built ahead of forced alignment, so none of the 19,894 wrong entries was ever rendered. An earlier draft of this PR said the highlight "lands on the wrong source text"; that overstated it. This is therefore low-risk rather than urgent — it corrects the index before anything depends on it.

The one remaining case is correct, not a defect: an inline code span inside a block quote, whose document extent legitimately includes the `> ` continuation marker the output drops. Expressing "subsequence" strictly enough to pass it would mean re-implementing the extractor in the checker, so it stays a known-good outlier rather than a weakened assertion.

## `SourceLength` also changes

It now comes from the span rather than being set equal to the output length, so a backslash escape reports the two source characters it consumed instead of the one it emitted. That is the subsequence contract `TextRange`'s own doc comment already describes ("consumers should not assume the two slices are equal-length"), and it matches what `CodeInline` has always done with its backticks.

## Also fixed: the output side of the same index (review follow-up)

`Run` trims trailing whitespace off the builder but never shortened the last range, so a document whose tail markup emits nothing left a range pointing past the end of `Text`:

```
"hello ![img](/x.png)"  → Text="hello" (5), last range Output[0,6]
"text <span>"           → Text="text"  (4), last range Output[0,5]
```

A consumer walking the index to slice `Text` gets an `ArgumentOutOfRangeException` — a throw, not a wrong highlight. **Latent in this repo** (0 occurrences across the same 425 files, before *and* after), but the shape is ordinary — a README whose last line is a badge — and the invariant test below was one `[InlineData]` away from dying with an exception instead of a readable assert. Fixed at the source rather than only asserted around.

`CodeInline` was the last path still doing raw span arithmetic; it now goes through the same bounds check, so "every recorded range is sliceable" holds by construction rather than per-case. To be precise about what that buys: the reroute is a no-op on real input (code-inline ranges are byte-identical across all 425 files) and does *not* fix the one surviving bad range, which is correct as recorded — it closes the last path that could produce an unsliceable one.

`BlockSpan` had the identical overrun, on the identical inputs — `"hello ![img](/x.png)"` gives `Paragraph[0,6]` against a 5-character `Text`. Same defect one list over, latent for the same reason and one step further removed (`FindBlockIndex` does a containment lookup and never slices). Clamped alongside rather than left as the twin of a bug fixed inches away, and the invariant test now walks `Blocks` as well as `Ranges`.

Two more surfaced by review, both pre-existing and neither fixed here — a synthesized inline can carry a degenerate span (`"+-\n[1]"`), which the clamp renders harmless, and `lit.Span` is off by one for tab-led heading text (`"# \tabc"`), identical on both versions and not worth second-guessing Markdig over. Both recorded in the investigation doc. The literal case's comment claimed `lit.Span` is in document coordinates "in every case"; that overstated it, and it now says what the bounds check is for.

## Tests

The pre-existing range tests asserted `Assert.Contains(outSlice, srcSlice)` on one construct each — which passes by luck whenever a wrong offset still lands inside a long enough slice. Added:

- a 16-case theory asserting the in-bounds (output *and* source) + containment invariant across the container shapes that were broken, plus alerts, CRLF, escapes and dropped trailing markup;
- three `[Fact]`s pinning the bug report's exact offsets (16 not 12; 2 not 0; 13 not 0);
- one pinning the wider source span for a backslash escape, and one pinning the trailing-markup clamp.

**17 of the 21 new cases fail against the unfixed extractor.**

Full write-up in `docs/investigations/markdown_source_span_investigation.md`.

## Verification

- Solution builds clean.
- 27 + 63 + 170 + 23 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc
