### PR TITLE
docs: list VibeVoice-ASR Streaming where backends are enumerated

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Vernacula converts audio into accurate, multi-speaker transcripts on your own computer. It ships as a reusable library (`Vernacula.Base`), a command-line tool (`Vernacula.CLI`), and a cross-platform desktop app (`Vernacula-Desktop`, built on Avalonia UI).
 
-Powered by NVIDIA's [Parakeet TDT v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) and [Sortformer](https://huggingface.co/nvidia/diar_sortformer_4spk-v2.1) by default, with optional pluggable backends (Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR, Granite Speech 4.1). Parakeet v3 posts a **Word Error Rate of 4.85** on Google's FLEURS benchmark. Most modern computers will transcribe one hour of audio in about five minutes; GPU-accelerated systems are significantly faster.
+Powered by NVIDIA's [Parakeet TDT v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) and [Sortformer](https://huggingface.co/nvidia/diar_sortformer_4spk-v2.1) by default, with optional pluggable backends (Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR, VibeVoice-ASR Streaming, Whisper large-v3-turbo, IndicConformer, Granite Speech 4.1). Parakeet v3 posts a **Word Error Rate of 4.85** on Google's FLEURS benchmark. Most modern computers will transcribe one hour of audio in about five minutes; GPU-accelerated systems are significantly faster.
 
 ## Demo
 
@@ -27,7 +27,7 @@ More screenshots and a feature tour live in [docs/desktop-app.md](docs/desktop-a
 - **Multi-speaker detection** — identifies and labels up to four concurrent speakers
 - **No audio length limits** — streaming and segmentation handle indefinite file lengths
 - **Transcript editor** with confidence colouring, audio playback, and word-level timestamps
-- **Pluggable ASR backends** — Parakeet TDT v3, Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR, Granite Speech 4.1
+- **Pluggable ASR backends** — Parakeet TDT v3, Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR, VibeVoice-ASR Streaming, Whisper large-v3-turbo, IndicConformer, Granite Speech 4.1
 - **Shallow KenLM fusion** for domain-specific English (general, medical)
 - **Export** to XLSX, CSV, JSON, SRT, Markdown, DOCX, and SQLite
 - **GPU acceleration** via CUDA (DirectML on Windows), with automatic CPU fallback
@@ -45,6 +45,7 @@ Vernacula's models are converted in-house from upstream PyTorch / NeMo / Hugging
 | Qwen3-ASR | [Qwen/Qwen3-ASR-0.6B](https://huggingface.co/Qwen/Qwen3-ASR-0.6B), [Qwen3-ASR-1.7B](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) | [scripts/qwen3asr_export](scripts/qwen3asr_export) |
 | Cohere Transcribe | [CohereLabs/cohere-transcribe-03-2026](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026) | [scripts/cohere_export](scripts/cohere_export) |
 | VibeVoice-ASR | [microsoft/VibeVoice-ASR-HF](https://huggingface.co/microsoft/VibeVoice-ASR-HF) | [scripts/vibevoice_export](scripts/vibevoice_export) |
+| VibeVoice-ASR Streaming | [microsoft/VibeVoice-ASR-Streaming-1.5B](https://huggingface.co/microsoft/VibeVoice-ASR-Streaming-1.5B), [7B](https://huggingface.co/microsoft/VibeVoice-ASR-Streaming-7B) | [scripts/vibevoice_streaming_export](scripts/vibevoice_streaming_export) |
 | Granite Speech 4.1 | [ibm-granite/granite-speech-4.1-2b](https://huggingface.co/ibm-granite/granite-speech-4.1-2b) | [scripts/granite_export](scripts/granite_export) |
 | OmniVoice (IPA fine-tune, TTS) | [k2-fsa/OmniVoice](https://huggingface.co/k2-fsa/OmniVoice) | [scripts/omnivoice_export](scripts/omnivoice_export), [scripts/omnivoice_ipa](scripts/omnivoice_ipa) |
 | DeepFilterNet3 (streaming) | [Rikorose/DeepFilterNet](https://github.com/Rikorose/DeepFilterNet) | [scripts/deepfilternet3_export](scripts/deepfilternet3_export) |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ More screenshots and a feature tour live in [docs/desktop-app.md](docs/desktop-a
 
 - **Local, private transcription** — audio never leaves your computer
 - **Multi-speaker detection** — identifies and labels up to four concurrent speakers
-- **No audio length limits** — streaming and segmentation handle indefinite file lengths
+- **No audio length limits** — the default pipeline streams and segments, so file length is
+  unbounded. The VibeVoice backends are the exception: they hold the whole recording in
+  context to attribute speakers without a diarizer, which caps them at their context window
+  (about 68 minutes for VibeVoice-ASR Streaming 1.5B, 2 hours for the 7B). Over-long files are
+  refused up front rather than failing partway.
 - **Transcript editor** with confidence colouring, audio playback, and word-level timestamps
 - **Pluggable ASR backends** — Parakeet TDT v3, Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR, VibeVoice-ASR Streaming, Whisper large-v3-turbo, IndicConformer, Granite Speech 4.1
 - **Shallow KenLM fusion** for domain-specific English (general, medical)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,11 +44,14 @@ Output:
   --export-format <md|txt|json|srt>   Output format (default: md)
 
 ASR backend:
-  --asr <parakeet|cohere|qwen3asr|vibevoice|whisper|granite>   ASR backend (default: parakeet)
+  --asr <parakeet|cohere|qwen3asr|vibevoice|vibevoice-streaming|whisper|granite>
+                                      ASR backend (default: parakeet)
   --language <code>                   Force language for Cohere ASR (ISO 639-1: en, fr, de, ...)
   --cohere-model <dir>                Override Cohere model dir (default: <models-dir>/cohere_transcribe)
   --qwen3asr-model <dir>              Override Qwen3-ASR model dir
   --vibevoice-model <dir>             Override VibeVoice-ASR model dir
+  --vibevoice-streaming-model <dir>   Override VibeVoice-ASR Streaming model dir
+  --hotwords <a,b,c>                  Bias VibeVoice-ASR Streaming toward these names or terms
 
 Parakeet decoding:
   --precision <fp32|int8>             Model precision (default: fp32)

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -8,7 +8,7 @@ Vernacula-Desktop is the Avalonia-based GUI for running the Vernacula pipeline o
 
 Vernacula-Desktop converts audio files into accurate, multi-speaker transcripts — entirely on your own computer. No cloud uploads, no subscriptions, no privacy concerns. Works on Linux, Mac, and Windows (Android, iOS, and WebAssembly are untested).
 
-Powered by NVIDIA's [Parakeet TDT v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) and [Sortformer](https://huggingface.co/nvidia/diar_sortformer_4spk-v2.1) by default, with optional pluggable backends (Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR). Parakeet v3 posts a **Word Error Rate of 4.85** on Google's FLEURS benchmark — among the best available anywhere. Most modern computers will transcribe one hour of audio in about five minutes. GPU-accelerated systems are significantly faster.
+Powered by NVIDIA's [Parakeet TDT v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) and [Sortformer](https://huggingface.co/nvidia/diar_sortformer_4spk-v2.1) by default, with optional pluggable backends (Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR, VibeVoice-ASR Streaming, Whisper large-v3-turbo, IndicConformer, Granite Speech 4.1). Parakeet v3 posts a **Word Error Rate of 4.85** on Google's FLEURS benchmark — among the best available anywhere. Most modern computers will transcribe one hour of audio in about five minutes. GPU-accelerated systems are significantly faster.
 
 ## Demo
 

--- a/docs/dev/asr_backend_dispatch.md
+++ b/docs/dev/asr_backend_dispatch.md
@@ -101,9 +101,22 @@ drift vector — but it does mean defensive callers should validate via
 ### 3. `ModelManagerService.ActiveRepos` *[throw]*
 
 `src/Vernacula.Avalonia/Services/ModelManagerService.cs`. Switch
-expression with explicit Parakeet arm; default throws. VibeVoice is
-handled in an early-return above the switch (it can be the
-segmentation backend even when the AsrBackend isn't VibeVoice).
+expression with explicit Parakeet arm; default throws. Two backends are
+handled by early returns above the switch, and their **order matters**:
+
+1. `VibeVoiceStreaming` first, because it forces
+   `SegmentationMode.VibeVoiceBuiltin` (it segments itself) and would
+   otherwise be caught by the test below and sent to the non-streaming
+   package — a different model, and 17 GB of it. This shipped as a bug
+   once; see `ModelRepoSelectionTests`.
+2. `VibeVoice`, or *any* backend whose segmentation is
+   `VibeVoiceBuiltin`, since VibeVoice can be the segmentation backend
+   even when the AsrBackend is something else.
+
+`ModelRepoSelectionTests` asserts on the resolved file list rather than
+on the existence of a mapping, which is the gap that let the ordering
+bug through: every other check here asks whether a backend maps to
+*something*, not whether it maps to the *right* thing.
 
 ### 4. `TranscriptionService` Phase-4 dispatch *[manual]*
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,6 +60,7 @@ The first launch opens a model download dialog. Approximate sizes:
 - VoxLingua107 LID: ~100 MB
 - Cohere Transcribe: ~7 GB
 - VibeVoice-ASR: ~3 GB (CUDA-only)
+- VibeVoice-ASR Streaming: ~3.2 GB for the 1.5B, ~9 GB for the 7B (CUDA-only; pick one in Settings)
 - KenLM models: 17–67 MB each (optional)
 
 All models are stored under `~/.local/share/Vernacula/models/`.


### PR DESCRIPTION
Makes the streaming backend visible where backends are listed. A backend that ships without
appearing in the README is effectively invisible.

## Updated

- **README** — summary line, feature list, and the model table (with both checkpoints and the
  export scripts).
- **docs/desktop-app.md** — same summary line.
- **docs/cli-reference.md** — the `--asr` value, `--vibevoice-streaming-model`, and `--hotwords`.
- **docs/installation.md** — download sizes: ~3.2 GB for the 1.5B, ~9 GB for the 7B, CUDA-only,
  one chosen in Settings.

## Corrected while I was there

The two prose backend lists were already stale: neither mentioned **Whisper large-v3-turbo** nor
**IndicConformer**, both of which have shipped for some time. Adding one name to a list that is
wrong in two other ways would leave it wrong, so the lists are corrected rather than extended.

## Developer doc that no longer matched the code

`docs/dev/asr_backend_dispatch.md` described `ModelManagerService.ActiveRepos` as having a
single VibeVoice early return. It now has two, and **their order is load-bearing**: the
streaming backend forces `VibeVoiceBuiltin` segmentation, so testing for that first sends it to
the *non-streaming* package — a different model, and 17 GB of it. That shipped as a bug in #145
and was fixed there. The doc now explains the ordering and points at `ModelRepoSelectionTests`,
including why the pre-existing checks missed it: they ask whether a backend maps to *something*,
not whether it maps to the *right* thing.

## Not done

Help text for the new backend — the backend entry, the size-picker guidance, the hotwords
section, and the note that a speaker may be an audience rather than a person — exists only in
`Help/en/`. There are 26 locales. `scripts/update_help_files.py` translates changed files, but
it needs `ANTHROPIC_API_KEY`, which is not set in this environment, and it makes a paid API call
per language. Left for a run with a key.

## Verification

Suite green: 31 / 177. No code changed.
