### PR TITLE
chore(deps): NAudio 2.2.1 -> 2.3.0

### DIFF
--- a/docs/investigations/dependency_upgrade_investigation.md
+++ b/docs/investigations/dependency_upgrade_investigation.md
@@ -157,3 +157,66 @@ Markdig's re-assembled container content instead. In the Run 2 corpus,
 first alert — and `second line` reports 12, both offsets into
 `"plain quote\nsecond line"`. Identical on 0.34.0 and 1.3.2, so it predates
 this work; filed separately.
+
+## Run 3 — 2026-09-05 — NAudio 2.2.1 → 3.0.1, and why it landed on 2.3.0
+
+**Question.** Nine projects pin NAudio 2.2.1. Applying Run 2's method note —
+ask what the new version *changed or removed* before diffing what still works
+— what does NAudio 3 drop?
+
+**Command.** Compare the metapackage's dependency groups across versions
+(`naudio.nuspec` from the flat container), then resolve each into a scratch
+`net10.0` project and reflect over the assemblies for the types this repo uses.
+
+**Raw finding — the metapackage stops shipping the Windows backends to
+non-Windows TFMs, and it happens at 2.4.0, not 3.0:**
+
+```
+NAudio 2.2.1  -> net6.0: WinMM     (Asio, Core, Midi, Wasapi, WinMM)
+NAudio 2.3.0  -> net6.0: WinMM     (Asio, Core, Midi, Wasapi, WinMM)
+NAudio 2.4.0  -> net6.0: NO WinMM  (Core, Midi)
+NAudio 3.0.1  -> net9.0: NO WinMM  (Core, Midi)
+```
+
+`NAudio.WinMM` 3.0.1 is not merely absent from the closure — it ships *only*
+`net9.0-windows7.0`, so referencing it directly from a `net10.0` project fails
+restore outright (NU1202). Every project here targets plain `net10.0`.
+
+Type-by-type on a `net10.0` resolve of 3.0.1, over what this repo actually
+uses: `WaveFormat`, `WaveFileWriter`, `WaveFileReader`, `AudioFileReader`,
+`BufferedWaveProvider`, `ISampleProvider`, `IWaveProvider`, `WaveStream`,
+`WdlResamplingSampleProvider`, `SampleToWaveProvider16` and
+`MonoToStereoSampleProvider` all survive. **`WaveOutEvent` does not** (nor
+`WasapiOut`, `Mp3FileReader`, `MediaFoundationResampler`, none of which we
+use). `WaveOutEvent` is the Windows-native playback path — 10 references
+across `PlaybackService` and `TranscriptEditorViewModel`, guarded at runtime
+by `OperatingSystem.IsWindows()` with ffplay used elsewhere. Runtime-guarded
+still has to compile.
+
+Second, independent break: NAudio 3 replaces
+`ISampleProvider.Read(float[], int, int)` with `Read(Span<float>)` (and
+`IWaveProvider.Read` with `Read(Span<byte>)`). Four provider classes and about
+six call sites need migrating. Mechanical, and half-done before the blocker
+above settled the direction. One subtlety worth keeping: on `AudioFileReader`
+the array-based call silently rebinds to `WaveStream.Read(byte[], int, int)`
+and fails as a type error rather than a missing-method one, so the fix is to
+go through the `ISampleProvider` interface explicitly.
+
+**Implication.** Adopting 3.x is not a version bump; it is a target-framework
+change. It needs `net10.0;net10.0-windows` multi-targeting on
+`Vernacula.Avalonia` and `Vernacula.Tts.Avalonia` (and a decision for their
+dependents, `Vernacula.Tts.Avalonia` and `tests/AsrBackendCoverage`) with the
+`WaveOutEvent` path behind the Windows TFM — or dropping native Windows
+playback in favour of ffplay everywhere, which is a user-visible regression
+since Windows currently needs no external binary.
+
+**Landed: 2.3.0.** The last version that keeps WinMM on a non-Windows TFM.
+Zero code changes, solution builds clean, 283 tests pass, no advisories, and
+the resolve still carries `NAudio.WinMM/2.3.0` for `net10.0`. The 3.x
+migration is filed separately so it can be scoped as the TFM change it
+actually is, rather than riding along on a dependency bump.
+
+**Method note, confirming Run 2's.** The lesson generalized: what mattered
+here was not in the API diff at all, but in the *packaging* — which
+sub-packages the metapackage hands a given TFM. For a metapackage, diff the
+dependency groups per target framework before anything else.

--- a/docs/investigations/dependency_upgrade_investigation.md
+++ b/docs/investigations/dependency_upgrade_investigation.md
@@ -182,11 +182,11 @@ NAudio 3.0.1  -> net9.0: NO WinMM  (Core, Midi)
 `net9.0-windows7.0`, so referencing it directly from a `net10.0` project fails
 restore outright (NU1202). Every project here targets plain `net10.0`.
 
-Type-by-type on a `net10.0` resolve of 3.0.1, over what this repo actually
-uses: `WaveFormat`, `WaveFileWriter`, `WaveFileReader`, `AudioFileReader`,
-`BufferedWaveProvider`, `ISampleProvider`, `IWaveProvider`, `WaveStream`,
-`WdlResamplingSampleProvider`, `SampleToWaveProvider16` and
-`MonoToStereoSampleProvider` all survive. **`WaveOutEvent` does not** (nor
+Type-by-type on a `net10.0` resolve of 3.0.1, over the NAudio types this repo
+actually references: `WaveFormat`, `WaveFileWriter`, `WaveFileReader`,
+`AudioFileReader`, `BufferedWaveProvider`, `ISampleProvider`, `IWaveProvider`,
+`WaveStream`, `WdlResamplingSampleProvider`, `StoppedEventArgs` and
+`WaveExtensionMethods` all survive. **`WaveOutEvent` does not** (nor
 `WasapiOut`, `Mp3FileReader`, `MediaFoundationResampler`, none of which we
 use). `WaveOutEvent` is the Windows-native playback path — 10 references
 across `PlaybackService` and `TranscriptEditorViewModel`, guarded at runtime
@@ -196,7 +196,16 @@ still has to compile.
 Second, independent break: NAudio 3 replaces
 `ISampleProvider.Read(float[], int, int)` with `Read(Span<float>)` (and
 `IWaveProvider.Read` with `Read(Span<byte>)`). Four provider classes and about
-six call sites need migrating. Mechanical, and half-done before the blocker
+six call sites need migrating.
+
+Third — found by review, and the reason a member-level diff beats a
+type-level one — `BufferedWaveProvider` reshapes: `BufferLength` becomes
+read-only with sizing moved into `.ctor(WaveFormat, TimeSpan?)`, and
+`AddSamples` grows a `ReadOnlySpan` form. `PlaybackService.cs:150` sets
+`BufferLength` in an object initializer, so it breaks too. Reflected on
+3.0.1 to confirm rather than inferred. `WaveExtensionMethods.Init` also loses
+its three-argument overload; our two call sites use the two-argument form and
+survive. Mechanical, and half-done before the blocker
 above settled the direction. One subtlety worth keeping: on `AudioFileReader`
 the array-based call silently rebinds to `WaveStream.Read(byte[], int, int)`
 and fails as a type error rather than a missing-method one, so the fix is to
@@ -210,7 +219,14 @@ dependents, `Vernacula.Tts.Avalonia` and `tests/AsrBackendCoverage`) with the
 playback in favour of ffplay everywhere, which is a user-visible regression
 since Windows currently needs no external binary.
 
-**Landed: 2.3.0.** The last version that keeps WinMM on a non-Windows TFM.
+**Landed: 2.3.0.** The last version whose *metapackage* lists WinMM in its
+non-Windows dependency group. Worth being precise, because it does not mean
+2.4.0 is closed off: `NAudio.WinMM` 2.4.0 still ships `lib/net6.0`, still
+contains `WaveOutEvent`, and still has the array-based `ISampleProvider.Read`.
+So `NAudio` 2.4.0 plus explicit `NAudio.WinMM`/`Wasapi`/`Asio` pins is a
+viable zero-code-change alternative worth one more version of currency, at the
+cost of four pins per project instead of one. Not taken — the churn buys
+little when 3.x needs the TFM change regardless.
 Zero code changes, solution builds clean, 283 tests pass, no advisories, and
 the resolve still carries `NAudio.WinMM/2.3.0` for `net10.0`. The 3.x
 migration is filed separately so it can be scoped as the TFM change it
@@ -220,3 +236,8 @@ actually is, rather than riding along on a dependency bump.
 here was not in the API diff at all, but in the *packaging* — which
 sub-packages the metapackage hands a given TFM. For a metapackage, diff the
 dependency groups per target framework before anything else.
+
+And a second-order one, from review catching the `BufferedWaveProvider`
+break: checking *type* availability is not the same as checking the *members*
+used. Types that survive can still lose the setter or overload the code
+depends on. Diff at member granularity for the types actually referenced.

--- a/scripts/TtsAsrProbe/TtsAsrProbe.csproj
+++ b/scripts/TtsAsrProbe/TtsAsrProbe.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -73,7 +73,7 @@
 
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
     <PackageReference Include="SoundTouch.Net" Version="2.1.2" />
     <PackageReference Include="ClosedXML" Version="0.104.1" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />

--- a/src/Vernacula.Base/Vernacula.Base.csproj
+++ b/src/Vernacula.Base/Vernacula.Base.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio"            Version="2.2.1" />
+    <PackageReference Include="NAudio"            Version="2.3.0" />
     <PackageReference Include="MathNet.Numerics"  Version="5.0.0" />
     <!-- Note: NemoNfaAligner uses an in-house SimpleSpTokenizer (greedy LPM
          over vocab.txt). Microsoft.ML.Tokenizers 2.0.0's

--- a/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
+++ b/src/Vernacula.Tts.Avalonia/Vernacula.Tts.Avalonia.csproj
@@ -33,7 +33,7 @@
          implementation of its own, which Avalonia 11.3 rejects: any document containing `code`
          logged "Unsupported IBinding implementation" and the whole markdown view rendered blank. -->
     <PackageReference Include="Markdown.Avalonia"           Version="11.0.3" />
-    <PackageReference Include="NAudio"                      Version="2.2.1" />
+    <PackageReference Include="NAudio"                      Version="2.3.0" />
   </ItemGroup>
 
   <!-- Both pull OnnxRuntime under PrivateAssets, so we provide the

--- a/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
+++ b/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>
 
   <!--

--- a/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
+++ b/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
@@ -34,7 +34,7 @@
 
   <!-- NAudio: voice-prompt WAV decode + resample to 24 kHz mono. -->
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>
 
   <!-- Markdig: markdown AST for MarkdownTextExtractor. Kept in step with the

--- a/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
+++ b/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
+++ b/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
+++ b/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Continues the upgrade queue after #123 (Markdig) and #125.

Nine projects go from NAudio 2.2.1 to **2.3.0** — csproj-only, no code changes.

## Why 2.3.0 and not 3.0.1

Applying the method note from the Markdig bump (ask what the new version *removed*, not just diff what still works) turned up a blocker that isn't in the API surface at all — it's in the packaging. The metapackage stops handing the Windows backends to non-Windows target frameworks, and that happens at **2.4.0**, not 3.0:

```
NAudio 2.2.1  -> net6.0: WinMM     (Asio, Core, Midi, Wasapi, WinMM)
NAudio 2.3.0  -> net6.0: WinMM     (Asio, Core, Midi, Wasapi, WinMM)
NAudio 2.4.0  -> net6.0: NO WinMM  (Core, Midi)
NAudio 3.0.1  -> net9.0: NO WinMM  (Core, Midi)
```

`NAudio.WinMM` 3.0.1 isn't just outside the closure — it ships **only** `net9.0-windows7.0`, so referencing it directly from a `net10.0` project fails restore with NU1202. All nine projects target plain `net10.0`.

Reflecting over a `net10.0` resolve of 3.0.1 for every NAudio type this repo references: `WaveFormat`, `WaveFileWriter`, `WaveFileReader`, `AudioFileReader`, `BufferedWaveProvider`, `ISampleProvider`, `IWaveProvider`, `WaveStream`, `WdlResamplingSampleProvider`, `StoppedEventArgs`, `WaveExtensionMethods` all survive. **`WaveOutEvent` does not.** That's the Windows-native playback path — 10 references across `PlaybackService` and `TranscriptEditorViewModel`, guarded at runtime by `OperatingSystem.IsWindows()` with ffplay used elsewhere. Runtime-guarded still has to compile.

There's a second, independent break: NAudio 3 replaces `ISampleProvider.Read(float[], int, int)` with `Read(Span<float>)`. Four provider classes and ~6 call sites. Mechanical — I had half of it done before the packaging finding settled the direction.

A third, surfaced by review: `BufferedWaveProvider` survives as a *type* but reshapes — `BufferLength` becomes read-only, with sizing moved into `.ctor(WaveFormat, TimeSpan?)`. `PlaybackService.cs:150` sets it in an object initializer. The lesson is that checking type availability isn't the same as checking the members used, and it's folded into #127 and the doc's method note.

So 3.x is a **target-framework change**, not a version bump: it needs `net10.0;net10.0-windows` multi-targeting on the two Avalonia projects with the `WaveOutEvent` path behind the Windows TFM, or dropping native Windows playback for ffplay everywhere (a user-visible regression, since Windows currently needs no external binary). Filed as its own issue rather than smuggled into a dependency bump.

## What landed

The largest bump that needs no code change.

## Verification

- Solution builds clean, no new warnings.
- `NAudio.WinMM/2.3.0` still resolves for `net10.0` — the property that matters.
- No vulnerable packages (transitive included).
- 27 + 63 + 170 + 23 tests pass.

Write-up in `docs/investigations/dependency_upgrade_investigation.md` (Run 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdK3aFddy4HFvL6tXLLcjc
