### PR TITLE
fix(build): cut the transitive CPU ONNX Runtime off at the submodule (closes #131)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,47 +1,31 @@
 <Project>
 
   <!--
-    Repo-wide build rules that must run AFTER each project body. Directory.Build.props (imported
-    before it) cannot carry these: a `PackageReference Update` there would run before the item it
-    updates exists, and would silently do nothing.
+    Repo-wide build rules that must run AFTER each project body — Directory.Build.props is
+    imported before it, so anything that inspects a project's own items belongs here.
   -->
 
-  <!-- ⚠ THE CPU ONNX RUNTIME MUST NOT FLOW OUT OF THE PHONEMIZER. Vernacula.Phonemizer is a git
-       submodule and takes a plain (CPU) Microsoft.ML.OnnxRuntime reference for its neural G2P.
-       Without PrivateAssets it flows transitively into every consumer of Vernacula.Tts.Base, and
-       the CPU `libonnxruntime.so` lands in the same runtimes/<rid>/native/ directory as the GPU
-       one. Whichever copies last wins, so a CUDA build quietly runs on a CPU runtime — with no
-       build error, and the CUDA provider libraries still sitting next to it.
+  <!-- ⚠ THE CPU ONNX RUNTIME MUST NOT REACH A GPU BUILD'S OUTPUT. Vernacula.Phonemizer, a git
+       submodule, takes a plain (CPU) Microsoft.ML.OnnxRuntime reference for its neural G2P.
+       Vernacula.Tts.Base stops that package's native from flowing onward — ExcludeAssets="native"
+       on its ProjectReference, explained there — so no consumer needs the ExcludeAssets="all" shim
+       eight of them used to carry, and a new consumer is correct by default (#131).
 
-       Every EP-selecting consumer used to carry its own `ExcludeAssets="all"` shim to outrank it.
-       There were eight, each conditioned to stay in lockstep with the EP package group above it,
-       and the guard against a ninth was a comment. Cutting it off here makes a new consumer
-       correct by default (#131).
-
-       Scoped by project name because the submodule has no props file of its own, so this file
-       reaches it; edit it in the submodule instead and the fix would live in the wrong repo. The
-       phonemizer still compiles against ORT — PrivateAssets governs what flows to consumers, not
-       what the project itself resolves — and every consumer brings the EP-appropriate package. -->
-  <ItemGroup Condition="$(MSBuildProjectDirectory.StartsWith('$(MSBuildThisFileDirectory)external'))">
-    <PackageReference Update="Microsoft.ML.OnnxRuntime" PrivateAssets="all" />
-  </ItemGroup>
-
-  <!-- ⚠ AND THE RULE, BECAUSE THE ABOVE IS STILL SOMETHING SOMEONE CAN ROUTE AROUND. The scoping
-       is by directory rather than project name so a rename inside the submodule cannot quietly
-       switch it off, but a plain Microsoft.ML.OnnxRuntime added directly to a GPU consumer would
-       leak the same way, and the symptom is a working build that runs on the wrong runtime.
-
-       So: under a GPU execution provider, the CPU package must not contribute a native. Windows
-       and Linux only, the two platforms whose GPU packages actually ship one — on macOS x64 the
-       plain package IS the runtime, at a pinned 1.19.2, and is referenced deliberately.
+       This target is the rule behind that. An edge attribute is still something a direct plain
+       reference in a GPU consumer can sidestep, and the symptom of getting it wrong is a build
+       that succeeds and runs on the wrong runtime: the CPU `libonnxruntime.so` lands in the same
+       runtimes/<rid>/native/ directory as the GPU one, whichever copies last wins, and the CUDA
+       provider libraries sit uselessly beside it. So: under a GPU execution provider, the CPU
+       package must not contribute a native. Windows and Linux only, the two platforms whose GPU
+       packages actually ship one — on macOS x64 the plain package IS the runtime, at a pinned
+       1.19.2, and is referenced deliberately.
 
        A project that genuinely wants the CPU runtime while the rest of the build is on a GPU EP —
        a CPU-only test host, say — sets AllowCpuOnnxRuntime, which says so where a reader will
        see it.
 
        Vendored projects under external/ are exempt: the submodule owns that reference for its own
-       compilation, the rule above already stops it flowing to consumers, and its own bin/ is not
-       what anything ships. -->
+       compilation and its own tests, and its bin/ is not what anything here ships. -->
   <Target Name="RejectCpuOnnxRuntimeUnderGpuEp"
           AfterTargets="ResolveReferences"
           Condition="'$(EP)' != 'Cpu' AND '$(AllowCpuOnnxRuntime)' != 'true'

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,54 @@
+<Project>
+
+  <!--
+    Repo-wide build rules that must run AFTER each project body. Directory.Build.props (imported
+    before it) cannot carry these: a `PackageReference Update` there would run before the item it
+    updates exists, and would silently do nothing.
+  -->
+
+  <!-- ⚠ THE CPU ONNX RUNTIME MUST NOT FLOW OUT OF THE PHONEMIZER. Vernacula.Phonemizer is a git
+       submodule and takes a plain (CPU) Microsoft.ML.OnnxRuntime reference for its neural G2P.
+       Without PrivateAssets it flows transitively into every consumer of Vernacula.Tts.Base, and
+       the CPU `libonnxruntime.so` lands in the same runtimes/<rid>/native/ directory as the GPU
+       one. Whichever copies last wins, so a CUDA build quietly runs on a CPU runtime — with no
+       build error, and the CUDA provider libraries still sitting next to it.
+
+       Every EP-selecting consumer used to carry its own `ExcludeAssets="all"` shim to outrank it.
+       There were eight, each conditioned to stay in lockstep with the EP package group above it,
+       and the guard against a ninth was a comment. Cutting it off here makes a new consumer
+       correct by default (#131).
+
+       Scoped by project name because the submodule has no props file of its own, so this file
+       reaches it; edit it in the submodule instead and the fix would live in the wrong repo. The
+       phonemizer still compiles against ORT — PrivateAssets governs what flows to consumers, not
+       what the project itself resolves — and every consumer brings the EP-appropriate package. -->
+  <ItemGroup Condition="$(MSBuildProjectDirectory.StartsWith('$(MSBuildThisFileDirectory)external'))">
+    <PackageReference Update="Microsoft.ML.OnnxRuntime" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- ⚠ AND THE RULE, BECAUSE THE ABOVE IS STILL SOMETHING SOMEONE CAN ROUTE AROUND. The scoping
+       is by directory rather than project name so a rename inside the submodule cannot quietly
+       switch it off, but a plain Microsoft.ML.OnnxRuntime added directly to a GPU consumer would
+       leak the same way, and the symptom is a working build that runs on the wrong runtime.
+
+       So: under a GPU execution provider, the CPU package must not contribute a native. Windows
+       and Linux only, the two platforms whose GPU packages actually ship one — on macOS x64 the
+       plain package IS the runtime, at a pinned 1.19.2, and is referenced deliberately.
+
+       A project that genuinely wants the CPU runtime while the rest of the build is on a GPU EP —
+       a CPU-only test host, say — sets AllowCpuOnnxRuntime, which says so where a reader will
+       see it.
+
+       Vendored projects under external/ are exempt: the submodule owns that reference for its own
+       compilation, the rule above already stops it flowing to consumers, and its own bin/ is not
+       what anything ships. -->
+  <Target Name="RejectCpuOnnxRuntimeUnderGpuEp"
+          AfterTargets="ResolveReferences"
+          Condition="'$(EP)' != 'Cpu' AND '$(AllowCpuOnnxRuntime)' != 'true'
+                     AND !$(MSBuildProjectDirectory.StartsWith('$(MSBuildThisFileDirectory)external'))
+                     AND ($([MSBuild]::IsOSPlatform('Windows')) OR $([MSBuild]::IsOSPlatform('Linux')))">
+    <Error Condition="'%(RuntimeTargetsCopyLocalItems.NuGetPackageId)' == 'Microsoft.ML.OnnxRuntime'"
+           Text="$(MSBuildProjectName) builds as EP=$(EP) but the CPU Microsoft.ML.OnnxRuntime package is contributing runtime assets (e.g. %(RuntimeTargetsCopyLocalItems.DestinationSubPath)). Its native would land on top of the GPU native of the same name and win the copy, so the build would succeed while running on the wrong runtime. Drop the reference that brings it in, or set AllowCpuOnnxRuntime=true if this project really is CPU-only." />
+  </Target>
+
+</Project>

--- a/scripts/ChatterboxAttentionProbe/ChatterboxAttentionProbe.csproj
+++ b/scripts/ChatterboxAttentionProbe/ChatterboxAttentionProbe.csproj
@@ -13,9 +13,6 @@
 
   <ItemGroup Condition="'$(EP)' == 'Cuda'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="$(OnnxRuntimeVersion)" />
-    <!-- Vernacula.Phonemizer pins a plain (CPU) runtime; without this suppression its native lands
-         beside the GPU one and wins the copy, leaving a 1.29 managed assembly on a 1.24.4 core. -->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(EP)' == 'Cpu'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />

--- a/scripts/TtsAsrProbe/TtsAsrProbe.csproj
+++ b/scripts/TtsAsrProbe/TtsAsrProbe.csproj
@@ -13,9 +13,6 @@
 
   <ItemGroup Condition="'$(EP)' == 'Cuda'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="$(OnnxRuntimeVersion)" />
-    <!-- Vernacula.Phonemizer pins a plain (CPU) runtime; without this suppression its native lands
-         beside the GPU one and wins the copy, leaving a 1.29 managed assembly on a 1.24.4 core. -->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(EP)' == 'Cpu'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />

--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -108,18 +108,6 @@
     <ProjectReference Include="..\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj" />
   </ItemGroup>
 
-  <!--
-    Vernacula.Phonemizer (via Vernacula.Tts.Base) takes a plain (CPU) Microsoft.ML.OnnxRuntime
-    reference. Left alone it flows into this app's output next to the EP variant above and both
-    ship a native onnxruntime library — whichever lands last wins, which is how a CUDA build
-    silently ends up on the CPU runtime. A DIRECT reference outranks the transitive one, and
-    ExcludeAssets="all" then contributes nothing, so the EP package is the only runtime shipped.
-    Only for the GPU EPs: the Cpu / macOS branches above already reference the plain package.
-  -->
-  <ItemGroup Condition="('$(EP)' == 'Cuda' AND ($([MSBuild]::IsOSPlatform('Windows')) OR $([MSBuild]::IsOSPlatform('Linux')))) OR ('$(EP)' == 'DirectML' AND $([MSBuild]::IsOSPlatform('Windows')))">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
-  </ItemGroup>
-
   <ItemGroup>
     <!-- Dispatch-fan-out coverage test (issue #37) reflects on internal
          types (SettingsService, SettingsViewModel, VocabService). -->

--- a/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
+++ b/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
@@ -35,19 +35,6 @@
     <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>
 
-  <!--
-    Vernacula.Phonemizer (via Vernacula.Tts.Base) takes a plain (CPU) Microsoft.ML.OnnxRuntime
-    reference. Left alone it flows into this app's output next to the EP variant above and both
-    ship a native onnxruntime library — whichever lands last wins, which is how a CUDA build
-    silently ends up on the CPU runtime. A DIRECT reference outranks the transitive one, and
-    ExcludeAssets="all" then contributes nothing, so the EP package is the only runtime shipped.
-  -->
-  <!-- The version comes from OnnxRuntimeVersion in Directory.Build.props, which is
-       what keeps it equal to the native runtime this EP ships. -->
-  <ItemGroup Condition="'$(EP)' != 'Cpu'">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
-  </ItemGroup>
-
   <ItemGroup>
     <!-- No SetConfiguration: EP is a global property and already reaches both (and Base again
          through Tts.Base) with the same value — an override here would build Base twice. -->

--- a/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
+++ b/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
@@ -69,11 +69,12 @@
          rendered through KokoroFormat, Kokoro's G2P. Vendored as a git submodule under external/;
          its data/ tree is located at runtime by PhonemizerData.
 
-         ⚠ Its Microsoft.ML.OnnxRuntime reference is a PLAIN (CPU) one, not PrivateAssets="all"
-         like the EP-selected package above, so it flows transitively into every consumer of this
-         project. A Cuda/DirectML consumer must outrank it with a direct ExcludeAssets="all"
-         reference or the CPU native library lands next to the GPU one and whichever copies last
-         wins — see Vernacula.Tts.CLI.csproj for the block and the explanation. -->
+         ⚠ Its Microsoft.ML.OnnxRuntime reference is a PLAIN (CPU) one, and the submodule does not
+         mark it PrivateAssets="all" the way the EP-selected package above is. Left alone it would
+         flow transitively into every consumer of this project, putting the CPU native beside the
+         GPU one where whichever copies last wins. Directory.Build.targets cuts it off at the
+         submodule instead, so consumers need nothing (#131); read that file before changing this
+         reference. -->
     <ProjectReference Include="..\..\external\vernacula-phonemizer\csharp\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" />
   </ItemGroup>
 

--- a/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
+++ b/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
@@ -70,12 +70,19 @@
          its data/ tree is located at runtime by PhonemizerData.
 
          ⚠ Its Microsoft.ML.OnnxRuntime reference is a PLAIN (CPU) one, and the submodule does not
-         mark it PrivateAssets="all" the way the EP-selected package above is. Left alone it would
-         flow transitively into every consumer of this project, putting the CPU native beside the
-         GPU one where whichever copies last wins. Directory.Build.targets cuts it off at the
-         submodule instead, so consumers need nothing (#131); read that file before changing this
-         reference. -->
-    <ProjectReference Include="..\..\external\vernacula-phonemizer\csharp\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" />
+         mark it PrivateAssets="all" the way the EP-selected package above is. Left alone it flows
+         transitively into every consumer of this project, and its native lands beside the GPU
+         one where whichever copies last wins (#131).
+
+         ExcludeAssets="native" on this edge stops exactly that: the phonemizer's own assembly and
+         the managed ORT still flow, the CPU `libonnxruntime.so` does not. It is "native" and not
+         "runtime" because on a ProjectReference "runtime" also excludes the referenced project's
+         own DLL — measured: Vernacula.Phonemizer.dll vanishes from every consumer's output. And
+         it is on THIS edge rather than PrivateAssets on the submodule's own reference because the
+         submodule's tests and tools get their ORT through that same reference; cutting it there
+         left them with no native at all when built in place. The rule that keeps this honest is
+         RejectCpuOnnxRuntimeUnderGpuEp in Directory.Build.targets. -->
+    <ProjectReference Include="..\..\external\vernacula-phonemizer\csharp\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" ExcludeAssets="native" />
   </ItemGroup>
 
 </Project>

--- a/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
+++ b/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
@@ -31,21 +31,6 @@
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />
   </ItemGroup>
 
-  <!--
-    Vernacula.Phonemizer takes a plain (CPU) Microsoft.ML.OnnxRuntime reference for its neural
-    G2P models rather than the PrivateAssets="all" convention Vernacula.Base uses. Left alone,
-    that transitive package flows into this app's output next to the EP variant above and both
-    ship a `Microsoft.ML.OnnxRuntime.dll` plus a native `libonnxruntime.so` — whichever native
-    lands last wins, which is how a CUDA build silently ends up on the CPU runtime. A DIRECT
-    reference outranks the transitive one, and ExcludeAssets="all" then contributes nothing, so
-    the EP package above is the only runtime in the output.
-  -->
-  <!-- The version comes from OnnxRuntimeVersion in Directory.Build.props, which is
-       what keeps it equal to the native runtime this EP ships. -->
-  <ItemGroup Condition="'$(EP)' != 'Cpu'">
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.3.0" />
   </ItemGroup>

--- a/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
+++ b/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
@@ -40,7 +40,11 @@
          through Tts.Base) with the same value — an override here would build Base twice. -->
     <ProjectReference Include="..\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj" />
     <ProjectReference Include="..\Vernacula.Base\Vernacula.Base.csproj" />
-    <ProjectReference Include="..\..\external\vernacula-phonemizer\csharp\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" />
+    <!-- ⚠ ExcludeAssets="native", for the same reason as the identical edge in Vernacula.Tts.Base:
+         this is a second, direct path for the phonemizer's plain (CPU) ONNX Runtime native to
+         reach a GPU build's output, and the edge in Tts.Base does not cover it. The guard in
+         Directory.Build.targets is what caught it (#131). -->
+    <ProjectReference Include="..\..\external\vernacula-phonemizer\csharp\Vernacula.Phonemizer\Vernacula.Phonemizer.csproj" ExcludeAssets="native" />
   </ItemGroup>
 
 </Project>

--- a/tests/AsrBackendCoverage/AsrBackendCoverage.csproj
+++ b/tests/AsrBackendCoverage/AsrBackendCoverage.csproj
@@ -10,6 +10,9 @@
          override to Cpu so the test host loads cleanly without CUDA. -->
     <Platforms>x64</Platforms>
     <RootNamespace>Vernacula.Tests.AsrBackendCoverage</RootNamespace>
+    <!-- CPU-only test host: it references the plain ONNX Runtime on purpose, so the
+         Directory.Build.targets guard against the CPU package under a GPU EP does not apply. -->
+    <AllowCpuOnnxRuntime>true</AllowCpuOnnxRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
+++ b/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
@@ -15,9 +15,6 @@
        machine needs the plain runtime rather than a suppressed one. -->
   <ItemGroup Condition="'$(EP)' == 'Cuda'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="$(OnnxRuntimeVersion)" />
-    <!-- Vernacula.Phonemizer pins a plain (CPU) runtime; without this suppression it lands beside
-         the GPU one and the managed assembly meets the wrong native. -->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(EP)' != 'Cuda'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />

--- a/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
+++ b/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
@@ -27,11 +27,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
       <Private>true</Private>
-      <SetConfiguration>EP=Cuda</SetConfiguration>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
       <Private>true</Private>
-      <SetConfiguration>EP=Cuda</SetConfiguration>
     </ProjectReference>
   </ItemGroup>
 

--- a/tests/GraniteSpeechSmoke/GraniteSpeechSmoke.csproj
+++ b/tests/GraniteSpeechSmoke/GraniteSpeechSmoke.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
       <Private>true</Private>
-      <SetConfiguration>EP=Cuda</SetConfiguration>
     </ProjectReference>
   </ItemGroup>
 

--- a/tests/IndicConformerTest/IndicConformerTest.csproj
+++ b/tests/IndicConformerTest/IndicConformerTest.csproj
@@ -12,6 +12,9 @@
          here so InferenceSession(..., new SessionOptions()) in the test
          host resolves cleanly without a GPU. -->
     <Platforms>x64</Platforms>
+    <!-- CPU-only test host: it references the plain ONNX Runtime on purpose, so the
+         Directory.Build.targets guard against the CPU package under a GPU EP does not apply. -->
+    <AllowCpuOnnxRuntime>true</AllowCpuOnnxRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/KokoroPerf/KokoroPerf.csproj
+++ b/tests/KokoroPerf/KokoroPerf.csproj
@@ -13,9 +13,6 @@
   <ItemGroup>
     <!-- .Gpu includes the CPU provider as fallback; covers both EP modes. -->
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="$(OnnxRuntimeVersion)" />
-    <!-- Outranks the plain CPU ORT that Vernacula.Phonemizer pulls in transitively; see
-         Vernacula.Tts.Base.csproj. -->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/KokoroPerf/KokoroPerf.csproj
+++ b/tests/KokoroPerf/KokoroPerf.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
       <Private>true</Private>
-      <SetConfiguration>EP=Cuda</SetConfiguration>
     </ProjectReference>
   </ItemGroup>
 

--- a/tests/OmniVoiceIoProbe/OmniVoiceIoProbe.csproj
+++ b/tests/OmniVoiceIoProbe/OmniVoiceIoProbe.csproj
@@ -17,7 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
       <Private>true</Private>
-      <SetConfiguration>EP=Cuda</SetConfiguration>
     </ProjectReference>
   </ItemGroup>
 

--- a/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
+++ b/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
@@ -15,9 +15,6 @@
        machine needs the plain runtime rather than a suppressed one. -->
   <ItemGroup Condition="'$(EP)' == 'Cuda'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="$(OnnxRuntimeVersion)" />
-    <!-- Vernacula.Phonemizer pins a plain (CPU) runtime; without this suppression it lands beside
-         the GPU one and the managed assembly meets the wrong native. -->
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" ExcludeAssets="all" />
   </ItemGroup>
   <ItemGroup Condition="'$(EP)' != 'Cuda'">
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />

--- a/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
+++ b/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
@@ -27,11 +27,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
       <Private>true</Private>
-      <SetConfiguration>EP=Cuda</SetConfiguration>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
       <Private>true</Private>
-      <SetConfiguration>EP=Cuda</SetConfiguration>
     </ProjectReference>
   </ItemGroup>
 

--- a/tests/Vernacula.Tts.Tests/Vernacula.Tts.Tests.csproj
+++ b/tests/Vernacula.Tts.Tests/Vernacula.Tts.Tests.csproj
@@ -12,6 +12,9 @@
          still resolves the EP). -->
     <Platforms>x64</Platforms>
     <RootNamespace>Vernacula.Tts.Tests</RootNamespace>
+    <!-- CPU-only test host: it references the plain ONNX Runtime on purpose, so the
+         Directory.Build.targets guard against the CPU package under a GPU EP does not apply. -->
+    <AllowCpuOnnxRuntime>true</AllowCpuOnnxRuntime>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #131.

## Measured first

Before changing anything, I removed the shim from `tests/KokoroPerf` and built `EP=Cuda`:

| | `linux-x64/native/libonnxruntime.so` |
|---|---|
| with the shim | **31,958,904** (GPU package) |
| without it | **22,159,232** (CPU package) |

…with `libonnxruntime_providers_cuda.so` still sitting next to it. The transitive package pins
**1.24.4** while the repo is on 1.29.0, so the real result is a 1.29.0 managed assembly on a
1.24.4 core — exactly the API-version throw the old comments described.

## The fix: `ExcludeAssets="native"` on the edges into the phonemizer

Two `ProjectReference`s in this repo point at the submodule — `Vernacula.Tts.Base` and, directly,
`Vernacula.Tts.CLI`. Both now carry `ExcludeAssets="native"`. The phonemizer's assembly and the
managed ORT still flow; the CPU `libonnxruntime.so` does not. All eight consumer shims are gone.

This is the issue's proposal (b), corrected on one word: it suggested `"runtime"`, but on a
`ProjectReference` that also excludes the referenced project's own DLL — measured,
`Vernacula.Phonemizer.dll` disappears from every consumer's output. `"native"` is the asset class
that actually contains the problem.

**Why not the issue's proposal (a)** — `PrivateAssets` via `Directory.Build.props`:
- `Directory.Build.props` is imported *before* the project body, so a `PackageReference Update`
  there runs before the item exists. Tried it: build succeeded, CPU native still won, no warning.
- Moving it to `Directory.Build.targets` made it apply — and that was my first version of this PR.
  Reviewing it caught a regression: the submodule's own tests and tools get their ORT through that
  same reference, so cutting it at the source left `Vernacula.Phonemizer.Tests` with **no native
  at all** when built in place (22,159,232 bytes on `main`, nothing on the branch). The edge
  attribute fixes our consumers without reaching into the submodule.

## And a rule, since your framing was "the guard is a comment"

`Directory.Build.targets` now carries `RejectCpuOnnxRuntimeUnderGpuEp`: under a GPU EP, if the CPU
package contributes a runtime asset, the build fails naming the file and what would happen. Vendored
projects under `external/` are exempt (they own that reference legitimately); the three CPU-only test
hosts set `AllowCpuOnnxRuntime`, stating the exception where a reader sees it.

**The guard paid for itself before merge.** On the first clean solution build it found the second
leak path — `Vernacula.Tts.CLI`'s direct edge to the phonemizer, which the `Tts.Base` edge alone
didn't cover. Then it refused an incoherent build in five out-of-solution test projects that forced
`SetConfiguration EP=Cuda` on their references: under `-p:EP=Cpu` the child *restores* for Cpu and
*builds* as Cuda. That's the same #121/#128 hazard, still lingering in `tests/`. EP already defaults
to Cuda, so the override bought nothing; removed.

## Corrections to the issue

- **Eight shims, not three** — five consumers were added after it was written.
- `tests/Vernacula.Tts.Tests` looks like a consumer that forgot the shim; it's deliberately CPU-only
  with a direct plain reference.

## Verification (final)

- Guard fires at `Vernacula.Tts.Base` when the edge exclusion is removed.
- Clean `EP=Cuda` solution build: every GPU consumer ships the **byte-identical** GPU native with the
  CUDA provider beside it, phonemizer DLL present.
- Clean `EP=Cpu`: no project left without a runtime.
- All **seven** out-of-solution consumers build on both EPs.
- The submodule's tests, built in place, get their native; submodule tree stays clean.
- Granite transcribes on CUDA from the rebuilt CLI. Suites 27 / 137 / 173.

Left alone, noted for a follow-up: `SetConfiguration EP=$(EP)` / `EP=Cpu` overrides remain in seven
other test/script projects. They don't misbehave today, but they're the same mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq
