### PR TITLE
refactor(models): one table of TTS model sets, no enum, no switches (closes #133)

### DIFF
--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -7,12 +7,15 @@ using Vernacula.Base;
 using Vernacula.Base.Models;
 using Vernacula.App.Models;
 using Vernacula.Tts.Base;
+using Vernacula.App.Services.Tts;
 
 namespace Vernacula.App.Services;
 
+/// <summary>One file of a model set: where it lives under the set's directory, and where it is in the repo.</summary>
+internal readonly record struct ModelAsset(string LocalRelativePath, string RemoteRelativePath);
+
 internal class ModelManagerService
 {
-    private readonly record struct ModelAsset(string LocalRelativePath, string RemoteRelativePath);
     private readonly record struct AssetRepo(string RepoBase, string ManifestUrl, ModelAsset[] Assets);
     private readonly record struct RepoAsset(string RepoBase, string LocalRelativePath, string RemoteRelativePath);
 
@@ -395,29 +398,39 @@ internal class ModelManagerService
         {
             if (string.IsNullOrWhiteSpace(repo.ManifestUrl))
                 continue;
-            var manifest = await FetchManifestAsync(repo.ManifestUrl, ct);
-            if (manifest is null) return null;
-
-            foreach (var asset in repo.Assets)
-            {
-                // Skip Sortformer .onnx.data files — ONNX Runtime regenerates
-                // these as external weights at runtime, so their hashes will
-                // never match the manifest.  The main .onnx model file is
-                // checked normally below.
-                if (asset.LocalRelativePath.EndsWith(Config.SortformerDataFile, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                string path = Path.Combine(dir, asset.LocalRelativePath);
-                if (manifest.TryGetValue(asset.RemoteRelativePath, out var expectedHash) &&
-                    expectedHash is not null &&
-                    File.Exists(path))
-                {
-                    toCheck.Add((asset.LocalRelativePath, expectedHash));
-                }
-            }
+            // Skip Sortformer .onnx.data files — ONNX Runtime regenerates these as external
+            // weights at runtime, so their hashes will never match the manifest. The main
+            // .onnx model file is checked normally.
+            var assets = repo.Assets.Where(a =>
+                !a.LocalRelativePath.EndsWith(Config.SortformerDataFile, StringComparison.OrdinalIgnoreCase));
+            var checks = await ManifestChecksAsync(dir, repo.ManifestUrl, assets, ct);
+            if (checks is null) return null;
+            toCheck.AddRange(checks);
         }
 
         return await HashCompareAsync(dir, toCheck, progress, ct);
+    }
+
+    /// <summary>
+    /// The (local path, expected MD5) pairs a manifest lets us verify for the assets that are
+    /// on disk under <paramref name="dir"/> — the one loop behind the ASR and TTS update checks.
+    /// Null when the manifest cannot be fetched or parsed (offline), so callers can skip.
+    /// </summary>
+    private async Task<List<(string localRelativePath, string expectedHash)>?> ManifestChecksAsync(
+        string dir, string manifestUrl, IEnumerable<ModelAsset> assets, CancellationToken ct)
+    {
+        var manifest = await FetchManifestAsync(manifestUrl, ct);
+        if (manifest is null) return null;
+
+        var toCheck = new List<(string, string)>();
+        foreach (var asset in assets)
+        {
+            if (manifest.TryGetValue(asset.RemoteRelativePath, out var expected)
+                && !string.IsNullOrEmpty(expected)
+                && File.Exists(Path.Combine(dir, asset.LocalRelativePath)))
+                toCheck.Add((asset.LocalRelativePath, expected));
+        }
+        return toCheck;
     }
 
     /// <summary>The repo's manifest as remote path → MD5, or null when it cannot be fetched or parsed (offline).</summary>
@@ -837,212 +850,39 @@ internal class ModelManagerService
 
     // ── Text-to-speech model sets ─────────────────────────────────────────────
     //
-    // Each set is one directory the Settings → TTS tab shows a status line for. The three
-    // engine exports are our own (scripts/chatterbox_export, kokoro_export, omnivoice_export)
-    // and ship as Hub repos with the same (local path, remote path) asset tables as the ASR
-    // bundles above; the OmniVoice voice library rides in the OmniVoice repo under voices/.
-    // The phonemizer data tree is not hosted: its RepoBase is empty, the download button
-    // stays hidden, and the status line names the folder to fill by hand — the "not hosted
-    // yet" convention Qwen3-ASR uses.
-    //
-    // OmniVoice's manifest.json covers the files fetched here (not the int4 browser build) and
-    // keys the diff by its Hub name, ipa_diff.onnx.
+    // The sets themselves — names, directories, repos, files, presence rules — are the table in
+    // TtsModelSets (Services/Tts). What lives here is only the operations, which take a set and
+    // reuse the same manifest / hash / download machinery as the ASR bundles above. The
+    // difference from the ASR side is that each TTS set has its own directory where the ASR
+    // bundles share the models dir; that is the one reason these are separate entry points.
 
-    public enum TtsModelSet { Chatterbox, Kokoro, OmniVoice, OmniVoiceVoices, PhonemizerData }
-
-    private const string ChatterboxRepoBase =
-        "https://huggingface.co/christopherthompson81/chatterbox-tts-onnx/resolve/main";
-    private const string ChatterboxManifestUrl =
-        "https://huggingface.co/christopherthompson81/chatterbox-tts-onnx/resolve/main/manifest.json";
-    private const string KokoroRepoBase =
-        "https://huggingface.co/christopherthompson81/kokoro-82m-onnx/resolve/main";
-    private const string KokoroManifestUrl =
-        "https://huggingface.co/christopherthompson81/kokoro-82m-onnx/resolve/main/manifest.json";
-    private const string OmniVoiceRepoBase =
-        "https://huggingface.co/christopherthompson81/omnivoice-ipa-onnx/resolve/main";
-    private const string OmniVoiceManifestUrl =
-        "https://huggingface.co/christopherthompson81/omnivoice-ipa-onnx/resolve/main/manifest.json";
-    private const string OmniVoiceVoiceLibRepoBase  = OmniVoiceRepoBase;
-    private const string PhonemizerDataRepoBase     = "";
-
-    // The four Chatterbox stages. Every graph keeps its weights in an external-data sidecar
-    // spelled `<graph>.onnx_data` (underscore — that is what the graphs reference). The
-    // vocoder is listed in its merged-Loop layout, which is what the C# Vocoder loads first;
-    // the split graphs (flow_encoder / cfm_estimator / mel2wav) are in the repo too but are
-    // only a fallback, so they are neither required nor fetched. tokenizer.json may also come
-    // from the HF cache (ChatterboxPipeline.LocateCachedTokenizerJson) and is checked apart.
-    private static readonly ModelAsset[] ChatterboxFiles =
-        [
-            new("speech_encoder.onnx",                 "speech_encoder.onnx"),
-            new("speech_encoder.onnx_data",            "speech_encoder.onnx_data"),
-            new("embed_tokens.onnx",                   "embed_tokens.onnx"),
-            new("embed_tokens.onnx_data",              "embed_tokens.onnx_data"),
-            new("language_model.onnx",                 "language_model.onnx"),
-            new("language_model.onnx_data",            "language_model.onnx_data"),
-            new("conditional_decoder_loop.onnx",       "conditional_decoder_loop.onnx"),
-            new("conditional_decoder_loop.onnx_data",  "conditional_decoder_loop.onnx_data"),
-        ];
-
-    // Kokoro v1.0's 28 English voices — what scripts/kokoro_export/export_voices.py emits by
-    // default and what the repo holds. A voice missing from here would not be fetched.
-    internal static readonly string[] KokoroVoices =
-        [
-            "af_alloy", "af_aoede", "af_bella", "af_heart", "af_jessica", "af_kore", "af_nicole",
-            "af_nova", "af_river", "af_sarah", "af_sky",
-            "am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael", "am_onyx",
-            "am_puck", "am_santa",
-            "bf_alice", "bf_emma", "bf_isabella", "bf_lily",
-            "bm_daniel", "bm_fable", "bm_george", "bm_lewis",
-        ];
-
-    private static readonly ModelAsset[] KokoroFiles =
-        [
-            new("kokoro.onnx", "kokoro.onnx"),
-            .. KokoroVoices.Select(v => new ModelAsset(Path.Combine("voices", $"{v}.bin"), $"voices/{v}.bin")),
-        ];
-
-    // The base transformer + codec + the IPA fine-tune diff + tokenizer. The repo names the
-    // diff `ipa_diff.onnx` (its card says which extraction it is); locally it keeps the
-    // versioned name IpaFineTune.DefaultDiffFile so a stale diff cannot pass as current —
-    // bump both when the fine-tune moves. The int4 browser build in the repo is not fetched.
-    private static readonly ModelAsset[] OmniVoiceFiles =
-        [
-            new("omnivoice_transformer.onnx",       "omnivoice_transformer.onnx"),
-            new("omnivoice_transformer.onnx.data",  "omnivoice_transformer.onnx.data"),
-            new("higgs_encoder.onnx",               "higgs_encoder.onnx"),
-            new("higgs_decoder.onnx",               "higgs_decoder.onnx"),
-            new(IpaFineTune.DefaultDiffFile,        "ipa_diff.onnx"),
-        ];
-
-    // The library sits at the root of its own directory locally (what StoredVoice.IsLibrary
-    // checks) and under voices/ in the repo, beside the graphs it belongs with.
-    private static readonly ModelAsset[] OmniVoiceVoiceLibFiles =
-        [
-            new("voices.jsonc",     "voices/voices.jsonc"),
-            new("voice-codes.json", "voices/voice-codes.json"),
-        ];
-
-    public string GetTtsModelSetDir(TtsModelSet set) => TtsModelSetDir(set, _settings);
-
-    public static string TtsModelSetDir(TtsModelSet set, SettingsService settings) => set switch
-    {
-        TtsModelSet.Chatterbox      => settings.GetChatterboxModelsDir(),
-        TtsModelSet.Kokoro          => settings.GetKokoroModelsDir(),
-        TtsModelSet.OmniVoice       => settings.GetOmniVoiceModelsDir(),
-        TtsModelSet.OmniVoiceVoices => settings.GetOmniVoiceVoiceLibDir(),
-        TtsModelSet.PhonemizerData  => settings.GetPhonemizerDataDir(),
-        _                           => throw new ArgumentOutOfRangeException(nameof(set)),
-    };
-
-    private static string RepoBaseFor(TtsModelSet set) => set switch
-    {
-        TtsModelSet.Chatterbox      => ChatterboxRepoBase,
-        TtsModelSet.Kokoro          => KokoroRepoBase,
-        TtsModelSet.OmniVoice       => OmniVoiceRepoBase,
-        TtsModelSet.OmniVoiceVoices => OmniVoiceVoiceLibRepoBase,
-        TtsModelSet.PhonemizerData  => PhonemizerDataRepoBase,
-        _                           => "",
-    };
-
-    /// <summary>The set's manifest.json URL, or "" where the repo has none (update check skips it).</summary>
-    public static string ManifestUrlFor(TtsModelSet set) => set switch
-    {
-        TtsModelSet.Chatterbox => ChatterboxManifestUrl,
-        TtsModelSet.Kokoro     => KokoroManifestUrl,
-        TtsModelSet.OmniVoice       => OmniVoiceManifestUrl,
-        TtsModelSet.OmniVoiceVoices => OmniVoiceManifestUrl,
-        _                           => "",
-    };
-
-    private static ModelAsset[] AssetsFor(TtsModelSet set) => set switch
-    {
-        TtsModelSet.Chatterbox      => ChatterboxFiles,
-        TtsModelSet.Kokoro          => KokoroFiles,
-        TtsModelSet.OmniVoice       => OmniVoiceFiles,
-        TtsModelSet.OmniVoiceVoices => OmniVoiceVoiceLibFiles,
-        _                           => [],
-    };
-
-    /// <summary>True once the set's files are published somewhere this app can fetch them from.</summary>
-    public static bool CanDownloadTtsModelSet(TtsModelSet set) => !string.IsNullOrEmpty(RepoBaseFor(set));
+    public string GetTtsModelSetDir(TtsModelSet set) => set.Dir(_settings);
 
     /// <summary>
     /// The files a set still needs, relative to its directory. Empty means the backend can
-    /// load. The listed assets are the fetchable ones; the entries after them are the
-    /// alternatives a hand-placed folder may satisfy another way.
+    /// load. Static so the job runner and the New TTS Job dialog check the same files Settings
+    /// does.
     /// </summary>
-    public IReadOnlyList<string> GetMissingTtsFiles(TtsModelSet set) => GetMissingTtsFiles(set, _settings);
-
-    /// <summary>Static so the job runner and the New TTS Job dialog check the same files Settings does.</summary>
-    public static IReadOnlyList<string> GetMissingTtsFiles(TtsModelSet set, SettingsService settings)
-    {
-        string dir = TtsModelSetDir(set, settings);
-        var missing = new List<string>();
-        switch (set)
-        {
-            case TtsModelSet.Chatterbox:
-                // A monolithic conditional_decoder.onnx (the --no-split --no-merge export) stands
-                // in for the merged-Loop pair.
-                bool monolithic = File.Exists(Path.Combine(dir, "conditional_decoder.onnx"));
-                missing.AddRange(ChatterboxFiles
-                    .Where(a => !(monolithic && a.LocalRelativePath.StartsWith("conditional_decoder_loop", StringComparison.Ordinal)))
-                    .Where(a => !File.Exists(Path.Combine(dir, a.LocalRelativePath)))
-                    .Select(a => a.LocalRelativePath));
-                if (!File.Exists(Path.Combine(dir, "tokenizer.json"))
-                    && ChatterboxPipeline.LocateCachedTokenizerJson() is null)
-                    missing.Add("tokenizer.json");
-                break;
-
-            case TtsModelSet.Kokoro:
-                if (!File.Exists(Path.Combine(dir, "kokoro.onnx"))) missing.Add("kokoro.onnx");
-                // Any voice pack will do to run; the download fills in the full set.
-                string voices = Path.Combine(dir, "voices");
-                if (!Directory.Exists(voices) || !Directory.EnumerateFiles(voices, "*.bin").Any())
-                    missing.Add("voices/*.bin");
-                break;
-
-            case TtsModelSet.OmniVoice:
-                missing.AddRange(OmniVoiceFiles
-                    .Where(a => !File.Exists(Path.Combine(dir, a.LocalRelativePath)))
-                    .Select(a => a.LocalRelativePath));
-                if (!File.Exists(settings.Current.OmniVoiceTokenizerJson)
-                    && (!Directory.Exists(dir) || OmniVoiceIpaTts.LocateTokenizerJson(dir) is null))
-                    missing.Add("tokenizer.json");
-                break;
-
-            case TtsModelSet.OmniVoiceVoices:
-                missing.AddRange(OmniVoiceVoiceLibFiles
-                    .Where(a => !File.Exists(Path.Combine(dir, a.LocalRelativePath)))
-                    .Select(a => a.LocalRelativePath));
-                break;
-
-            case TtsModelSet.PhonemizerData:
-                if (!PhonemizerData.IsDataRoot(dir)) missing.Add("core/phonology.jsonc (the data/ tree)");
-                break;
-        }
-        return missing;
-    }
+    public IReadOnlyList<string> GetMissingTtsFiles(TtsModelSet set) => set.MissingFiles(_settings);
 
     /// <summary>
-    /// Downloads a set's missing files into its directory — the asset table plus, for the
-    /// engines, tokenizer.json when no copy is beside the graphs. A set with no repo throws
-    /// with the folder to fill by hand.
+    /// Downloads a set's missing files into its directory. A set with no repo throws with the
+    /// folder to fill by hand.
     /// </summary>
     public async Task DownloadMissingTtsModelsAsync(
         TtsModelSet set,
         IProgress<DownloadProgress> progress,
         CancellationToken ct = default)
     {
-        string repoBase = RepoBaseFor(set);
-        string dir = GetTtsModelSetDir(set);
-        if (string.IsNullOrEmpty(repoBase))
+        string dir = set.Dir(_settings);
+        if (!set.CanDownload)
             throw new InvalidOperationException(
-                $"{set} is not published for download yet. Place the files in {dir} (see docs/tts-cli.md).");
+                $"{set.Name} is not published for download yet. Place the files in {dir} (see docs/tts-cli.md).");
         Directory.CreateDirectory(dir);
 
-        var missing = DownloadableTtsAssets(set)
+        var missing = set.Downloadable
             .Where(a => !File.Exists(Path.Combine(dir, a.LocalRelativePath)))
-            .Select(a => new RepoAsset(repoBase, a.LocalRelativePath, a.RemoteRelativePath))
+            .Select(a => new RepoAsset(set.RepoBase, a.LocalRelativePath, a.RemoteRelativePath))
             .ToList();
         await DownloadMissingAssetsAsync(dir, missing, progress, ct);
     }
@@ -1058,19 +898,10 @@ internal class ModelManagerService
         IProgress<(string fileName, int index, int total)>? progress = null,
         CancellationToken ct = default)
     {
-        string manifestUrl = ManifestUrlFor(set);
-        if (string.IsNullOrEmpty(manifestUrl)) return null;
-        var manifest = await FetchManifestAsync(manifestUrl, ct);
-        if (manifest is null) return null;
-
-        string dir = GetTtsModelSetDir(set);
-        var toCheck = new List<(string localRelativePath, string expectedHash)>();
-        foreach (var asset in DownloadableTtsAssets(set))
-        {
-            string path = Path.Combine(dir, asset.LocalRelativePath);
-            if (manifest.TryGetValue(asset.RemoteRelativePath, out var expected) && File.Exists(path))
-                toCheck.Add((asset.LocalRelativePath, expected));
-        }
+        if (!set.HasManifest) return null;
+        string dir = set.Dir(_settings);
+        var toCheck = await ManifestChecksAsync(dir, set.ManifestUrl, set.Downloadable, ct);
+        if (toCheck is null) return null;
         return await HashCompareAsync(dir, toCheck, progress, ct);
     }
 
@@ -1085,7 +916,7 @@ internal class ModelManagerService
         IProgress<DownloadProgress> progress,
         CancellationToken ct = default)
     {
-        string dir = GetTtsModelSetDir(set);
+        string dir = set.Dir(_settings);
         var moved = new List<(string current, string aside)>();
         foreach (string rel in localRelativePaths)
         {
@@ -1110,14 +941,5 @@ internal class ModelManagerService
         }
         foreach (var (_, aside) in moved)
             if (File.Exists(aside)) File.Delete(aside);
-    }
-
-    /// <summary>Everything <see cref="DownloadMissingTtsModelsAsync"/> would fetch for the set.</summary>
-    private static IEnumerable<ModelAsset> DownloadableTtsAssets(TtsModelSet set)
-    {
-        IEnumerable<ModelAsset> assets = AssetsFor(set);
-        if (set is TtsModelSet.Chatterbox or TtsModelSet.OmniVoice)
-            assets = assets.Append(new ModelAsset("tokenizer.json", "tokenizer.json"));
-        return assets;
     }
 }

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -6,7 +6,6 @@ using Microsoft.ML.OnnxRuntime;
 using Vernacula.Base;
 using Vernacula.Base.Models;
 using Vernacula.App.Models;
-using Vernacula.Tts.Base;
 using Vernacula.App.Services.Tts;
 
 namespace Vernacula.App.Services;
@@ -415,6 +414,9 @@ internal class ModelManagerService
     /// The (local path, expected MD5) pairs a manifest lets us verify for the assets that are
     /// on disk under <paramref name="dir"/> — the one loop behind the ASR and TTS update checks.
     /// Null when the manifest cannot be fetched or parsed (offline), so callers can skip.
+    /// An entry with no MD5 is left out rather than compared: it can never match, so listing it
+    /// would report the file as outdated on every check and re-fetch it to no effect. (The
+    /// Sortformer check below already treats a missing hash as "cannot say".)
     /// </summary>
     private async Task<List<(string localRelativePath, string expectedHash)>?> ManifestChecksAsync(
         string dir, string manifestUrl, IEnumerable<ModelAsset> assets, CancellationToken ct)
@@ -859,9 +861,10 @@ internal class ModelManagerService
     public string GetTtsModelSetDir(TtsModelSet set) => set.Dir(_settings);
 
     /// <summary>
-    /// The files a set still needs, relative to its directory. Empty means the backend can
-    /// load. Static so the job runner and the New TTS Job dialog check the same files Settings
-    /// does.
+    /// The files a set still needs, relative to its directory; empty means the backend can
+    /// load. The rule is the set's own (<see cref="TtsModelSet.Missing"/>), which is also what
+    /// the job runner and the New TTS Job dialog consult through <see cref="TtsModelSet.MissingFiles"/>,
+    /// so the three cannot disagree.
     /// </summary>
     public IReadOnlyList<string> GetMissingTtsFiles(TtsModelSet set) => set.MissingFiles(_settings);
 

--- a/src/Vernacula.Avalonia/Services/SettingsService.cs
+++ b/src/Vernacula.Avalonia/Services/SettingsService.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using Vernacula.Base;
 using Vernacula.App.Models;
 
+using Vernacula.App.Services.Tts;
+
 namespace Vernacula.App.Services;
 
 internal class SettingsService
@@ -228,51 +230,16 @@ internal class SettingsService
         Path.Combine(GetModelsDir(), Config.KenLmParakeetSubDir);
 
     // ── Text-to-speech locations ─────────────────────────────────────────
-    // Each is the user's pick when set, else a subfolder of the models dir so a
-    // fresh install has one place to put (or download) everything.
+    // Each set's directory is decided by its entry in TtsModelSets — the user's pick when
+    // set, else a resolver (an environment variable, a checkout beside a source build), else
+    // a subfolder of the models dir so a fresh install has one place to put everything. These
+    // stay as the named entry points callers already use.
 
-    public string GetChatterboxModelsDir() =>
-        string.IsNullOrWhiteSpace(Current.ChatterboxBundleDir)
-            ? Path.Combine(GetModelsDir(), Config.ChatterboxSubDir)
-            : Current.ChatterboxBundleDir;
-
-    public string GetKokoroModelsDir() =>
-        string.IsNullOrWhiteSpace(Current.KokoroModelDir)
-            ? Path.Combine(GetModelsDir(), Config.KokoroSubDir)
-            : Current.KokoroModelDir;
-
-    public string GetOmniVoiceModelsDir() =>
-        string.IsNullOrWhiteSpace(Current.OmniVoiceOnnxDir)
-            ? (Environment.GetEnvironmentVariable("OMNIVOICE_ONNX_DIR")
-               ?? Path.Combine(GetModelsDir(), Config.OmniVoiceSubDir))
-            : Current.OmniVoiceOnnxDir;
-
-    /// <summary>
-    /// The vernacula-phonemizer data/ root: the user's pick as given (even while still empty —
-    /// it may be the folder they are about to fill), else whatever
-    /// <see cref="Vernacula.Tts.Base.PhonemizerData.Resolve"/> finds (VERNACULA_DATA_DIR, then
-    /// the submodule beside a source build), else the models-dir default. May not exist.
-    /// </summary>
-    public string GetPhonemizerDataDir()
-    {
-        if (!string.IsNullOrWhiteSpace(Current.PhonemizerDataDir))
-            return Current.PhonemizerDataDir;
-        return Vernacula.Tts.Base.PhonemizerData.Resolve(null)
-               ?? Path.Combine(GetModelsDir(), Config.PhonemizerDataSubDir);
-    }
-
-    /// <summary>
-    /// The OmniVoice stored-voice library: the user's pick as given (an empty folder chosen as
-    /// the download target must stay the target, not fall back), else the web demo's library
-    /// beside a source build, else the models-dir default.
-    /// </summary>
-    public string GetOmniVoiceVoiceLibDir()
-    {
-        if (!string.IsNullOrWhiteSpace(Current.OmniVoiceVoiceLib))
-            return Current.OmniVoiceVoiceLib;
-        return Vernacula.Tts.Base.StoredVoice.ResolveDefaultLibrary()
-               ?? Path.Combine(GetModelsDir(), Config.OmniVoiceVoiceLibSubDir);
-    }
+    public string GetChatterboxModelsDir()   => TtsModelSets.Chatterbox.Dir(this);
+    public string GetKokoroModelsDir()       => TtsModelSets.Kokoro.Dir(this);
+    public string GetOmniVoiceModelsDir()    => TtsModelSets.OmniVoice.Dir(this);
+    public string GetPhonemizerDataDir()     => TtsModelSets.PhonemizerData.Dir(this);
+    public string GetOmniVoiceVoiceLibDir()  => TtsModelSets.OmniVoiceVoices.Dir(this);
 
     public string GetJobsDir()
     {

--- a/src/Vernacula.Avalonia/Services/Tts/TtsEngine.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsEngine.cs
@@ -29,7 +29,7 @@ internal abstract class TtsEngine
     /// <summary>Output sample rate (Hz) — the reader needs it before any audio exists.</summary>
     public abstract int SampleRate { get; }
     /// <summary>The model sets that must be complete on disk before a job can run.</summary>
-    public abstract ModelManagerService.TtsModelSet[] RequiredSets { get; }
+    public abstract TtsModelSet[] RequiredSets { get; }
 
     /// <summary>How the export's phoneme column was produced, named in the CSV.</summary>
     public virtual string PhonemeScheme => "ipa";
@@ -136,8 +136,8 @@ internal sealed class KokoroEngine : TtsEngine
     public override string Description =>
         "Small and fast. Named English voices (American and British), adjustable speed, word timing from the model's own durations.";
     public override int SampleRate => Kokoro.SampleRate;
-    public override ModelManagerService.TtsModelSet[] RequiredSets =>
-        [ModelManagerService.TtsModelSet.Kokoro, ModelManagerService.TtsModelSet.PhonemizerData];
+    public override TtsModelSet[] RequiredSets =>
+        [TtsModelSets.Kokoro, TtsModelSets.PhonemizerData];
     public override string PhonemeScheme => "kokoro";   // its own vocabulary, exactly what the model consumed
 
     public override bool UsesVoiceList => true;
@@ -199,11 +199,11 @@ internal sealed class OmniVoiceEngine : TtsEngine
     public override string Description =>
         "Any of the phonemizer's 190+ languages through the IPA fine-tune, in a stored voice from the voice library. Large model; word timing is estimated.";
     public override int SampleRate => OmniVoiceIpaTts.SampleRate;
-    public override ModelManagerService.TtsModelSet[] RequiredSets =>
+    public override TtsModelSet[] RequiredSets =>
     [
-        ModelManagerService.TtsModelSet.OmniVoice,
-        ModelManagerService.TtsModelSet.OmniVoiceVoices,
-        ModelManagerService.TtsModelSet.PhonemizerData,
+        TtsModelSets.OmniVoice,
+        TtsModelSets.OmniVoiceVoices,
+        TtsModelSets.PhonemizerData,
     ];
 
     public override bool UsesLanguage => true;
@@ -265,7 +265,7 @@ internal sealed class ChatterboxEngine : TtsEngine
     public override string Description =>
         "English voice cloning from a short reference clip. Word timing from the model's cross-attention.";
     public override int SampleRate => ChatterboxConstants.S3GenSr;
-    public override ModelManagerService.TtsModelSet[] RequiredSets => [ModelManagerService.TtsModelSet.Chatterbox];
+    public override TtsModelSet[] RequiredSets => [TtsModelSets.Chatterbox];
 
     public override bool UsesReferenceClip => true;
 

--- a/src/Vernacula.Avalonia/Services/Tts/TtsJobRunner.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsJobRunner.cs
@@ -114,20 +114,10 @@ internal static class TtsPrerequisites
         var engine = TtsEngines.For(kind);
         foreach (var set in engine.RequiredSets)
         {
-            var missing = ModelManagerService.GetMissingTtsFiles(set, s);
+            var missing = set.MissingFiles(s);
             if (missing.Count > 0)
-                return $"{SetName(set)} incomplete in {ModelManagerService.TtsModelSetDir(set, s)}: missing {string.Join(", ", missing)}. See Settings → Text-to-Speech.";
+                return $"{set.Name} incomplete in {set.Dir(s)}: missing {string.Join(", ", missing)}. See Settings → Text-to-Speech.";
         }
         return job is null ? null : engine.DescribeJobIssue(s, job);
     }
-
-    private static string SetName(ModelManagerService.TtsModelSet set) => set switch
-    {
-        ModelManagerService.TtsModelSet.Chatterbox      => "Chatterbox bundle",
-        ModelManagerService.TtsModelSet.Kokoro          => "Kokoro model",
-        ModelManagerService.TtsModelSet.OmniVoice       => "OmniVoice ONNX set",
-        ModelManagerService.TtsModelSet.OmniVoiceVoices => "OmniVoice voice library",
-        ModelManagerService.TtsModelSet.PhonemizerData  => "Phonemizer data",
-        _                                               => set.ToString(),
-    };
 }

--- a/src/Vernacula.Avalonia/Services/Tts/TtsModelSets.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/TtsModelSets.cs
@@ -1,0 +1,262 @@
+using Vernacula.App.Models;
+using Vernacula.Base;
+using Vernacula.Tts.Base;
+
+namespace Vernacula.App.Services.Tts;
+
+/// <summary>
+/// One text-to-speech model set: a directory the Settings → TTS tab shows a status row for,
+/// that an engine lists in <see cref="TtsEngine.RequiredSets"/>, and that the job runner and
+/// the New TTS Job dialog check before anything loads.
+/// <para>
+/// Every per-set fact is a <c>required</c> member, and there is no enum beside it: adding a set
+/// is one entry in <see cref="TtsModelSets"/>, and leaving any piece out is a compile error
+/// rather than a switch's default arm quietly reporting the set as ready with nothing to
+/// download (#133). The only things a new set needs outside this file are the AppSettings
+/// field its override lives in and the Config constant naming its default subfolder — and both
+/// are referenced from here, so they cannot be forgotten either.
+/// </para>
+/// </summary>
+internal sealed class TtsModelSet
+{
+    /// <summary>The row's title, and the name the job runner uses when the set is incomplete.</summary>
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+
+    /// <summary>Default location: this subfolder of the models directory.</summary>
+    public required string SubDir { get; init; }
+    /// <summary>The user's pick from Settings, "" for the default; where it is stored.</summary>
+    public required Func<AppSettings, string>   GetOverride { get; init; }
+    public required Action<AppSettings, string> SetOverride { get; init; }
+    /// <summary>
+    /// Where the set is found when there is no pick and before the models-dir default — an
+    /// environment variable, a checkout beside a source build. Null result falls through.
+    /// </summary>
+    public Func<string?>? ResolveDefault { get; init; }
+
+    /// <summary>Hub URL prefix, or "" while the set is not hosted (download button hidden).</summary>
+    public required string RepoBase { get; init; }
+    /// <summary>The repo's manifest.json, or "" where it has none (update check skipped).</summary>
+    public required string ManifestUrl { get; init; }
+    /// <summary>The set's files, (local path under the set's directory, path in the repo).</summary>
+    public required ModelAsset[] Assets { get; init; }
+    /// <summary>Fetched with the set but judged for presence another way (a tokenizer the engine can also find elsewhere).</summary>
+    public ModelAsset[] ExtraDownloads { get; init; } = [];
+
+    /// <summary>
+    /// What the set still needs, relative to its directory, given the directory and settings.
+    /// Empty means the backend can load. This is per set because presence is not always "each
+    /// asset exists": an alternative export layout, any-one-voice-pack, a tokenizer found
+    /// through a cache, a sentinel file for a data tree.
+    /// </summary>
+    public required Func<string, SettingsService, IEnumerable<string>> Missing { get; init; }
+
+    public bool CanDownload => RepoBase.Length > 0;
+    public bool HasManifest => ManifestUrl.Length > 0;
+
+    /// <summary>Everything a download of this set fetches.</summary>
+    public IEnumerable<ModelAsset> Downloadable => Assets.Concat(ExtraDownloads);
+
+    /// <summary>
+    /// The set's directory: the user's pick as given (even while still empty — it may be the
+    /// folder they are about to fill or have chosen as the download target), else
+    /// <see cref="ResolveDefault"/>, else the subfolder of the models directory.
+    /// </summary>
+    public string Dir(SettingsService settings)
+    {
+        string pick = GetOverride(settings.Current);
+        if (!string.IsNullOrWhiteSpace(pick)) return pick;
+        return ResolveDefault?.Invoke() ?? Path.Combine(settings.GetModelsDir(), SubDir);
+    }
+
+    public IReadOnlyList<string> MissingFiles(SettingsService settings) => Missing(Dir(settings), settings).ToList();
+
+    public override string ToString() => Name;
+
+    /// <summary>The usual presence rule: each listed asset exists under <paramref name="dir"/>.</summary>
+    public static IEnumerable<string> MissingAssets(string dir, IEnumerable<ModelAsset> assets) =>
+        assets.Where(a => !File.Exists(Path.Combine(dir, a.LocalRelativePath))).Select(a => a.LocalRelativePath);
+}
+
+/// <summary>
+/// The table of TTS model sets, in the order the Settings → TTS tab lists them. The three
+/// engine exports are our own (scripts/chatterbox_export, kokoro_export, omnivoice_export) and
+/// ship as Hub repos with the same (local path, remote path) asset tables as the ASR bundles in
+/// <see cref="ModelManagerService"/>; the OmniVoice voice library rides in the OmniVoice repo
+/// under voices/. The phonemizer data tree is not hosted: its RepoBase is empty, so the
+/// download button stays hidden and the status line names the folder to fill by hand — the
+/// "not hosted yet" convention Qwen3-ASR uses.
+/// </summary>
+internal static class TtsModelSets
+{
+    private const string ChatterboxRepoBase =
+        "https://huggingface.co/christopherthompson81/chatterbox-tts-onnx/resolve/main";
+    private const string KokoroRepoBase =
+        "https://huggingface.co/christopherthompson81/kokoro-82m-onnx/resolve/main";
+    private const string OmniVoiceRepoBase =
+        "https://huggingface.co/christopherthompson81/omnivoice-ipa-onnx/resolve/main";
+
+    // Kokoro v1.0's 28 English voices — what scripts/kokoro_export/export_voices.py emits by
+    // default and what the repo holds. A voice missing from here would not be fetched.
+    internal static readonly string[] KokoroVoices =
+        [
+            "af_alloy", "af_aoede", "af_bella", "af_heart", "af_jessica", "af_kore", "af_nicole",
+            "af_nova", "af_river", "af_sarah", "af_sky",
+            "am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael", "am_onyx",
+            "am_puck", "am_santa",
+            "bf_alice", "bf_emma", "bf_isabella", "bf_lily",
+            "bm_daniel", "bm_fable", "bm_george", "bm_lewis",
+        ];
+
+    // The four Chatterbox stages. Every graph keeps its weights in an external-data sidecar
+    // spelled `<graph>.onnx_data` (underscore — that is what the graphs reference). The
+    // vocoder is listed in its merged-Loop layout, which is what the C# Vocoder loads first;
+    // the split graphs (flow_encoder / cfm_estimator / mel2wav) are in the repo too but are
+    // only a fallback, so they are neither required nor fetched. tokenizer.json may also come
+    // from the HF cache (ChatterboxPipeline.LocateCachedTokenizerJson) and is checked apart.
+    private static readonly ModelAsset[] ChatterboxFiles =
+        [
+            new("speech_encoder.onnx",                 "speech_encoder.onnx"),
+            new("speech_encoder.onnx_data",            "speech_encoder.onnx_data"),
+            new("embed_tokens.onnx",                   "embed_tokens.onnx"),
+            new("embed_tokens.onnx_data",              "embed_tokens.onnx_data"),
+            new("language_model.onnx",                 "language_model.onnx"),
+            new("language_model.onnx_data",            "language_model.onnx_data"),
+            new("conditional_decoder_loop.onnx",       "conditional_decoder_loop.onnx"),
+            new("conditional_decoder_loop.onnx_data",  "conditional_decoder_loop.onnx_data"),
+        ];
+
+    private static readonly ModelAsset[] KokoroFiles =
+        [
+            new("kokoro.onnx", "kokoro.onnx"),
+            .. KokoroVoices.Select(v => new ModelAsset(Path.Combine("voices", $"{v}.bin"), $"voices/{v}.bin")),
+        ];
+
+    // The base transformer + codec + the IPA fine-tune diff + tokenizer. The repo names the
+    // diff `ipa_diff.onnx` (its card says which extraction it is); locally it keeps the
+    // versioned name IpaFineTune.DefaultDiffFile so a stale diff cannot pass as current —
+    // bump both when the fine-tune moves. The int4 browser build in the repo is not fetched.
+    // OmniVoice's manifest.json covers the files fetched here and keys the diff by its Hub name.
+    private static readonly ModelAsset[] OmniVoiceFiles =
+        [
+            new("omnivoice_transformer.onnx",       "omnivoice_transformer.onnx"),
+            new("omnivoice_transformer.onnx.data",  "omnivoice_transformer.onnx.data"),
+            new("higgs_encoder.onnx",               "higgs_encoder.onnx"),
+            new("higgs_decoder.onnx",               "higgs_decoder.onnx"),
+            new(IpaFineTune.DefaultDiffFile,        "ipa_diff.onnx"),
+        ];
+
+    // The library sits at the root of its own directory locally (what StoredVoice.IsLibrary
+    // checks) and under voices/ in the repo, beside the graphs it belongs with.
+    private static readonly ModelAsset[] OmniVoiceVoiceLibFiles =
+        [
+            new("voices.jsonc",     "voices/voices.jsonc"),
+            new("voice-codes.json", "voices/voice-codes.json"),
+        ];
+
+    private static readonly ModelAsset[] TokenizerJson = [new("tokenizer.json", "tokenizer.json")];
+
+    public static readonly TtsModelSet Kokoro = new()
+    {
+        Name        = "Kokoro-82M",
+        Description = "kokoro.onnx + voices/*.bin from scripts/kokoro_export. English voices; fast, light.",
+        SubDir      = Config.KokoroSubDir,
+        GetOverride = a => a.KokoroModelDir,
+        SetOverride = (a, v) => a.KokoroModelDir = v,
+        RepoBase    = KokoroRepoBase,
+        ManifestUrl = KokoroRepoBase + "/manifest.json",
+        Assets      = KokoroFiles,
+        Missing     = (dir, _) =>
+        {
+            var missing = new List<string>();
+            if (!File.Exists(Path.Combine(dir, "kokoro.onnx"))) missing.Add("kokoro.onnx");
+            // Any voice pack will do to run; the download fills in the full set.
+            string voices = Path.Combine(dir, "voices");
+            if (!Directory.Exists(voices) || !Directory.EnumerateFiles(voices, "*.bin").Any())
+                missing.Add("voices/*.bin");
+            return missing;
+        },
+    };
+
+    public static readonly TtsModelSet OmniVoice = new()
+    {
+        Name        = "OmniVoice-IPA",
+        Description = "The OmniVoice base transformer, Higgs codec graphs and the IPA fine-tune diff (scripts/omnivoice_export). Any language the phonemizer covers.",
+        SubDir      = Config.OmniVoiceSubDir,
+        GetOverride = a => a.OmniVoiceOnnxDir,
+        SetOverride = (a, v) => a.OmniVoiceOnnxDir = v,
+        ResolveDefault = () => Environment.GetEnvironmentVariable("OMNIVOICE_ONNX_DIR"),
+        RepoBase    = OmniVoiceRepoBase,
+        ManifestUrl = OmniVoiceRepoBase + "/manifest.json",
+        Assets      = OmniVoiceFiles,
+        ExtraDownloads = TokenizerJson,
+        Missing     = (dir, s) =>
+        {
+            var missing = TtsModelSet.MissingAssets(dir, OmniVoiceFiles).ToList();
+            if (!File.Exists(s.Current.OmniVoiceTokenizerJson)
+                && (!Directory.Exists(dir) || OmniVoiceIpaTts.LocateTokenizerJson(dir) is null))
+                missing.Add("tokenizer.json");
+            return missing;
+        },
+    };
+
+    public static readonly TtsModelSet OmniVoiceVoices = new()
+    {
+        Name        = "OmniVoice voice library",
+        Description = "voices.jsonc + voice-codes.json — 530 stored reference voices OmniVoice reads in, one or more per language (shared with the web demo).",
+        SubDir      = Config.OmniVoiceVoiceLibSubDir,
+        GetOverride = a => a.OmniVoiceVoiceLib,
+        SetOverride = (a, v) => a.OmniVoiceVoiceLib = v,
+        // The web demo's library beside a source build, when there is one.
+        ResolveDefault = StoredVoice.ResolveDefaultLibrary,
+        RepoBase    = OmniVoiceRepoBase,
+        ManifestUrl = OmniVoiceRepoBase + "/manifest.json",
+        Assets      = OmniVoiceVoiceLibFiles,
+        Missing     = (dir, _) => TtsModelSet.MissingAssets(dir, OmniVoiceVoiceLibFiles),
+    };
+
+    public static readonly TtsModelSet Chatterbox = new()
+    {
+        Name        = "Chatterbox",
+        Description = "The Chatterbox ONNX bundle (scripts/chatterbox_export) + tokenizer.json. English; clones a reference clip.",
+        SubDir      = Config.ChatterboxSubDir,
+        GetOverride = a => a.ChatterboxBundleDir,
+        SetOverride = (a, v) => a.ChatterboxBundleDir = v,
+        RepoBase    = ChatterboxRepoBase,
+        ManifestUrl = ChatterboxRepoBase + "/manifest.json",
+        Assets      = ChatterboxFiles,
+        ExtraDownloads = TokenizerJson,
+        Missing     = (dir, _) =>
+        {
+            // A monolithic conditional_decoder.onnx (the --no-split --no-merge export) stands
+            // in for the merged-Loop pair.
+            bool monolithic = File.Exists(Path.Combine(dir, "conditional_decoder.onnx"));
+            var missing = TtsModelSet.MissingAssets(dir, ChatterboxFiles
+                .Where(a => !(monolithic && a.LocalRelativePath.StartsWith("conditional_decoder_loop", StringComparison.Ordinal))))
+                .ToList();
+            if (!File.Exists(Path.Combine(dir, "tokenizer.json"))
+                && ChatterboxPipeline.LocateCachedTokenizerJson() is null)
+                missing.Add("tokenizer.json");
+            return missing;
+        },
+    };
+
+    public static readonly TtsModelSet PhonemizerData = new()
+    {
+        Name        = "Phonemizer data",
+        Description = "The vernacula-phonemizer data/ tree (text → IPA) that Kokoro and OmniVoice need. Found automatically beside a source checkout.",
+        SubDir      = Config.PhonemizerDataSubDir,
+        GetOverride = a => a.PhonemizerDataDir,
+        SetOverride = (a, v) => a.PhonemizerDataDir = v,
+        // VERNACULA_DATA_DIR, then the submodule beside a source build.
+        ResolveDefault = () => Vernacula.Tts.Base.PhonemizerData.Resolve(null),
+        RepoBase    = "",
+        ManifestUrl = "",
+        Assets      = [],
+        Missing     = (dir, _) =>
+            Vernacula.Tts.Base.PhonemizerData.IsDataRoot(dir) ? [] : ["core/phonology.jsonc (the data/ tree)"],
+    };
+
+    /// <summary>Every set, in Settings row order.</summary>
+    public static IReadOnlyList<TtsModelSet> All { get; } = [Kokoro, OmniVoice, OmniVoiceVoices, Chatterbox, PhonemizerData];
+}

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.Tts.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.Tts.cs
@@ -123,21 +123,10 @@ internal partial class SettingsViewModel
             TtsEngineOptions.Add(new TtsEngineOptionViewModel(engine, SelectedTtsEngine));
 
         void Changed() => OnTtsModelsChanged?.Invoke();
-        TtsModelSets.Add(new(ModelManagerService.TtsModelSet.Kokoro, "Kokoro-82M",
-            "kokoro.onnx + voices/*.bin from scripts/kokoro_export. English voices; fast, light.",
-            _modelMgr, _svc, Changed));
-        TtsModelSets.Add(new(ModelManagerService.TtsModelSet.OmniVoice, "OmniVoice-IPA",
-            "The OmniVoice base transformer, Higgs codec graphs and the IPA fine-tune diff (scripts/omnivoice_export). Any language the phonemizer covers.",
-            _modelMgr, _svc, Changed));
-        TtsModelSets.Add(new(ModelManagerService.TtsModelSet.OmniVoiceVoices, "OmniVoice voice library",
-            "voices.jsonc + voice-codes.json — 530 stored reference voices OmniVoice reads in, one or more per language (shared with the web demo).",
-            _modelMgr, _svc, Changed));
-        TtsModelSets.Add(new(ModelManagerService.TtsModelSet.Chatterbox, "Chatterbox",
-            "The Chatterbox ONNX bundle (scripts/chatterbox_export) + tokenizer.json. English; clones a reference clip.",
-            _modelMgr, _svc, Changed));
-        TtsModelSets.Add(new(ModelManagerService.TtsModelSet.PhonemizerData, "Phonemizer data",
-            "The vernacula-phonemizer data/ tree (text → IPA) that Kokoro and OmniVoice need. Found automatically beside a source checkout.",
-            _modelMgr, _svc, Changed));
+        // One row per set — the list is the table, not a hand-written copy of it. (Fully
+        // qualified: this view model's own TtsModelSets property, the rows, shadows the class.)
+        foreach (var set in Services.Tts.TtsModelSets.All)
+            TtsModelSets.Add(new(set, _modelMgr, _svc, Changed));
     }
 
     // Presence only. The manifest compare hashes the whole set (9 GB for Chatterbox) and is

--- a/src/Vernacula.Avalonia/ViewModels/TtsModelSetStatusViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TtsModelSetStatusViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Vernacula.App.Models;
 using Vernacula.App.Services;
+using Vernacula.App.Services.Tts;
 
 namespace Vernacula.App.ViewModels;
 
@@ -20,9 +21,9 @@ internal sealed partial class TtsModelSetStatusViewModel : ObservableObject
     private readonly Action              _onChanged;
     private CancellationTokenSource?     _downloadCts;
 
-    public ModelManagerService.TtsModelSet Set { get; }
-    public string Name        { get; }
-    public string Description { get; }
+    public TtsModelSet Set         { get; }
+    public string      Name        => Set.Name;
+    public string      Description => Set.Description;
 
     [ObservableProperty] private string _locationText       = "";
     [ObservableProperty] private string _statusText         = "";
@@ -44,46 +45,28 @@ internal sealed partial class TtsModelSetStatusViewModel : ObservableObject
 
     public bool HasOutdatedFiles => OutdatedFiles.Count > 0;
 
-    /// <summary>Hidden until the set is published somewhere fetchable (see ModelManagerService).</summary>
-    public bool CanDownload => ModelManagerService.CanDownloadTtsModelSet(Set);
+    /// <summary>Hidden until the set is published somewhere fetchable (see TtsModelSets).</summary>
+    public bool CanDownload => Set.CanDownload;
 
     public TtsModelSetStatusViewModel(
-        ModelManagerService.TtsModelSet set, string name, string description,
-        ModelManagerService modelMgr, SettingsService svc, Action onChanged)
+        TtsModelSet set, ModelManagerService modelMgr, SettingsService svc, Action onChanged)
     {
         Set          = set;
-        Name         = name;
-        Description  = description;
         _modelMgr    = modelMgr;
         _svc         = svc;
         _onChanged   = onChanged;
-        StatusText   = $"Checking {name}…";
+        StatusText   = $"Checking {set.Name}…";
         LocationText = modelMgr.GetTtsModelSetDir(set);
     }
 
-    // ── Where the set's directory is stored in AppSettings ───────────────────
+    // ── Where the set's directory is stored in AppSettings: the set says ─────
 
     private string CustomLocation
     {
-        get => Set switch
-        {
-            ModelManagerService.TtsModelSet.Chatterbox      => _svc.Current.ChatterboxBundleDir,
-            ModelManagerService.TtsModelSet.Kokoro          => _svc.Current.KokoroModelDir,
-            ModelManagerService.TtsModelSet.OmniVoice       => _svc.Current.OmniVoiceOnnxDir,
-            ModelManagerService.TtsModelSet.OmniVoiceVoices => _svc.Current.OmniVoiceVoiceLib,
-            ModelManagerService.TtsModelSet.PhonemizerData  => _svc.Current.PhonemizerDataDir,
-            _                                               => "",
-        };
+        get => Set.GetOverride(_svc.Current);
         set
         {
-            switch (Set)
-            {
-                case ModelManagerService.TtsModelSet.Chatterbox:      _svc.Current.ChatterboxBundleDir = value; break;
-                case ModelManagerService.TtsModelSet.Kokoro:          _svc.Current.KokoroModelDir      = value; break;
-                case ModelManagerService.TtsModelSet.OmniVoice:       _svc.Current.OmniVoiceOnnxDir    = value; break;
-                case ModelManagerService.TtsModelSet.OmniVoiceVoices: _svc.Current.OmniVoiceVoiceLib   = value; break;
-                case ModelManagerService.TtsModelSet.PhonemizerData:  _svc.Current.PhonemizerDataDir   = value; break;
-            }
+            Set.SetOverride(_svc.Current, value);
             _svc.Save();
         }
     }
@@ -110,7 +93,7 @@ internal sealed partial class TtsModelSetStatusViewModel : ObservableObject
     }
 
     /// <summary>Can the set be compared against a published manifest at all.</summary>
-    public bool CanCheckForUpdates => CanDownload && !string.IsNullOrEmpty(ModelManagerService.ManifestUrlFor(Set));
+    public bool CanCheckForUpdates => CanDownload && Set.HasManifest;
 
     /// <summary>
     /// Compares the set's files against its repo manifest (hashes every file, so it is behind
@@ -123,7 +106,7 @@ internal sealed partial class TtsModelSetStatusViewModel : ObservableObject
     public async Task CheckForUpdatesAsync()
     {
         OutdatedFiles = [];
-        if (!Ready || !CanDownload || string.IsNullOrEmpty(ModelManagerService.ManifestUrlFor(Set)))
+        if (!Ready || !CanCheckForUpdates)
         {
             UpdateStatusText = "";
             return;

--- a/tests/AsrBackendCoverage/TtsModelSetTableTests.cs
+++ b/tests/AsrBackendCoverage/TtsModelSetTableTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Linq;
+using Vernacula.App.Models;
+using Vernacula.App.Services;
+using Vernacula.App.Services.Tts;
+using Xunit;
+
+namespace Vernacula.Tests.AsrBackendCoverage;
+
+/// <summary>
+/// TTS model sets used to be an enum plus seven switch tables, and a set missing from any one
+/// of them still compiled — the default arms reported it as ready with nothing downloadable.
+/// Now each set is one entry in <see cref="TtsModelSets"/> with every fact required (#133).
+/// These pin what the compiler cannot: that the entries are consistent with each other, with
+/// the engines that require them, and with the settings fields they read and write.
+/// </summary>
+public class TtsModelSetTableTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "vernacula-tests", Guid.NewGuid().ToString("N"));
+
+    public TtsModelSetTableTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static SettingsService NewSettings()
+    {
+        var s = new SettingsService();
+        s.Current.ModelsDir = Path.Combine(Path.GetTempPath(), "vernacula-tests", "models-root");
+        return s;
+    }
+
+    [Fact]
+    public void EveryEntryIsCompleteAndDistinct()
+    {
+        Assert.NotEmpty(TtsModelSets.All);
+        foreach (var set in TtsModelSets.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(set.Name), "a set needs a name");
+            Assert.False(string.IsNullOrWhiteSpace(set.Description), $"{set.Name} needs a description");
+            Assert.False(string.IsNullOrWhiteSpace(set.SubDir), $"{set.Name} needs a default subfolder");
+            // A hosted set must say where its manifest is, or explicitly have none; an unhosted
+            // set cannot have one. Either way the two flags agree with the URLs.
+            Assert.Equal(set.RepoBase.Length > 0, set.CanDownload);
+            Assert.Equal(set.ManifestUrl.Length > 0, set.HasManifest);
+            if (set.HasManifest) Assert.True(set.CanDownload, $"{set.Name} has a manifest but no repo");
+            if (set.CanDownload) Assert.NotEmpty(set.Downloadable);
+        }
+        Assert.Equal(TtsModelSets.All.Count, TtsModelSets.All.Select(s => s.Name).Distinct().Count());
+        Assert.Equal(TtsModelSets.All.Count, TtsModelSets.All.Select(s => s.SubDir).Distinct().Count());
+        // The named statics are the table, not copies of it.
+        foreach (var named in new[] { TtsModelSets.Kokoro, TtsModelSets.OmniVoice, TtsModelSets.OmniVoiceVoices, TtsModelSets.Chatterbox, TtsModelSets.PhonemizerData })
+            Assert.Single(TtsModelSets.All, s => ReferenceEquals(s, named));
+    }
+
+    [Fact]
+    public void EveryEngineRequiresOnlySetsInTheTable()
+    {
+        foreach (var engine in TtsEngines.All)
+        {
+            Assert.NotEmpty(engine.RequiredSets);
+            foreach (var set in engine.RequiredSets)
+                Assert.Contains(TtsModelSets.All, s => ReferenceEquals(s, set));
+        }
+    }
+
+    /// <summary>
+    /// GetOverride and SetOverride are two lambdas per entry that must name the same
+    /// AppSettings field; nothing but this test notices when a copy-paste makes them differ.
+    /// </summary>
+    [Fact]
+    public void OverrideReadsBackWhatItWrote_ForEverySet()
+    {
+        var settings = NewSettings();
+        foreach (var set in TtsModelSets.All)
+        {
+            string pick = Path.Combine(_dir, set.SubDir + "-picked");
+            set.SetOverride(settings.Current, pick);
+            Assert.Equal(pick, set.GetOverride(settings.Current));
+            Assert.Equal(pick, set.Dir(settings));          // the pick wins over every default
+            set.SetOverride(settings.Current, "");
+            Assert.Equal("", set.GetOverride(settings.Current));
+        }
+        // And no two sets share a field: setting one must not change another.
+        foreach (var a in TtsModelSets.All)
+        {
+            a.SetOverride(settings.Current, "/only/" + a.SubDir);
+            foreach (var b in TtsModelSets.All.Where(b => !ReferenceEquals(a, b)))
+                Assert.NotEqual("/only/" + a.SubDir, b.GetOverride(settings.Current));
+            a.SetOverride(settings.Current, "");
+        }
+    }
+
+    [Fact]
+    public void DefaultDirectoryIsTheSubfolderOfTheModelsDir()
+    {
+        var settings = NewSettings();
+        // Kokoro and Chatterbox have no resolver, so with no pick the default is fully determined.
+        Assert.Equal(Path.Combine(settings.GetModelsDir(), TtsModelSets.Kokoro.SubDir), TtsModelSets.Kokoro.Dir(settings));
+        Assert.Equal(Path.Combine(settings.GetModelsDir(), TtsModelSets.Chatterbox.SubDir), TtsModelSets.Chatterbox.Dir(settings));
+        // The named SettingsService entry points are the same answer, not a second copy of the rule.
+        Assert.Equal(TtsModelSets.Kokoro.Dir(settings), settings.GetKokoroModelsDir());
+        Assert.Equal(TtsModelSets.Chatterbox.Dir(settings), settings.GetChatterboxModelsDir());
+        Assert.Equal(TtsModelSets.OmniVoice.Dir(settings), settings.GetOmniVoiceModelsDir());
+        Assert.Equal(TtsModelSets.OmniVoiceVoices.Dir(settings), settings.GetOmniVoiceVoiceLibDir());
+        Assert.Equal(TtsModelSets.PhonemizerData.Dir(settings), settings.GetPhonemizerDataDir());
+    }
+
+    [Fact]
+    public void KokoroPresenceIsTheGraphPlusAnyVoicePack()
+    {
+        var settings = NewSettings();
+        TtsModelSets.Kokoro.SetOverride(settings.Current, _dir);
+
+        Assert.Equal(["kokoro.onnx", "voices/*.bin"], TtsModelSets.Kokoro.MissingFiles(settings));
+
+        File.WriteAllText(Path.Combine(_dir, "kokoro.onnx"), "");
+        Assert.Equal(["voices/*.bin"], TtsModelSets.Kokoro.MissingFiles(settings));
+
+        Directory.CreateDirectory(Path.Combine(_dir, "voices"));
+        File.WriteAllText(Path.Combine(_dir, "voices", "af_heart.bin"), "");
+        Assert.Empty(TtsModelSets.Kokoro.MissingFiles(settings));   // one voice is enough to run
+        // ...but a download would still fetch every voice the repo holds.
+        Assert.Equal(TtsModelSets.KokoroVoices.Length + 1, TtsModelSets.Kokoro.Downloadable.Count());
+    }
+
+    [Fact]
+    public void UnhostedDataTreeIsJudgedByItsSentinel()
+    {
+        var settings = NewSettings();
+        TtsModelSets.PhonemizerData.SetOverride(settings.Current, _dir);
+        Assert.False(TtsModelSets.PhonemizerData.CanDownload);
+        var missing = Assert.Single(TtsModelSets.PhonemizerData.MissingFiles(settings));
+        Assert.Contains("core/phonology.jsonc", missing);
+    }
+
+    [Fact]
+    public void TokenizerRidesWithTheEnginesThatNeedIt()
+    {
+        Assert.Contains(TtsModelSets.Chatterbox.Downloadable, a => a.LocalRelativePath == "tokenizer.json");
+        Assert.Contains(TtsModelSets.OmniVoice.Downloadable,  a => a.LocalRelativePath == "tokenizer.json");
+        Assert.DoesNotContain(TtsModelSets.Kokoro.Downloadable, a => a.LocalRelativePath == "tokenizer.json");
+        // The voice library is not judged by the tokenizer either way.
+        Assert.Equal(["voices.jsonc", "voice-codes.json"], TtsModelSets.OmniVoiceVoices.Assets.Select(a => a.LocalRelativePath));
+    }
+}


### PR DESCRIPTION
Closes #133.

## What changed

Each TTS model set is now one entry in `TtsModelSets` with every per-set fact a **`required`** member — name, description, default subfolder, the `AppSettings` field its override lives in (read *and* write), repo, manifest, assets, presence rule. Leaving one out is a compile error. The enum is gone; `TtsEngine.RequiredSets` holds table entries, and the Settings rows are a `foreach` over `TtsModelSets.All`.

| removed | replaced by |
|---|---|
| `TtsModelSet` enum + `GetTtsModelSetDir` / `RepoBaseFor` / `ManifestUrlFor` / `AssetsFor` / `DownloadableTtsAssets` / `GetMissingTtsFiles` switches | one `TtsModelSet` entry per set |
| `TtsPrerequisites.SetName` switch — **a seventh table the issue didn't count** | `set.Name` |
| `TtsModelSetStatusViewModel.CustomLocation` get/set switch | `set.GetOverride` / `set.SetOverride` |
| five hand-written rows in `SettingsViewModel.InitTtsSettings` | `foreach (var set in TtsModelSets.All)` |
| five copies of the directory rule in `SettingsService` | one `Dir()`; the getters delegate to it |
| two near-identical manifest-compare loops (ASR repos, TTS sets) | `ManifestChecksAsync`, used by both |

That seventh table had already drifted: the job runner said "Kokoro model" / "Chatterbox bundle" / "OmniVoice ONNX set" where the Settings tab said "Kokoro-82M" / "Chatterbox" / "OmniVoice-IPA". The "incomplete" message now uses the Settings name, so it matches the tab it points at — the one user-visible wording change.

## What deliberately stayed per set

Presence rules. They're not "each asset exists" everywhere — Chatterbox accepts a monolithic alternative export, Kokoro needs any one voice pack, OmniVoice's tokenizer can come from settings or the graphs' folder, the phonemizer tree is judged by a sentinel. Each moved verbatim into its entry as a `required` delegate, so a set *cannot* be added without saying how it's judged.

The `AppSettings` field and the `Config.*SubDir` constant a set needs are the only things outside this file, and both are referenced from its entry — forgetting either is also a compile error.

## One behaviour change inside the shared loop

`ManifestChecksAsync` now backs both the ASR and TTS update checks. It leaves out a manifest
entry whose `md5` is empty; both loops it replaced would have compared against `""` and reported
the file outdated on every check — an Update that could never satisfy it. That's the rule
`CheckSortformerModelAsync` already applied to the same case in the same file, so the two now
agree. No published manifest has such an entry, so nothing visible changes today; it's recorded
here rather than left to be rediscovered.

## Tests (+7)

Pin what the compiler cannot: entries complete and distinct; every engine's sets in the table; **each set's override reads back what it wrote and no two share a field** (two lambdas per entry that must name the same field — nothing but a test notices a copy-paste); the default directory rule matches every `SettingsService` entry point; Kokoro and phonemizer presence rules on a temp directory.

The round-trip test was checked by pointing Kokoro's writer at the Chatterbox field: it fails on exactly that line.

## Verification

Suites 27 / **144** / 178, solution builds clean. Headless launch under Xvfb with an isolated data dir: zero exceptions; Settings → Text-to-Speech renders its "Models & data" rows from the table — name, description, the presence rule's own "incomplete (2 missing): kokoro.onnx, voices/*.bin", and the resolved default `…/models/kokoro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq

