### PR TITLE
fix(vibevoice-streaming): run on the CPU, and make the picker agree with the planner

### DIFF
--- a/docs/dev/vibevoice_asr_streaming_investigation.md
+++ b/docs/dev/vibevoice_asr_streaming_investigation.md
@@ -1301,9 +1301,11 @@ gets exactly that dimension, so an older download keeps working unchanged.
 
 ### The 1.5B "not using the GPU"
 
-Not reproduced, and the screenshots argue against it. This backend cannot silently fall back:
-the KV cache comes from a CUDA device allocator, and a decoder session that is not on CUDA has
-none, which raises before the first window. Task Manager's Performance page shows GPU 0 at 0%
+Not reproduced, and the screenshots argue against it. At the time of this run the backend
+could not fall back at all: the KV cache came from a CUDA device allocator, and a decoder
+session that is not on CUDA has none, so it raised before the first window. (Run 35 changes
+that — the refusal turned out to be a choice, not a constraint — but it means the reported run
+was on the GPU or it would not have produced a transcript.) Task Manager's Performance page shows GPU 0 at 0%
 *and 77 °C* — the utilisation graph there does not include the compute engine by default,
 while the temperature does not lie. CPU sits at 30% of eight logical processors, which is a
 session feeding a GPU, not one running a 1.5B decoder.
@@ -1312,3 +1314,67 @@ The real gap is that nothing in the application answers the question. On a two-G
 "NVIDIA GPU ✓" does not say *which* card, and every CUDA path here is pinned to device 0. The
 hardware panel now names it, from `nvmlDeviceGetName`, and says "GPU 0 of 2" when there is
 more than one.
+
+
+
+## Run 35 — 2026-09-08 08:20 — the CPU refusal was a choice, not a constraint
+
+Reviewing Run 34 the question came back: why does this backend refuse to run without CUDA at
+all? The refusal was mine. `CreateSharedKvBuffers` takes its tensors from an allocator, and the
+only reason that allocator had to be a CUDA one is that a CUDA session copies a host-allocated
+cache both ways on every step — measured at 9x slower back in Run 12. On a session that is
+already on the CPU, host memory is simply where the cache belongs.
+
+So the CUDA allocator is now attempted and its absence tolerated, and the cache sizing moved
+after that decision: free VRAM is the constraint when the cache lands on the device and is not
+a constraint worth modelling when it lands in host memory, where the whole ceiling is 1.75 GiB
+against system memory measured in tens of gigabytes.
+
+Measured on the published 1.5B, 30 seconds of two-speaker audio, same package both ways:
+
+| build | RTF | text | speaker labels |
+|---|---|---|---|
+| EP=Cuda, RTX 3090 | 0.198 | — | 9 segments |
+| EP=Cpu, 16 threads | 12.23 | identical | identical |
+
+Identical output, about 62x slower. `com.microsoft::GroupQueryAttention` has a working CPU
+kernel for this graph's float16 tensors, which was the open question; nothing had to be
+changed in the export.
+
+RTF 12 is not a substitute for a GPU — a ten-minute file is about two hours — but it is the
+difference between a machine that can run this backend and one that cannot, and the earlier
+behaviour refused a configuration that works. The settings window now offers it on any
+machine, labelled "(CPU - very slow)" with the cost stated in the description, rather than
+greyed out as "Unavailable - CUDA Missing".
+
+An earlier reading of this run had the speaker labels diverging on CPU. They do not: that
+comparison was against a 60-second run, and against the same 30 seconds the two agree exactly.
+Worth recording because it is the mistake this comparison exists to avoid.
+
+
+Regression-checked on the GPU after the reordering: the 7B on the same 60-second file gives an
+identical transcript at RTF 0.194 against 0.196 before, so tolerating a missing CUDA allocator
+costs the CUDA path nothing.
+
+### The picker and the planner disagreed twice
+
+Reviewing the Run 34 code turned up three defects in the settings warning, two of which a
+single-point test would have missed.
+
+**It compared against a rounded ceiling.** The 7B warned only below 120 minutes, but the
+package carries 131,072 positions — about 136. A card good for 125 minutes was told it was
+fine. It now derives the figure from the package's own ceiling.
+
+**It measured the card by total VRAM while the planner measures free.** That overstated
+capacity by a gigabyte or more, in exactly the small-card case the warning exists for.
+
+**It could promise a length the planner then refuses.** Found by a test that runs the picker's
+own answer through `PlanKvTokens`. Two causes, each sufficient on its own: the picker ignored
+the prompt slack and the two rounded opposite ways, and the picker ignored the context ceiling
+entirely, so a large card was told "68 minutes" for a 1.5B whose ceiling allows 67.7.
+
+The first version of that test checked one card size and passed with either mitigation removed
+— luck, not coverage. Sweeping about 1,170 card sizes per checkpoint makes each mitigation
+independently load-bearing: remove either and the sweep fails. The arithmetic now lives in
+`VibeVoiceStreamingBudget`, which the backend and the settings window both call, rather than in
+two copies that had to agree and did not.

