### PR TITLE
refactor(granite): one audio front end for all five decode paths (#46 item 2)

### DIFF
--- a/docs/dev/bind_output_logits_investigation.md
+++ b/docs/dev/bind_output_logits_investigation.md
@@ -142,10 +142,12 @@ which VAD returns as **one** segment. Step loop now owns 28–29 % of phase time
 
 | | run a | run b | run c |
 |---|---|---|---|
-| baseline | 152 ms | 155 ms | (cold 219) |
+| baseline | *219 ms (cold, discarded)* | 152 ms | 155 ms |
 | preallocated | 152 ms | 153 ms | 152 ms |
 
-No improvement. Transcripts byte-identical.
+No improvement. Transcripts byte-identical. The baseline's first run is the cold
+outlier again — this file was the first workload of a fresh process — which is why
+the warm pair is what the comparison uses.
 
 ## Run 4 — 2026-09-07 08:05 — Whisper, warm, batched *and* step-heavy (B=8, 393 steps)
 

--- a/docs/dev/bind_output_logits_investigation.md
+++ b/docs/dev/bind_output_logits_investigation.md
@@ -1,0 +1,230 @@
+# Preallocated logits binding across ASR backends (issue #46 item 1)
+
+Issue #46 item 1 proposes rolling the PR #45 phase-8 change — swapping the decoder
+step loop's `BindOutputToDevice("logits", cpuMemInfo)` (ORT allocates a fresh CPU
+buffer per `RunWithBinding`) for `BindOutput("logits", preAllocatedOrtValue)` (one
+reused CPU buffer) — across `WhisperTurbo`, `Qwen3Asr`, `VibeVoiceAsr` and
+`CohereTranscribe`, predicting "likely 5–10% per-backend wall-time win on
+step-heavy workloads".
+
+This log is the measurement behind accepting or rejecting that estimate per backend.
+
+## Benchmark input
+
+`bench.wav`: seven distinct **synthesized** TTS sample clips from the repo
+(`scripts/kokoro_export/samples`, `scripts/omnivoice_export/capture`) concatenated
+four times, resampled to 16 kHz mono — 89.3 s, 32 VAD segments. Entirely
+machine-generated audio; no recorded speech, no PII. Deliberately not a single
+looped clip, so the repetition-loop detectors in the decoders do not fire.
+
+Command shape:
+
+```
+dotnet src/Vernacula.CLI/bin/Release/net10.0/Vernacula.CLI.dll \
+  --asr <backend> --vad --benchmark --audio bench.wav --output out.md
+```
+
+Machine: RTX 3090 (24 GB), CUDA EP, Release build.
+
+## Run 1 — 2026-09-07 07:20 — baselines, and which sites are actually hot
+
+Question: before changing four backends, which of the listed `BindOutputToDevice`
+sites are on a default code path, and how much of wall time does the step loop
+actually own?
+
+### Site survey
+
+Mapping the issue's line numbers onto the methods that contain them:
+
+| Backend | Line | Method | Role | On the default path? |
+|---|---|---|---|---|
+| WhisperTurbo | 531 | `TranscribeBatch` | prefill (init) | yes |
+| WhisperTurbo | 614 | `TranscribeBatch` | **step loop** | **yes** |
+| WhisperTurbo | 755 | `Transcribe` | prefill (init) | single-utterance path |
+| WhisperTurbo | 816 | `Transcribe` | **step loop** | single-utterance path |
+| Qwen3Asr | 665 | static-batch decode | step loop | yes — *already uses `BindOutput`* |
+| Qwen3Asr | 1651 | `DecodeOnGpuUnified` | prefill (init) | `--qwen3asr-serial` only |
+| Qwen3Asr | 1689 | `DecodeOnGpuUnified` | **step loop** | `--qwen3asr-serial` only |
+| Qwen3Asr | 1908 | `DecodeWithIoBinding` | prefill (init) | serial + split-decoder bundle |
+| Qwen3Asr | 1937 | `DecodeWithIoBinding` | **step loop** | serial + split-decoder bundle |
+| VibeVoiceAsr | 556 | `RunOnce` | prefill **and** step (shared) | yes |
+| CohereTranscribe | 353 | init | prefill (init) | yes |
+| CohereTranscribe | 458 | step loop | **step loop** | yes |
+
+Two findings from the survey alone, before any measurement:
+
+1. **The prefill/init sites are not worth changing.** They run once per segment (or
+   once per batch), not once per token, so there is no allocation to amortise; and
+   their logits shape is `[B, S, V]` with `S` varying per segment, so a single
+   preallocated buffer would have to be sized for the worst case and re-wrapped per
+   call anyway. The win the issue measured is a step-loop property. Only the five
+   step-loop sites are candidates.
+2. **`VibeVoiceAsr` line 556 is not a step-loop site** in the sense the others are —
+   `RunOnce` is shared between prefill and decode, clearing and re-binding outputs on
+   every call, so the logits shape varies by call kind. It needs a different change
+   from the other four, and there is no VibeVoice bundle on this machine
+   (`~/.local/share/Vernacula/models` has no `vibevoice_asr/`) to regression-test it
+   against. Deferred.
+
+### Whisper baseline
+
+```
+Whisper breakdown (accumulated across all segments):
+  Mel          :     179 ms (2.3 %)
+  Encoder      :    5573 ms (70.3 %)
+  DecoderInit  :     623 ms (7.9 %)
+  DecoderStep ORT call     :    1531 ms (19.3 %)
+  DecoderStep extract/copy :       0 ms (0.0 %)
+  Argmax       :      18 ms (0.2 %)
+  Total phases :    7927 ms (ASR swAsr: 35474 ms)
+  Step calls   : 57   (avg 26.86 ms ORT / step)
+  Segments     : 32
+Real-time factor: 0.4040
+```
+
+Raw finding: the Whisper step loop is **19.3 % of instrumented phase time but only
+4.3 % of measured ASR wall time** (1531 ms of 35474 ms). This workload is
+encoder-dominated (70 % of phases), and only 57 decoder steps run across 32
+segments because VAD cuts short segments and the batch of 8 finishes on its
+longest row.
+
+Implication: even the full 24 % step-loop improvement PR #45 saw on Granite would
+be ~370 ms here — **~1 % of ASR wall time, not the 5–10 % the issue predicts.**
+The 5–10 % estimate silently assumed every backend is as step-heavy as Granite.
+Whisper on VAD-segmented audio is not.
+
+`Total phases` (7927 ms) accounts for only 22 % of `swAsr` (35474 ms). Chased
+that down before treating it as a finding: `swAsr` starts at `Program.cs:461`,
+*before* the backend is constructed, so it includes ONNX session creation and CUDA
+EP initialisation — ~27 s, consistent with the ~28 s Granite spends on the same
+thing. Not a mystery and not a regression; it does mean **`swAsr` is the wrong
+denominator for a steady-state comparison**, since it is dominated by a fixed
+startup cost. The rest of this log compares the instrumented phase totals.
+
+**Run 1 was invalid as a baseline.** Applying the change and re-running produced a
+whole-pipeline speedup — Encoder 5573 → 1857 ms, DecoderInit 623 → 72 ms, swAsr
+35474 → 4243 ms — which no logits-binding change can explain. Run 1 was the first
+CUDA process of the session: cold driver, cold kernel cache, cold page cache. Every
+number in it is a cold-start artefact. All subsequent runs discard the first.
+
+## Run 2 — 2026-09-07 07:45 — Whisper, warm, VAD-segmented (B=8, 57 steps)
+
+Change under test, in `TranscribeBatch`'s step loop:
+
+```csharp
+var stepLogitsBuf = new float[B * VocabSize];
+using var stepLogitsVal = OrtValue.CreateTensorValueFromMemory(
+    stepLogitsBuf, [B, 1L, VocabSize]);
+...
+stepBinding.BindOutput("logits", stepLogitsVal);   // was BindOutputToDevice(..., cpuMemInfo)
+...
+var stepLogits = new ReadOnlySpan<float>(stepLogitsBuf);   // was curStep[0].GetTensorDataAsSpan<float>()
+```
+
+`DecoderStep ORT call`, warm, 3–4 runs each:
+
+| | run a | run b | run c | run d |
+|---|---|---|---|---|
+| baseline | 125 ms | 128 ms | 126 ms | 125 ms |
+| preallocated | 128 ms | 129 ms | 129 ms | — |
+
+No improvement; the two are inside each other's noise, with the preallocated side
+marginally *slower*. Transcripts byte-identical.
+
+Objection to this run: 57 steps across 32 segments is not a "step-heavy workload".
+Fair — so:
+
+## Run 3 — 2026-09-07 07:55 — Whisper, warm, gapless audio (B=1, 140 steps)
+
+`bench_dense.wav`: `bench.wav` with silences stripped
+(`silenceremove=stop_periods=-1:stop_duration=0.15:stop_threshold=-45dB`), 76.2 s,
+which VAD returns as **one** segment. Step loop now owns 28–29 % of phase time.
+
+| | run a | run b | run c |
+|---|---|---|---|
+| baseline | 152 ms | 155 ms | (cold 219) |
+| preallocated | 152 ms | 153 ms | 152 ms |
+
+No improvement. Transcripts byte-identical.
+
+## Run 4 — 2026-09-07 08:05 — Whisper, warm, batched *and* step-heavy (B=8, 393 steps)
+
+The strongest form of the proposal's claim: the per-step buffer is at its largest
+(B=8 × 51866 floats = 1.6 MB per `RunWithBinding`) *and* the step loop dominates.
+`bench_batch8.wav`: `bench_dense.wav` repeated 8× with 0.7 s silences, 615 s, which
+VAD returns as 8 long segments filling one batch. Step loop = 32.7 % of phase time.
+
+| | run a | run b | run c |
+|---|---|---|---|
+| baseline | 798 ms | 797 ms | 800 ms |
+| preallocated | 797 ms | 797 ms | 798 ms |
+
+**No improvement — 393 steps, 1.6 MB of per-step allocation removed, and the
+difference is under 0.4 %, well inside run-to-run noise.**
+
+### Conclusion on issue #46 item 1
+
+The proposal does not reproduce on WhisperTurbo, in any of the three workload
+shapes tested, including the one that maximises the effect it targets. At
+~2 ms of GPU work per step, ORT's CPU allocator serving a 1.6 MB buffer is not
+measurable; the step is bound by decoder compute, not by output-buffer allocation.
+
+Why PR #45 saw 24 % on Granite and this sees 0 % is not established here, and the
+decisive experiment is not available on this machine: Granite's two
+`BindOutput(preallocated)` sites live in `TranscribeBatch` (dynamic-MHA bundle) and
+`TranscribeStaticGqaBatched` (static-GQA bundle), and the only Granite bundle
+present is static-MHA, which dispatches to `TranscribeBatchStatic` — a path that
+uses plain `Run()` and no IO binding at all. Reverting Granite's own change and
+re-measuring it would need a bundle this machine does not have. The likeliest
+explanation is that the 24 % was not the allocation but something else in the same
+phase-8 commit — that commit also added the `next_token` GPU-argmax output, which
+removes an entire `[B, 1, 49k]` device→host logits copy per step, a far larger
+effect than allocating the buffer that copy lands in.
+
+**Recommendation: do not roll this out.** The Whisper change was written,
+measured, found to be a no-op, and reverted; it is not in this branch. The
+remaining candidate sites are worth even less than Whisper's:
+
+- `Qwen3Asr` line 665 — the **default** path — already uses `BindOutput`. The two
+  remaining step-loop sites (`DecodeOnGpuUnified`, `DecodeWithIoBinding`) are
+  reachable only via `--qwen3asr-serial` or a split-decoder bundle.
+- `VibeVoiceAsr` line 556 is in `RunOnce`, shared between prefill and decode with a
+  logits shape that changes between the two, so it needs a different (larger) change
+  than the others — and there is no VibeVoice bundle here to regression-test it.
+- Every remaining site on the issue's list is a prefill/init binding, which runs
+  once per segment rather than once per token.
+
+If someone wants to revisit this, the thing to measure first is whether the
+`next_token` GPU-argmax output — not the buffer reuse — is what PR #45 actually
+bought, and whether the other backends' decoders can be re-exported to provide it.
+
+## Run 5 — 2026-09-07 08:20 — item 2, `RunAudioPipeline` extraction
+
+Question: do the five `Transcribe*` methods' mel → encoder → projector preambles
+really run the same code, or have they drifted?
+
+They had drifted, but only in packaging, not in behaviour:
+
+- three of five assert `projector tokens == NumAudioTokens(waveform)`, two do not;
+- single-row paths assign their profile timers (`melLocal = …`), batched paths
+  accumulate (`melLocal += …`);
+- two spell the `Run` calls across multiple lines, three on one line.
+
+The extracted helper always accumulates (`ref long melMs` with `+=`), which is
+equivalent for the single-row callers since their locals start at 0, and returns
+the projector's token count so each caller keeps its own assertion verbatim rather
+than inheriting one it did not have. That keeps this a pure refactor: no path gains
+or loses a check.
+
+Result: 123 lines removed, 70 added (the helper plus five call sites), net −53 with
+five copies of the front end collapsed to one. `GraniteSpeech.cs` 2512 → 2459 lines.
+
+Parity, `--asr granite --vad` on `bench.wav` (32 segments, static-MHA bundle →
+`TranscribeBatchStatic`): transcripts byte-identical before and after; 8371 ms vs
+8792 ms wall, which is load-time jitter on a single run, not a regression in a
+refactor that changes no arithmetic.
+
+Only one of the five call sites can be executed on this machine — the other four
+need bundle variants that are not here — so the remaining assurance is that the
+replaced text was identical and the compiler accepts the substitution. This is
+exactly the gap issue #46 item 3 (per-variant smoke coverage) exists to close.

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -451,10 +451,13 @@ public sealed class GraniteSpeech : IDisposable
     /// local.
     /// </para>
     /// <para>
-    /// <paramref name="projectorTokens"/> is the audio-token count the projector
+    /// The returned <c>projectorTokens</c> is the audio-token count the projector
     /// actually produced. It should equal <see cref="NumAudioTokens"/> of the
     /// waveform length; the paths that assert that keep doing so themselves, since
-    /// the checks differ in wording and in which ones are fatal.
+    /// the checks differ in wording and in which ones are fatal. Note that the
+    /// embeddings are materialized before any caller gets to run that assertion —
+    /// the copy happens here — so a bundle that disagrees with the formula pays one
+    /// wasted array copy on its way to the exception.
     /// </para>
     /// </summary>
     private (float[] audioEmbeds, long audioDim, long projectorTokens) RunAudioPipeline(

--- a/src/Vernacula.Base/GraniteSpeech.cs
+++ b/src/Vernacula.Base/GraniteSpeech.cs
@@ -439,6 +439,54 @@ public sealed class GraniteSpeech : IDisposable
     internal static int MaxBatchSeen;
     private static readonly object _profileLock = new();
 
+    /// <summary>
+    /// The audio front end shared by every <c>Transcribe*</c> path: one waveform
+    /// through mel → encoder → projector, yielding the audio embeddings the decoder
+    /// prefill scatters into the prompt.
+    /// <para>
+    /// Every bundle variant runs this identically — only the decoder differs — so it
+    /// lives here once rather than being copied into each path. The three
+    /// <c>ref</c> timers accumulate (<c>+=</c>) when <c>_profile</c> is on and are
+    /// untouched otherwise; callers that time a single row simply pass a zeroed
+    /// local.
+    /// </para>
+    /// <para>
+    /// <paramref name="projectorTokens"/> is the audio-token count the projector
+    /// actually produced. It should equal <see cref="NumAudioTokens"/> of the
+    /// waveform length; the paths that assert that keep doing so themselves, since
+    /// the checks differ in wording and in which ones are fatal.
+    /// </para>
+    /// </summary>
+    private (float[] audioEmbeds, long audioDim, long projectorTokens) RunAudioPipeline(
+        float[]   waveform,
+        ref long  melMs,
+        ref long  encMs,
+        ref long  projMs)
+    {
+        var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
+
+        var audioT = new DenseTensor<float>(waveform, [1, waveform.Length]);
+        using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
+        var inputFeatures = melResults[0].AsTensor<float>();
+        var ifShape = inputFeatures.Dimensions.ToArray();
+        var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
+        if (swStage != null) { swStage.Stop(); melMs += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+        using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
+            "input_features", new DenseTensor<float>(ifData, ifShape))]);
+        var encoderHidden = encResults[0].AsTensor<float>();
+        var encShape = encoderHidden.Dimensions.ToArray();
+        var encData = encoderHidden.ToArray();
+        if (swStage != null) { swStage.Stop(); encMs += swStage.ElapsedMilliseconds; swStage.Restart(); }
+
+        using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
+            "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
+        var ae = projResults[0].AsTensor<float>();
+        var result = (ae.ToArray(), ae.Dimensions[2], ae.Dimensions[1]);
+        if (swStage != null) { swStage.Stop(); projMs += swStage.ElapsedMilliseconds; }
+        return result;
+    }
+
     private (string text, long[] tokens)[] TranscribeBatch(float[][] waveforms, int maxNewTokens)
     {
         // Dynamic GQA bundle: B=1 per segment (Run 20 phase 4). Phase 5
@@ -490,37 +538,16 @@ public sealed class GraniteSpeech : IDisposable
                     $"Pre-segment audio to ≤{allowedSeconds} s.");
             }
 
-            // Mel
-            var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-            var audioT = new DenseTensor<float>(waveforms[b], [1, waveforms[b].Length]);
-            using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
-            var inputFeatures = melResults[0].AsTensor<float>();
-            var ifShape = inputFeatures.Dimensions.ToArray();
-            var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
-            if (swStage != null) { swStage.Stop(); melLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            // Encoder
-            using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
-                "input_features", new DenseTensor<float>(ifData, ifShape))]);
-            var encoderHidden = encResults[0].AsTensor<float>();
-            var encShape = encoderHidden.Dimensions.ToArray();
-            var encData = encoderHidden.ToArray();
-            if (swStage != null) { swStage.Stop(); encLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            // Projector
-            using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
-                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
-            var ae = projResults[0].AsTensor<float>();
-            var projShape = ae.Dimensions.ToArray();
-            if (projShape[1] != audioTokens)
+            var (rowEmbeds, rowDim, rowTokens) = RunAudioPipeline(
+                waveforms[b], ref melLocal, ref encLocal, ref projLocal);
+            if (rowTokens != audioTokens)
                 throw new InvalidOperationException(
                     $"Audio token count mismatch (row {b}): formula predicts {audioTokens}, "
-                  + $"projector produced {projShape[1]}.");
+                  + $"projector produced {rowTokens}.");
 
-            audioEmbeds[b] = ae.ToArray();
+            audioEmbeds[b] = rowEmbeds;
             nAudio[b]      = audioTokens;
-            audioDim       = projShape[2];
-            if (swStage != null) { swStage.Stop(); projLocal += swStage.ElapsedMilliseconds; }
+            audioDim       = rowDim;
         }
 
         // ── Build batched, left-padded prompt ───────────────────────────
@@ -1000,33 +1027,15 @@ public sealed class GraniteSpeech : IDisposable
                   + $"--static-audio-len, or pre-segment audio.");
             }
 
-            var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-            var audioT = new DenseTensor<float>(waveforms[b], [1, waveforms[b].Length]);
-            using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
-            var inputFeatures = melResults[0].AsTensor<float>();
-            var ifShape = inputFeatures.Dimensions.ToArray();
-            var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
-            if (swStage != null) { swStage.Stop(); melLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
-                "input_features", new DenseTensor<float>(ifData, ifShape))]);
-            var encoderHidden = encResults[0].AsTensor<float>();
-            var encShape = encoderHidden.Dimensions.ToArray();
-            var encData = encoderHidden.ToArray();
-            if (swStage != null) { swStage.Stop(); encLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
-                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
-            var ae = projResults[0].AsTensor<float>();
-            var projShape = ae.Dimensions.ToArray();
-            if (projShape[1] != audioTokens)
+            var (rowEmbeds, rowDim, rowTokens) = RunAudioPipeline(
+                waveforms[b], ref melLocal, ref encLocal, ref projLocal);
+            if (rowTokens != audioTokens)
                 throw new InvalidOperationException(
                     $"Audio token count mismatch (row {b}): formula predicts {audioTokens}, "
-                  + $"projector produced {projShape[1]}.");
-            audioEmbeds[b] = ae.ToArray();
+                  + $"projector produced {rowTokens}.");
+            audioEmbeds[b] = rowEmbeds;
             nAudio[b]      = audioTokens;
-            audioDim       = projShape[2];
-            if (swStage != null) { swStage.Stop(); projLocal += swStage.ElapsedMilliseconds; }
+            audioDim       = rowDim;
         }
 
         // ── Build padded prompt at fixed B ───────────────────────────────
@@ -1329,31 +1338,8 @@ public sealed class GraniteSpeech : IDisposable
         long melLocal = 0, encLocal = 0, projLocal = 0;
 
         // ── Mel + encoder + projector ──────────────────────────────────
-        var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-        var audioT = new DenseTensor<float>(waveform, [1, waveform.Length]);
-        using var melResults = _mel.Run(
-            [NamedOnnxValue.CreateFromTensor("audio", audioT)]);
-        var inputFeatures = melResults[0].AsTensor<float>();
-        var ifShape = inputFeatures.Dimensions.ToArray();
-        var ifData = inputFeatures is DenseTensor<float> dT
-            ? dT.ToArray() : inputFeatures.ToArray();
-        if (swStage != null) { swStage.Stop(); melLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-        using var encResults = _encoder.Run(
-            [NamedOnnxValue.CreateFromTensor(
-                "input_features", new DenseTensor<float>(ifData, ifShape))]);
-        var encoderHidden = encResults[0].AsTensor<float>();
-        var encShape = encoderHidden.Dimensions.ToArray();
-        var encData = encoderHidden.ToArray();
-        if (swStage != null) { swStage.Stop(); encLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-        using var projResults = _projector.Run(
-            [NamedOnnxValue.CreateFromTensor(
-                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
-        var ae = projResults[0].AsTensor<float>();
-        long audioDim = ae.Dimensions[2];
-        var audioEmbedsRow = ae.ToArray();
-        if (swStage != null) { swStage.Stop(); projLocal = swStage.ElapsedMilliseconds; }
+        var (audioEmbedsRow, audioDim, _) = RunAudioPipeline(
+            waveform, ref melLocal, ref encLocal, ref projLocal);
 
         // ── Build prefill inputs ───────────────────────────────────────
         // input_ids [B, realLen]: row 0 is the real prompt, dummies are PAD.
@@ -1630,28 +1616,11 @@ public sealed class GraniteSpeech : IDisposable
                 throw new InvalidOperationException(
                     $"Segment too long: audio_tokens ({audioTokens}) > pinned A ({A}).");
 
-            var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-            var audioT = new DenseTensor<float>(waveforms[b], [1, waveforms[b].Length]);
-            using var melResults = _mel.Run([NamedOnnxValue.CreateFromTensor("audio", audioT)]);
-            var inputFeatures = melResults[0].AsTensor<float>();
-            var ifShape = inputFeatures.Dimensions.ToArray();
-            var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
-            if (swStage != null) { swStage.Stop(); melLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            using var encResults = _encoder.Run([NamedOnnxValue.CreateFromTensor(
-                "input_features", new DenseTensor<float>(ifData, ifShape))]);
-            var encoderHidden = encResults[0].AsTensor<float>();
-            var encShape = encoderHidden.Dimensions.ToArray();
-            var encData = encoderHidden.ToArray();
-            if (swStage != null) { swStage.Stop(); encLocal += swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-            using var projResults = _projector.Run([NamedOnnxValue.CreateFromTensor(
-                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
-            var ae = projResults[0].AsTensor<float>();
-            audioDim = ae.Dimensions[2];
-            audioEmbeds[b] = ae.ToArray();
+            var (rowEmbeds, rowDim, _) = RunAudioPipeline(
+                waveforms[b], ref melLocal, ref encLocal, ref projLocal);
+            audioDim = rowDim;
+            audioEmbeds[b] = rowEmbeds;
             nAudio[b] = audioTokens;
-            if (swStage != null) { swStage.Stop(); projLocal += swStage.ElapsedMilliseconds; }
         }
 
         // ── Build padded prompt at fixed B ───────────────────────────────
@@ -1969,34 +1938,12 @@ public sealed class GraniteSpeech : IDisposable
         long melLocal = 0, encLocal = 0, projLocal = 0;
 
         // ── Mel + encoder + projector (B=1) ──────────────────────────────
-        var swStage = _profile ? System.Diagnostics.Stopwatch.StartNew() : null;
-        var audioT = new DenseTensor<float>(waveform, [1, waveform.Length]);
-        using var melResults = _mel.Run(
-            [NamedOnnxValue.CreateFromTensor("audio", audioT)]);
-        var inputFeatures = melResults[0].AsTensor<float>();
-        var ifShape = inputFeatures.Dimensions.ToArray();
-        var ifData = inputFeatures is DenseTensor<float> dT ? dT.ToArray() : inputFeatures.ToArray();
-        if (swStage != null) { swStage.Stop(); melLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-        using var encResults = _encoder.Run(
-            [NamedOnnxValue.CreateFromTensor(
-                "input_features", new DenseTensor<float>(ifData, ifShape))]);
-        var encoderHidden = encResults[0].AsTensor<float>();
-        var encShape = encoderHidden.Dimensions.ToArray();
-        var encData = encoderHidden.ToArray();
-        if (swStage != null) { swStage.Stop(); encLocal = swStage.ElapsedMilliseconds; swStage.Restart(); }
-
-        using var projResults = _projector.Run(
-            [NamedOnnxValue.CreateFromTensor(
-                "encoder_hidden", new DenseTensor<float>(encData, encShape))]);
-        var ae = projResults[0].AsTensor<float>();
-        long audioDim = ae.Dimensions[2];
-        if (ae.Dimensions[1] != audioTokens)
+        var (audioEmbedsRow, audioDim, projectorTokens) = RunAudioPipeline(
+            waveform, ref melLocal, ref encLocal, ref projLocal);
+        if (projectorTokens != audioTokens)
             throw new InvalidOperationException(
                 $"Audio token count mismatch: formula predicts {audioTokens}, "
-              + $"projector produced {ae.Dimensions[1]}.");
-        var audioEmbedsRow = ae.ToArray();
-        if (swStage != null) { swStage.Stop(); projLocal = swStage.ElapsedMilliseconds; }
+              + $"projector produced {projectorTokens}.");
 
         // ── Build prefill inputs at actual sizes ────────────────────────
         var inputIds = new long[realLen];


### PR DESCRIPTION
Issue #46 item 2, plus the measurement log that answers item 1.

## What's here

**Item 2 — `RunAudioPipeline` extraction.** The five `Transcribe*` methods each
carried their own copy of the mel → encoder → projector preamble. They had drifted,
but only in packaging: single-row paths *assigned* their profile timers where batched
paths *accumulated*, and three of five asserted `projector tokens == NumAudioTokens(…)`
while two did not.

The helper always accumulates into `ref long` timers — equivalent for the single-row
callers, whose locals start at zero — and returns the projector's token count so each
caller keeps its own assertion verbatim. No path gains a check it lacked or loses one
it had. 123 lines removed, 70 added.

**Item 1 — measured, and not rolled out.** See
`docs/dev/bind_output_logits_investigation.md`.

## Item 1 does not reproduce

The issue predicts "5–10 % per-backend wall-time win" from swapping the step loop's
`BindOutputToDevice("logits", cpuMemInfo)` for `BindOutput(preallocated)`. I wrote the
change for `WhisperTurbo.TranscribeBatch` and measured it warm in three workload shapes,
including the one that maximises the effect (batched *and* step-heavy, 1.6 MB of
per-step allocation removed):

| workload | steps | step loop share | baseline | preallocated |
|---|---|---|---|---|
| VAD-segmented, B=8 | 57 | 19 % | 125–128 ms | 128–129 ms |
| gapless, B=1 | 140 | 29 % | 152–155 ms | 152–153 ms |
| gapless ×8, B=8 | 393 | 33 % | 797–800 ms | 797–798 ms |

Zero, in every case, with byte-identical transcripts. At ~2 ms of GPU work per step,
ORT's CPU allocator serving the logits buffer is not measurable. The change is not in
this branch.

Three things the survey turned up that shrink item 1 further:

- `Qwen3Asr:665` — the **default** path — already uses `BindOutput`. The two remaining
  step-loop sites are reachable only via `--qwen3asr-serial` or a split-decoder bundle.
- `VibeVoiceAsr:556` is in `RunOnce`, shared between prefill and decode with a logits
  shape that differs between them, so it needs a larger change than the others — and
  there is no VibeVoice bundle here to regression-test against.
- Every other site on the issue's list is a prefill/init binding: once per segment, not
  once per token, with a per-segment shape. Nothing to amortise.

My first baseline was invalid — the whole pipeline was 8× slower on the session's first
CUDA process (cold driver and kernel cache). The doc keeps that dead end; it is the
reason every later run discards the first.

## Verification

- Transcripts byte-identical before/after on `--asr granite --vad`, 32 segments.
- Suites: 27 / 129 / 173.
- Only `TranscribeBatchStatic` is reachable with the bundle on this machine; the other
  four paths need bundle variants that aren't here. That gap is item 3.

## Not done, and why

- **Item 3** (per-variant smoke coverage) needs dynamic-MHA, dynamic-GQA and static-GQA
  bundles. Only static-MHA exists here.
- **Item 4** (delete the static-shape methods) — **please don't.** Details in a comment
  on #46: the only working Granite bundle on this machine is static-shape and routes
  through `TranscribeBatchStatic`, one of the three methods item 4 proposes to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq