### PR TITLE
chore: settle deferred execution-provider and job-kind cleanups

### DIFF
--- a/scripts/ChatterboxAttentionProbe/ChatterboxAttentionProbe.csproj
+++ b/scripts/ChatterboxAttentionProbe/ChatterboxAttentionProbe.csproj
@@ -22,10 +22,8 @@
     <!-- No SetConfiguration: EP is a global property that already reaches every referenced
          project with the same value. Overriding it per reference builds Base twice and lets
          restore and build disagree about which runtime package applies. -->
-    <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj" />
+    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj" />
   </ItemGroup>
 
 </Project>

--- a/scripts/ChatterboxAttentionProbe/ChatterboxAttentionProbe.csproj
+++ b/scripts/ChatterboxAttentionProbe/ChatterboxAttentionProbe.csproj
@@ -19,11 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- No SetConfiguration: EP is a global property that already reaches every referenced
+         project with the same value. Overriding it per reference builds Base twice and lets
+         restore and build disagree about which runtime package applies. -->
     <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
-      <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
-      <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>
   </ItemGroup>
 

--- a/scripts/TtsAsrProbe/TtsAsrProbe.csproj
+++ b/scripts/TtsAsrProbe/TtsAsrProbe.csproj
@@ -26,10 +26,8 @@
     <!-- No SetConfiguration: EP is a global property that already reaches every referenced
          project with the same value. Overriding it per reference builds Base twice and lets
          restore and build disagree about which runtime package applies. -->
-    <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj" />
+    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj" />
   </ItemGroup>
 
 </Project>

--- a/scripts/TtsAsrProbe/TtsAsrProbe.csproj
+++ b/scripts/TtsAsrProbe/TtsAsrProbe.csproj
@@ -23,11 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- No SetConfiguration: EP is a global property that already reaches every referenced
+         project with the same value. Overriding it per reference builds Base twice and lets
+         restore and build disagree about which runtime package applies. -->
     <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
-      <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
-      <SetConfiguration>EP=$(EP)</SetConfiguration>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/MainViewModel.cs
@@ -136,14 +136,23 @@ internal partial class MainViewModel : ObservableObject
         // Home → Results (load a completed ASR job) / Reader (open a completed TTS job)
         Home.LoadJobToResults = job =>
         {
-            if (job.IsTts)
+            // Exhaustive on purpose: an `else` here would open a future job kind in the
+            // transcript view, which would look like a bug in that feature rather than a
+            // missing case here.
+            switch (job.Kind)
             {
-                TtsReader.Open(job);
-                CurrentPanel = AppPanel.TtsReader;
-                return;
+                case JobKind.Tts:
+                    TtsReader.Open(job);
+                    CurrentPanel = AppPanel.TtsReader;
+                    break;
+                case JobKind.Asr:
+                    Results.Load(job.ResultsFile, job.AudioBaseName, _mainWindow, job.JobId);
+                    CurrentPanel = AppPanel.Results;
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"No completed-job view for {job.Kind}. Add a case here and in MonitorJob.");
             }
-            Results.Load(job.ResultsFile, job.AudioBaseName, _mainWindow, job.JobId);
-            CurrentPanel = AppPanel.Results;
         };
 
         // Reader → Home (back) / cancel the watched job
@@ -219,14 +228,20 @@ internal partial class MainViewModel : ObservableObject
         // Home → Progress (monitor a running / queued ASR job) / Reader (a TTS job)
         Home.MonitorJob = job =>
         {
-            if (job.IsTts)
+            switch (job.Kind)
             {
-                TtsReader.Open(job);
-                CurrentPanel = AppPanel.TtsReader;
-                return;
+                case JobKind.Tts:
+                    TtsReader.Open(job);
+                    CurrentPanel = AppPanel.TtsReader;
+                    break;
+                case JobKind.Asr:
+                    Progress.WatchJob(job.JobId, job.ResultsFile, job.AudioFilePath, job.AudioBaseName);
+                    CurrentPanel = AppPanel.Progress;
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"No running-job view for {job.Kind}. Add a case here and in LoadJobToResults.");
             }
-            Progress.WatchJob(job.JobId, job.ResultsFile, job.AudioFilePath, job.AudioBaseName);
-            CurrentPanel = AppPanel.Progress;
         };
 
         // Home → Bulk enqueue multiple files with auto-generated names
@@ -409,7 +424,7 @@ internal partial class MainViewModel : ObservableObject
                 job.IsActivelyRunning = true;
                 job.ProgressPercent   = _queue.GetJobProgress(job.JobId);
 
-                if (job.IsTts)
+                if (job.Kind == JobKind.Tts)
                 {
                     if (_queue.GetTtsJobLastProgress(job.JobId) is { } tp)
                         ApplyTtsProgress(job.JobId, tp);

--- a/tests/AsrBackendCoverage/AsrBackendCoverage.csproj
+++ b/tests/AsrBackendCoverage/AsrBackendCoverage.csproj
@@ -25,6 +25,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Avalonia\Vernacula.Avalonia.csproj">
       <Private>true</Private>
+      <!-- Deliberate, not a straggler: this project is CPU-only (AllowCpuOnnxRuntime above),
+           so Base must be built for the CPU provider or its GPU native would land here and the
+           build guard in Directory.Build.targets would reject it. Contrast the probe projects
+           under scripts/, where the same metadata was redundant and was removed. -->
       <SetConfiguration>EP=Cpu</SetConfiguration>
     </ProjectReference>
   </ItemGroup>

--- a/tests/AsrBackendCoverage/JobKindCoverageTests.cs
+++ b/tests/AsrBackendCoverage/JobKindCoverageTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vernacula.App.Models;
+using Vernacula.Base.Models;
+using Xunit;
+
+namespace Vernacula.Tests.AsrBackendCoverage;
+
+/// <summary>
+/// Every job kind must be described by the row model. These exist because the alternative to a
+/// missing case here is not an error but a wrong answer: a new kind silently rendered as a
+/// transcription, which reads as a bug in that feature rather than an omission in this one.
+/// The navigation in MainViewModel now throws on an unhandled kind for the same reason.
+/// </summary>
+public class JobKindCoverageTests
+{
+    public static IEnumerable<object[]> AllKinds =>
+        Enum.GetValues<JobKind>().Select(k => new object[] { k });
+
+    private static JobRecord Row(JobKind kind) => new()
+    {
+        JobId = 1, Kind = kind, ResultsFile = "/tmp/r.json",
+        AudioFilePath = "/tmp/a.wav", Status = JobStatus.Complete,
+    };
+
+    [Theory]
+    [MemberData(nameof(AllKinds))]
+    public void EveryKindHasALabelAndAnActionName(JobKind kind)
+    {
+        var row = Row(kind);
+        Assert.False(string.IsNullOrWhiteSpace(row.KindLabel), $"{kind} has no KindLabel");
+        Assert.False(string.IsNullOrWhiteSpace(row.LoadLabel), $"{kind} has no LoadLabel");
+    }
+
+    [Theory]
+    [MemberData(nameof(AllKinds))]
+    public void EveryKindClaimsExactlyOneProgressRow(JobKind kind)
+    {
+        // The two progress bars are mutually exclusive by construction; a kind that claims
+        // both would draw twice, and one that claims neither would show no progress at all.
+        var row = Row(kind);
+        row.Status = JobStatus.Running;
+        row.IsActivelyRunning = true;
+        Assert.True(row.ShowAsrProgress ^ row.ShowTtsProgress,
+            $"{kind} claims {(row.ShowAsrProgress ? "ASR" : "")}{(row.ShowTtsProgress ? "TTS" : "")} progress");
+    }
+
+    [Fact]
+    public void KindPredicatesPartitionTheKinds()
+    {
+        // IsAsr/IsTts are used as an either-or across the UI; that only holds while there are
+        // exactly two kinds. If a third arrives this fails, which is the point.
+        foreach (var kind in Enum.GetValues<JobKind>())
+        {
+            var row = Row(kind);
+            Assert.True(row.IsAsr ^ row.IsTts,
+                $"{kind} is neither ASR nor TTS, so every `IsTts ? … : …` in the UI is now wrong for it");
+        }
+    }
+}

--- a/tests/IndicConformerTest/IndicConformerTest.csproj
+++ b/tests/IndicConformerTest/IndicConformerTest.csproj
@@ -31,6 +31,10 @@
            runtime in the output directory, so suppress Base's transitive
            EP selection by passing EP=Cpu down the build graph. -->
       <Private>true</Private>
+      <!-- Deliberate, not a straggler: this project is CPU-only (AllowCpuOnnxRuntime above),
+           so Base must be built for the CPU provider or its GPU native would land here and the
+           build guard in Directory.Build.targets would reject it. Contrast the probe projects
+           under scripts/, where the same metadata was redundant and was removed. -->
       <SetConfiguration>EP=Cpu</SetConfiguration>
     </ProjectReference>
   </ItemGroup>

--- a/tests/Vernacula.Tests/Vernacula.Tests.csproj
+++ b/tests/Vernacula.Tests/Vernacula.Tests.csproj
@@ -21,6 +21,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
       <Private>true</Private>
+      <!-- Deliberate, not a straggler: these tests never load a GPU runtime, so Base is built
+           for the CPU provider here. Contrast the probe projects under scripts/, where the same
+           metadata merely restated the global EP and was removed. -->
       <SetConfiguration>EP=Cpu</SetConfiguration>
     </ProjectReference>
   </ItemGroup>

--- a/tests/Vernacula.Tts.Tests/Vernacula.Tts.Tests.csproj
+++ b/tests/Vernacula.Tts.Tests/Vernacula.Tts.Tests.csproj
@@ -29,6 +29,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Vernacula.Tts.Base\Vernacula.Tts.Base.csproj">
       <Private>true</Private>
+      <!-- Deliberate, not a straggler: this project is CPU-only (AllowCpuOnnxRuntime above),
+           so Base must be built for the CPU provider or its GPU native would land here and the
+           build guard in Directory.Build.targets would reject it. Contrast the probe projects
+           under scripts/, where the same metadata was redundant and was removed. -->
       <SetConfiguration>EP=Cpu</SetConfiguration>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Clears the deferred items that were still hanging off earlier work. Two were real, two were not.

## Execution-provider overrides (real, and two different things)

One note covered two patterns that deserved opposite treatment.

`<SetConfiguration>EP=$(EP)</SetConfiguration>` in `scripts/TtsAsrProbe` and
`scripts/ChatterboxAttentionProbe` merely restated the global property. Removed, and verified:
the natives are byte-identical before and after at both providers (31,958,904 for CUDA,
28,497,752 for CPU). The CLI projects already carry a comment explaining why this metadata is
unnecessary; these two predated it.

`<SetConfiguration>EP=Cpu</SetConfiguration>` in the four test projects is the opposite: it is
load-bearing, paired with `AllowCpuOnnxRuntime`, and forcing Base to the CPU provider is what
keeps the build guard satisfied. It stays, now with a comment saying it is deliberate and
pointing at the probes, so a future sweep does not remove it by analogy.

## Job-kind branching in the presentation layer (real)

`MainViewModel`'s two navigation sites routed with `if (job.IsTts) … else …`. A third job kind
would not have failed — it would have opened in the transcript view, which reads as a bug in
that feature rather than a missing case here. Both are now exhaustive `switch`es that throw and
name the sites to update, matching the convention `ModelManagerService.ActiveRepos` already
uses for ASR backends.

`JobKindCoverageTests` pins the assumptions the rest of the UI rests on: every kind has a label
and an action name, claims exactly one of the two progress rows, and `IsAsr`/`IsTts` still
partition the kinds. That last one fails deliberately if a third kind is added, because at that
moment every `IsTts ? … : …` in the UI becomes wrong.

## Not actionable, recorded so they stop resurfacing

Issue #46 is closed. Its item 2 (the audio-pipeline extraction) landed earlier this session;
item 1 was investigated and declined on measurements — the binding change that gave Granite 24 %
was a no-op on Whisper, logged in `docs/dev/bind_output_logits_investigation.md`; item 3 needs
bundle variants this machine does not have.

The broken `granite_speech_4_1_2b_static_mha_bf16` bundle is a 5.3 GB artifact of a paused
fused-attention experiment. It is not auto-discovered by the app, so it cannot mislead a user,
and deleting 5.3 GB of someone's compute output is their call rather than mine.

## Verification

Suite green: 31 / 177 / 178. Both probe projects build clean and produce the correct native at
each provider. Headless Xvfb launch of the app: no exceptions.