--- a/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
+++ b/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
@@ -70,6 +70,12 @@ hold the checkpoint, or when it can hold it but not for the full recording lengt
 The two install into separate folders, so switching between them does not re-download the one
 you already have.
 
+**Without an NVIDIA GPU.** The backend still runs, on the CPU, and produces the same transcript
+and the same speaker labels — but roughly 12 times slower than the recording is long, so a
+ten-minute file takes about two hours. The option is offered rather than hidden, labelled
+"(CPU — very slow)". For anything but a short clip, another backend is the better answer on a
+machine without CUDA.
+
 **Hotwords.** A text box under the size picker takes names or technical terms, separated by
 commas, which are spliced into the model's prompt to bias recognition toward them. On
 upstream's own demo clip this is the difference between "Y-voice" and "VibeVoice", and between

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -31,7 +31,7 @@ internal partial class SettingsViewModel : ObservableObject
     private SegmentationMode _selectedSegmentation;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrVibeVoiceStreaming), nameof(IsAsrIndicConformer), nameof(IsAsrWhisperTurbo), nameof(IsAsrGraniteSpeech), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(CanUseVibeVoiceStreamingAsr), nameof(VibeVoiceStreamingAsrLabel), nameof(VibeVoiceStreamingAsrDescription), nameof(ShowVibeVoiceStreamingSizePicker), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker), nameof(ShowWhisperTurboLanguagePicker))]
+    [NotifyPropertyChangedFor(nameof(IsAsrParakeet), nameof(IsAsrCohere), nameof(IsAsrQwen3Asr), nameof(IsAsrVibeVoice), nameof(IsAsrVibeVoiceStreaming), nameof(IsAsrIndicConformer), nameof(IsAsrWhisperTurbo), nameof(IsAsrGraniteSpeech), nameof(ShowStandardSegmentationOptions), nameof(ShowVibeVoiceBuiltinSegmentation), nameof(ShowDiariZenInSegmentation), nameof(ShowGatedSegmentationHint), nameof(CanUseVibeVoiceAsr), nameof(VibeVoiceAsrLabel), nameof(VibeVoiceAsrDescription), nameof(CanUseVibeVoiceStreamingAsr), nameof(VibeVoiceStreamingOnCpu), nameof(VibeVoiceStreamingAsrLabel), nameof(VibeVoiceStreamingAsrDescription), nameof(ShowVibeVoiceStreamingSizePicker), nameof(ShowCohereLanguagePicker), nameof(ShowQwen3AsrLanguagePicker), nameof(ShowIndicConformerLanguagePicker), nameof(ShowWhisperTurboLanguagePicker))]
     private AsrBackend _selectedAsrBackend;
 
     [ObservableProperty]
@@ -149,60 +149,92 @@ internal partial class SettingsViewModel : ObservableObject
     public bool IsAsrWhisperTurbo   => SelectedAsrBackend == AsrBackend.WhisperTurbo;
     public bool IsAsrGraniteSpeech  => SelectedAsrBackend == AsrBackend.GraniteSpeech;
     public bool CanUseVibeVoiceAsr  => CudaEpWorking;
-    public bool CanUseVibeVoiceStreamingAsr => CudaEpWorking;
+    /// <summary>
+    /// Always selectable. The backend takes its KV cache from host memory when the session is
+    /// not on CUDA, so a machine without a working CUDA provider transcribes correctly — it is
+    /// simply slow. Measured at RTF 12.2 on a 16-thread CPU against 0.20 on an RTX 3090, with
+    /// byte-identical text and speaker labels (Run 35). Gating the option off meant refusing a
+    /// working configuration; the description says what it costs instead.
+    /// </summary>
+    public bool CanUseVibeVoiceStreamingAsr => true;
+
+    /// <summary>Whether this machine will run the streaming backend on the GPU or the CPU.</summary>
+    public bool VibeVoiceStreamingOnCpu => !CudaEpWorking;
 
     public bool IsVibeVoiceStreamingSmall => SelectedVibeVoiceStreamingSize == VibeVoiceStreamingSize.Small1_5B;
     public bool IsVibeVoiceStreamingLarge => SelectedVibeVoiceStreamingSize == VibeVoiceStreamingSize.Large7B;
 
     /// <summary>
-    /// The fixed device-memory cost of each checkpoint: weights plus the working set ONNX
-    /// Runtime needs around them, in GiB. Measured on the published packages (Run 34) at
-    /// 3.19 + 1.39 for the 1.5B and 9.03 + 2.36 for the 7B, rounded up.
+    /// The shape of each published package, as the settings window has to know it before
+    /// anything is downloaded: bytes of weights on disk, the decoder's hidden size, the KV
+    /// geometry, and the export's context ceiling in positions. The memory arithmetic itself
+    /// lives in <see cref="VibeVoiceStreamingBudget"/>, which is what the backend uses on the
+    /// package it has actually loaded — one model, two callers.
     /// </summary>
-    private static double VibeVoiceStreamingFixedGiB(VibeVoiceStreamingSize size) =>
-        size == VibeVoiceStreamingSize.Large7B ? 11.8 : 5.0;
-
-    /// <summary>GiB of KV cache one minute of audio costs: 16 positions a second, fp16.</summary>
-    private static double VibeVoiceStreamingCacheGiBPerMinute(VibeVoiceStreamingSize size) =>
-        60 * 16.0 * (size == VibeVoiceStreamingSize.Large7B ? 57344.0 : 28672.0) / (1 << 30);
+    internal static (long WeightBytes, int HiddenSize, int Layers, int KvHeads, int HeadDim, int Ceiling)
+        VibeVoiceStreamingShape(VibeVoiceStreamingSize size) =>
+            size == VibeVoiceStreamingSize.Large7B
+                ? (9_700_788_736L, 3584, 28, 4, 128, 131072)
+                : (3_421_310_464L, 1536, 28, 2, 128,  65536);
 
     /// <summary>
-    /// Says what this card can actually do with the selected checkpoint. The cache is now sized
-    /// to the recording rather than to the export ceiling (issue #150), so the honest answer is
-    /// not "fits / does not fit" but the length that fits: a 16 GB card runs the 7B fine for an
-    /// hour of audio and cannot run it for two.
+    /// Says what this card can actually do with the selected checkpoint. The cache is sized to
+    /// the recording rather than to the export ceiling (issue #150), so the honest answer is
+    /// not "fits / does not fit" but the length that fits: a 16 GB card runs the 7B for about
+    /// an hour of audio and cannot run it for the full two.
+    ///
+    /// Reads FREE memory, not total. The runtime decides on what is free when the job starts,
+    /// and a card is never entirely yours — the desktop alone is most of a gigabyte. Quoting
+    /// the total overstated exactly the small-card case this warning exists for.
     /// </summary>
     public string VibeVoiceStreamingSizeWarning
     {
         get
         {
-            var (totalMb, _) = HardwareInfo.GetGpuMemoryMb();
-            if (totalMb <= 0) return "";
-
-            double haveGiB  = totalMb / 1024.0;
-            double fixedGiB = VibeVoiceStreamingFixedGiB(SelectedVibeVoiceStreamingSize);
-            if (haveGiB < fixedGiB)
-                return $"This card reports {haveGiB:F1} GB of VRAM; this checkpoint needs about "
-                     + $"{fixedGiB:F1} GB before any audio is cached.";
-
-            // Leave a little for the desktop; a card is never entirely yours.
-            double capMinutes = SelectedVibeVoiceStreamingSize == VibeVoiceStreamingSize.Large7B ? 120 : 68;
-            double fits = (haveGiB - fixedGiB - 0.5)
-                        / VibeVoiceStreamingCacheGiBPerMinute(SelectedVibeVoiceStreamingSize);
-            return fits >= capMinutes
-                ? ""
-                : $"This card reports {haveGiB:F1} GB of VRAM, which fits about {fits:F0} minutes "
-                + $"of audio with this checkpoint rather than the full {capMinutes:F0}.";
+            var (totalMb, freeMb) = HardwareInfo.GetGpuMemoryMb();
+            if (totalMb <= 0 || freeMb <= 0) return "";
+            return VibeVoiceStreamingWarningFor(SelectedVibeVoiceStreamingSize, freeMb * 1024L * 1024L);
         }
     }
 
+    /// <summary>
+    /// The warning itself, given a checkpoint and the free memory to spend on it. Separated from
+    /// the NVML read so it can be tested: the bug this replaced was in the threshold, not the
+    /// arithmetic, and a threshold is only reachable with a particular card in front of you.
+    /// </summary>
+    internal static string VibeVoiceStreamingWarningFor(VibeVoiceStreamingSize size, long freeBytes)
+    {
+        var shape = VibeVoiceStreamingShape(size);
+        double fits = VibeVoiceStreamingBudget.MinutesThatFit(
+            freeBytes, shape.WeightBytes, shape.HiddenSize,
+            VibeVoiceStreamingBudget.KvBytesPerPosition(shape.Layers, shape.KvHeads, shape.HeadDim),
+            shape.Ceiling);
+
+        double freeGiB = freeBytes / (double)(1L << 30);
+        if (fits <= 0)
+        {
+            double fixedGiB = (shape.WeightBytes + VibeVoiceStreamingBudget.WorkingSetBytes(shape.HiddenSize))
+                            / (double)(1L << 30);
+            return $"This card has {freeGiB:F1} GB of VRAM free; this checkpoint needs about "
+                 + $"{fixedGiB:F1} GB before any audio is cached.";
+        }
+
+        // The ceiling the package itself carries, not a rounded figure: quoting "2 hours" here
+        // would call a card short at 130 minutes and stay silent at 125.
+        double capMinutes = VibeVoiceStreamingBudget.CeilingMinutes(shape.Ceiling);
+        return fits >= capMinutes
+            ? ""
+            : $"This card has {freeGiB:F1} GB of VRAM free, which fits about {fits:F0} minutes "
+            + $"of audio with this checkpoint rather than the full {capMinutes:F0}.";
+    }
+
     public bool ShowVibeVoiceStreamingSizeWarning => VibeVoiceStreamingSizeWarning.Length > 0;
-    public string VibeVoiceStreamingAsrLabel => CanUseVibeVoiceStreamingAsr
-        ? "VibeVoice-ASR Streaming"
-        : "VibeVoice-ASR Streaming (Unavailable - CUDA Missing)";
-    public string VibeVoiceStreamingAsrDescription => CanUseVibeVoiceStreamingAsr
-        ? "Chunked ASR with built-in speaker attribution, in 10 languages. Text appears as the recording is decoded rather than after it finishes. Recording length is capped by the checkpoint's context: about 68 minutes (1.5B) or 2 hours (7B)."
-        : "Unavailable because the CUDA execution provider check did not pass.";
+    public string VibeVoiceStreamingAsrLabel => VibeVoiceStreamingOnCpu
+        ? "VibeVoice-ASR Streaming (CPU - very slow)"
+        : "VibeVoice-ASR Streaming";
+    public string VibeVoiceStreamingAsrDescription => VibeVoiceStreamingOnCpu
+        ? "Chunked ASR with built-in speaker attribution, in 10 languages. No CUDA provider was found, so this runs on the CPU: the transcript is the same but decoding takes roughly 12x the length of the recording, so a 10-minute file is about two hours. Use the 1.5B, and prefer another backend for anything long."
+        : "Chunked ASR with built-in speaker attribution, in 10 languages. Text appears as the recording is decoded rather than after it finishes. Recording length is capped by the checkpoint's context: about 68 minutes (1.5B) or 2 hours (7B).";
     public string VibeVoiceAsrLabel => CanUseVibeVoiceAsr ? "VibeVoice-ASR" : "VibeVoice-ASR (Unavailable - CUDA Missing)";
     public string VibeVoiceAsrDescription => CanUseVibeVoiceAsr
         ? "Whole-recording ASR with built-in diarization. Downloads into the vibevoice_asr models folder."
@@ -852,6 +884,7 @@ internal partial class SettingsViewModel : ObservableObject
                 : (HardwareInfo.CudaProbeNote ?? FirstLine(cudaMessage) ?? "");
             OnPropertyChanged(nameof(CanUseVibeVoiceAsr));
             OnPropertyChanged(nameof(CanUseVibeVoiceStreamingAsr));
+            OnPropertyChanged(nameof(VibeVoiceStreamingOnCpu));
             OnPropertyChanged(nameof(VibeVoiceStreamingAsrLabel));
             OnPropertyChanged(nameof(VibeVoiceStreamingAsrDescription));
             OnPropertyChanged(nameof(VibeVoiceAsrLabel));

--- a/src/Vernacula.Base/Vernacula.Base.csproj
+++ b/src/Vernacula.Base/Vernacula.Base.csproj
@@ -55,6 +55,7 @@
        that are deliberately not part of the public API. -->
   <ItemGroup>
     <InternalsVisibleTo Include="Vernacula.Tests" />
+    <InternalsVisibleTo Include="AsrBackendCoverage" />
   </ItemGroup>
 
 </Project>

--- a/src/Vernacula.Base/VibeVoiceStreamingAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceStreamingAsr.cs
@@ -57,13 +57,8 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
     /// <summary>Longest recording this package can transcribe, from its cache ceiling.</summary>
     public double MaxAudioSeconds => _maxKvTokens / PositionsPerSecond;
 
-    /// <summary>
-    /// Cache positions consumed per second of audio. Each hop contributes its frames, the two
-    /// speech markers, the chunk-end token and the text generated for it; only the last varies,
-    /// with speech density. Measured at ~16.0 (Run 14), against a floor of ~9.9 for audio with
-    /// no speech at all.
-    /// </summary>
-    private const double PositionsPerSecond = 16.0;
+    /// <inheritdoc cref="VibeVoiceStreamingBudget.PositionsPerSecond"/>
+    private const double PositionsPerSecond = VibeVoiceStreamingBudget.PositionsPerSecond;
 
     /// <summary>
     /// How much of the estimate to allocate. The estimate is an average and the buffer cannot
@@ -74,25 +69,18 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
     /// </summary>
     private const double KvSafetyFactor = 2.5;
 
-    /// <summary>Prompt, hotwords, and the rounding on the last partial window.</summary>
-    private const int PromptPositionSlack = 512;
+    /// <inheritdoc cref="VibeVoiceStreamingBudget.PromptPositionSlack"/>
+    private const int PromptPositionSlack = VibeVoiceStreamingBudget.PromptPositionSlack;
 
     /// <summary>Never allocate a cache too small to hold the prompt and a few windows.</summary>
     private const int MinKvTokens = 2048;
 
-    /// <summary>
-    /// Device memory one cached position costs: a key and a value, every layer, float16.
-    /// 28 KiB for the 1.5B, 56 KiB for the 7B.
-    /// </summary>
-    public long KvBytesPerPosition => (long)_numLayers * 2 * _numKvHeads * _headDim * 2;
+    /// <inheritdoc cref="VibeVoiceStreamingBudget.KvBytesPerPosition"/>
+    public long KvBytesPerPosition =>
+        VibeVoiceStreamingBudget.KvBytesPerPosition(_numLayers, _numKvHeads, _headDim);
 
-    /// <summary>
-    /// Device memory the run needs beyond the weights and the cache: ONNX Runtime's CUDA arena,
-    /// the encoder's activations for one window, and the logits buffer. Measured against the
-    /// published packages at 1.39 GiB (1.5B) and 2.36 GiB (7B) — Run 34 — so it scales with the
-    /// decoder's hidden size, and this rounds up on both rather than sailing close.
-    /// </summary>
-    public long WorkingSetBytes => (1L << 30) + (long)_hiddenSize * 512 * 1024;
+    /// <inheritdoc cref="VibeVoiceStreamingBudget.WorkingSetBytes"/>
+    public long WorkingSetBytes => VibeVoiceStreamingBudget.WorkingSetBytes(_hiddenSize);
 
     /// <summary>
     /// Cache positions to allocate for a recording of <paramref name="audioSeconds"/>, and the
@@ -107,11 +95,16 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
     /// The estimate is <see cref="PositionsPerSecond"/>, an average; <see cref="KvSafetyFactor"/>
     /// covers speech denser than average, and running out anyway is reported by <see cref="Step"/>.
     /// </summary>
-    private int ChooseKvTokens(double audioSeconds)
+    private int ChooseKvTokens(double audioSeconds, bool onDevice)
     {
-        var (_, freeMb) = HardwareInfo.GetGpuMemoryMb();
+        long freeBytes = 0;
+        if (onDevice)
+        {
+            var (_, freeMb) = HardwareInfo.GetGpuMemoryMb();
+            if (freeMb > 0) freeBytes = freeMb * 1024L * 1024L;
+        }
         return PlanKvTokens(audioSeconds, _maxKvTokens, _fixedKvTokens, KvBytesPerPosition,
-                            WorkingSetBytes, freeMb > 0 ? freeMb * 1024L * 1024L : 0);
+                            WorkingSetBytes, freeBytes);
     }
 
     /// <summary>
@@ -255,28 +248,32 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         int totalChunks = audio.Length == 0 ? 0 : (audio.Length + HopSamples - 1) / HopSamples;
         var chunks = new List<VibeVoiceStreamingChunk>(totalChunks);
 
-        int kvTokens = ChooseKvTokens(audio.Length / (double)SampleRate);
-
-        // The cache must live on the device. Allocating it from OrtAllocator.DefaultInstance
-        // puts it in host memory, and every step then copies the whole buffer both ways --
-        // measured at 9x slower than the Python harness before this was fixed.
+        // The cache belongs on the device when there is one. Allocating it from
+        // OrtAllocator.DefaultInstance puts it in host memory, and a CUDA session then copies
+        // the whole buffer both ways every step -- measured at 9x slower than the Python
+        // harness before this was fixed. On a CPU session host memory is simply where it goes.
         using var cudaMemInfo = new OrtMemoryInfo(OrtMemoryInfo.allocatorCUDA, OrtAllocatorType.DeviceAllocator, 0, OrtMemType.Default);
-        OrtAllocator deviceAlloc;
+        OrtAllocator? cudaAlloc = null;
         try
         {
-            deviceAlloc = new OrtAllocator(_decoder, cudaMemInfo);
+            cudaAlloc = new OrtAllocator(_decoder, cudaMemInfo);
         }
-        catch (OnnxRuntimeException ex)
+        catch (OnnxRuntimeException)
         {
-            // ORT reports this as "No requested allocator available", which says nothing about
-            // the cause. It means the decoder session is not running on CUDA, so there is no
-            // device allocator to take the KV cache from.
-            throw new InvalidOperationException(
-                "VibeVoice-ASR-Streaming needs the CUDA execution provider: the decoder session " +
-                "has no device allocator for its KV cache. Check that CUDA is available and that " +
-                "this build ships the GPU ONNX Runtime.", ex);
+            // "No requested allocator available" — the decoder session is not on CUDA, so there
+            // is no device allocator to take the cache from. Not fatal: the same buffers work in
+            // host memory when the session is on the CPU too, and the cost of that is speed
+            // rather than correctness. Refusing here would have made a GPU the price of entry.
         }
-        using var ownedAlloc = deviceAlloc;
+        using var ownedAlloc = cudaAlloc;
+        OrtAllocator deviceAlloc = cudaAlloc ?? OrtAllocator.DefaultInstance;
+
+        // Sized after the allocator is settled, because the budget depends on where the cache
+        // lands: VRAM is the constraint on the device, and on the host it is not a constraint
+        // worth modelling -- the whole ceiling is 7.0 GiB against system memory measured in
+        // tens of gigabytes.
+        int kvTokens = ChooseKvTokens(audio.Length / (double)SampleRate, onDevice: cudaAlloc is not null);
+
         using var binding    = _decoder.CreateIoBinding();
         using var runOptions = new RunOptions();
         var kvBuffers = CreateSharedKvBuffers(deviceAlloc, kvTokens);

--- a/src/Vernacula.Base/VibeVoiceStreamingBudget.cs
+++ b/src/Vernacula.Base/VibeVoiceStreamingBudget.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace Vernacula.Base;
+
+/// <summary>
+/// The device-memory model for VibeVoice-ASR-Streaming, in one place.
+///
+/// <see cref="VibeVoiceStreamingAsr"/> applies it to the package it has loaded, to decide how
+/// large a KV cache to allocate. The settings window applies it to the published packages'
+/// known shapes, to tell someone what a card will manage before anything is downloaded. Those
+/// two answers have to agree, and they did not while each carried its own copy of the
+/// arithmetic (issue #150 review).
+/// </summary>
+public static class VibeVoiceStreamingBudget
+{
+    /// <summary>
+    /// Cache positions consumed per second of audio. Each hop contributes its frames, the two
+    /// speech markers, the chunk-end token and the text generated for it; only the last varies,
+    /// with speech density. Measured at ~16.0 (Run 14), against a floor of ~9.9 for audio with
+    /// no speech at all.
+    /// </summary>
+    public const double PositionsPerSecond = 16.0;
+
+    /// <summary>
+    /// Positions a run spends before the audio: the prompt, its hotwords, and the rounding on
+    /// the last partial window. Small, but it is the difference between promising a length and
+    /// then refusing it.
+    /// </summary>
+    public const int PromptPositionSlack = 512;
+
+    /// <summary>
+    /// Device memory one cached position costs: a key and a value, every layer, float16.
+    /// 28 KiB for the published 1.5B, 56 KiB for the 7B.
+    /// </summary>
+    public static long KvBytesPerPosition(int numLayers, int numKvHeads, int headDim) =>
+        (long)numLayers * 2 * numKvHeads * headDim * 2;
+
+    /// <summary>
+    /// Device memory a run needs beyond the weights and the cache: ONNX Runtime's CUDA arena,
+    /// the encoder's activations for one window, and the logits buffer. Measured against the
+    /// published packages at 1.39 GiB (1.5B, hidden 1536) and 2.36 GiB (7B, hidden 3584) —
+    /// Run 34 — so it scales with the decoder's hidden size, and this rounds up on both rather
+    /// than sailing close.
+    /// </summary>
+    public static long WorkingSetBytes(int hiddenSize) =>
+        (1L << 30) + (long)hiddenSize * 512 * 1024;
+
+    /// <summary>
+    /// Minutes of audio a run can actually take: the lesser of what
+    /// <paramref name="freeBytes"/> pays for once the weights and working set are covered, and
+    /// what the package's own context ceiling allows. Negative when the model does not fit at
+    /// all, so callers can tell "no room for audio" from "no room".
+    ///
+    /// Both limits are net of <see cref="PromptPositionSlack"/> and rounded down to a whole
+    /// minute, because the planner rounds the other way — it takes the ceiling of the estimate
+    /// for the length it is handed. A figure that used the last position exactly would come
+    /// back refused by one, which is the bug this shape exists to prevent.
+    /// </summary>
+    public static double MinutesThatFit(
+        long freeBytes, long weightBytes, int hiddenSize, long kvBytesPerPosition,
+        int ceilingPositions)
+    {
+        double byMemory = Math.Floor(
+                              (freeBytes - weightBytes - WorkingSetBytes(hiddenSize))
+                              / (double)kvBytesPerPosition)
+                        - PromptPositionSlack;
+        return Math.Floor(Math.Min(byMemory, CeilingPositions(ceilingPositions))
+                          / PositionsPerSecond / 60);
+    }
+
+    /// <summary>Minutes the package's context ceiling allows, whatever the card can hold.</summary>
+    public static double CeilingMinutes(int ceilingPositions) =>
+        Math.Floor(CeilingPositions(ceilingPositions) / PositionsPerSecond / 60);
+
+    private static double CeilingPositions(int ceilingPositions) =>
+        ceilingPositions - PromptPositionSlack;
+}

--- a/tests/AsrBackendCoverage/VibeVoiceStreamingSizeWarningTests.cs
+++ b/tests/AsrBackendCoverage/VibeVoiceStreamingSizeWarningTests.cs
@@ -1,0 +1,106 @@
+using Vernacula.App.Models;
+using Vernacula.App.ViewModels;
+using Vernacula.Base;
+using Xunit;
+
+namespace Vernacula.Tests.AsrBackendCoverage;
+
+/// <summary>
+/// What the size picker promises about a card, against what the runtime will actually do with
+/// it. These two used to be separate pieces of arithmetic with separate constants, and they
+/// disagreed: the warning measured the card by its total VRAM while the runtime measures free,
+/// and it compared against a rounded "2 hours" while the 7B package carries 131,072 positions
+/// — about 136 minutes. A card good for 130 minutes was therefore told it was fine.
+/// </summary>
+public class VibeVoiceStreamingSizeWarningTests
+{
+    private const long GiB = 1L << 30;
+
+    private static string Warn(VibeVoiceStreamingSize size, double freeGiB) =>
+        SettingsViewModel.VibeVoiceStreamingWarningFor(size, (long)(freeGiB * GiB));
+
+    private static long KvPerPosition(VibeVoiceStreamingSize size)
+    {
+        var s = SettingsViewModel.VibeVoiceStreamingShape(size);
+        return VibeVoiceStreamingBudget.KvBytesPerPosition(s.Layers, s.KvHeads, s.HeadDim);
+    }
+
+    [Fact]
+    public void ThePublishedShapesCostWhatTheDocumentationSays()
+    {
+        Assert.Equal(28 * 1024, KvPerPosition(VibeVoiceStreamingSize.Small1_5B));
+        Assert.Equal(56 * 1024, KvPerPosition(VibeVoiceStreamingSize.Large7B));
+    }
+
+    [Fact]
+    public void ACardShortOfTheFullContextIsWarnedRatherThanReassured()
+    {
+        // The reported machine: 16 GB, most of it free, running the 7B.
+        string w = Warn(VibeVoiceStreamingSize.Large7B, 15.3);
+        Assert.Contains("rather than the full", w);
+        Assert.Contains("136", w);   // the package's own ceiling, not a rounded "120"
+    }
+
+    [Fact]
+    public void ACardJustShortOfTheCeilingIsStillWarned()
+    {
+        // The regression the old threshold hid: between the rounded 120 it compared against and
+        // the package's real 137 it said nothing at all.
+        var s = SettingsViewModel.VibeVoiceStreamingShape(VibeVoiceStreamingSize.Large7B);
+        long free = s.WeightBytes + VibeVoiceStreamingBudget.WorkingSetBytes(s.HiddenSize)
+                  + (long)(130 * 60 * 16 + VibeVoiceStreamingBudget.PromptPositionSlack)
+                    * KvPerPosition(VibeVoiceStreamingSize.Large7B);
+        string w = Warn(VibeVoiceStreamingSize.Large7B, free / (double)GiB);
+        Assert.Contains("rather than the full 136", w);
+        Assert.Contains("130 minutes", w);
+    }
+
+    [Fact]
+    public void ACardWithRoomForTheWholeContextSaysNothing()
+    {
+        Assert.Equal("", Warn(VibeVoiceStreamingSize.Small1_5B, 22.5));
+        Assert.Equal("", Warn(VibeVoiceStreamingSize.Large7B, 21.0));
+    }
+
+    [Fact]
+    public void ACardThatCannotHoldTheModelSaysSoRatherThanQuotingZeroMinutes()
+    {
+        string w = Warn(VibeVoiceStreamingSize.Large7B, 8.0);
+        Assert.Contains("before any audio is cached", w);
+        Assert.DoesNotContain("0 minutes", w);
+    }
+
+    [Fact]
+    public void TheWarningAgreesWithWhatTheRuntimeWouldAllocate()
+    {
+        // The whole point of sharing the budget: if the picker says an hour fits, planning an
+        // hour must not come back refused.
+        //
+        // Swept rather than sampled. The picker rounds down and the planner rounds up, so the
+        // two only disagree at the boundary — a single card size passes by luck, and the first
+        // version of this test did exactly that.
+        foreach (var size in new[] { VibeVoiceStreamingSize.Small1_5B, VibeVoiceStreamingSize.Large7B })
+        {
+            var s = SettingsViewModel.VibeVoiceStreamingShape(size);
+            long perPos = KvPerPosition(size);
+            long floor  = s.WeightBytes + VibeVoiceStreamingBudget.WorkingSetBytes(s.HiddenSize);
+
+            for (long extraMiB = 0; extraMiB <= 8192; extraMiB += 7)   // a prime-ish step, ~1170 cards
+            {
+                long free = floor + extraMiB * 1024 * 1024;
+                double fits = VibeVoiceStreamingBudget.MinutesThatFit(
+                    free, s.WeightBytes, s.HiddenSize, perPos, s.Ceiling);
+                if (fits <= 0) continue;
+
+                // The planner sees the card after the weights are resident.
+                int planned = VibeVoiceStreamingAsr.PlanKvTokens(
+                    fits * 60, s.Ceiling, 0, perPos,
+                    VibeVoiceStreamingBudget.WorkingSetBytes(s.HiddenSize), free - s.WeightBytes);
+
+                Assert.True(planned >= fits * 60 * VibeVoiceStreamingBudget.PositionsPerSecond,
+                    $"{size} with {free / (double)GiB:F2} GiB free: picker promised {fits:F0} " +
+                    $"minutes, planner allocated {planned} positions");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #151. Relates to #149 and #150; no closing keyword, both stay open for the reporter.

## CPU fallback was a choice, not a constraint

`CreateSharedKvBuffers` takes its tensors from an allocator, and the only reason that allocator had to be a CUDA one is that a CUDA session copies a host-allocated cache both ways on every step (Run 12, measured at 9x). On a session already on the CPU, host memory is simply where the cache belongs — so the refusal was mine, not the model's.

The CUDA allocator is now attempted and its absence tolerated, and the cache sizing moved after that decision: free VRAM constrains a cache that lands on the device, and is not a constraint worth modelling for one that lands in host memory.

Measured on the published 1.5B, 30 seconds of two-speaker audio, same package both ways:

| build | RTF | text | speaker labels |
|---|---|---|---|
| EP=Cuda, RTX 3090 | 0.198 | — | 9 segments |
| EP=Cpu, 16 threads | 12.23 | identical | identical |

`com.microsoft::GroupQueryAttention` has a working CPU kernel for this graph's float16 tensors, which was the open question; nothing in the export had to change.

RTF 12 is not a substitute for a GPU — a ten-minute file is about two hours — but the previous behaviour refused a configuration that works. The settings window now offers the backend on any machine, labelled **"VibeVoice-ASR Streaming (CPU — very slow)"** with the cost stated in the description, instead of greyed out as "Unavailable - CUDA Missing". That label also answers #149's underlying question directly: it says which way the run will go without opening Task Manager.

GPU regression-checked — identical transcript at RTF 0.194 against 0.196 before.

## The picker disagreed with the planner three ways

Reviewing #151's own code:

1. **Rounded ceiling.** The 7B warned only below 120 minutes; the package carries 131,072 positions ≈ 136. A card good for 125 minutes was told it was fine.
2. **Total VRAM, not free.** The planner decides on free memory. Quoting the total overstated capacity by a gigabyte or more — in exactly the small-card case the warning exists for.
3. **It could promise a length the planner then refuses.** Two independent causes: it ignored the prompt slack while rounding the opposite way to the planner, and it ignored the context ceiling entirely (so a big card was promised 68 minutes of 1.5B whose ceiling allows 67.7).

The arithmetic now lives in `VibeVoiceStreamingBudget`, which the backend applies to the package it has loaded and the settings window applies to the published packages' known shapes — one model, two callers, instead of two copies that had to agree and did not.

## Tests

`VibeVoiceStreamingSizeWarningTests`, 6 cases, including one that runs the picker's own answer back through `PlanKvTokens`. It sweeps ~1,170 card sizes per checkpoint rather than sampling one: the first version checked a single size, passed with either mitigation removed, and was luck rather than coverage. Negative-checked — removing the whole-minute floor fails it, and so does removing the prompt slack, independently. Reverting the ceiling fix fails two others.

Full suite green: 40 / 178 / 183 / 23.

`docs/dev/vibevoice_asr_streaming_investigation.md`, Run 35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq