### PR TITLE
test(vocab): per-VocabKind decode smoke tests (closes #38)

### DIFF
--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -395,12 +395,20 @@ internal class VocabService
         if (tokenBytes.Length == 0)
             return "";
 
+        // ⚠ FEED THE DECODER EVEN WHEN THIS TOKEN COMPLETES NO CHARACTER. Cohere spells a
+        // character outside its subword vocab as one <0xNN> token per byte, so a two-byte
+        // character arrives as two tokens: the first completes nothing (charCount 0) and must
+        // still be handed to the decoder to be held as state. Returning early instead dropped
+        // it, and the next token's continuation byte then decoded alone as U+FFFD — an accented
+        // word rendered with a replacement character in the editor's per-token runs while the
+        // whole-sequence decode above got it right. The other byte-level kinds always call
+        // GetChars for this reason; this path used to be the exception.
         int charCount = decoder.GetCharCount(tokenBytes, 0, tokenBytes.Length, flush: false);
+        char[] chars = new char[charCount];
+        decoder.GetChars(tokenBytes, 0, tokenBytes.Length, chars, 0, flush: false);
         if (charCount == 0)
             return "";
 
-        char[] chars = new char[charCount];
-        decoder.GetChars(tokenBytes, 0, tokenBytes.Length, chars, 0, flush: false);
         string text = new(chars);
 
         if (stripLeadingSpace && text.Length > 0)

--- a/src/Vernacula.Avalonia/Services/VocabService.cs
+++ b/src/Vernacula.Avalonia/Services/VocabService.cs
@@ -226,6 +226,47 @@ internal class VocabService
         };
     }
 
+    /// <summary>
+    /// Whatever a streaming decoder is still holding after the last token, as the final run's
+    /// tail. A sequence that ends mid-character (a segment cut after the first byte of a
+    /// two-byte character) leaves bytes in the decoder; flushing turns them into the same
+    /// replacement character the whole-sequence decode produces for them. Without it the runs
+    /// were silently shorter than the content they annotate — the trailing-edge twin of the
+    /// dropped-pending-byte bug fixed in DecodeCohereTokenIncrement.
+    /// </summary>
+    private static void AppendDecoderTail(Decoder decoder, List<(string text, float logprob)> runs)
+    {
+        if (runs.Count == 0) return;
+        int tail = decoder.GetCharCount([], 0, 0, flush: true);
+        if (tail == 0) return;
+        char[] chars = new char[tail];
+        decoder.GetChars([], 0, 0, chars, 0, flush: true);
+        runs[^1] = (runs[^1].text + new string(chars), runs[^1].logprob);
+    }
+
+    /// <summary>
+    /// Trims the boundary whitespace off the ends of a run list, as the text decoders' Trim()
+    /// does to the whole string, so the runs say exactly what DecodeTokens says. The editor
+    /// renders these runs AS the card's text, so a leading space here is one the user sees on
+    /// a card whose content does not have it. Runs are never dropped — only their text is
+    /// trimmed — because each run is paired positionally with its token's confidence.
+    /// </summary>
+    private static void TrimRunEdges(List<(string text, float logprob)> runs)
+    {
+        for (int i = 0; i < runs.Count; i++)
+        {
+            string trimmed = runs[i].text.TrimStart();
+            if (trimmed.Length > 0) { runs[i] = (trimmed, runs[i].logprob); break; }
+            runs[i] = ("", runs[i].logprob);
+        }
+        for (int i = runs.Count - 1; i >= 0; i--)
+        {
+            string trimmed = runs[i].text.TrimEnd();
+            if (trimmed.Length > 0) { runs[i] = (trimmed, runs[i].logprob); break; }
+            runs[i] = ("", runs[i].logprob);
+        }
+    }
+
     /// <summary>Returns (text, logprob) pairs for each token.</summary>
     public IReadOnlyList<(string text, float logprob)> GetTokenRuns(
         IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs, string? targetText = null)
@@ -239,20 +280,23 @@ internal class VocabService
         if (_kind == VocabKind.GraniteSpeech)
             return GetGraniteSpeechTokenRuns(tokens, logprobs);
 
-        var runs = new List<(string, float)>(tokens.Count);
+        var runs = new List<(string text, float logprob)>(tokens.Count);
         for (int i = 0; i < tokens.Count; i++)
         {
             string text = DecodeToken(tokens[i]);
             float  lp   = i < logprobs.Count ? logprobs[i] : 0f;
             runs.Add((text, lp));
         }
+        // The word-start marker on the first token becomes a leading space; DecodeTokens trims
+        // it and so must these, or the card renders a space its content does not have.
+        TrimRunEdges(runs);
         return runs;
     }
 
     private IReadOnlyList<(string text, float logprob)> GetCohereTokenRuns(
         IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
     {
-        var runs = new List<(string, float)>(tokens.Count);
+        var runs = new List<(string text, float logprob)>(tokens.Count);
         Decoder decoder = Encoding.UTF8.GetDecoder();
         bool stripLeadingSpace = true;
 
@@ -263,6 +307,7 @@ internal class VocabService
             runs.Add((runText, lp));
         }
 
+        AppendDecoderTail(decoder, runs);
         return runs;
     }
 
@@ -326,7 +371,7 @@ internal class VocabService
         // boundary they actually finish at. Matches the Qwen3 / VibeVoice
         // pattern; no leading-space-strip or quote-trim because Granite's
         // raw decode already lines up with Content (no prefix-quote artefact).
-        var runs = new List<(string, float)>(tokens.Count);
+        var runs = new List<(string text, float logprob)>(tokens.Count);
         Decoder decoder = Encoding.UTF8.GetDecoder();
 
         for (int i = 0; i < tokens.Count; i++)
@@ -349,6 +394,7 @@ internal class VocabService
             runs.Add((runText, lp));
         }
 
+        AppendDecoderTail(decoder, runs);
         return runs;
     }
 
@@ -406,10 +452,7 @@ internal class VocabService
         int charCount = decoder.GetCharCount(tokenBytes, 0, tokenBytes.Length, flush: false);
         char[] chars = new char[charCount];
         decoder.GetChars(tokenBytes, 0, tokenBytes.Length, chars, 0, flush: false);
-        if (charCount == 0)
-            return "";
-
-        string text = new(chars);
+        string text = new(chars);   // "" when this token completed no character
 
         if (stripLeadingSpace && text.Length > 0)
         {
@@ -438,7 +481,7 @@ internal class VocabService
     private IReadOnlyList<(string text, float logprob)> GetVibeVoiceTokenRuns(
         IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs, string? targetText)
     {
-        var runs = new List<(string, float)>(tokens.Count);
+        var runs = new List<(string text, float logprob)>(tokens.Count);
         Decoder decoder = Encoding.UTF8.GetDecoder();
 
         for (int i = 0; i < tokens.Count; i++)
@@ -461,13 +504,14 @@ internal class VocabService
             runs.Add((runText, lp));
         }
 
+        AppendDecoderTail(decoder, runs);
         return ClipRunsToTargetText(runs, targetText);
     }
 
     private IReadOnlyList<(string text, float logprob)> GetQwen3AsrTokenRuns(
         IReadOnlyList<int> tokens, IReadOnlyList<float> logprobs)
     {
-        var runs = new List<(string, float)>(tokens.Count);
+        var runs = new List<(string text, float logprob)>(tokens.Count);
         Decoder decoder = Encoding.UTF8.GetDecoder();
         bool stripLeadingSpace = true;
 
@@ -497,6 +541,7 @@ internal class VocabService
             runs.Add((runText, lp));
         }
 
+        AppendDecoderTail(decoder, runs);
         return runs;
     }
 

--- a/tests/AsrBackendCoverage/Fixtures/VocabFixtures.cs
+++ b/tests/AsrBackendCoverage/Fixtures/VocabFixtures.cs
@@ -89,14 +89,74 @@ internal static class VocabFixtures
         public void Dispose() => Cleanup(Dir);
     }
 
-    /// <summary>A throwaway models directory holding the fixture for <paramref name="kind"/>.</summary>
-    public static Fixture Write(VocabService.VocabKind kind)
-    {
-        string dir = WriteModelsDir(kind);
-        int[] tokens = kind == VocabService.VocabKind.Cohere
+    /// <summary>The tokens that spell <see cref="Phrase"/> in <paramref name="kind"/>'s fixture.</summary>
+    public static int[] PhraseTokensFor(VocabService.VocabKind kind) =>
+        kind == VocabService.VocabKind.Cohere
             ? [Hello, SpaceW, OSplitHigh, OSplitLowRld, CohereRld, CohereDot]
             : [Hello, SpaceW, OSplitHigh, OSplitLowRld, Dot];
-        return new Fixture(dir, tokens);
+
+    /// <summary>
+    /// The tokens for a sequence that stops in the MIDDLE of "ö" — the last token carries only
+    /// that character's first byte, leaving the streaming decoders holding it.
+    /// </summary>
+    public static int[] TruncatedMidCharacterTokens => [Hello, SpaceW, OSplitHigh];
+
+    /// <summary>
+    /// What <see cref="TruncatedMidCharacterTokens"/> decodes to, which depends on the format:
+    /// the byte-level vocabs really are cut mid-character, so the held byte becomes the Unicode
+    /// replacement character, while the text formats spell "ö" as one whole token and simply
+    /// end with it. Both are correct; only the byte-level kinds exercise the decoder's tail.
+    /// </summary>
+    public static string TruncatedPhraseFor(VocabService.VocabKind kind) =>
+        kind is VocabService.VocabKind.Parakeet or VocabService.VocabKind.IndicConformer
+            ? "Hello wö"
+            : "Hello w\uFFFD";
+
+    /// <summary>A throwaway models directory holding the fixture for <paramref name="kind"/>.</summary>
+    public static Fixture Write(VocabService.VocabKind kind) =>
+        new(WriteModelsDir(kind), PhraseTokensFor(kind));
+
+    /// <summary>
+    /// Granite in its BF16 bundle rather than the FP32 one. The loader prefers BF16 when both
+    /// are installed, and BF16 is what the app fetches on hardware that supports it — so the
+    /// preferred arm needs a fixture of its own.
+    /// </summary>
+    public static Fixture WriteGraniteBf16()
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "vernacula-vocab-fixtures", Guid.NewGuid().ToString("N"));
+        WriteFile(Path.Combine(dir, Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile), HfTokenizerJson());
+        return new Fixture(dir, PhraseTokensFor(VocabService.VocabKind.GraniteSpeech));
+    }
+
+    /// <summary>
+    /// Both Granite bundles installed, spelling DIFFERENT phrases, so a test can tell which one
+    /// the loader actually read. Returns the directory and what each bundle spells.
+    /// </summary>
+    public static Fixture WriteGraniteBothBundles(out string bf16Phrase, out string fp32Phrase)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "vernacula-vocab-fixtures", Guid.NewGuid().ToString("N"));
+        bf16Phrase = Phrase;
+        fp32Phrase = "WRONG BUNDLE";
+        WriteFile(Path.Combine(dir, Config.GraniteSpeechBf16SubDir, GraniteSpeech.TokenizerFile), HfTokenizerJson());
+        WriteFile(Path.Combine(dir, Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile),
+                  SingleWordTokenizerJson(fp32Phrase));
+        return new Fixture(dir, PhraseTokensFor(VocabService.VocabKind.GraniteSpeech));
+    }
+
+    /// <summary>A tokenizer.json whose FIRST token is the whole phrase and whose rest are empty,
+    /// so the shared token sequence decodes to exactly that phrase.</summary>
+    private static string SingleWordTokenizerJson(string phrase)
+    {
+        var vocab = new (string Spelling, int Id)[]
+        {
+            (ToByteLevel(phrase), Hello),
+            (ToByteLevel(""),     SpaceW),
+            (ToByteLevel(""),     OSplitHigh),
+            (ToByteLevel(""),     OSplitLowRld),
+            (ToByteLevel(""),     Dot),
+        };
+        string entries = string.Join(",", vocab.Select(v => $"{Quoted(v.Spelling)}:{v.Id}"));
+        return $"{{\"model\":{{\"vocab\":{{{entries}}}}}}}";
     }
 
     /// <summary>A throwaway models directory holding the fixture for <paramref name="kind"/>.</summary>

--- a/tests/AsrBackendCoverage/Fixtures/VocabFixtures.cs
+++ b/tests/AsrBackendCoverage/Fixtures/VocabFixtures.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Vernacula.Base;
+using Vernacula.App.Services;
+
+namespace Vernacula.Tests.AsrBackendCoverage.Fixtures;
+
+/// <summary>
+/// Tiny hand-built vocabularies, one per <see cref="VocabService.VocabKind"/>, written into a
+/// throwaway models directory at the exact paths the loader probes.
+///
+/// <para>
+/// They are built here rather than committed as blobs for two reasons: a real vocab is
+/// megabytes of tokens irrelevant to what is being checked, and a fixture whose expected text
+/// is known BY CONSTRUCTION is a stronger assertion than one whose expected text was copied
+/// out of a previous run. Each vocab is written in its format's documented shape — the
+/// SentencePiece word-boundary marker, the <c>&lt;0xNN&gt;</c> byte fallback, the HF
+/// <c>tokenizer.json</c> object — so decoding it is a claim about the format, not about this
+/// implementation.
+/// </para>
+/// </summary>
+internal static class VocabFixtures
+{
+    /// <summary>The phrase every fixture encodes. Chosen for what it exercises, not for length:
+    /// a word boundary, and an "ö" whose two UTF-8 bytes are deliberately split across two
+    /// tokens so the per-token streaming decoders have to carry a partial character.</summary>
+    public const string Phrase = "Hello wörld.";
+
+    /// <summary>SentencePiece's word-boundary marker (U+2581), which the text loaders turn into a space.</summary>
+    private const string WordStart = "▁";
+
+    // ── GPT-2 ByteLevel, from the specification ──────────────────────────────
+    //
+    // ⚠ COMPUTED HERE, NOT BORROWED FROM VocabService. The HF-format loaders decode a token's
+    // characters back to bytes through their own copy of this table; if the fixtures were
+    // encoded with that same copy, a wrong table would round-trip and the tests would pass on
+    // a broken decoder. Building it independently from the published mapping (printable ASCII
+    // and Latin-1 ranges map to themselves; every other byte maps to U+0100 + its rank among
+    // the non-printables, so 0x20 becomes U+0120 "Ġ") makes the tests check the table too.
+
+    private static readonly Dictionary<byte, char> ByteToChar = BuildByteToChar();
+
+    private static Dictionary<byte, char> BuildByteToChar()
+    {
+        var printable = new HashSet<int>(
+            Enumerable.Range('!', '~' - '!' + 1)
+            .Concat(Enumerable.Range('¡', '¬' - '¡' + 1))
+            .Concat(Enumerable.Range('®', 'ÿ' - '®' + 1)));
+
+        var map = new Dictionary<byte, char>(256);
+        int extra = 0;
+        for (int b = 0; b < 256; b++)
+            map[(byte)b] = printable.Contains(b) ? (char)b : (char)(0x100 + extra++);
+        return map;
+    }
+
+    /// <summary>A string's UTF-8 bytes as the characters a GPT-2 ByteLevel vocab spells them with.</summary>
+    public static string ToByteLevel(string text) =>
+        new(Encoding.UTF8.GetBytes(text).Select(b => ByteToChar[b]).ToArray());
+
+    // ── Token ids, shared by every fixture ───────────────────────────────────
+    // The same five ids spell the phrase in every format, so a test can name a sequence once.
+
+    public const int Hello = 0, SpaceW = 1, OSplitHigh = 2, OSplitLowRld = 3, Dot = 4;
+    /// <summary>An added ("special") token — the HF kinds disagree about what to do with it.</summary>
+    public const int Special = 5;
+    /// <summary>"Hello" with a leading space, for the kinds that strip one at the start.</summary>
+    public const int SpaceHello = 6;
+    /// <summary>A double quote, for the kind that trims them at the boundaries.</summary>
+    public const int Quote = 7;
+
+    public const string SpecialContent = "<|endoftext|>";
+
+    // Cohere spends a token per raw byte, so "rld" and "." sit one slot further along.
+    public const int CohereRld = 4, CohereDot = 5;
+
+    /// <summary>
+    /// The tokens that spell <see cref="Phrase"/> in a given fixture, and the directory holding
+    /// it. The sequence is per kind because the formats genuinely differ in how few tokens can
+    /// spell the phrase — a Cohere <c>&lt;0xNN&gt;</c> token is a whole byte and cannot also
+    /// carry text, so its "ö" costs two tokens where a ByteLevel vocab folds the second byte
+    /// into the next token.
+    /// </summary>
+    public sealed record Fixture(string Dir, int[] PhraseTokens) : IDisposable
+    {
+        public void Dispose() => Cleanup(Dir);
+    }
+
+    /// <summary>A throwaway models directory holding the fixture for <paramref name="kind"/>.</summary>
+    public static Fixture Write(VocabService.VocabKind kind)
+    {
+        string dir = WriteModelsDir(kind);
+        int[] tokens = kind == VocabService.VocabKind.Cohere
+            ? [Hello, SpaceW, OSplitHigh, OSplitLowRld, CohereRld, CohereDot]
+            : [Hello, SpaceW, OSplitHigh, OSplitLowRld, Dot];
+        return new Fixture(dir, tokens);
+    }
+
+    /// <summary>A throwaway models directory holding the fixture for <paramref name="kind"/>.</summary>
+    public static string WriteModelsDir(VocabService.VocabKind kind)
+    {
+        string dir = Path.Combine(Path.GetTempPath(), "vernacula-vocab-fixtures", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        switch (kind)
+        {
+            case VocabService.VocabKind.Parakeet:
+                // "<token> <id>" per line; the loader splits on the LAST space.
+                WriteFile(Path.Combine(dir, Config.VocabFile), string.Join('\n',
+                [
+                    $"{WordStart}Hello {Hello}",
+                    $"{WordStart}w {SpaceW}",
+                    $"ö {OSplitHigh}",           // text formats have no byte-level split to make
+                    $"rld {OSplitLowRld}",
+                    $". {Dot}",
+                ]));
+                break;
+
+            case VocabService.VocabKind.IndicConformer:
+                // One token per line; the id IS the line index.
+                WriteFile(Path.Combine(dir, Config.IndicConformerSubDir, Config.VocabFile), string.Join('\n',
+                [
+                    $"{WordStart}Hello",
+                    $"{WordStart}w",
+                    "ö",
+                    "rld",
+                    ".",
+                ]));
+                break;
+
+            case VocabService.VocabKind.Cohere:
+                // A JSON array; the index is the id. "ö" is split into its two UTF-8 bytes
+                // using the <0xNN> fallback, which is how this format spells raw bytes.
+                WriteFile(Path.Combine(dir, "cohere_transcribe", CohereTranscribe.VocabFile),
+                    $"[\"{WordStart}Hello\",\"{WordStart}w\",\"<0xC3>\",\"<0xB6>\",\"rld\",\".\"]");
+                break;
+
+            case VocabService.VocabKind.VibeVoice:
+                WriteFile(Path.Combine(dir, Config.VibeVoiceSubDir, VibeVoiceAsr.TokenizerFile), HfTokenizerJson());
+                break;
+
+            case VocabService.VocabKind.Qwen3Asr:
+                WriteFile(Path.Combine(dir, Config.Qwen3AsrSubDir, Qwen3Asr.TokenizerFile), HfTokenizerJson());
+                break;
+
+            case VocabService.VocabKind.GraniteSpeech:
+                // The FP32 sibling; the loader falls back to it when the BF16 one is absent.
+                WriteFile(Path.Combine(dir, Config.GraniteSpeechSubDir, GraniteSpeech.TokenizerFile), HfTokenizerJson());
+                break;
+
+            case VocabService.VocabKind.WhisperTurbo:
+                WriteFile(Path.Combine(dir, Config.WhisperTurboSubDir, WhisperTurbo.TokenizerFile), HfTokenizerJson());
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind), kind,
+                    "VocabFixtures has no fixture for this kind. Add one alongside the new VocabKind.");
+        }
+
+        return dir;
+    }
+
+    /// <summary>
+    /// The HF <c>tokenizer.json</c> shape the ByteLevel kinds read: <c>model.vocab</c> maps a
+    /// token's spelling to its id, <c>added_tokens</c> carries the specials. "ö" is split
+    /// mid-character: its high byte is one token, its low byte opens the next.
+    /// </summary>
+    private static string HfTokenizerJson()
+    {
+        var vocab = new (string Spelling, int Id)[]
+        {
+            (ToByteLevel("Hello"),  Hello),
+            (ToByteLevel(" w"),     SpaceW),
+            (ByteLevelOf(0xC3),     OSplitHigh),
+            (ByteLevelOf(0xB6) + ToByteLevel("rld"), OSplitLowRld),
+            (ToByteLevel("."),      Dot),
+            (ToByteLevel(" Hello"), SpaceHello),
+            (ToByteLevel("\""),     Quote),
+        };
+
+        string entries = string.Join(",", vocab.Select(v => $"{Quoted(v.Spelling)}:{v.Id}"));
+        string added = $"[{{\"id\":{Special},\"content\":{Quoted(SpecialContent)}}}]";
+        return $"{{\"model\":{{\"vocab\":{{{entries}}}}},\"added_tokens\":{added}}}";
+    }
+
+    private static string ByteLevelOf(byte b) => ByteToChar[b].ToString();
+
+    /// <summary>JSON string literal — the spellings hold quotes and backslashes.</summary>
+    private static string Quoted(string s) => System.Text.Json.JsonSerializer.Serialize(s);
+
+    private static void WriteFile(string path, string content)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    /// <summary>Deletes a directory made by <see cref="WriteModelsDir"/>; best effort.</summary>
+    public static void Cleanup(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); } catch { /* a leftover temp dir is harmless */ }
+    }
+}

--- a/tests/AsrBackendCoverage/VocabServiceSmokeTests.cs
+++ b/tests/AsrBackendCoverage/VocabServiceSmokeTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Vernacula.App.Models;
+using Vernacula.App.Services;
+using Vernacula.Tests.AsrBackendCoverage.Fixtures;
+using Xunit;
+
+namespace Vernacula.Tests.AsrBackendCoverage;
+
+/// <summary>
+/// Per-<see cref="VocabService.VocabKind"/> decode smoke tests (issue #38).
+///
+/// <para>
+/// The Granite Speech editor bug (PR #35) was a missing <c>VocabKind</c> case: the dispatch
+/// fell through to the Parakeet text loader, which read a JSON <c>vocab.json</c> as lines,
+/// produced an empty vocab, and left the editor rendering raw GPT-2 ByteLevel characters. The
+/// existing coverage test proves each backend's model name is RECOGNISED; nothing proved the
+/// branch it selects can actually decode. These tests close that gap: every kind loads a tiny
+/// fixture vocab from disk and decodes a known token sequence.
+/// </para>
+///
+/// <para>
+/// They also pin the three HF-format kinds APART. VibeVoice, Qwen3/Whisper and Granite share a
+/// loader and a byte table but post-process differently — a boundary-quote trim, a
+/// leading-space strip, and neither — so "it decoded something" would not catch one being
+/// wired to another's decoder. The divergence tests below are the ones that would.
+/// </para>
+/// </summary>
+[Collection(nameof(AsrBackendCoverageTests))]
+public class VocabServiceSmokeTests
+{
+    // Parameterised by BACKEND rather than by kind: VocabKind is internal, so it cannot appear
+    // in a public test signature, and the backend is what a caller actually has anyway. Every
+    // kind is still exercised — EveryVocabKindIsReachableFromABackend keeps that true.
+    public static IEnumerable<object[]> AllBackends =>
+        Enum.GetValues<AsrBackend>().Select(b => new object[] { b });
+
+    private static VocabService.VocabKind KindOf(AsrBackend backend) => VocabService.KindOfBackend(backend);
+
+    private static VocabService Load(AsrBackend backend, string dir) =>
+        new(dir, AsrLanguageSupport.ModelName(backend));
+
+    private static VocabService Load(VocabService.VocabKind kind, string dir) =>
+        new(dir, AsrLanguageSupport.ModelName(
+            Enum.GetValues<AsrBackend>().First(b => VocabService.KindOfBackend(b) == kind)));
+
+    [Fact]
+    public void EveryVocabKindIsReachableFromABackend()
+    {
+        // The theories below iterate backends, so a VocabKind no backend maps to would go
+        // untested in silence. Fail here instead.
+        var covered = Enum.GetValues<AsrBackend>().Select(VocabService.KindOfBackend).ToHashSet();
+        Assert.Equal(Enum.GetValues<VocabService.VocabKind>().ToHashSet(), covered);
+    }
+
+    // ── Every kind decodes its own fixture ───────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(AllBackends))]
+    public void EveryKind_DecodesItsFixtureToTheKnownPhrase(AsrBackend backend)
+    {
+        using var fixture = VocabFixtures.Write(KindOf(backend));
+        var vocab = Load(backend, fixture.Dir);
+        Assert.Equal(VocabFixtures.Phrase, vocab.DecodeTokens(fixture.PhraseTokens));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllBackends))]
+    public void EveryKind_ProducesOneRunPerToken_ThatConcatenatesToTheDecodedText(AsrBackend backend)
+    {
+        using var fixture = VocabFixtures.Write(KindOf(backend));
+        var vocab = Load(backend, fixture.Dir);
+        {
+            var tokens = fixture.PhraseTokens;
+            var logprobs = tokens.Select((_, i) => -0.1f * (i + 1)).ToArray();
+
+            var runs = vocab.GetTokenRuns(tokens, logprobs);
+
+            // One run per token: the editor pairs runs with tokens positionally, so a
+            // dropped or merged run silently misattributes every later token's confidence.
+            Assert.Equal(tokens.Length, runs.Count);
+            Assert.Equal(logprobs, runs.Select(r => r.logprob));
+
+            // ⚠ NOT "every run is non-empty". The fixture splits "ö" across two tokens, and a
+            // streaming UTF-8 decoder correctly emits nothing for the first half — that is the
+            // behaviour being checked, not a defect. What must hold is that the runs together
+            // say the same thing as the whole-sequence decode.
+            Assert.Equal(vocab.DecodeTokens(tokens).Trim(),
+                         string.Concat(runs.Select(r => r.text)).Trim());
+            Assert.Contains(runs, r => r.text.Length > 0);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllBackends))]
+    public void EveryKind_ToleratesShortLogprobsAndUnknownTokens(AsrBackend backend)
+    {
+        using var fixture = VocabFixtures.Write(KindOf(backend));
+        var vocab = Load(backend, fixture.Dir);
+
+        // A token id past the end of the vocab reaches the editor whenever a model and its
+        // vocab drift apart; it must render as nothing rather than throw.
+        int[] tokens = [.. fixture.PhraseTokens, 99_999];
+
+        var runs = vocab.GetTokenRuns(tokens, [-0.1f]);   // deliberately too few logprobs
+
+        Assert.Equal(tokens.Length, runs.Count);
+        Assert.Equal(0f, runs[^1].logprob);               // missing logprobs default, not throw
+        Assert.Equal("", runs[^1].text);
+        Assert.Equal(VocabFixtures.Phrase, vocab.DecodeTokens(tokens));
+    }
+
+    // ── The HF-format kinds must not be wired to each other's decoder ────────
+
+    [Fact]
+    public void VibeVoice_TrimsBoundaryQuotes_WhereGraniteKeepsThem()
+    {
+        // VibeVoice is a JSON-mode model whose output arrives wrapped in quotes; Granite is
+        // plain ASR, where a quote is content. Same bytes, deliberately different results.
+        int[] quoted = [VocabFixtures.Quote, .. HfPhrase, VocabFixtures.Quote];
+
+        string vibe = Decode(VocabService.VocabKind.VibeVoice, quoted);
+        string granite = Decode(VocabService.VocabKind.GraniteSpeech, quoted);
+
+        Assert.Equal(VocabFixtures.Phrase, vibe);
+        Assert.Equal($"\"{VocabFixtures.Phrase}\"", granite);
+    }
+
+    [Fact]
+    public void Qwen3AndWhisper_StripOneLeadingSpace_WhereGraniteKeepsIt()
+    {
+        int[] leadingSpace = [VocabFixtures.SpaceHello, VocabFixtures.SpaceW,
+                              VocabFixtures.OSplitHigh, VocabFixtures.OSplitLowRld, VocabFixtures.Dot];
+
+        Assert.Equal(VocabFixtures.Phrase, Decode(VocabService.VocabKind.Qwen3Asr, leadingSpace));
+        Assert.Equal(VocabFixtures.Phrase, Decode(VocabService.VocabKind.WhisperTurbo, leadingSpace));
+        Assert.Equal($" {VocabFixtures.Phrase}", Decode(VocabService.VocabKind.GraniteSpeech, leadingSpace));
+    }
+
+    [Fact]
+    public void SpecialTokens_RenderAsContentForVibeVoiceAndGranite_AndAreDroppedByQwen3AndWhisper()
+    {
+        int[] withSpecial = [.. HfPhrase, VocabFixtures.Special];
+        string expectedWithContent = VocabFixtures.Phrase + VocabFixtures.SpecialContent;
+
+        Assert.Equal(expectedWithContent, Decode(VocabService.VocabKind.VibeVoice, withSpecial));
+        Assert.Equal(expectedWithContent, Decode(VocabService.VocabKind.GraniteSpeech, withSpecial));
+        Assert.Equal(VocabFixtures.Phrase, Decode(VocabService.VocabKind.Qwen3Asr, withSpecial));
+        Assert.Equal(VocabFixtures.Phrase, Decode(VocabService.VocabKind.WhisperTurbo, withSpecial));
+    }
+
+    /// <summary>The phrase's tokens in the shared HF-format fixture (the divergence tests are HF-only).</summary>
+    private static int[] HfPhrase => VocabFixtures.Write(VocabService.VocabKind.GraniteSpeech) is var f
+        ? Use(f) : [];
+
+    private static int[] Use(VocabFixtures.Fixture f)
+    {
+        using (f) return f.PhraseTokens;
+    }
+
+    private static string Decode(VocabService.VocabKind kind, IReadOnlyList<int> tokens)
+    {
+        using var fixture = VocabFixtures.Write(kind);
+        return Load(kind, fixture.Dir).DecodeTokens(tokens);
+    }
+
+    // ── The loud-fallthrough path ────────────────────────────────────────────
+
+    [Fact]
+    public void UnrecognisedModelName_WarnsAndStillLoads()
+    {
+        // The other half of the Granite bug: a backend whose branch is missing must say so on
+        // stderr rather than mis-decode in silence. Console.SetError is process-global, hence
+        // this class's [Collection] with parallelization disabled.
+        using var fixture = VocabFixtures.Write(VocabService.VocabKind.Parakeet);
+        var origErr = Console.Error;
+        using var stderr = new StringWriter();
+        VocabService vocab;
+        Console.SetError(stderr);
+        try { vocab = new VocabService(fixture.Dir, "acme/some-unreleased-asr"); }
+        finally { Console.SetError(origErr); }
+
+        string err = stderr.ToString();
+        Assert.Contains("WARNING", err, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("acme/some-unreleased-asr", err, StringComparison.Ordinal);
+
+        // And it falls back to Parakeet rather than throwing — the editor still opens.
+        Assert.Equal(VocabFixtures.Phrase, vocab.DecodeTokens(fixture.PhraseTokens));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NoModelName_FallsBackToParakeetSilently(string? asrModel)
+    {
+        // A job whose asr_model row has not been written yet is a legitimate caller, not a
+        // dispatch gap: it must not cry wolf on stderr.
+        using var fixture = VocabFixtures.Write(VocabService.VocabKind.Parakeet);
+        var origErr = Console.Error;
+        using var stderr = new StringWriter();
+        VocabService vocab;
+        Console.SetError(stderr);
+        try { vocab = new VocabService(fixture.Dir, asrModel); }
+        finally { Console.SetError(origErr); }
+
+        Assert.DoesNotContain("WARNING", stderr.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(VocabFixtures.Phrase, vocab.DecodeTokens(fixture.PhraseTokens));
+    }
+
+    // ── Missing files ────────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(AllBackends))]
+    public void EveryKind_SurvivesAMissingVocabFile(AsrBackend backend)
+    {
+        // Every loader returns an empty vocab for a missing file: the editor opens on a job
+        // whose model was never downloaded, showing nothing rather than crashing.
+        string empty = Path.Combine(Path.GetTempPath(), "vernacula-vocab-fixtures", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(empty);
+        try
+        {
+            var vocab = Load(backend, empty);
+            int[] tokens = [VocabFixtures.Hello, VocabFixtures.SpaceW, VocabFixtures.Dot];
+            Assert.Equal("", vocab.DecodeTokens(tokens));
+            Assert.Equal(tokens.Length, vocab.GetTokenRuns(tokens, []).Count);
+        }
+        finally { VocabFixtures.Cleanup(empty); }
+    }
+}

--- a/tests/AsrBackendCoverage/VocabServiceSmokeTests.cs
+++ b/tests/AsrBackendCoverage/VocabServiceSmokeTests.cs
@@ -87,8 +87,12 @@ public class VocabServiceSmokeTests
             // streaming UTF-8 decoder correctly emits nothing for the first half — that is the
             // behaviour being checked, not a defect. What must hold is that the runs together
             // say the same thing as the whole-sequence decode.
-            Assert.Equal(vocab.DecodeTokens(tokens).Trim(),
-                         string.Concat(runs.Select(r => r.text)).Trim());
+            //
+            // ⚠ AND NOT .Trim() ON EITHER SIDE. The editor renders these runs AS the card's
+            // text (TranscriptEditorViewModel.RefreshAdjacentCardAppearance), so trimming here
+            // would hide exactly the divergence that matters: the word-start marker on the
+            // first token used to leave the runs a space longer than the content.
+            Assert.Equal(vocab.DecodeTokens(tokens), string.Concat(runs.Select(r => r.text)));
             Assert.Contains(runs, r => r.text.Length > 0);
         }
     }
@@ -152,18 +156,76 @@ public class VocabServiceSmokeTests
     }
 
     /// <summary>The phrase's tokens in the shared HF-format fixture (the divergence tests are HF-only).</summary>
-    private static int[] HfPhrase => VocabFixtures.Write(VocabService.VocabKind.GraniteSpeech) is var f
-        ? Use(f) : [];
-
-    private static int[] Use(VocabFixtures.Fixture f)
-    {
-        using (f) return f.PhraseTokens;
-    }
+    private static int[] HfPhrase => VocabFixtures.PhraseTokensFor(VocabService.VocabKind.GraniteSpeech);
 
     private static string Decode(VocabService.VocabKind kind, IReadOnlyList<int> tokens)
     {
         using var fixture = VocabFixtures.Write(kind);
         return Load(kind, fixture.Dir).DecodeTokens(tokens);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllBackends))]
+    public void EveryKind_EndingMidCharacter_SaysTheSameThingInRunsAsInTheDecode(AsrBackend backend)
+    {
+        // A segment cut after the first byte of a two-byte character leaves the streaming
+        // decoders holding it. The whole-sequence decode turns it into a replacement character;
+        // the runs must agree, or the card renders shorter than its own content.
+        using var fixture = VocabFixtures.Write(KindOf(backend));
+        var vocab = Load(backend, fixture.Dir);
+        int[] tokens = VocabFixtures.TruncatedMidCharacterTokens;
+
+        string decoded = vocab.DecodeTokens(tokens);
+        var runs = vocab.GetTokenRuns(tokens, []);
+
+        Assert.Equal(VocabFixtures.TruncatedPhraseFor(KindOf(backend)), decoded);
+        Assert.Equal(tokens.Length, runs.Count);
+        Assert.Equal(decoded, string.Concat(runs.Select(r => r.text)));
+    }
+
+    // ── VibeVoice's clip-to-content path ────────────────────────────────────
+
+    [Fact]
+    public void VibeVoice_ClipsRunsToTheSegmentContent()
+    {
+        // The editor passes seg.Content as targetText, and VibeVoice is the only kind that acts
+        // on it: its model wraps output in quotes, and the runs are clipped back to the content
+        // the card actually shows. This is the most offset-sensitive code in the file and the
+        // branch every production VibeVoice call takes.
+        using var fixture = VocabFixtures.Write(VocabService.VocabKind.VibeVoice);
+        var vocab = Load(VocabService.VocabKind.VibeVoice, fixture.Dir);
+        int[] quoted = [VocabFixtures.Quote, .. fixture.PhraseTokens, VocabFixtures.Quote];
+
+        var runs = vocab.GetTokenRuns(quoted, [], VocabFixtures.Phrase);
+
+        Assert.Equal(quoted.Length, runs.Count);                       // still one run per token
+        Assert.Equal(VocabFixtures.Phrase, string.Concat(runs.Select(r => r.text)));
+        Assert.Equal("", runs[0].text);                                // the opening quote is clipped away
+        Assert.Equal("", runs[^1].text);                               // and the closing one
+    }
+
+    // ── Granite's two sibling bundles ───────────────────────────────────────
+
+    [Fact]
+    public void GraniteSpeech_ReadsTheBf16BundleWhenItIsInstalled()
+    {
+        // BF16 is what the app installs on hardware that supports it, and the loader prefers it.
+        // The FP32-only fixture the other tests use exercises the fallback arm; this one covers
+        // the preferred arm, so a wrong subdirectory constant cannot hide behind it.
+        using var fixture = VocabFixtures.WriteGraniteBf16();
+        var vocab = Load(VocabService.VocabKind.GraniteSpeech, fixture.Dir);
+        Assert.Equal(VocabFixtures.Phrase, vocab.DecodeTokens(fixture.PhraseTokens));
+    }
+
+    [Fact]
+    public void GraniteSpeech_PrefersBf16OverFp32WhenBothAreInstalled()
+    {
+        using var fixture = VocabFixtures.WriteGraniteBothBundles(out string bf16Phrase, out string fp32Phrase);
+        var vocab = Load(VocabService.VocabKind.GraniteSpeech, fixture.Dir);
+
+        string decoded = vocab.DecodeTokens(fixture.PhraseTokens);
+        Assert.Equal(bf16Phrase, decoded);
+        Assert.NotEqual(fp32Phrase, decoded);
     }
 
     // ── The loud-fallthrough path ────────────────────────────────────────────


### PR DESCRIPTION
Closes #38.

## Summary

The existing coverage test proves every backend's model name is **recognised** by `VocabService`; nothing proved the branch it selects can actually **decode**. That is the gap the Granite Speech editor bug fell through (PR #35) — a missing `VocabKind` case sent a JSON `tokenizer.json` to the Parakeet line loader, which produced an empty vocab and left the editor rendering raw GPT-2 ByteLevel characters.

Each kind now loads a tiny fixture vocab from disk, at the exact path its loader probes and in its format's documented shape, and decodes a known token sequence.

The tests also **pin the three HF-format kinds apart**. VibeVoice, Qwen3/Whisper and Granite share a loader and a byte table but post-process differently — a boundary-quote trim, a leading-space strip, and neither — so "it decoded something" would not catch one being wired to another's decoder.

## A bug this found

Cohere spells a character outside its subword vocab as one `<0xNN>` token per byte, so a two-byte character arrives as two tokens. `DecodeCohereTokenIncrement` returned early when a token completed no character, so the pending byte was never handed to the streaming decoder; the continuation byte then decoded alone as **U+FFFD**. An accented word showed a replacement character in the editor's per-token runs while the whole-sequence decode got it right. Fixed here — the other byte-level kinds always call `GetChars` for exactly this reason.

## Design notes

- **Fixtures are built in code, not committed as blobs.** A real vocab is megabytes of tokens irrelevant to the check, and a fixture whose expected text is known *by construction* is a stronger claim than one copied out of a previous run. They total 16 KB of readable C#.
- **The GPT-2 ByteLevel table is computed from the published mapping**, not borrowed from `VocabService` — otherwise a wrong table in the loader would round-trip past the tests.
- **Extends `AsrBackendCoverage`** rather than adding `tests/VocabServiceSmoke/` (the issue allows either): `VocabService` is `internal` and that project already has `InternalsVisibleTo`, the stderr-capture collection, and a CI step.
- **Theories are parameterised by `AsrBackend`**, since `VocabKind` is internal and cannot appear in a public test signature. `EveryVocabKindIsReachableFromABackend` keeps that from hiding an untested kind.

## One deviation from the issue's checklist

It asks that `GetTokenRuns` return runs "with non-empty content". The fixtures deliberately split a character across two tokens, and a streaming decoder *correctly* emits nothing for the first half — that is the behaviour under test, not a defect. The tests assert the run count matches the token count and that the runs concatenate to the whole-sequence decode, which is the property the editor actually depends on.

## Test plan

Verified the tests catch the real thing, not just themselves:

- [x] Deleting the `GraniteSpeech` branch (reproducing PR #35) fails **6** of the new tests
- [x] Wiring Granite to VibeVoice's decoder fails the quote-trim divergence test specifically
- [x] The Cohere fix: its test failed before the fix, passes after
- [x] Solution builds (`EP=Cpu`), no new warnings; `Vernacula.Tests` 27, `Vernacula.Tts.Tests` 173, `AsrBackendCoverage` 119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq