### PR TITLE
refactor(db): per-job engine settings as one JSON column (closes #130)

### DIFF
--- a/src/Vernacula.Avalonia/Models/JobRecord.cs
+++ b/src/Vernacula.Avalonia/Models/JobRecord.cs
@@ -48,14 +48,23 @@ public class JobRecord : ObservableObject
     public string  AudioFileSha256Sum        { get; set; } = "";
 
     // ── TTS-only settings, snapshotted per job so a requeue renders the same way ──
+    /// <summary>
+    /// The job's TTS choices, read from the jobs table's <c>job_settings</c> JSON column; null
+    /// for ASR jobs and for TTS rows written before that column existed and never opened by a
+    /// build that backfills them. The accessors below are conveniences over this one field —
+    /// a new engine knob goes in <see cref="TtsJobSettings"/> and needs nothing here unless
+    /// something binds to it directly.
+    /// </summary>
+    public TtsJobSettings? TtsSettings        { get; set; }
+
     /// <summary>TtsBackendKind name ("Chatterbox" / "Kokoro" / "OmniVoice"); "" for ASR jobs.</summary>
-    public string  TtsBackend                { get; set; } = "";
+    public string  TtsBackend                => TtsSettings?.Backend  ?? "";
     /// <summary>vernacula-phonemizer language code (OmniVoice); "" where the backend has no choice.</summary>
-    public string  TtsLanguage               { get; set; } = "";
+    public string  TtsLanguage               => TtsSettings?.Language ?? "";
     /// <summary>Backend-specific voice: a WAV path (Chatterbox), a voice name (Kokoro), a library id (OmniVoice).</summary>
-    public string  TtsVoice                  { get; set; } = "";
-    public float   TtsSpeed                  { get; set; } = 1.0f;
-    public int     TtsNumStep                { get; set; } = 32;
+    public string  TtsVoice                  => TtsSettings?.Voice    ?? "";
+    public float   TtsSpeed                  => TtsSettings?.Speed    ?? 1.0f;
+    public int     TtsNumStep                => TtsSettings?.NumStep  ?? 32;
     public string  AsrModelName              { get; set; } = "nvidia/parakeet-tdt-0.6b-v3";
     public string  AsrLanguageCode           { get; set; } = "auto";
     public string? AudioFileDatestamp        { get; set; }

--- a/src/Vernacula.Avalonia/Services/ControlDb.cs
+++ b/src/Vernacula.Avalonia/Services/ControlDb.cs
@@ -63,11 +63,70 @@ internal sealed class ControlDb : IDisposable
             "ALTER TABLE jobs ADD COLUMN tts_speed REAL NOT NULL DEFAULT 1.0",
             "ALTER TABLE jobs ADD COLUMN tts_num_step INTEGER NOT NULL DEFAULT 32",
             "ALTER TABLE jobs ADD COLUMN output_duration_seconds REAL",
+            // Per-kind engine settings as one JSON blob, superseding the five tts_* columns
+            // above (issue #130). Those stay in the schema, unwritten, so a database written
+            // by this version still opens in an older build; nothing reads them any more
+            // except the backfill below.
+            "ALTER TABLE jobs ADD COLUMN job_settings TEXT",
         })
         {
             try { Execute(ddl); }
             catch (SqliteException) { /* column already present — ignore */ }
         }
+
+        BackfillTtsJobSettings();
+    }
+
+    /// <summary>
+    /// Moves TTS rows written before <c>job_settings</c> existed into it. Idempotent — it only
+    /// touches rows that have no JSON yet — so it is safe to run on every open, which also
+    /// covers a process that died between the ALTER and the copy.
+    /// </summary>
+    private void BackfillTtsJobSettings()
+    {
+        var legacy = new List<(int JobId, TtsJobSettings Tts)>();
+        using (var read = _conn.CreateCommand())
+        {
+            read.CommandText = """
+                SELECT job_id, tts_backend, tts_language, tts_voice, tts_speed, tts_num_step
+                FROM jobs
+                WHERE job_kind = 'tts' AND job_settings IS NULL
+                """;
+            using var r = read.ExecuteReader();
+            while (r.Read())
+                legacy.Add((r.GetInt32(0), new TtsJobSettings(
+                    r.IsDBNull(1) ? "" : r.GetString(1),
+                    r.IsDBNull(2) ? "" : r.GetString(2),
+                    r.IsDBNull(3) ? "" : r.GetString(3),
+                    r.IsDBNull(4) ? 1.0f : (float)r.GetDouble(4),
+                    r.IsDBNull(5) ? 32 : r.GetInt32(5))));
+        }
+        if (legacy.Count == 0) return;
+
+        using var tx = _conn.BeginTransaction();
+        foreach (var (jobId, tts) in legacy)
+        {
+            using var upd = _conn.CreateCommand();
+            upd.Transaction = tx;
+            upd.CommandText = "UPDATE jobs SET job_settings = $js WHERE job_id = $id";
+            upd.Parameters.AddWithValue("$js", SerializeTts(tts));
+            upd.Parameters.AddWithValue("$id", jobId);
+            upd.ExecuteNonQuery();
+        }
+        tx.Commit();
+    }
+
+    // The jobs table stores per-kind engine settings as JSON so that a new engine knob is one
+    // edit to the record rather than a column, two SQL statements, a parameter, a property and
+    // a reader ordinal. System.Text.Json is culture-invariant, which the column needs to be.
+    private static string SerializeTts(TtsJobSettings tts) =>
+        System.Text.Json.JsonSerializer.Serialize(tts);
+
+    private static TtsJobSettings? DeserializeTts(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try { return System.Text.Json.JsonSerializer.Deserialize<TtsJobSettings>(json); }
+        catch (System.Text.Json.JsonException) { return null; }   // unreadable row → treat as unset
     }
 
     /// <summary>
@@ -137,16 +196,40 @@ internal sealed class ControlDb : IDisposable
                             string sha256, string audioDateStamp, int streamIndex = -1,
                             string asrLanguageCode = "auto",
                             string asrModelName = "nvidia/parakeet-tdt-0.6b-v3")
+        => InsertJob(JobKind.Asr, title, resultsFile, audioPath, sha256, audioDateStamp,
+                     streamIndex, asrLanguageCode, asrModelName, settingsJson: null);
+
+    /// <summary>
+    /// Inserts a brand-new text-to-speech job with 'queued' status. A job for the same
+    /// results_file (same document + same backend/voice/language, see
+    /// JobQueueService.TtsResultsFileName) is updated in place and its job_id returned, so
+    /// re-adding a document re-renders rather than duplicating the row.
+    /// </summary>
+    public int InsertNewTtsJob(string title, string resultsFile, string documentPath,
+                               string sha256, string documentDateStamp, TtsJobSettings tts)
+        => InsertJob(JobKind.Tts, title, resultsFile, documentPath, sha256, documentDateStamp,
+                     streamIndex: -1, asrLanguageCode: "auto",
+                     asrModelName: "nvidia/parakeet-tdt-0.6b-v3",
+                     settingsJson: SerializeTts(tts));
+
+    /// <summary>
+    /// The one upsert-by-results_file behind both. Re-adding a job re-runs it: the row goes
+    /// back to 'queued' with its previous outcome cleared, or Home would keep showing the old
+    /// result (and its Resume button) while the new run overwrote the files underneath it.
+    /// </summary>
+    private int InsertJob(JobKind kind, string title, string resultsFile, string inputPath,
+                          string sha256, string inputDateStamp, int streamIndex,
+                          string asrLanguageCode, string asrModelName, string? settingsJson)
     {
+        string kindText = kind == JobKind.Tts ? "tts" : "asr";
+        object settingsValue = (object?)settingsJson ?? DBNull.Value;
+
         using var check = _conn.CreateCommand();
         check.CommandText = "SELECT job_id FROM jobs WHERE results_file = $rf";
         check.Parameters.AddWithValue("$rf", resultsFile);
         if (check.ExecuteScalar() is long existingId)
         {
             using var upd = _conn.CreateCommand();
-            // Re-adding a job re-runs it: the row goes back to 'queued' with its old outcome
-            // cleared, or Home would keep showing the previous result (and its Resume button)
-            // while the new run overwrites the files underneath it.
             upd.CommandText = """
                 UPDATE jobs
                 SET job_title = $jt,
@@ -156,75 +239,8 @@ internal sealed class ControlDb : IDisposable
                     stream_index = $si,
                     asr_language_code = $lc,
                     asr_model_name = $am,
-                    status = 'queued',
-                    error_message = NULL,
-                    run_time_seconds = NULL,
-                    transcription_run_datestamp = NULL
-                WHERE job_id = $id
-                """;
-            upd.Parameters.AddWithValue("$jt", title);
-            upd.Parameters.AddWithValue("$ap", audioPath);
-            upd.Parameters.AddWithValue("$sh", sha256);
-            upd.Parameters.AddWithValue("$ad", audioDateStamp);
-            upd.Parameters.AddWithValue("$si", streamIndex);
-            upd.Parameters.AddWithValue("$lc", asrLanguageCode);
-            upd.Parameters.AddWithValue("$am", asrModelName);
-            upd.Parameters.AddWithValue("$id", existingId);
-            upd.ExecuteNonQuery();
-            return (int)existingId;
-        }
-
-        using var ins = _conn.CreateCommand();
-        ins.CommandText = """
-            INSERT INTO jobs
-                (job_title, results_file, transcription_run_datestamp,
-                 audio_file_path, audio_file_sha256sum, audio_file_datestamp,
-                 status, created_at, stream_index, asr_language_code, asr_model_name)
-            VALUES ($jt, $rf, NULL, $ap, $sh, $ad, 'queued', $ca, $si, $lc, $am)
-            """;
-        ins.Parameters.AddWithValue("$jt", title);
-        ins.Parameters.AddWithValue("$rf", resultsFile);
-        ins.Parameters.AddWithValue("$ap", audioPath);
-        ins.Parameters.AddWithValue("$sh", sha256);
-        ins.Parameters.AddWithValue("$ad", audioDateStamp);
-        ins.Parameters.AddWithValue("$ca", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
-        ins.Parameters.AddWithValue("$si", streamIndex);
-        ins.Parameters.AddWithValue("$lc", asrLanguageCode);
-        ins.Parameters.AddWithValue("$am", asrModelName);
-        ins.ExecuteNonQuery();
-
-        using var lastId = _conn.CreateCommand();
-        lastId.CommandText = "SELECT last_insert_rowid()";
-        return (int)(long)lastId.ExecuteScalar()!;
-    }
-
-    /// <summary>
-    /// Inserts a brand-new text-to-speech job with 'queued' status. Mirrors
-    /// <see cref="InsertNewJob"/>: a job for the same results_file (same document + same
-    /// backend/voice/language, see JobQueueService.TtsResultsFileName) is updated in place and
-    /// its job_id returned, so re-adding a document re-renders rather than duplicating the row.
-    /// </summary>
-    public int InsertNewTtsJob(string title, string resultsFile, string documentPath,
-                               string sha256, string documentDateStamp, TtsJobSettings tts)
-    {
-        using var check = _conn.CreateCommand();
-        check.CommandText = "SELECT job_id FROM jobs WHERE results_file = $rf";
-        check.Parameters.AddWithValue("$rf", resultsFile);
-        if (check.ExecuteScalar() is long existingId)
-        {
-            using var upd = _conn.CreateCommand();
-            upd.CommandText = """
-                UPDATE jobs
-                SET job_title = $jt,
-                    audio_file_path = $ap,
-                    audio_file_sha256sum = $sh,
-                    audio_file_datestamp = $ad,
-                    job_kind = 'tts',
-                    tts_backend = $tb,
-                    tts_language = $tl,
-                    tts_voice = $tv,
-                    tts_speed = $ts,
-                    tts_num_step = $tn,
+                    job_kind = $jk,
+                    job_settings = $js,
                     output_duration_seconds = NULL,
                     status = 'queued',
                     error_message = NULL,
@@ -232,11 +248,8 @@ internal sealed class ControlDb : IDisposable
                     transcription_run_datestamp = NULL
                 WHERE job_id = $id
                 """;
-            upd.Parameters.AddWithValue("$jt", title);
-            upd.Parameters.AddWithValue("$ap", documentPath);
-            upd.Parameters.AddWithValue("$sh", sha256);
-            upd.Parameters.AddWithValue("$ad", documentDateStamp);
-            AddTtsParameters(upd, tts);
+            AddCommonParameters(upd, title, inputPath, sha256, inputDateStamp,
+                                streamIndex, asrLanguageCode, asrModelName, kindText, settingsValue);
             upd.Parameters.AddWithValue("$id", existingId);
             upd.ExecuteNonQuery();
             return (int)existingId;
@@ -247,18 +260,14 @@ internal sealed class ControlDb : IDisposable
             INSERT INTO jobs
                 (job_title, results_file, transcription_run_datestamp,
                  audio_file_path, audio_file_sha256sum, audio_file_datestamp,
-                 status, created_at, stream_index, job_kind,
-                 tts_backend, tts_language, tts_voice, tts_speed, tts_num_step)
-            VALUES ($jt, $rf, NULL, $ap, $sh, $ad, 'queued', $ca, -1, 'tts',
-                    $tb, $tl, $tv, $ts, $tn)
+                 status, created_at, stream_index, asr_language_code, asr_model_name,
+                 job_kind, job_settings)
+            VALUES ($jt, $rf, NULL, $ap, $sh, $ad, 'queued', $ca, $si, $lc, $am, $jk, $js)
             """;
-        ins.Parameters.AddWithValue("$jt", title);
+        AddCommonParameters(ins, title, inputPath, sha256, inputDateStamp,
+                            streamIndex, asrLanguageCode, asrModelName, kindText, settingsValue);
         ins.Parameters.AddWithValue("$rf", resultsFile);
-        ins.Parameters.AddWithValue("$ap", documentPath);
-        ins.Parameters.AddWithValue("$sh", sha256);
-        ins.Parameters.AddWithValue("$ad", documentDateStamp);
         ins.Parameters.AddWithValue("$ca", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
-        AddTtsParameters(ins, tts);
         ins.ExecuteNonQuery();
 
         using var lastId = _conn.CreateCommand();
@@ -266,13 +275,20 @@ internal sealed class ControlDb : IDisposable
         return (int)(long)lastId.ExecuteScalar()!;
     }
 
-    private static void AddTtsParameters(SqliteCommand cmd, TtsJobSettings tts)
+    private static void AddCommonParameters(
+        SqliteCommand cmd, string title, string inputPath, string sha256, string inputDateStamp,
+        int streamIndex, string asrLanguageCode, string asrModelName, string kindText,
+        object settingsValue)
     {
-        cmd.Parameters.AddWithValue("$tb", tts.Backend);
-        cmd.Parameters.AddWithValue("$tl", tts.Language);
-        cmd.Parameters.AddWithValue("$tv", tts.Voice);
-        cmd.Parameters.AddWithValue("$ts", tts.Speed);
-        cmd.Parameters.AddWithValue("$tn", tts.NumStep);
+        cmd.Parameters.AddWithValue("$jt", title);
+        cmd.Parameters.AddWithValue("$ap", inputPath);
+        cmd.Parameters.AddWithValue("$sh", sha256);
+        cmd.Parameters.AddWithValue("$ad", inputDateStamp);
+        cmd.Parameters.AddWithValue("$si", streamIndex);
+        cmd.Parameters.AddWithValue("$lc", asrLanguageCode);
+        cmd.Parameters.AddWithValue("$am", asrModelName);
+        cmd.Parameters.AddWithValue("$jk", kindText);
+        cmd.Parameters.AddWithValue("$js", settingsValue);
     }
 
     /// <summary>TTS: the rendered audio length recorded for a job, if any.</summary>
@@ -449,11 +465,7 @@ internal sealed class ControlDb : IDisposable
             JobTitle                  = r.GetString(r.GetOrdinal("job_title")),
             Kind                      = string.Equals(GetNullable("job_kind"), "tts", StringComparison.OrdinalIgnoreCase)
                                             ? JobKind.Tts : JobKind.Asr,
-            TtsBackend                = GetNullable("tts_backend") ?? "",
-            TtsLanguage               = GetNullable("tts_language") ?? "",
-            TtsVoice                  = GetNullable("tts_voice") ?? "",
-            TtsSpeed                  = (float)r.GetDouble(r.GetOrdinal("tts_speed")),
-            TtsNumStep                = r.GetInt32(r.GetOrdinal("tts_num_step")),
+            TtsSettings               = DeserializeTts(GetNullable("job_settings")),
             OutputDurationSeconds     = r.IsDBNull(odOrd) ? null : r.GetDouble(odOrd),
             ResultsFile               = r.GetString(r.GetOrdinal("results_file")),
             AudioFilePath             = r.GetString(r.GetOrdinal("audio_file_path")),

--- a/src/Vernacula.Avalonia/Services/ControlDb.cs
+++ b/src/Vernacula.Avalonia/Services/ControlDb.cs
@@ -126,7 +126,14 @@ internal sealed class ControlDb : IDisposable
     {
         if (string.IsNullOrWhiteSpace(json)) return null;
         try { return System.Text.Json.JsonSerializer.Deserialize<TtsJobSettings>(json); }
-        catch (System.Text.Json.JsonException) { return null; }   // unreadable row → treat as unset
+        catch (System.Text.Json.JsonException ex)
+        {
+            // Treat an unreadable row as unset rather than refusing to open the whole job
+            // history, but say so: the job keeps its title and status while quietly losing the
+            // voice it was rendered with, and a requeue would render something else.
+            Console.Error.WriteLine($"[ControlDb] Ignoring unreadable job_settings: {ex.Message}");
+            return null;
+        }
     }
 
     /// <summary>
@@ -208,8 +215,6 @@ internal sealed class ControlDb : IDisposable
     public int InsertNewTtsJob(string title, string resultsFile, string documentPath,
                                string sha256, string documentDateStamp, TtsJobSettings tts)
         => InsertJob(JobKind.Tts, title, resultsFile, documentPath, sha256, documentDateStamp,
-                     streamIndex: -1, asrLanguageCode: "auto",
-                     asrModelName: "nvidia/parakeet-tdt-0.6b-v3",
                      settingsJson: SerializeTts(tts));
 
     /// <summary>
@@ -218,8 +223,10 @@ internal sealed class ControlDb : IDisposable
     /// result (and its Resume button) while the new run overwrote the files underneath it.
     /// </summary>
     private int InsertJob(JobKind kind, string title, string resultsFile, string inputPath,
-                          string sha256, string inputDateStamp, int streamIndex,
-                          string asrLanguageCode, string asrModelName, string? settingsJson)
+                          string sha256, string inputDateStamp, int streamIndex = -1,
+                          string asrLanguageCode = "auto",
+                          string asrModelName = "nvidia/parakeet-tdt-0.6b-v3",
+                          string? settingsJson = null)
     {
         string kindText = kind == JobKind.Tts ? "tts" : "asr";
         object settingsValue = (object?)settingsJson ?? DBNull.Value;

--- a/src/Vernacula.Avalonia/Services/JobQueueService.cs
+++ b/src/Vernacula.Avalonia/Services/JobQueueService.cs
@@ -183,6 +183,12 @@ internal sealed class JobQueueService
     internal static string TtsResultsFileName(string documentSha256, TtsJobSettings tts)
     {
         // Invariant formatting: the key names a file that must stay the same under any UI culture.
+        //
+        // This list is deliberately written out rather than derived from the settings record, even
+        // though the record is now what the jobs table stores (issue #130). The key identifies a
+        // rendered file on disk: adding a field here re-keys every existing render and orphans it.
+        // A new engine knob belongs in this string only if two jobs differing in it must produce
+        // two files.
         string settingsKey = string.Create(System.Globalization.CultureInfo.InvariantCulture,
             $"{tts.Backend}|{tts.Language}|{tts.Voice}|{tts.Speed:F2}|{tts.NumStep}");
         string settingsHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(settingsKey)))[..8].ToLowerInvariant();

--- a/src/Vernacula.Avalonia/Services/JobRunner.cs
+++ b/src/Vernacula.Avalonia/Services/JobRunner.cs
@@ -166,8 +166,8 @@ internal sealed class TtsQueueRunner : IJobRunner
 
     public QueueEntry EntryFor(JobRecord job) =>
         new(job.JobId, job.AudioFilePath, job.ResultsFile, Kind: JobKind.Tts,
-            Tts: new TtsJobSettings(job.TtsBackend, job.TtsLanguage, job.TtsVoice,
-                                    job.TtsSpeed, job.TtsNumStep));
+            Tts: job.TtsSettings ?? new TtsJobSettings(job.TtsBackend, job.TtsLanguage, job.TtsVoice,
+                                                       job.TtsSpeed, job.TtsNumStep));
 
     public async Task RunAsync(
         QueueEntry entry, IJobUiState uiState, Action onPercentChanged, CancellationToken ct)

--- a/tests/AsrBackendCoverage/TtsEngineRegistryTests.cs
+++ b/tests/AsrBackendCoverage/TtsEngineRegistryTests.cs
@@ -84,18 +84,18 @@ public class TtsEngineRegistryTests
     [Fact]
     public void JobDescriptionAndAnnotationLanguageComeFromTheEngine()
     {
-        var british = new JobRecord { Kind = JobKind.Tts, TtsBackend = "Kokoro", TtsVoice = "bf_emma", TtsSpeed = 1.0f };
+        var british = new JobRecord { Kind = JobKind.Tts, TtsSettings = new("Kokoro", "", "bf_emma", Speed: 1.0f) };
         Assert.Equal("en-GB", TtsEngines.For(british).AnnotationLanguage(british));
         Assert.Contains("bf_emma", TtsEngines.For(british).DescribeJob(british));
 
-        var american = new JobRecord { Kind = JobKind.Tts, TtsBackend = "Kokoro", TtsVoice = "af_heart" };
+        var american = new JobRecord { Kind = JobKind.Tts, TtsSettings = new("Kokoro", "", "af_heart") };
         Assert.Equal("en", TtsEngines.For(american).AnnotationLanguage(american));
 
-        var omni = new JobRecord { Kind = JobKind.Tts, TtsBackend = "OmniVoice", TtsLanguage = "cy", TtsVoice = "v1", TtsNumStep = 32 };
+        var omni = new JobRecord { Kind = JobKind.Tts, TtsSettings = new("OmniVoice", "cy", "v1", NumStep: 32) };
         Assert.Equal("cy", TtsEngines.For(omni).AnnotationLanguage(omni));
 
         // Chatterbox's voice is a path; the reader shows the file name, not the whole path.
-        var cb = new JobRecord { Kind = JobKind.Tts, TtsBackend = "Chatterbox", TtsVoice = "/home/someone/clips/ref.wav" };
+        var cb = new JobRecord { Kind = JobKind.Tts, TtsSettings = new("Chatterbox", "", "/home/someone/clips/ref.wav") };
         Assert.Contains("ref.wav", TtsEngines.For(cb).DescribeJob(cb));
         Assert.DoesNotContain(TtsEngines.For(cb).DescribeJob(cb), p => p.Contains('/'));
     }

--- a/tests/AsrBackendCoverage/TtsJobPersistenceTests.cs
+++ b/tests/AsrBackendCoverage/TtsJobPersistenceTests.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using Microsoft.Data.Sqlite;
 using Vernacula.App.Models;
 using Vernacula.App.Services;
 using Xunit;
@@ -60,6 +63,8 @@ public class TtsJobPersistenceTests : IDisposable
         Assert.Equal("cy_default", job.TtsVoice);
         Assert.Equal(1.25f, job.TtsSpeed);
         Assert.Equal(24, job.TtsNumStep);
+        // The five accessors above are conveniences over the one stored object (issue #130).
+        Assert.Equal(tts, job.TtsSettings);
         Assert.Equal(12.5, job.OutputDurationSeconds);
         Assert.Equal("/docs/page.md", job.AudioFilePath);
         Assert.Equal(Path.ChangeExtension(sidecar, ".wav"), job.OutputAudioPath);
@@ -156,5 +161,79 @@ public class TtsJobPersistenceTests : IDisposable
         Assert.NotEqual(a, b);
         Assert.StartsWith(sha[..16] + "_", a);
         Assert.EndsWith("_tts.json", a);
+    }
+
+    /// <summary>
+    /// TTS jobs written before job_settings existed live in five tts_* columns. Opening such a
+    /// database must move them across, or every one of those jobs loses the voice and language
+    /// it was rendered with and a requeue renders something else.
+    /// </summary>
+    [Fact]
+    public void LegacyTtsColumnsAreBackfilledIntoJobSettings()
+    {
+        string dbPath = Path.Combine(_dir, "control.db");
+        using (var _ = new ControlDb(dbPath)) { /* create the schema, including job_settings */ }
+
+        // A row as the previous version wrote it: tts_* populated, job_settings absent.
+        using (var raw = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            raw.Open();
+            using var cmd = raw.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO jobs
+                    (job_title, results_file, audio_file_path, audio_file_sha256sum,
+                     audio_file_datestamp, status, created_at, job_kind,
+                     tts_backend, tts_language, tts_voice, tts_speed, tts_num_step)
+                VALUES ('old', '/jobs/old_tts.json', '/docs/old.md', 'abc',
+                        '2026-01-01 00:00:00', 'complete', '2026-01-01 00:00:00', 'tts',
+                        'OmniVoice', 'cy', 'cy_default', 1.25, 24)
+                """;
+            cmd.ExecuteNonQuery();
+        }
+
+        using (var reopened = new ControlDb(dbPath))
+        {
+            var job = Assert.Single(reopened.GetJobs());
+            Assert.Equal(new TtsJobSettings("OmniVoice", "cy", "cy_default", 1.25f, 24), job.TtsSettings);
+        }
+
+        // Idempotent: a second open must not disturb a row it already migrated.
+        using (var again = new ControlDb(dbPath))
+            Assert.Equal("cy_default", Assert.Single(again.GetJobs()).TtsVoice);
+    }
+
+    /// <summary>ASR rows carry no engine settings at all — they used to carry TTS defaults.</summary>
+    [Fact]
+    public void AsrJobsHaveNoEngineSettings()
+    {
+        string dbPath = Path.Combine(_dir, "control.db");
+        using var db = new ControlDb(dbPath);
+        db.InsertNewJob("asr", Path.Combine(_dir, "a_results.sqlite3"), "/media/a.wav", "abc", "2026-01-01 00:00:00");
+
+        var job = Assert.Single(db.GetJobs());
+        Assert.Null(job.TtsSettings);
+        Assert.Equal("", job.TtsBackend);
+        Assert.Equal(1.0f, job.TtsSpeed);
+    }
+
+    /// <summary>
+    /// The stored JSON must not depend on the running culture: a comma decimal separator would
+    /// make Speed unreadable on the next open under a different locale.
+    /// </summary>
+    [Fact]
+    public void SettingsSurviveACommaDecimalCulture()
+    {
+        var previous = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+        try
+        {
+            string dbPath = Path.Combine(_dir, "control.db");
+            var tts = new TtsJobSettings("Kokoro", "", "af_heart", Speed: 1.25f);
+            using var db = new ControlDb(dbPath);
+            db.InsertNewTtsJob("t", Path.Combine(_dir, "d_tts.json"), "/docs/d.md", "abc", "2026-01-01 00:00:00", tts);
+
+            Assert.Equal(1.25f, Assert.Single(db.GetJobs()).TtsSpeed);
+        }
+        finally { Thread.CurrentThread.CurrentCulture = previous; }
     }
 }

--- a/tests/AsrBackendCoverage/TtsJobPersistenceTests.cs
+++ b/tests/AsrBackendCoverage/TtsJobPersistenceTests.cs
@@ -236,4 +236,68 @@ public class TtsJobPersistenceTests : IDisposable
         }
         finally { Thread.CurrentThread.CurrentCulture = previous; }
     }
+
+    /// <summary>
+    /// The point of storing settings as JSON (issue #130) is that a new engine knob is one edit
+    /// to the record. That only holds if rows written before the knob existed read back with the
+    /// knob's declared default rather than zero — System.Text.Json does honour a record's
+    /// optional constructor parameters, and this pins that, because if it ever stopped every
+    /// existing job would silently take 0 for the new field.
+    /// </summary>
+    [Fact]
+    public void SettingsWrittenBeforeAFieldExistedReadBackWithItsDefault()
+    {
+        string dbPath = Path.Combine(_dir, "control.db");
+        using (var _ = new ControlDb(dbPath)) { /* schema */ }
+
+        // Speed and NumStep absent, as they would be had they been added after this row.
+        using (var raw = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            raw.Open();
+            using var cmd = raw.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO jobs
+                    (job_title, results_file, audio_file_path, audio_file_sha256sum,
+                     audio_file_datestamp, status, created_at, job_kind, job_settings)
+                VALUES ('partial', '/jobs/p_tts.json', '/docs/p.md', 'abc',
+                        '2026-01-01 00:00:00', 'complete', '2026-01-01 00:00:00', 'tts',
+                        '{"Backend":"Kokoro","Language":"","Voice":"af_heart"}')
+                """;
+            cmd.ExecuteNonQuery();
+        }
+
+        using var db = new ControlDb(dbPath);
+        var job = Assert.Single(db.GetJobs());
+        Assert.Equal("af_heart", job.TtsVoice);
+        Assert.Equal(1.0f, job.TtsSpeed);    // not 0
+        Assert.Equal(32, job.TtsNumStep);    // not 0
+    }
+
+    /// <summary>An unreadable settings blob must not take the whole job list down with it.</summary>
+    [Fact]
+    public void UnreadableSettingsLeaveTheJobListable()
+    {
+        string dbPath = Path.Combine(_dir, "control.db");
+        using (var _ = new ControlDb(dbPath)) { /* schema */ }
+
+        using (var raw = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            raw.Open();
+            using var cmd = raw.CreateCommand();
+            cmd.CommandText = """
+                INSERT INTO jobs
+                    (job_title, results_file, audio_file_path, audio_file_sha256sum,
+                     audio_file_datestamp, status, created_at, job_kind, job_settings)
+                VALUES ('broken', '/jobs/b_tts.json', '/docs/b.md', 'abc',
+                        '2026-01-01 00:00:00', 'complete', '2026-01-01 00:00:00', 'tts',
+                        'not json at all')
+                """;
+            cmd.ExecuteNonQuery();
+        }
+
+        using var db = new ControlDb(dbPath);
+        var job = Assert.Single(db.GetJobs());
+        Assert.Equal("broken", job.JobTitle);
+        Assert.Null(job.TtsSettings);
+    }
 }


### PR DESCRIPTION
Closes #130.

## The change

One `job_settings TEXT` column holds the serialized `TtsJobSettings`, replacing the five
`tts_*` columns. A new engine knob is now one edit to the record instead of six
(`ALTER`, a `$param` in the INSERT and the UPDATE, an `AddTtsParameters` line, a
`JobRecord` property, a reader ordinal). ASR rows store `NULL` rather than
`tts_speed = 1.0, tts_num_step = 32`.

`InsertNewJob` and `InsertNewTtsJob` were two copies of the same upsert-by-`results_file`
dance; both are now thin wrappers over one `InsertJob`.

`JobRecord` keeps `TtsBackend` / `TtsLanguage` / `TtsVoice` / `TtsSpeed` / `TtsNumStep` as
read-only accessors over the one stored object, so the twenty-odd call sites that read
them are untouched.

## The hashing trap the issue flagged

`TtsResultsFileName`'s field list is deliberately still written out by hand rather than
derived from the record, now with a comment saying why: the key names a **file on disk**,
so folding a new field into it re-keys every existing render and orphans it. A knob belongs
in that string only if two jobs differing in it must produce two files.

## Migration

A backfill copies legacy `tts_*` rows into `job_settings`. It only touches rows with no
JSON yet, so it runs on every open and also covers a process that died between the `ALTER`
and the copy.

**Verified against a copy of a real control database** (never the original) carrying a
legacy TTS row alongside four ASR rows: the column is added, the TTS row backfills to the
right backend/voice/speed/steps, the ASR rows stay `NULL`, and Home renders all five
normally under Xvfb with no exceptions.

That check also caught a flaw in my own verification first — my initial run showed the
column added but nothing backfilled, which turned out to be `dotnet run --no-build` reusing
the binary from a negative check that had the backfill commented out. Worth knowing: after
deliberately breaking something to prove a test fails, restoring the source is not enough.

The five `tts_*` columns **stay in the schema, unwritten**. Dropping them would break both
the additive-migration convention this file follows and the downgrade path — a database
written by this version still opens in an older build, with those jobs' settings blank.
Removing them is a separate, deliberate step.

## Two behaviour changes from unifying the upsert

Both strictly more correct, neither reachable today:

- The ASR update now also writes `job_kind` and clears `output_duration_seconds`.
- The TTS insert now writes the ASR columns explicitly instead of relying on their defaults.

Same values either way, since ASR (`{sha16}_results.sqlite3`) and TTS
(`{sha16}_{settings8}_tts.json`) results-file names cannot collide.

## Tests

Suites 27 / **135** / 173 (+3). New: the backfill, its idempotency across a second open,
ASR rows having no settings, and a round trip under a comma-decimal culture (`de-DE`) —
the column has to stay culture-invariant or `Speed` becomes unreadable on the next open
elsewhere. The backfill test was checked by disabling the backfill and watching it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq