### PR TITLE
refactor(tts): one registry describes each TTS engine

### DIFF
--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -78,10 +78,9 @@ internal class SettingsService
             var legacy = JsonSerializer.Deserialize<LegacyReaderSettings>(File.ReadAllText(legacyPath));
             if (legacy is null) return;
 
-            bool changed = false;
             void Take(Func<string> get, Action<string> set, string? value)
             {
-                if (string.IsNullOrWhiteSpace(get()) && !string.IsNullOrWhiteSpace(value)) { set(value); changed = true; }
+                if (string.IsNullOrWhiteSpace(get()) && !string.IsNullOrWhiteSpace(value)) set(value);
             }
             var c = Current;
             Take(() => c.ChatterboxBundleDir, v => c.ChatterboxBundleDir = v, legacy.OnnxBundleDir);
@@ -94,10 +93,10 @@ internal class SettingsService
             Take(() => c.OmniVoiceTokenizerJson,  v => c.OmniVoiceTokenizerJson = v, legacy.OmniVoiceTokenizerJson);
             Take(() => c.OmniVoiceVoiceLib,       v => c.OmniVoiceVoiceLib = v,   legacy.OmniVoiceVoiceLib);
             Take(() => c.OmniVoiceVoice,          v => c.OmniVoiceVoice = v,      legacy.OmniVoiceVoice);
-            if (!string.IsNullOrWhiteSpace(legacy.TtsBackend))   { c.TtsBackend = legacy.TtsBackend; changed = true; }
-            if (!string.IsNullOrWhiteSpace(legacy.OmniVoiceLang)) { c.OmniVoiceLang = legacy.OmniVoiceLang; changed = true; }
-            if (legacy.KokoroSpeed > 0)                            { c.KokoroSpeed = legacy.KokoroSpeed; changed = true; }
-            if (legacy.OmniVoiceNumStep is > 0 and <= 64)          { c.OmniVoiceNumStep = legacy.OmniVoiceNumStep; changed = true; }
+            if (!string.IsNullOrWhiteSpace(legacy.TtsBackend))   c.TtsBackend = legacy.TtsBackend;
+            if (!string.IsNullOrWhiteSpace(legacy.OmniVoiceLang)) c.OmniVoiceLang = legacy.OmniVoiceLang;
+            if (legacy.KokoroSpeed > 0)                           c.KokoroSpeed = legacy.KokoroSpeed;
+            if (legacy.OmniVoiceNumStep is > 0 and <= 64)         c.OmniVoiceNumStep = legacy.OmniVoiceNumStep;
             c.TtsShowIpaAnnotation = legacy.ShowIpaAnnotation;
             c.TtsSettingsMigrated  = true;
             Save();

--- a/src/Vernacula.Avalonia/Services/Tts/TtsEngine.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsEngine.cs
@@ -103,14 +103,27 @@ internal static class TtsEngines
     public static IReadOnlyList<TtsEngine> All { get; } =
         [new KokoroEngine(), new OmniVoiceEngine(), new ChatterboxEngine()];
 
+    /// <summary>The default for a new job, and the fallback for anything unrecognised.</summary>
+    public static TtsEngine Default => All[0];
+
     public static TtsEngine For(TtsBackendKind kind) =>
-        All.FirstOrDefault(e => e.Kind == kind) ?? All[0];
+        All.FirstOrDefault(e => e.Kind == kind) ?? Default;
 
-    /// <summary>By persisted name ("Kokoro"); an unknown name falls back to the first engine.</summary>
-    public static TtsEngine For(string? name) =>
-        Enum.TryParse<TtsBackendKind>(name, ignoreCase: true, out var kind) ? For(kind) : All[0];
+    /// <summary>
+    /// By persisted name ("Kokoro"), or null when the name is empty or names no engine this
+    /// build has. Callers that must produce audio use <see cref="For(string?)"/>; callers that
+    /// merely DESCRIBE a stored job use this, so a job saved by another build is reported as
+    /// what it says it is rather than relabelled as the fallback.
+    /// </summary>
+    public static TtsEngine? TryFor(string? name) =>
+        Enum.TryParse<TtsBackendKind>(name, ignoreCase: true, out var kind)
+            ? All.FirstOrDefault(e => e.Kind == kind)
+            : null;
 
-    /// <summary>The engine a job was rendered with.</summary>
+    /// <summary>By persisted name; an unknown name falls back to <see cref="Default"/>.</summary>
+    public static TtsEngine For(string? name) => TryFor(name) ?? Default;
+
+    /// <summary>The engine a job was rendered with (the fallback applies to an unknown name).</summary>
     public static TtsEngine For(JobRecord job) => For(job.TtsBackend);
 }
 

--- a/src/Vernacula.Avalonia/Services/Tts/TtsEngine.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsEngine.cs
@@ -1,0 +1,294 @@
+using Vernacula.App.Models;
+using Vernacula.Phonemizer;
+using Vernacula.Tts.Base;
+
+namespace Vernacula.App.Services.Tts;
+
+/// <summary>
+/// Everything the app needs to know about one text-to-speech engine, in one place: what it is
+/// called, what it needs on disk, how to build it, how a job's choices become a request, how
+/// its output is phonemized, and which per-job controls it wants shown.
+///
+/// <para>
+/// ⚠ THIS IS THE ONLY PLACE AN ENGINE IS ENUMERATED. Before it existed the Kokoro / OmniVoice /
+/// Chatterbox branch was repeated in about a dozen switch expressions across the runner,
+/// prerequisites, export, reader and two view models, each with a <c>_ =&gt;</c> arm that
+/// silently treated an unknown engine as Chatterbox — so adding one was a scavenger hunt with
+/// no compiler help. Adding an engine now means: a subclass here, an entry in
+/// <see cref="TtsEngines.All"/>, a <see cref="TtsBackendKind"/> member, and its model set in
+/// ModelManagerService.
+/// </para>
+/// </summary>
+internal abstract class TtsEngine
+{
+    public abstract TtsBackendKind Kind { get; }
+    /// <summary>Short name, shown in pickers and in the reader's job line.</summary>
+    public abstract string DisplayName { get; }
+    /// <summary>One or two sentences for the Settings radio: what it is good at, what it costs.</summary>
+    public abstract string Description { get; }
+    /// <summary>Output sample rate (Hz) — the reader needs it before any audio exists.</summary>
+    public abstract int SampleRate { get; }
+    /// <summary>The model sets that must be complete on disk before a job can run.</summary>
+    public abstract ModelManagerService.TtsModelSet[] RequiredSets { get; }
+
+    /// <summary>How the export's phoneme column was produced, named in the CSV.</summary>
+    public virtual string PhonemeScheme => "ipa";
+
+    // ── Which per-job controls the dialog shows ──────────────────────────────
+    // Capabilities, not identity: a new engine with named voices gets the voice drop-down by
+    // saying so, without any view or view model learning its name.
+
+    /// <summary>Clones a reference clip picked per job (Chatterbox).</summary>
+    public virtual bool UsesReferenceClip => false;
+    /// <summary>Has a fixed list of named voices to choose from (Kokoro).</summary>
+    public virtual bool UsesVoiceList => false;
+    /// <summary>Reads any phonemizer language, with the voice chosen per language (OmniVoice).</summary>
+    public virtual bool UsesLanguage => false;
+    /// <summary>Has a speech-rate multiplier.</summary>
+    public virtual bool UsesSpeed => false;
+    /// <summary>Has a diffusion step count.</summary>
+    public virtual bool UsesDiffusionSteps => false;
+
+    // ── Building and running ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Identity of a loaded backend: everything that would make the cached one wrong. The job
+    /// runner rebuilds when this changes, so a model location edited in Settings takes effect
+    /// on the next job without an app restart.
+    /// </summary>
+    public abstract string CacheKey(SettingsService s);
+
+    public abstract ITtsBackend CreateBackend(SettingsService s);
+
+    /// <summary>The job's choices as a request for this engine — it decides which fields mean anything.</summary>
+    public virtual TtsRequest BuildRequest(string text, string wavPath, string segmentsDir, TtsJobSettings job) =>
+        new(text, wavPath, job.Voice, SegmentsDir: segmentsDir);
+
+    /// <summary>
+    /// What is wrong with this job's own choices (an unpicked voice, a language the catalogue
+    /// does not know), or null. Whether the MODEL FILES are present is not asked here — that is
+    /// <see cref="TtsPrerequisites.Describe"/>'s job, via <see cref="RequiredSets"/>, so there
+    /// is one on-disk truth for the runner, the dialog and the Settings rows.
+    /// </summary>
+    public virtual string? DescribeJobIssue(SettingsService s, TtsJobSettings job) => null;
+
+    /// <summary>Text → the phonemes this engine would be given, for the export's CSV. Blocking.</summary>
+    public abstract Func<string, string> CreatePhonemizer(SettingsService s, TtsJobSettings job);
+
+    // ── Describing a finished job ────────────────────────────────────────────
+
+    /// <summary>The language the reader's IPA annotation is read in for this job.</summary>
+    public virtual string AnnotationLanguage(JobRecord job) => "en";
+
+    /// <summary>The parts after the engine name in the reader's job line ("af_heart", "1.00×").</summary>
+    public virtual IEnumerable<string> DescribeJob(JobRecord job)
+    {
+        if (!string.IsNullOrWhiteSpace(job.TtsVoice)) yield return job.TtsVoice;
+    }
+
+    // ── Per-engine defaults in AppSettings ───────────────────────────────────
+    // The voice lives in a different field per engine (a path, a name, a library id), so the
+    // engine reads and writes its own.
+
+    public abstract string ReadStoredVoice(AppSettings s);
+    public abstract void WriteStoredVoice(AppSettings s, string voice);
+
+    /// <summary>The named voices on disk, for an engine with a fixed list (<see cref="UsesVoiceList"/>).</summary>
+    public virtual IReadOnlyList<string> AvailableVoices(SettingsService s) => [];
+}
+
+/// <summary>The engines this build ships, in the order they are offered.</summary>
+internal static class TtsEngines
+{
+    public static IReadOnlyList<TtsEngine> All { get; } =
+        [new KokoroEngine(), new OmniVoiceEngine(), new ChatterboxEngine()];
+
+    public static TtsEngine For(TtsBackendKind kind) =>
+        All.FirstOrDefault(e => e.Kind == kind) ?? All[0];
+
+    /// <summary>By persisted name ("Kokoro"); an unknown name falls back to the first engine.</summary>
+    public static TtsEngine For(string? name) =>
+        Enum.TryParse<TtsBackendKind>(name, ignoreCase: true, out var kind) ? For(kind) : All[0];
+
+    /// <summary>The engine a job was rendered with.</summary>
+    public static TtsEngine For(JobRecord job) => For(job.TtsBackend);
+}
+
+// ── Kokoro ───────────────────────────────────────────────────────────────────
+
+internal sealed class KokoroEngine : TtsEngine
+{
+    public override TtsBackendKind Kind => TtsBackendKind.Kokoro;
+    public override string DisplayName => "Kokoro-82M";
+    public override string Description =>
+        "Small and fast. Named English voices (American and British), adjustable speed, word timing from the model's own durations.";
+    public override int SampleRate => Kokoro.SampleRate;
+    public override ModelManagerService.TtsModelSet[] RequiredSets =>
+        [ModelManagerService.TtsModelSet.Kokoro, ModelManagerService.TtsModelSet.PhonemizerData];
+    public override string PhonemeScheme => "kokoro";   // its own vocabulary, exactly what the model consumed
+
+    public override bool UsesVoiceList => true;
+    public override bool UsesSpeed => true;
+
+    /// <summary>The bf_/bm_ voices are the British ones, which is also what picks en-GB phonemization.</summary>
+    private static bool IsBritish(string voice) =>
+        voice.StartsWith("bf_", StringComparison.Ordinal) || voice.StartsWith("bm_", StringComparison.Ordinal);
+
+    public override string CacheKey(SettingsService s) =>
+        $"kokoro|{s.GetKokoroModelsDir()}|{s.GetPhonemizerDataDir()}";
+
+    public override ITtsBackend CreateBackend(SettingsService s) =>
+        new KokoroSynthesisService(s.GetKokoroModelsDir(), s.GetPhonemizerDataDir());
+
+    public override TtsRequest BuildRequest(string text, string wavPath, string segmentsDir, TtsJobSettings job) =>
+        new(text, wavPath, job.Voice, job.Speed, SegmentsDir: segmentsDir);
+
+    public override string? DescribeJobIssue(SettingsService s, TtsJobSettings job)
+    {
+        if (string.IsNullOrWhiteSpace(job.Voice)) return "No Kokoro voice selected.";
+        string path = Path.Combine(s.GetKokoroModelsDir(), "voices", job.Voice + ".bin");
+        return File.Exists(path) ? null : $"Kokoro voice not found: {path}";
+    }
+
+    public override Func<string, string> CreatePhonemizer(SettingsService s, TtsJobSettings job)
+    {
+        var g2p = new KokoroPhonemizer(s.GetPhonemizerDataDir());
+        bool british = IsBritish(job.Voice);
+        return text => g2p.ToPhonemes(text, british);
+    }
+
+    public override string AnnotationLanguage(JobRecord job) => IsBritish(job.TtsVoice) ? "en-GB" : "en";
+
+    public override IEnumerable<string> DescribeJob(JobRecord job)
+    {
+        if (!string.IsNullOrWhiteSpace(job.TtsVoice)) yield return job.TtsVoice;
+        yield return $"{job.TtsSpeed:F2}×";
+    }
+
+    /// <summary>The voice packs on disk, by name (scripts/kokoro_export/export_voices.py writes them).</summary>
+    public override IReadOnlyList<string> AvailableVoices(SettingsService s)
+    {
+        var dir = Path.Combine(s.GetKokoroModelsDir(), "voices");
+        if (!Directory.Exists(dir)) return [];
+        return [.. Directory.EnumerateFiles(dir, "*.bin").Select(Path.GetFileNameWithoutExtension).OrderBy(v => v)!];
+    }
+
+    public override string ReadStoredVoice(AppSettings s) => s.KokoroVoice;
+    public override void WriteStoredVoice(AppSettings s, string voice) => s.KokoroVoice = voice;
+}
+
+// ── OmniVoice-IPA ────────────────────────────────────────────────────────────
+
+internal sealed class OmniVoiceEngine : TtsEngine
+{
+    public override TtsBackendKind Kind => TtsBackendKind.OmniVoice;
+    public override string DisplayName => "OmniVoice-IPA";
+    public override string Description =>
+        "Any of the phonemizer's 190+ languages through the IPA fine-tune, in a stored voice from the voice library. Large model; word timing is estimated.";
+    public override int SampleRate => OmniVoiceIpaTts.SampleRate;
+    public override ModelManagerService.TtsModelSet[] RequiredSets =>
+    [
+        ModelManagerService.TtsModelSet.OmniVoice,
+        ModelManagerService.TtsModelSet.OmniVoiceVoices,
+        ModelManagerService.TtsModelSet.PhonemizerData,
+    ];
+
+    public override bool UsesLanguage => true;
+    public override bool UsesDiffusionSteps => true;
+
+    private static string LangOf(string? code) => string.IsNullOrWhiteSpace(code) ? "en" : code.Trim();
+
+    public override string CacheKey(SettingsService s) =>
+        $"omnivoice|{s.GetOmniVoiceModelsDir()}|{s.Current.OmniVoiceTokenizerJson}"
+        + $"|{s.GetPhonemizerDataDir()}|{s.GetOmniVoiceVoiceLibDir()}";
+
+    public override ITtsBackend CreateBackend(SettingsService s) =>
+        new OmniVoiceSynthesisService(
+            s.GetOmniVoiceModelsDir(),
+            File.Exists(s.Current.OmniVoiceTokenizerJson) ? s.Current.OmniVoiceTokenizerJson : null,
+            s.GetPhonemizerDataDir(),
+            s.GetOmniVoiceVoiceLibDir());
+
+    public override TtsRequest BuildRequest(string text, string wavPath, string segmentsDir, TtsJobSettings job) =>
+        new(text, wavPath, job.Voice, Lang: LangOf(job.Language), NumStep: job.NumStep, SegmentsDir: segmentsDir);
+
+    public override string? DescribeJobIssue(SettingsService s, TtsJobSettings job)
+    {
+        if (string.IsNullOrWhiteSpace(job.Voice)) return "No OmniVoice voice selected.";
+        if (LanguageCatalog.ByCode(job.Language) is null)
+            return $"Unknown language \"{job.Language}\" — pick one from the list.";
+        return null;
+    }
+
+    public override Func<string, string> CreatePhonemizer(SettingsService s, TtsJobSettings job)
+    {
+        if (PhonemizerData.Resolve(s.GetPhonemizerDataDir()) is null)
+            throw new DirectoryNotFoundException(PhonemizerData.NotFoundMessage());
+        Registry.EnsureLanguages();
+        string lang = LangOf(job.Language);
+        return text => OmniVoiceIpaTts.Phonemize(text, lang);
+    }
+
+    public override string AnnotationLanguage(JobRecord job) => LangOf(job.TtsLanguage);
+
+    public override IEnumerable<string> DescribeJob(JobRecord job)
+    {
+        if (!string.IsNullOrWhiteSpace(job.TtsLanguage))
+            yield return LanguageCatalog.ByCode(job.TtsLanguage)?.Name ?? job.TtsLanguage;
+        if (!string.IsNullOrWhiteSpace(job.TtsVoice)) yield return job.TtsVoice;
+        yield return $"{job.TtsNumStep} steps";
+    }
+
+    public override string ReadStoredVoice(AppSettings s) => s.OmniVoiceVoice;
+    public override void WriteStoredVoice(AppSettings s, string voice) => s.OmniVoiceVoice = voice;
+}
+
+// ── Chatterbox ───────────────────────────────────────────────────────────────
+
+internal sealed class ChatterboxEngine : TtsEngine
+{
+    public override TtsBackendKind Kind => TtsBackendKind.Chatterbox;
+    public override string DisplayName => "Chatterbox";
+    public override string Description =>
+        "English voice cloning from a short reference clip. Word timing from the model's cross-attention.";
+    public override int SampleRate => ChatterboxConstants.S3GenSr;
+    public override ModelManagerService.TtsModelSet[] RequiredSets => [ModelManagerService.TtsModelSet.Chatterbox];
+
+    public override bool UsesReferenceClip => true;
+
+    public override string CacheKey(SettingsService s) => $"chatterbox|{s.GetChatterboxModelsDir()}";
+
+    public override ITtsBackend CreateBackend(SettingsService s)
+    {
+        string dir = s.GetChatterboxModelsDir();
+        string tokenizer = Path.Combine(dir, "tokenizer.json");
+        return new ChatterboxSynthesisService(dir, File.Exists(tokenizer) ? tokenizer : null);
+    }
+
+    public override string? DescribeJobIssue(SettingsService s, TtsJobSettings job) =>
+        File.Exists(job.Voice)
+            ? null
+            : $"Reference voice clip not found: {(string.IsNullOrWhiteSpace(job.Voice) ? "(not set)" : job.Voice)}";
+
+    /// <summary>
+    /// Chatterbox is fed text, not phonemes, so the export's column is the phonemizer's reading
+    /// of that text — informative, not what the model consumed. The scheme column says "ipa" so
+    /// the distinction is on the page rather than implied.
+    /// </summary>
+    public override Func<string, string> CreatePhonemizer(SettingsService s, TtsJobSettings job)
+    {
+        if (PhonemizerData.Resolve(s.GetPhonemizerDataDir()) is null)
+            throw new DirectoryNotFoundException(PhonemizerData.NotFoundMessage());
+        Registry.EnsureLanguages();
+        return text => OmniVoiceIpaTts.Phonemize(text, "en");
+    }
+
+    public override IEnumerable<string> DescribeJob(JobRecord job)
+    {
+        // A path, so the file name is the useful half.
+        if (!string.IsNullOrWhiteSpace(job.TtsVoice)) yield return Path.GetFileName(job.TtsVoice);
+    }
+
+    public override string ReadStoredVoice(AppSettings s) => s.ChatterboxVoicePath;
+    public override void WriteStoredVoice(AppSettings s, string voice) => s.ChatterboxVoicePath = voice;
+}

--- a/src/Vernacula.Avalonia/Services/Tts/TtsExportService.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsExportService.cs
@@ -20,11 +20,7 @@ internal static class TtsExportService
     public sealed record SentenceRow(int Index, double StartSeconds, double EndSeconds, string Text, string Phonemes);
 
     /// <summary>How the phoneme column was produced — named in the CSV so it is never mistaken for another scheme.</summary>
-    public static string PhonemeScheme(TtsBackendKind kind) => kind switch
-    {
-        TtsBackendKind.Kokoro => "kokoro",              // Kokoro's own vocabulary, exactly what the model consumed
-        _                     => "ipa",                 // vernacula-phonemizer canonical IPA
-    };
+    public static string PhonemeScheme(TtsBackendKind kind) => TtsEngines.For(kind).PhonemeScheme;
 
     // Terminal punctuation (Latin, ellipsis, CJK) followed by whitespace. Only whitespace
     // boundaries are cut so every sentence is a whole number of whitespace-split words —
@@ -64,28 +60,10 @@ internal static class TtsExportService
     /// <summary>Phonemizes each sentence the way the job's engine would read it. Blocking; call off the UI thread.</summary>
     public static List<SentenceRow> BuildRows(
         IReadOnlyList<(string Text, double Start, double End)> sentences,
-        TtsBackendKind kind, string lang, string voice, string? phonemizerDataDir)
+        SettingsService settings, TtsJobSettings job)
     {
-        Func<string, string> phonemize;
-        switch (kind)
-        {
-            case TtsBackendKind.Kokoro:
-            {
-                bool british = voice.StartsWith("bf_", StringComparison.Ordinal) || voice.StartsWith("bm_", StringComparison.Ordinal);
-                var g2p = new KokoroPhonemizer(phonemizerDataDir);
-                phonemize = s => g2p.ToPhonemes(s, british);
-                break;
-            }
-            default:
-            {
-                if (PhonemizerData.Resolve(phonemizerDataDir) is null)
-                    throw new DirectoryNotFoundException(PhonemizerData.NotFoundMessage());
-                Registry.EnsureLanguages();
-                string code = string.IsNullOrWhiteSpace(lang) ? "en" : lang.Trim();
-                phonemize = s => OmniVoiceIpaTts.Phonemize(s, code);
-                break;
-            }
-        }
+        // The engine owns its own text → phonemes path, so the CSV shows what that engine reads.
+        var phonemize = TtsEngines.For(job.Backend).CreatePhonemizer(settings, job);
 
         var rows = new List<SentenceRow>(sentences.Count);
         for (int i = 0; i < sentences.Count; i++)

--- a/src/Vernacula.Avalonia/Services/Tts/TtsExportService.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsExportService.cs
@@ -19,9 +19,6 @@ internal static class TtsExportService
     /// <summary>One exported row.</summary>
     public sealed record SentenceRow(int Index, double StartSeconds, double EndSeconds, string Text, string Phonemes);
 
-    /// <summary>How the phoneme column was produced — named in the CSV so it is never mistaken for another scheme.</summary>
-    public static string PhonemeScheme(TtsBackendKind kind) => TtsEngines.For(kind).PhonemeScheme;
-
     // Terminal punctuation (Latin, ellipsis, CJK) followed by whitespace. Only whitespace
     // boundaries are cut so every sentence is a whole number of whitespace-split words —
     // the unit the alignment is keyed on. Paragraph breaks are whitespace too.

--- a/src/Vernacula.Avalonia/Services/Tts/TtsJobRunner.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsJobRunner.cs
@@ -25,15 +25,9 @@ internal sealed class TtsJobRunner : IDisposable
     public TtsJobRunner(SettingsService settings) => _settings = settings;
 
     /// <summary>Sample rate of the backend a job with <paramref name="tts"/> will produce.</summary>
-    public static int SampleRateFor(TtsJobSettings tts) => ParseBackend(tts.Backend) switch
-    {
-        TtsBackendKind.Kokoro    => Kokoro.SampleRate,
-        TtsBackendKind.OmniVoice => OmniVoiceIpaTts.SampleRate,
-        _                        => ChatterboxConstants.S3GenSr,
-    };
+    public static int SampleRateFor(TtsJobSettings tts) => TtsEngines.For(tts.Backend).SampleRate;
 
-    public static TtsBackendKind ParseBackend(string name) =>
-        Enum.TryParse<TtsBackendKind>(name, ignoreCase: true, out var kind) ? kind : TtsBackendKind.Chatterbox;
+    public static TtsBackendKind ParseBackend(string name) => TtsEngines.For(name).Kind;
 
     /// <summary>
     /// Synthesizes <paramref name="documentPath"/> and writes <paramref name="sidecarPath"/>
@@ -58,14 +52,7 @@ internal sealed class TtsJobRunner : IDisposable
         // A re-render starts clean: a shorter document must not leave stale paragraph files.
         if (Directory.Exists(segmentsDir)) Directory.Delete(segmentsDir, recursive: true);
 
-        var request = ParseBackend(tts.Backend) switch
-        {
-            TtsBackendKind.Kokoro    => new TtsRequest(text, wavPath, tts.Voice, tts.Speed, SegmentsDir: segmentsDir),
-            TtsBackendKind.OmniVoice => new TtsRequest(text, wavPath, tts.Voice,
-                                            Lang: string.IsNullOrWhiteSpace(tts.Language) ? "en" : tts.Language.Trim(),
-                                            NumStep: tts.NumStep, SegmentsDir: segmentsDir),
-            _                        => new TtsRequest(text, wavPath, tts.Voice, SegmentsDir: segmentsDir),
-        };
+        var request = TtsEngines.For(tts.Backend).BuildRequest(text, wavPath, segmentsDir, tts);
 
         var result = await backend.SynthesizeStreamingAsync(request, onChunkProduced, onProgress, ct);
 
@@ -86,37 +73,19 @@ internal sealed class TtsJobRunner : IDisposable
     /// </summary>
     private ITtsBackend EnsureBackend(TtsJobSettings tts)
     {
-        var kind = ParseBackend(tts.Backend);
-        string key = kind switch
-        {
-            TtsBackendKind.Kokoro    => $"kokoro|{_settings.GetKokoroModelsDir()}|{_settings.GetPhonemizerDataDir()}",
-            TtsBackendKind.OmniVoice => $"omnivoice|{_settings.GetOmniVoiceModelsDir()}|{_settings.Current.OmniVoiceTokenizerJson}"
-                                        + $"|{_settings.GetPhonemizerDataDir()}|{_settings.GetOmniVoiceVoiceLibDir()}",
-            _                        => $"chatterbox|{_settings.GetChatterboxModelsDir()}",
-        };
+        var engine = TtsEngines.For(tts.Backend);
+        string key = engine.CacheKey(_settings);
         if (_backend is not null && _backendKey == key) return _backend;
 
         _backend?.Dispose();
         _backend = null;
         _backendKey = null;
 
-        string? missing = TtsPrerequisites.Describe(kind, _settings, tts);
+        string? missing = TtsPrerequisites.Describe(engine.Kind, _settings, tts);
         if (missing is not null)
             throw new InvalidOperationException(missing);
 
-        _backend = kind switch
-        {
-            TtsBackendKind.Kokoro    => new KokoroSynthesisService(_settings.GetKokoroModelsDir(), _settings.GetPhonemizerDataDir()),
-            TtsBackendKind.OmniVoice => new OmniVoiceSynthesisService(
-                                            _settings.GetOmniVoiceModelsDir(),
-                                            File.Exists(_settings.Current.OmniVoiceTokenizerJson) ? _settings.Current.OmniVoiceTokenizerJson : null,
-                                            _settings.GetPhonemizerDataDir(),
-                                            _settings.GetOmniVoiceVoiceLibDir()),
-            _                        => new ChatterboxSynthesisService(
-                                            _settings.GetChatterboxModelsDir(),
-                                            File.Exists(Path.Combine(_settings.GetChatterboxModelsDir(), "tokenizer.json"))
-                                                ? Path.Combine(_settings.GetChatterboxModelsDir(), "tokenizer.json") : null),
-        };
+        _backend = engine.CreateBackend(_settings);
         _backendKey = key;
         return _backend;
     }
@@ -139,15 +108,6 @@ internal sealed class TtsJobRunner : IDisposable
 /// </summary>
 internal static class TtsPrerequisites
 {
-    /// <summary>The model sets a backend needs on disk.</summary>
-    public static ModelManagerService.TtsModelSet[] RequiredSets(TtsBackendKind kind) => kind switch
-    {
-        TtsBackendKind.Kokoro    => [ModelManagerService.TtsModelSet.Kokoro, ModelManagerService.TtsModelSet.PhonemizerData],
-        TtsBackendKind.OmniVoice => [ModelManagerService.TtsModelSet.OmniVoice, ModelManagerService.TtsModelSet.OmniVoiceVoices,
-                                     ModelManagerService.TtsModelSet.PhonemizerData],
-        _                        => [ModelManagerService.TtsModelSet.Chatterbox],
-    };
-
     /// <summary>
     /// Null when everything the backend needs is on disk; otherwise what is missing and where
     /// it was looked for. The on-disk part is ModelManagerService's own check — the same one
@@ -156,30 +116,14 @@ internal static class TtsPrerequisites
     /// </summary>
     public static string? Describe(TtsBackendKind kind, SettingsService s, TtsJobSettings? job = null)
     {
-        foreach (var set in RequiredSets(kind))
+        var engine = TtsEngines.For(kind);
+        foreach (var set in engine.RequiredSets)
         {
             var missing = ModelManagerService.GetMissingTtsFiles(set, s);
             if (missing.Count > 0)
                 return $"{SetName(set)} incomplete in {ModelManagerService.TtsModelSetDir(set, s)}: missing {string.Join(", ", missing)}. See Settings → Text-to-Speech.";
         }
-        if (job is null) return null;
-
-        switch (kind)
-        {
-            case TtsBackendKind.Kokoro:
-                if (string.IsNullOrWhiteSpace(job.Voice)) return "No Kokoro voice selected.";
-                string voicePath = Path.Combine(s.GetKokoroModelsDir(), "voices", job.Voice + ".bin");
-                if (!File.Exists(voicePath)) return $"Kokoro voice not found: {voicePath}";
-                return null;
-            case TtsBackendKind.OmniVoice:
-                if (string.IsNullOrWhiteSpace(job.Voice)) return "No OmniVoice voice selected.";
-                if (LanguageCatalog.ByCode(job.Language) is null) return $"Unknown language \"{job.Language}\" — pick one from the list.";
-                return null;
-            default:
-                if (!File.Exists(job.Voice))
-                    return $"Reference voice clip not found: {(string.IsNullOrWhiteSpace(job.Voice) ? "(not set)" : job.Voice)}";
-                return null;
-        }
+        return job is null ? null : engine.DescribeJobIssue(s, job);
     }
 
     private static string SetName(ModelManagerService.TtsModelSet set) => set switch

--- a/src/Vernacula.Avalonia/ViewModels/NewTtsJobViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/NewTtsJobViewModel.cs
@@ -31,25 +31,29 @@ internal partial class NewTtsJobViewModel : ObservableObject
 
     // ── Engine ───────────────────────────────────────────────────────────────
 
-    public IReadOnlyList<TtsBackendKind> Backends { get; } =
-        [TtsBackendKind.Kokoro, TtsBackendKind.OmniVoice, TtsBackendKind.Chatterbox];
+    public IReadOnlyList<TtsEngine> Engines => TtsEngines.All;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(StartCommand))]
-    [NotifyPropertyChangedFor(nameof(IsChatterbox), nameof(IsKokoro), nameof(IsOmniVoice))]
-    private TtsBackendKind _selectedBackend;
+    [NotifyPropertyChangedFor(nameof(ShowReferenceClip), nameof(ShowVoiceList), nameof(ShowLanguage),
+                              nameof(ShowSpeed), nameof(ShowDiffusionSteps))]
+    private TtsEngine _selectedEngine = TtsEngines.All[0];
 
-    public bool IsChatterbox => SelectedBackend == TtsBackendKind.Chatterbox;
-    public bool IsKokoro     => SelectedBackend == TtsBackendKind.Kokoro;
-    public bool IsOmniVoice  => SelectedBackend == TtsBackendKind.OmniVoice;
+    // Which controls the dialog shows is asked of the engine, not of its name, so a new engine
+    // gets the right ones by declaring its capabilities.
+    public bool ShowReferenceClip   => SelectedEngine.UsesReferenceClip;
+    public bool ShowVoiceList       => SelectedEngine.UsesVoiceList;
+    public bool ShowLanguage        => SelectedEngine.UsesLanguage;
+    public bool ShowSpeed           => SelectedEngine.UsesSpeed;
+    public bool ShowDiffusionSteps  => SelectedEngine.UsesDiffusionSteps;
 
-    // ── Chatterbox: reference clip ───────────────────────────────────────────
+    // ── Reference clip (a cloning engine) ────────────────────────────────────
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(StartCommand))]
     private string _chatterboxVoicePath = "";
 
-    // ── Kokoro: named voice + speed ──────────────────────────────────────────
+    // ── Named voice + speed (a fixed-voice engine) ───────────────────────────
 
     public ObservableCollection<string> KokoroVoices { get; } = new();
 
@@ -118,11 +122,11 @@ internal partial class NewTtsJobViewModel : ObservableObject
             DocumentPath = "";
             JobName = "";
             var s = _settings.Current;
-            SelectedBackend     = TtsJobRunner.ParseBackend(s.TtsBackend);
+            SelectedEngine      = TtsEngines.For(s.TtsBackend);
             ChatterboxVoicePath = s.ChatterboxVoicePath ?? "";
             KokoroSpeed         = s.KokoroSpeed > 0 ? s.KokoroSpeed : 1.0f;
             KokoroVoice         = s.KokoroVoice ?? "";
-            RefreshKokoroVoices();
+            RefreshVoiceList();
             OmniVoiceLang       = string.IsNullOrWhiteSpace(s.OmniVoiceLang) ? "en" : s.OmniVoiceLang;
             OmniVoiceLanguage   = LanguageCatalog.ByCode(OmniVoiceLang);
             OmniVoiceLangQuery  = OmniVoiceLanguage?.Name ?? OmniVoiceLang;
@@ -134,24 +138,38 @@ internal partial class NewTtsJobViewModel : ObservableObject
         UpdatePrerequisites();
     }
 
-    /// <summary>The choices as they would be stored on the job.</summary>
-    public TtsJobSettings CurrentSettings() => SelectedBackend switch
+    /// <summary>
+    /// The choices as they would be stored on the job. Which field holds "the voice" follows
+    /// the engine's capabilities — a path to clone, a name from a list, or a library id.
+    /// </summary>
+    public TtsJobSettings CurrentSettings()
     {
-        TtsBackendKind.Kokoro    => new TtsJobSettings("Kokoro", "", KokoroVoice, KokoroSpeed),
-        TtsBackendKind.OmniVoice => new TtsJobSettings("OmniVoice", OmniVoiceLang.Trim(), OmniVoiceVoice?.Id ?? "", NumStep: OmniVoiceNumStep),
-        _                        => new TtsJobSettings("Chatterbox", "", ChatterboxVoicePath),
-    };
+        var e = SelectedEngine;
+        string voice = e.UsesReferenceClip ? ChatterboxVoicePath
+                     : e.UsesVoiceList     ? KokoroVoice
+                     : OmniVoiceVoice?.Id ?? "";
+        return new TtsJobSettings(
+            e.Kind.ToString(),
+            e.UsesLanguage ? OmniVoiceLang.Trim() : "",
+            voice,
+            e.UsesSpeed ? KokoroSpeed : 1.0f,
+            e.UsesDiffusionSteps ? OmniVoiceNumStep : 32);
+    }
 
     private void UpdatePrerequisites()
     {
         if (_loading) return;
-        PrerequisiteMessage = TtsPrerequisites.Describe(SelectedBackend, _settings, CurrentSettings()) ?? "";
+        PrerequisiteMessage = TtsPrerequisites.Describe(SelectedEngine.Kind, _settings, CurrentSettings()) ?? "";
         StartCommand.NotifyCanExecuteChanged();
     }
 
     // ── Change hooks ─────────────────────────────────────────────────────────
 
-    partial void OnSelectedBackendChanged(TtsBackendKind value) => UpdatePrerequisites();
+    partial void OnSelectedEngineChanged(TtsEngine value)
+    {
+        RefreshVoiceList();
+        UpdatePrerequisites();
+    }
     partial void OnChatterboxVoicePathChanged(string value)     => UpdatePrerequisites();
     partial void OnKokoroVoiceChanged(string value)             => UpdatePrerequisites();
     partial void OnOmniVoiceVoiceChanged(StoredVoice.Info? value) => UpdatePrerequisites();
@@ -196,13 +214,12 @@ internal partial class NewTtsJobViewModel : ObservableObject
 
     // ── Voice lists ──────────────────────────────────────────────────────────
 
-    private void RefreshKokoroVoices()
+    /// <summary>The named voices of an engine that has a fixed list; empty for the others.</summary>
+    private void RefreshVoiceList()
     {
         KokoroVoices.Clear();
-        var dir = Path.Combine(_settings.GetKokoroModelsDir(), "voices");
-        if (!Directory.Exists(dir)) return;
-        foreach (var f in Directory.EnumerateFiles(dir, "*.bin").OrderBy(p => p))
-            KokoroVoices.Add(Path.GetFileNameWithoutExtension(f));
+        foreach (var v in SelectedEngine.AvailableVoices(_settings))
+            KokoroVoices.Add(v);
         if (KokoroVoices.Count > 0 && !KokoroVoices.Contains(KokoroVoice))
             KokoroVoice = KokoroVoices[0];
     }
@@ -318,22 +335,12 @@ internal partial class NewTtsJobViewModel : ObservableObject
     private void RememberChoices(TtsJobSettings tts)
     {
         var s = _settings.Current;
+        var e = SelectedEngine;
         s.TtsBackend = tts.Backend;
-        switch (SelectedBackend)
-        {
-            case TtsBackendKind.Kokoro:
-                s.KokoroVoice = KokoroVoice;
-                s.KokoroSpeed = KokoroSpeed;
-                break;
-            case TtsBackendKind.OmniVoice:
-                s.OmniVoiceLang    = OmniVoiceLang;
-                s.OmniVoiceVoice   = OmniVoiceVoice?.Id ?? "";
-                s.OmniVoiceNumStep = OmniVoiceNumStep;
-                break;
-            default:
-                s.ChatterboxVoicePath = ChatterboxVoicePath;
-                break;
-        }
+        e.WriteStoredVoice(s, tts.Voice);
+        if (e.UsesSpeed)           s.KokoroSpeed      = KokoroSpeed;
+        if (e.UsesLanguage)        s.OmniVoiceLang    = OmniVoiceLang;
+        if (e.UsesDiffusionSteps)  s.OmniVoiceNumStep = OmniVoiceNumStep;
         _settings.Save();
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/NewTtsJobViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/NewTtsJobViewModel.cs
@@ -214,12 +214,28 @@ internal partial class NewTtsJobViewModel : ObservableObject
 
     // ── Voice lists ──────────────────────────────────────────────────────────
 
-    /// <summary>The named voices of an engine that has a fixed list; empty for the others.</summary>
+    /// <summary>
+    /// The named voices of an engine that has a fixed list.
+    ///
+    /// ⚠ LEAVE THE LIST ALONE FOR AN ENGINE THAT HAS NONE. KokoroVoices is the voice
+    /// ComboBox's ItemsSource and its selection is bound two-way to KokoroVoice, so clearing
+    /// it clears the choice: switching the engine away and back would silently replace a
+    /// picked voice with the first in the list — and RememberChoices would then persist that.
+    /// </summary>
     private void RefreshVoiceList()
     {
-        KokoroVoices.Clear();
-        foreach (var v in SelectedEngine.AvailableVoices(_settings))
-            KokoroVoices.Add(v);
+        if (!SelectedEngine.UsesVoiceList) return;
+
+        // Rebuild in place only when the contents actually differ, so re-selecting the same
+        // engine does not disturb the ComboBox's selection at all.
+        var voices = SelectedEngine.AvailableVoices(_settings);
+        if (!KokoroVoices.SequenceEqual(voices))
+        {
+            string keep = KokoroVoice;
+            KokoroVoices.Clear();
+            foreach (var v in voices) KokoroVoices.Add(v);
+            if (voices.Contains(keep)) KokoroVoice = keep;
+        }
         if (KokoroVoices.Count > 0 && !KokoroVoices.Contains(KokoroVoice))
             KokoroVoice = KokoroVoices[0];
     }

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.Tts.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.Tts.cs
@@ -15,22 +15,27 @@ internal partial class SettingsViewModel
 {
     // ── Default engine ───────────────────────────────────────────────────────
 
+    /// <summary>One row per engine for the picker — the list is TtsEngines.All, not a hand-written set.</summary>
+    public ObservableCollection<TtsEngineOptionViewModel> TtsEngineOptions { get; } = new();
+
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsTtsChatterbox), nameof(IsTtsKokoro), nameof(IsTtsOmniVoice))]
-    private TtsBackendKind _selectedTtsBackend;
+    [NotifyPropertyChangedFor(nameof(ShowTtsSpeedDefault), nameof(ShowTtsStepsDefault),
+                              nameof(ShowTtsReferenceClipDefault), nameof(ShowTtsTokenizerDefault))]
+    private TtsEngine _selectedTtsEngine = TtsEngines.All[0];
 
-    public bool IsTtsChatterbox => SelectedTtsBackend == TtsBackendKind.Chatterbox;
-    public bool IsTtsKokoro     => SelectedTtsBackend == TtsBackendKind.Kokoro;
-    public bool IsTtsOmniVoice  => SelectedTtsBackend == TtsBackendKind.OmniVoice;
+    // The defaults section shows a control when the engine has that knob, not when it has that name.
+    public bool ShowTtsSpeedDefault         => SelectedTtsEngine.UsesSpeed;
+    public bool ShowTtsStepsDefault         => SelectedTtsEngine.UsesDiffusionSteps;
+    public bool ShowTtsReferenceClipDefault => SelectedTtsEngine.UsesReferenceClip;
+    /// <summary>Only the OmniVoice path needs a Qwen3 tokenizer pick; it is the one with a language picker.</summary>
+    public bool ShowTtsTokenizerDefault     => SelectedTtsEngine.UsesLanguage;
 
-    [RelayCommand] private void SetTtsBackend(string n)
+    [RelayCommand] private void SetTtsBackend(string n) => SelectedTtsEngine = TtsEngines.For(n);
+
+    partial void OnSelectedTtsEngineChanged(TtsEngine value)
     {
-        if (Enum.TryParse<TtsBackendKind>(n, out var k)) SelectedTtsBackend = k;
-    }
-
-    partial void OnSelectedTtsBackendChanged(TtsBackendKind value)
-    {
-        _svc.Current.TtsBackend = value.ToString();
+        foreach (var option in TtsEngineOptions) option.Refresh(value);
+        _svc.Current.TtsBackend = value.Kind.ToString();
         _svc.Save();
         OnTtsModelsChanged?.Invoke();
     }
@@ -107,12 +112,15 @@ internal partial class SettingsViewModel
         // the properties would fire the change hooks (a settings save, OnTtsModelsChanged) before
         // anything is wired. The analyzer only waives that for code textually inside a constructor.
 #pragma warning disable MVVMTK0034
-        _selectedTtsBackend     = TtsJobRunner.ParseBackend(_svc.Current.TtsBackend);
+        _selectedTtsEngine      = TtsEngines.For(_svc.Current.TtsBackend);
         _chatterboxVoicePath    = _svc.Current.ChatterboxVoicePath ?? "";
         _omniVoiceTokenizerJson = _svc.Current.OmniVoiceTokenizerJson ?? "";
         _kokoroSpeed            = _svc.Current.KokoroSpeed > 0 ? _svc.Current.KokoroSpeed : 1.0f;
         _omniVoiceNumStep       = _svc.Current.OmniVoiceNumStep is > 0 and <= 64 ? _svc.Current.OmniVoiceNumStep : 32;
 #pragma warning restore MVVMTK0034
+
+        foreach (var engine in TtsEngines.All)
+            TtsEngineOptions.Add(new TtsEngineOptionViewModel(engine, SelectedTtsEngine));
 
         void Changed() => OnTtsModelsChanged?.Invoke();
         TtsModelSets.Add(new(ModelManagerService.TtsModelSet.Kokoro, "Kokoro-82M",

--- a/src/Vernacula.Avalonia/ViewModels/TtsEngineOptionViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TtsEngineOptionViewModel.cs
@@ -1,0 +1,28 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Vernacula.App.Services.Tts;
+
+namespace Vernacula.App.ViewModels;
+
+/// <summary>
+/// One engine in the Settings → Text-to-Speech picker: what to show, and whether it is the
+/// current choice. A row per <see cref="TtsEngines.All"/> entry, so the picker gains an engine
+/// when the registry does rather than when someone remembers to add a RadioButton.
+/// </summary>
+internal sealed partial class TtsEngineOptionViewModel : ObservableObject
+{
+    public TtsEngine Engine { get; }
+    public string Name => Engine.DisplayName;
+    public string Description => Engine.Description;
+    /// <summary>Command parameter for SetTtsBackend.</summary>
+    public string KindName => Engine.Kind.ToString();
+
+    [ObservableProperty] private bool _isSelected;
+
+    public TtsEngineOptionViewModel(TtsEngine engine, TtsEngine selected)
+    {
+        Engine = engine;
+        _isSelected = ReferenceEquals(engine, selected);
+    }
+
+    public void Refresh(TtsEngine selected) => IsSelected = ReferenceEquals(Engine, selected);
+}

--- a/src/Vernacula.Avalonia/ViewModels/TtsReaderViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TtsReaderViewModel.cs
@@ -186,10 +186,15 @@ internal sealed partial class TtsReaderViewModel : ObservableObject, IDisposable
         }
     }
 
-    /// <summary>"Kokoro · af_heart · 1.00×" — the engine, then whatever it says identifies the job.</summary>
+    /// <summary>
+    /// "Kokoro-82M · af_heart · 1.00×" — the engine, then whatever it says identifies the job.
+    /// A job whose engine this build does not have is named by what it stored, not relabelled
+    /// as the fallback engine, and only its voice is shown (no engine is there to interpret it).
+    /// </summary>
     private static string DescribeJob(JobRecord job)
     {
-        var engine = TtsEngines.For(job);
+        if (TtsEngines.TryFor(job.TtsBackend) is not { } engine)
+            return string.Join("  ·  ", new[] { job.TtsBackend, job.TtsVoice }.Where(p => !string.IsNullOrWhiteSpace(p)));
         return string.Join("  ·  ", new[] { engine.DisplayName }.Concat(engine.DescribeJob(job)));
     }
 

--- a/src/Vernacula.Avalonia/ViewModels/TtsReaderViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TtsReaderViewModel.cs
@@ -161,8 +161,8 @@ internal sealed partial class TtsReaderViewModel : ObservableObject, IDisposable
         _audioPath    = null;
         _audioDuration = 0;
         _sidecar      = null;
-        _lang         = AnnotationLangFor(job);
-        _sampleRate   = TtsJobRunner.SampleRateFor(new TtsJobSettings(job.TtsBackend, job.TtsLanguage, job.TtsVoice));
+        _lang         = TtsEngines.For(job).AnnotationLanguage(job);
+        _sampleRate   = TtsEngines.For(job).SampleRate;
         lock (_receivedLock) { _receivedAudio.Clear(); _receivedWords.Clear(); }
         _streamWordCursor = 0;
 
@@ -186,30 +186,12 @@ internal sealed partial class TtsReaderViewModel : ObservableObject, IDisposable
         }
     }
 
+    /// <summary>"Kokoro · af_heart · 1.00×" — the engine, then whatever it says identifies the job.</summary>
     private static string DescribeJob(JobRecord job)
     {
-        var parts = new List<string> { job.TtsBackend };
-        if (!string.IsNullOrWhiteSpace(job.TtsLanguage))
-            parts.Add(LanguageCatalog.ByCode(job.TtsLanguage)?.Name ?? job.TtsLanguage);
-        if (!string.IsNullOrWhiteSpace(job.TtsVoice))
-            parts.Add(TtsJobRunner.ParseBackend(job.TtsBackend) == TtsBackendKind.Chatterbox
-                ? Path.GetFileName(job.TtsVoice) : job.TtsVoice);
-        if (TtsJobRunner.ParseBackend(job.TtsBackend) == TtsBackendKind.Kokoro)
-            parts.Add($"{job.TtsSpeed:F2}×");
-        if (TtsJobRunner.ParseBackend(job.TtsBackend) == TtsBackendKind.OmniVoice)
-            parts.Add($"{job.TtsNumStep} steps");
-        return string.Join("  ·  ", parts);
+        var engine = TtsEngines.For(job);
+        return string.Join("  ·  ", new[] { engine.DisplayName }.Concat(engine.DescribeJob(job)));
     }
-
-    /// <summary>The language the IPA annotation is read in: OmniVoice's picked language, Kokoro's
-    /// en/en-GB (its British voices are the bf_/bm_ ones), and en for Chatterbox.</summary>
-    private static string AnnotationLangFor(JobRecord job) => TtsJobRunner.ParseBackend(job.TtsBackend) switch
-    {
-        TtsBackendKind.OmniVoice => string.IsNullOrWhiteSpace(job.TtsLanguage) ? "en" : job.TtsLanguage.Trim(),
-        TtsBackendKind.Kokoro    => job.TtsVoice.StartsWith("bf_", StringComparison.Ordinal)
-                                    || job.TtsVoice.StartsWith("bm_", StringComparison.Ordinal) ? "en-GB" : "en",
-        _                        => "en",
-    };
 
     private static string ReadDocument(JobRecord job)
     {
@@ -669,10 +651,11 @@ internal sealed partial class TtsReaderViewModel : ObservableObject, IDisposable
         {
             await Task.Run(() =>
             {
-                var kind = TtsJobRunner.ParseBackend(job.TtsBackend);
+                var engine = TtsEngines.For(job);
+                var settings = new TtsJobSettings(job.TtsBackend, job.TtsLanguage, job.TtsVoice, job.TtsSpeed, job.TtsNumStep);
                 var sentences = TtsExportService.SplitSentences(sidecar.SourceText ?? _text, sidecar.Words);
-                var rows = TtsExportService.BuildRows(sentences, kind, _lang, job.TtsVoice, _settings.GetPhonemizerDataDir());
-                TtsExportService.WriteCsv(csvPath, rows, TtsExportService.PhonemeScheme(kind));
+                var rows = TtsExportService.BuildRows(sentences, _settings, settings);
+                TtsExportService.WriteCsv(csvPath, rows, engine.PhonemeScheme);
                 File.Copy(audioPath, wavPath, overwrite: true);
             });
             StatusMessage = Loc.Instance.T("tts_export_done", new()

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -1245,40 +1245,42 @@
                                        FontSize="11" TextWrapping="Wrap" />
                         </StackPanel>
 
-                        <!-- OmniVoice: diffusion steps + optional tokenizer -->
-                        <StackPanel IsVisible="{Binding ShowTtsStepsDefault}" Spacing="10">
-                            <StackPanel>
-                                <TextBlock Text="{Binding OmniVoiceNumStep, StringFormat='Diffusion steps: {0}'}"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextBrush}" />
-                                <Slider Minimum="8" Maximum="48" TickFrequency="4" IsSnapToTickEnabled="True"
-                                        Value="{Binding OmniVoiceNumStep}" />
-                                <TextBlock Text="More steps: cleaner audio, slower render. 32 is the usual trade-off."
-                                           Foreground="{DynamicResource SubtextBrush}"
-                                           FontSize="11" TextWrapping="Wrap" />
-                            </StackPanel>
-                            <StackPanel>
-                                <TextBlock Text="Qwen3 tokenizer.json (optional)"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextBrush}" />
-                                <TextBlock Text="Found automatically beside the graphs, in OMNIVOICE_MODEL_DIR, or in the Hugging Face cache. Pick it only when none of those apply."
-                                           Foreground="{DynamicResource SubtextBrush}"
-                                           FontSize="11" TextWrapping="Wrap" Margin="0,0,0,4" />
-                                <Grid ColumnDefinitions="*,Auto,Auto">
-                                    <TextBox Grid.Column="0"
-                                             Text="{Binding OmniVoiceTokenizerJson, Mode=OneWay}"
-                                             IsReadOnly="True"
-                                             Watermark="(auto-located)"
-                                             Margin="0,0,8,0" />
-                                    <Button Grid.Column="1" Content="Browse…"
-                                            Classes="secondary-button"
-                                            Command="{Binding PickOmniVoiceTokenizerCommand}"
-                                            Margin="0,0,6,0" />
-                                    <Button Grid.Column="2" Content="Clear"
-                                            Classes="secondary-button"
-                                            Command="{Binding ClearOmniVoiceTokenizerCommand}" />
-                                </Grid>
-                            </StackPanel>
+                        <!-- Diffusion steps, for an engine that has them -->
+                        <StackPanel IsVisible="{Binding ShowTtsStepsDefault}">
+                            <TextBlock Text="{Binding OmniVoiceNumStep, StringFormat='Diffusion steps: {0}'}"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextBrush}" />
+                            <Slider Minimum="8" Maximum="48" TickFrequency="4" IsSnapToTickEnabled="True"
+                                    Value="{Binding OmniVoiceNumStep}" />
+                            <TextBlock Text="More steps: cleaner audio, slower render. 32 is the usual trade-off."
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11" TextWrapping="Wrap" />
+                        </StackPanel>
+
+                        <!-- The Qwen3 tokenizer belongs to the phonemizing path, so it is gated on
+                             the language capability rather than on diffusion steps: an engine with
+                             a language but no steps still needs it. -->
+                        <StackPanel IsVisible="{Binding ShowTtsTokenizerDefault}">
+                            <TextBlock Text="Qwen3 tokenizer.json (optional)"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource TextBrush}" />
+                            <TextBlock Text="Found automatically beside the graphs, in OMNIVOICE_MODEL_DIR, or in the Hugging Face cache. Pick it only when none of those apply."
+                                       Foreground="{DynamicResource SubtextBrush}"
+                                       FontSize="11" TextWrapping="Wrap" Margin="0,0,0,4" />
+                            <Grid ColumnDefinitions="*,Auto,Auto">
+                                <TextBox Grid.Column="0"
+                                         Text="{Binding OmniVoiceTokenizerJson, Mode=OneWay}"
+                                         IsReadOnly="True"
+                                         Watermark="(auto-located)"
+                                         Margin="0,0,8,0" />
+                                <Button Grid.Column="1" Content="Browse…"
+                                        Classes="secondary-button"
+                                        Command="{Binding PickOmniVoiceTokenizerCommand}"
+                                        Margin="0,0,6,0" />
+                                <Button Grid.Column="2" Content="Clear"
+                                        Classes="secondary-button"
+                                        Command="{Binding ClearOmniVoiceTokenizerCommand}" />
+                            </Grid>
                         </StackPanel>
 
                         <!-- Chatterbox: default reference clip -->

--- a/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
+++ b/src/Vernacula.Avalonia/Views/SettingsWindow.axaml
@@ -1198,55 +1198,30 @@
                                    TextWrapping="Wrap"
                                    Margin="0,0,0,10" />
 
-                        <RadioButton GroupName="TtsBackend"
-                                     IsChecked="{Binding IsTtsKokoro, Mode=OneWay}"
-                                     Command="{Binding SetTtsBackendCommand}"
-                                     CommandParameter="Kokoro"
-                                     Foreground="{DynamicResource TextBrush}"
-                                     Margin="0,0,0,4">
-                            <StackPanel>
-                                <TextBlock Text="Kokoro-82M"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextBrush}" />
-                                <TextBlock Text="Small and fast. Named English voices (American and British), adjustable speed, word timing from the model's own durations."
-                                           Foreground="{DynamicResource SubtextBrush}"
-                                           FontSize="11"
-                                           TextWrapping="Wrap" />
-                            </StackPanel>
-                        </RadioButton>
-
-                        <RadioButton GroupName="TtsBackend"
-                                     IsChecked="{Binding IsTtsOmniVoice, Mode=OneWay}"
-                                     Command="{Binding SetTtsBackendCommand}"
-                                     CommandParameter="OmniVoice"
-                                     Foreground="{DynamicResource TextBrush}"
-                                     Margin="0,0,0,4">
-                            <StackPanel>
-                                <TextBlock Text="OmniVoice-IPA"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextBrush}" />
-                                <TextBlock Text="Any of the phonemizer's 190+ languages through the IPA fine-tune, in a stored voice from the voice library. Large model; word timing is estimated."
-                                           Foreground="{DynamicResource SubtextBrush}"
-                                           FontSize="11"
-                                           TextWrapping="Wrap" />
-                            </StackPanel>
-                        </RadioButton>
-
-                        <RadioButton GroupName="TtsBackend"
-                                     IsChecked="{Binding IsTtsChatterbox, Mode=OneWay}"
-                                     Command="{Binding SetTtsBackendCommand}"
-                                     CommandParameter="Chatterbox"
-                                     Foreground="{DynamicResource TextBrush}">
-                            <StackPanel>
-                                <TextBlock Text="Chatterbox"
-                                           FontWeight="SemiBold"
-                                           Foreground="{DynamicResource TextBrush}" />
-                                <TextBlock Text="English voice cloning from a short reference clip. Word timing from the model's cross-attention."
-                                           Foreground="{DynamicResource SubtextBrush}"
-                                           FontSize="11"
-                                           TextWrapping="Wrap" />
-                            </StackPanel>
-                        </RadioButton>
+                        <!-- One row per engine in the registry (TtsEngines.All), so a new
+                             engine appears here without a new block of XAML. -->
+                        <ItemsControl ItemsSource="{Binding TtsEngineOptions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <RadioButton GroupName="TtsBackend"
+                                                 IsChecked="{Binding IsSelected, Mode=OneWay}"
+                                                 Command="{Binding $parent[ItemsControl].DataContext.SetTtsBackendCommand}"
+                                                 CommandParameter="{Binding KindName}"
+                                                 Foreground="{DynamicResource TextBrush}"
+                                                 Margin="0,0,0,4">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource TextBrush}" />
+                                            <TextBlock Text="{Binding Description}"
+                                                       Foreground="{DynamicResource SubtextBrush}"
+                                                       FontSize="11"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+                                    </RadioButton>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
                     </StackPanel>
                 </Border>
 
@@ -1259,7 +1234,7 @@
                     <StackPanel Spacing="10">
 
                         <!-- Kokoro: speed -->
-                        <StackPanel IsVisible="{Binding IsTtsKokoro}">
+                        <StackPanel IsVisible="{Binding ShowTtsSpeedDefault}">
                             <TextBlock Text="{Binding KokoroSpeed, StringFormat='Speed: {0:F2}×'}"
                                        FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextBrush}" />
@@ -1271,7 +1246,7 @@
                         </StackPanel>
 
                         <!-- OmniVoice: diffusion steps + optional tokenizer -->
-                        <StackPanel IsVisible="{Binding IsTtsOmniVoice}" Spacing="10">
+                        <StackPanel IsVisible="{Binding ShowTtsStepsDefault}" Spacing="10">
                             <StackPanel>
                                 <TextBlock Text="{Binding OmniVoiceNumStep, StringFormat='Diffusion steps: {0}'}"
                                            FontWeight="SemiBold"
@@ -1307,7 +1282,7 @@
                         </StackPanel>
 
                         <!-- Chatterbox: default reference clip -->
-                        <StackPanel IsVisible="{Binding IsTtsChatterbox}">
+                        <StackPanel IsVisible="{Binding ShowTtsReferenceClipDefault}">
                             <TextBlock Text="Default reference voice clip"
                                        FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextBrush}" />

--- a/src/Vernacula.Avalonia/Views/TtsJobConfigView.axaml
+++ b/src/Vernacula.Avalonia/Views/TtsJobConfigView.axaml
@@ -61,13 +61,19 @@
                            Text="{local:Loc label_engine}"
                            Foreground="{DynamicResource TextBrush}"
                            Margin="0,0,0,4" />
-                <ComboBox ItemsSource="{Binding Backends}"
-                          SelectedItem="{Binding SelectedBackend}"
+                <ComboBox ItemsSource="{Binding Engines}"
+                          SelectedItem="{Binding SelectedEngine}"
                           HorizontalAlignment="Stretch"
-                          Margin="0,0,0,16" />
+                          Margin="0,0,0,16">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding DisplayName}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
 
-                <!-- ── Chatterbox: reference clip ── -->
-                <StackPanel IsVisible="{Binding IsChatterbox}">
+                <!-- ── A cloning engine: the reference clip ── -->
+                <StackPanel IsVisible="{Binding ShowReferenceClip}">
                     <TextBlock x:Name="ReferenceClipLabelText"
                                Text="{local:Loc label_reference_clip}"
                                Foreground="{DynamicResource TextBrush}"
@@ -88,8 +94,8 @@
                     </Grid>
                 </StackPanel>
 
-                <!-- ── Kokoro: voice + speed ── -->
-                <StackPanel IsVisible="{Binding IsKokoro}">
+                <!-- ── A fixed-voice engine: the named voice ── -->
+                <StackPanel IsVisible="{Binding ShowVoiceList}">
                     <TextBlock Text="{local:Loc label_voice}"
                                Foreground="{DynamicResource TextBrush}"
                                Margin="0,0,0,4" />
@@ -97,6 +103,10 @@
                               SelectedItem="{Binding KokoroVoice}"
                               HorizontalAlignment="Stretch"
                               Margin="0,0,0,12" />
+                </StackPanel>
+
+                <!-- ── Speech rate, for an engine that has one ── -->
+                <StackPanel IsVisible="{Binding ShowSpeed}">
                     <TextBlock Text="{Binding KokoroSpeed, StringFormat='Speed: {0:F2}×'}"
                                Foreground="{DynamicResource TextBrush}" />
                     <Slider Minimum="0.5" Maximum="2.0" TickFrequency="0.1"
@@ -107,7 +117,7 @@
                 <!-- ── OmniVoice: language + voice (type-ahead) + steps ── -->
                 <!-- FilterMode=None because the VM RANKS the matches (exact code first)
                      rather than merely filtering them; focus opens the full list (code-behind). -->
-                <StackPanel IsVisible="{Binding IsOmniVoice}">
+                <StackPanel IsVisible="{Binding ShowLanguage}">
                     <TextBlock Text="{local:Loc label_language}"
                                Foreground="{DynamicResource TextBrush}"
                                Margin="0,0,0,4" />
@@ -155,6 +165,10 @@
                         </AutoCompleteBox.ItemTemplate>
                     </AutoCompleteBox>
 
+                </StackPanel>
+
+                <!-- ── Diffusion steps, for an engine that has them ── -->
+                <StackPanel IsVisible="{Binding ShowDiffusionSteps}">
                     <TextBlock Text="{Binding OmniVoiceNumStep, StringFormat='Diffusion steps: {0}'}"
                                Foreground="{DynamicResource TextBrush}" />
                     <Slider Minimum="8" Maximum="48" TickFrequency="4" IsSnapToTickEnabled="True"

--- a/tests/AsrBackendCoverage/NewTtsJobViewModelTests.cs
+++ b/tests/AsrBackendCoverage/NewTtsJobViewModelTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Linq;
+using Vernacula.App.Models;
+using Vernacula.App.Services;
+using Vernacula.App.Services.Tts;
+using Vernacula.App.ViewModels;
+using Xunit;
+
+namespace Vernacula.Tests.AsrBackendCoverage;
+
+/// <summary>
+/// The New TTS Job dialog holds one set of fields for every engine and shows the subset the
+/// selected engine uses. These pin the part that is easy to get wrong: moving between engines
+/// must not quietly rewrite a choice, because Start persists whatever the fields hold.
+/// </summary>
+public class NewTtsJobViewModelTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "vernacula-tests", Guid.NewGuid().ToString("N"));
+
+    public NewTtsJobViewModelTests()
+    {
+        // A Kokoro voices folder with a known list, so the dialog has a voice list to disturb.
+        Directory.CreateDirectory(Path.Combine(_dir, "kokoro", "voices"));
+        foreach (var v in new[] { "af_alloy", "af_heart", "bf_emma" })
+            File.WriteAllBytes(Path.Combine(_dir, "kokoro", "voices", v + ".bin"), new byte[16]);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private NewTtsJobViewModel MakeViewModel()
+    {
+        var settings = new SettingsService();
+        settings.Current.KokoroModelDir = Path.Combine(_dir, "kokoro");
+        settings.Current.TtsBackend = "Kokoro";
+        settings.Current.KokoroVoice = "af_heart";
+        return new NewTtsJobViewModel(settings);
+    }
+
+    [Fact]
+    public void SwitchingEngineAndBackKeepsTheChosenVoice()
+    {
+        var vm = MakeViewModel();
+        Assert.Equal("af_heart", vm.KokoroVoice);
+
+        // The dialog's ComboBox binds SelectedItem two-way to KokoroVoice over this collection,
+        // so emptying the collection clears the selection — the half of the bug that only shows
+        // up with a control attached. Stand in for it here, or the round trip passes either way.
+        vm.KokoroVoices.CollectionChanged += (_, _) =>
+        {
+            if (vm.KokoroVoices.Count == 0) vm.KokoroVoice = "";
+        };
+
+        vm.SelectedEngine = TtsEngines.For(TtsBackendKind.OmniVoice);
+        vm.SelectedEngine = TtsEngines.For(TtsBackendKind.Kokoro);
+
+        Assert.Equal("af_heart", vm.KokoroVoice);
+        Assert.Equal("af_heart", vm.CurrentSettings().Voice);
+    }
+
+    [Fact]
+    public void AnEngineWithoutAVoiceListLeavesTheListAlone()
+    {
+        var vm = MakeViewModel();
+        var before = vm.KokoroVoices.ToArray();
+
+        vm.SelectedEngine = TtsEngines.For(TtsBackendKind.Chatterbox);
+
+        Assert.Equal(before, vm.KokoroVoices);
+        Assert.False(vm.ShowVoiceList);
+        Assert.True(vm.ShowReferenceClip);
+    }
+
+    [Fact]
+    public void CurrentSettingsCarriesOnlyWhatTheEngineUses()
+    {
+        var vm = MakeViewModel();
+        vm.KokoroSpeed = 1.4f;
+        vm.OmniVoiceNumStep = 16;
+
+        var kokoro = vm.CurrentSettings();
+        Assert.Equal("Kokoro", kokoro.Backend);
+        Assert.Equal(1.4f, kokoro.Speed);
+        Assert.Equal("", kokoro.Language);          // Kokoro has no language picker
+        Assert.Equal(32, kokoro.NumStep);           // nor diffusion steps: the record's default
+
+        vm.SelectedEngine = TtsEngines.For(TtsBackendKind.Chatterbox);
+        vm.ChatterboxVoicePath = "/clips/ref.wav";
+        var chatterbox = vm.CurrentSettings();
+        Assert.Equal("/clips/ref.wav", chatterbox.Voice);
+        Assert.Equal(1.0f, chatterbox.Speed);
+    }
+}

--- a/tests/AsrBackendCoverage/TtsEngineRegistryTests.cs
+++ b/tests/AsrBackendCoverage/TtsEngineRegistryTests.cs
@@ -69,6 +69,19 @@ public class TtsEngineRegistryTests
     }
 
     [Fact]
+    public void AnUnknownEngineNameIsRecognisedAsUnknown()
+    {
+        // For() falls back so a job can still be described and a settings file still loads;
+        // TryFor() reports the truth, which is what callers that only describe a job use so a
+        // job saved by another build is not relabelled as the fallback engine.
+        Assert.Null(TtsEngines.TryFor("PiperTTS"));
+        Assert.Null(TtsEngines.TryFor(""));
+        Assert.Null(TtsEngines.TryFor(null));
+        Assert.Equal(TtsEngines.Default.Kind, TtsEngines.For("PiperTTS").Kind);
+        Assert.Equal(TtsEngines.All[0], TtsEngines.Default);
+    }
+
+    [Fact]
     public void JobDescriptionAndAnnotationLanguageComeFromTheEngine()
     {
         var british = new JobRecord { Kind = JobKind.Tts, TtsBackend = "Kokoro", TtsVoice = "bf_emma", TtsSpeed = 1.0f };

--- a/tests/AsrBackendCoverage/TtsEngineRegistryTests.cs
+++ b/tests/AsrBackendCoverage/TtsEngineRegistryTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using Vernacula.App.Models;
+using Vernacula.App.Services;
+using Vernacula.App.Services.Tts;
+using Xunit;
+
+namespace Vernacula.Tests.AsrBackendCoverage;
+
+/// <summary>
+/// The engine registry is the one place an engine is enumerated (issue: the same three-way
+/// switch used to live in about a dozen files, each with a silent default arm). These assert
+/// that every TtsBackendKind is actually registered and describes itself completely, so a new
+/// enum member fails here rather than being quietly treated as Chatterbox at run time.
+/// </summary>
+public class TtsEngineRegistryTests
+{
+    [Fact]
+    public void EveryBackendKindHasAnEngine()
+    {
+        foreach (TtsBackendKind kind in Enum.GetValues<TtsBackendKind>())
+            Assert.Equal(kind, TtsEngines.For(kind).Kind);
+        Assert.Equal(Enum.GetValues<TtsBackendKind>().Length, TtsEngines.All.Count);
+    }
+
+    [Fact]
+    public void EveryEngineDescribesItself()
+    {
+        foreach (var e in TtsEngines.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(e.DisplayName), $"{e.Kind} DisplayName");
+            Assert.False(string.IsNullOrWhiteSpace(e.Description), $"{e.Kind} Description");
+            Assert.False(string.IsNullOrWhiteSpace(e.PhonemeScheme), $"{e.Kind} PhonemeScheme");
+            Assert.True(e.SampleRate > 0, $"{e.Kind} SampleRate");
+            Assert.NotEmpty(e.RequiredSets);
+            // A job's voice must come from somewhere the dialog can offer.
+            Assert.True(e.UsesReferenceClip || e.UsesVoiceList || e.UsesLanguage,
+                $"{e.Kind} offers no way to choose a voice");
+        }
+    }
+
+    [Fact]
+    public void EnginesAreLookedUpByPersistedNameAndFallBackSafely()
+    {
+        Assert.Equal(TtsBackendKind.Kokoro, TtsEngines.For("Kokoro").Kind);
+        Assert.Equal(TtsBackendKind.Kokoro, TtsEngines.For("kokoro").Kind);      // case-insensitive
+        Assert.Equal(TtsEngines.All[0].Kind, TtsEngines.For("nonsense").Kind);   // never throws on old settings
+        Assert.Equal(TtsEngines.All[0].Kind, TtsEngines.For((string?)null).Kind);
+    }
+
+    [Fact]
+    public void RequestCarriesTheFieldsTheEngineUses()
+    {
+        var job = new TtsJobSettings("Kokoro", "", "af_heart", Speed: 1.4f, NumStep: 24);
+        var req = TtsEngines.For(TtsBackendKind.Kokoro).BuildRequest("hi", "/tmp/o.wav", "/tmp/segs", job);
+        Assert.Equal(1.4f, req.Speed);
+        Assert.Equal("/tmp/segs", req.SegmentsDir);
+
+        var ovJob = new TtsJobSettings("OmniVoice", "cy", "cy_default", NumStep: 24);
+        var ovReq = TtsEngines.For(TtsBackendKind.OmniVoice).BuildRequest("hi", "/tmp/o.wav", "/tmp/segs", ovJob);
+        Assert.Equal("cy", ovReq.Lang);
+        Assert.Equal(24, ovReq.NumStep);
+
+        // An OmniVoice job with no language still renders: the engine defaults it rather than
+        // handing the phonemizer an empty code.
+        var blank = TtsEngines.For(TtsBackendKind.OmniVoice)
+            .BuildRequest("hi", "/tmp/o.wav", "/tmp/segs", new TtsJobSettings("OmniVoice", "", "v"));
+        Assert.Equal("en", blank.Lang);
+    }
+
+    [Fact]
+    public void JobDescriptionAndAnnotationLanguageComeFromTheEngine()
+    {
+        var british = new JobRecord { Kind = JobKind.Tts, TtsBackend = "Kokoro", TtsVoice = "bf_emma", TtsSpeed = 1.0f };
+        Assert.Equal("en-GB", TtsEngines.For(british).AnnotationLanguage(british));
+        Assert.Contains("bf_emma", TtsEngines.For(british).DescribeJob(british));
+
+        var american = new JobRecord { Kind = JobKind.Tts, TtsBackend = "Kokoro", TtsVoice = "af_heart" };
+        Assert.Equal("en", TtsEngines.For(american).AnnotationLanguage(american));
+
+        var omni = new JobRecord { Kind = JobKind.Tts, TtsBackend = "OmniVoice", TtsLanguage = "cy", TtsVoice = "v1", TtsNumStep = 32 };
+        Assert.Equal("cy", TtsEngines.For(omni).AnnotationLanguage(omni));
+
+        // Chatterbox's voice is a path; the reader shows the file name, not the whole path.
+        var cb = new JobRecord { Kind = JobKind.Tts, TtsBackend = "Chatterbox", TtsVoice = "/home/someone/clips/ref.wav" };
+        Assert.Contains("ref.wav", TtsEngines.For(cb).DescribeJob(cb));
+        Assert.DoesNotContain(TtsEngines.For(cb).DescribeJob(cb), p => p.Contains('/'));
+    }
+}

--- a/tests/AsrBackendCoverage/TtsExportServiceTests.cs
+++ b/tests/AsrBackendCoverage/TtsExportServiceTests.cs
@@ -68,8 +68,8 @@ public class TtsExportServiceTests
         var settings = new SettingsService(); settings.Load();
         if (TtsPrerequisites.Describe(TtsBackendKind.Kokoro, settings) is { } missing)
             Assert.Skip($"Kokoro not available here: {missing}");
-        var rows = TtsExportService.BuildRows([("Hello world.", 0, 1)], TtsBackendKind.Kokoro, "en", "af_heart",
-            settings.GetPhonemizerDataDir());
+        var rows = TtsExportService.BuildRows([("Hello world.", 0, 1)], settings,
+            new TtsJobSettings("Kokoro", "", "af_heart"));
         Assert.Single(rows);
         Assert.False(string.IsNullOrWhiteSpace(rows[0].Phonemes));
         Assert.DoesNotContain("<error", rows[0].Phonemes);


### PR DESCRIPTION
## Summary

The first of the refactors the review of #128 proposed. Adding a TTS engine meant editing about a dozen three-way switches, each with a `_ =>` arm that silently treated an unknown engine as Chatterbox:

- `TtsJobRunner` — sample rate, cache key, backend construction, request shape
- `TtsPrerequisites` — required model sets, per-job voice/language checks
- `TtsExportService` — phoneme scheme, phonemizer
- `TtsReaderViewModel` — job description line, annotation language, sample rate
- `NewTtsJobViewModel` — `CurrentSettings`, `RememberChoices`, seeding, voice list, three visibility flags
- `SettingsViewModel.Tts` + `SettingsWindow.axaml` — three hardcoded radio blocks, three defaults panels
- `TtsJobConfigView.axaml` — three per-engine panels

`TtsEngine` now holds all of it per engine, and `TtsEngines.All` is the only enumeration. There is no `TtsBackendKind.X` branch left anywhere outside the registry (and tests).

The views ask about **capabilities**, not identity — `UsesReferenceClip`, `UsesVoiceList`, `UsesLanguage`, `UsesSpeed`, `UsesDiffusionSteps` — so the Settings engine picker is an `ItemsControl` over the registry, and a control appears because the engine has that knob rather than because of its name.

Adding an engine is now: a subclass, an entry in `All`, a `TtsBackendKind` member, and its model set in `ModelManagerService`.

## Notes

- No behaviour change intended. One visible improvement: the dialog's engine drop-down shows display names ("OmniVoice-IPA") instead of raw enum names.
- `TtsExportService.BuildRows` now takes the caller's `SettingsService` and the job, rather than loose strings plus a fresh settings load.
- The remaining proposals from that review are filed as #129 (IJobRunner per job kind), #130 (job settings as one JSON column), #131 (fix the transitive CPU-ONNX-Runtime leak at source), #132 (define the sidecar once in Tts.Base), #133 (fold the TTS model sets into the ASR repo mechanism).

## Test plan

- [x] Solution builds (`EP=Cpu`), no new warnings
- [x] `Vernacula.Tests` 27, `Vernacula.Tts.Tests` 173, `AsrBackendCoverage` 80 — including five new registry tests asserting every `TtsBackendKind` is registered, describes itself, offers some way to choose a voice, and that lookups fall back safely on an unknown persisted name
- [x] GUI smoke under Xvfb: Settings → Text-to-Speech radios and defaults panel, New TTS Job dialog with its engine picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq