### PR TITLE
perf(ort-cache): inline .onnx tier beats the .ort fallback for subgraph graphs

### DIFF
--- a/docs/ort_loop_cache_investigation.md
+++ b/docs/ort_loop_cache_investigation.md
@@ -119,3 +119,289 @@ for normal graphs and uses `.ort` only where it has to. The sentinel
 infrastructure built in PR #58 is still there as a third tier; it
 has not been observed to trigger and probably never will for our
 current graphs, but it's cheap defense-in-depth.
+
+## Run 4 — 2026-09-08 09:07 — Upstream re-verification (issue #60)
+
+Question: is the ORT bug PR #59 worked around still live upstream, and is
+the root cause in issue #56/#60 stated correctly? Cloned upstream ORT to
+`~/Programming/onnxruntime` (shallow, HEAD `bb331b7`) and built a probe
+matrix against ORT 1.23.2 / 1.24.4 / 1.29.0 (`onnxruntime-gpu` wheels in
+`/mnt/data/ort-loop-repro/venv-gpu-*`).
+
+First attempt reproduced **nothing**. The real
+`conditional_decoder_loop.onnx` round-tripped cleanly:
+
+| ORT | EP | `.onnx` reload |
+|---|---|---|
+| 1.24.4 | CPU | OK (4.6 s) |
+| 1.23.2 | CUDA | OK (3.3 s) |
+
+That directly contradicts Run 1, which reported RELOAD-FAIL at every opt
+level on 1.23.2. Two synthetic Loop graphs (body-owned initializers;
+body capturing outer-scope initializers by name, the shape
+`merge_cond_decoder_loop.py` actually emits) also round-tripped fine on
+1.29.0.
+
+Negative result worth keeping: **the Loop op alone does not trigger the
+bug.** Neither does the CUDA EP, nor the opt level, nor outer-scope
+capture. Run 1's "bug is in the `.onnx` writer" conclusion was reached
+from a probe that didn't isolate the trigger.
+
+## Run 5 — 2026-09-08 09:09 — The actual trigger: external-initializer sidecar
+
+The probe was missing what `OrtSessionBuilder.CreateCachedSession`
+actually sets on the write pass:
+
+```
+session.optimized_model_external_initializers_file_name  = <cache>.onnx_data
+session.optimized_model_external_initializers_min_size_in_bytes = 1048576
+```
+
+Adding those two entries reproduces it verbatim, at every opt level:
+
+```
+INVALID_GRAPH : ... In Node, ("", Loop, "", -1) : ... ,
+Error t_now_1d_axes initializer name is not unique
+```
+
+| ORT | EP | ext-init off | ext-init on |
+|---|---|---|---|
+| 1.23.2 | CUDA | OK | **RELOAD-FAIL** |
+| 1.24.4 | CUDA | OK | **RELOAD-FAIL** |
+| 1.29.0 | CUDA | OK | **RELOAD-FAIL** |
+| 1.29.0 | CPU  | OK | **RELOAD-FAIL** |
+
+**Still live on 1.29.0, the current release** — which is also the version
+`Directory.Build.props` pins for the app, so the `.use-ort` sentinel sitting
+in `/mnt/data/models/chatterbox_export` is current, not stale.
+
+The bug is EP-independent (CPU reproduces) and opt-level-independent, but
+it needs the external-initializer writer. The `.onnx` serializer per se is
+fine.
+
+## Run 6 — 2026-09-08 09:10 — Minimal reproducer
+
+`/mnt/data/ort-loop-repro/make_minimal_extinit.py` builds a ~4 MB graph
+with the two features that matter:
+
+- a Loop body owning a **small** initializer (below the 1 MB threshold, so
+  it stays inline on write) — mirrors `t_now_1d_axes`, the axes input of
+  an Unsqueeze in the real body
+- an outer initializer **above** the threshold, which is what makes ORT
+  take the external-initializer path at all
+
+Fails identically on 1.29.0 / CPU. So the upstream report needs no 575 MB
+attachment and no GPU — a self-contained script is enough.
+
+## Run 7 — 2026-09-08 09:10 — Mechanism: duplication is *within* the body
+
+Dumped the initializer lists of ORT's own output:
+
+```
+outer initializers:            ['big_w', 'trip_count_const', 'loop_cond_init']
+body of the_loop initializers: ['t_now_1d_axes', 'body_bias',
+                                't_now_1d_axes', 'body_bias']
+```
+
+Every body initializer is written **twice into the same body subgraph**.
+
+This corrects issue #56's stated root cause ("these end up in *both* the
+outer graph's initializer list AND the body subgraph's"). Nothing is
+hoisted to the outer scope — the body list is simply appended to without
+being cleared first. The renaming and Constant-node workarounds tried in
+#56 could never have helped: any body-scope initializer duplicates.
+
+## Run 8 — 2026-09-08 09:11 — Located the upstream defect
+
+`onnxruntime/core/graph/graph.cc` has two sibling serializers that walk
+subgraphs the same way. The custom-handler one clears first:
+
+```cpp
+// ToGraphProtoWithCustomInitializerHandlingImpl, ~line 5390
+// Clear pre-existing initializers from the subgraph proto. The subgraph
+// proto was populated by Node::ToProto -> Graph::ToGraphProto() const,
+// which already inlined in-memory data. The recursive Impl call below
+// will re-add all initializers via the custom handler, so we must clear
+// to avoid duplicates.
+subgraph_proto->clear_initializer();
+subgraph_proto->clear_sparse_initializer();
+```
+
+`AddExternalInitializersToGraphProtoImpl` (~line 5191) has the identical
+loop and **no clear** before recursing. The subgraph proto arrives already
+populated by `Node::ToProto`, then the recursive call appends the same
+initializers again.
+
+So the fix upstream looks like the same two `clear_*` calls in the
+external-initializer path — the codebase already documents why they're
+needed a hundred lines further down.
+
+**Implications for us:**
+- The `.ort` fallback shipped in PR #59 stays correct and stays necessary.
+- A cheaper workaround now exists that we didn't know about: writing the
+  `.onnx` cache *without* the external-initializer entries round-trips
+  fine. Only worth taking for graphs that fit under protobuf's 2 GB limit
+  — which `conditional_decoder_loop` (575 MB) does. Worth measuring
+  against the `.ort` path's load time before changing anything.
+- Issue #60's draft upstream body needs rewriting: its affected-versions
+  line, its reproducer, and its root-cause paragraph are all wrong in
+  ways that would get the report bounced.
+
+## Run 9 — 2026-09-08 09:14 — Blast radius: which graphs actually fell back
+
+Swept `/mnt/data/models` for the sentinels the layered cache writes:
+
+```
+chatterbox_export/conditional_decoder_loop.opt.cuda.b21b9e70895b.use-ort
+nfa_ctc_onnx/nemo128.opt.cuda.df335d933882.use-ort   (May 17)
+nfa_ctc_onnx/nemo128.opt.cuda.912d0b9335e7.use-ort   (Sep 7)
+```
+
+No `.cache-disabled` anywhere — the third tier still has never fired.
+
+**`nemo128.onnx` is a second affected graph, and nobody noticed.** It's the
+NeMo log-mel preprocessor in the NFA CTC bundle (and the same op contract
+the Parakeet export uses). Its failure names a different op:
+
+```
+In Node, ("/If", If, "", -1) : ... , Error /Constant_34_output_0
+initializer name is not unique
+```
+
+Two corrections to the mental model from that:
+
+1. **It isn't a `Loop` bug — it's a subgraph bug.** `If` branches duplicate
+   the same way. Any control-flow op with a body qualifies.
+2. `nemo128.onnx`'s `If` branches ship with **empty** initializer lists.
+   The duplicated `/Constant_34_output_0` is a constant ORT itself folded
+   into the branch, and it happens at `DISABLE_ALL` — so ORT inserts
+   branch-scope constants even with optimization nominally off. That's the
+   detail the `merge_cond_decoder_loop.py` docstring guessed at back in May
+   and couldn't confirm.
+
+Issue #60's title and draft body both need to say "subgraph", not "Loop".
+
+## Run 10 — 2026-09-08 09:15 — The perf path that was never measured
+
+With the trigger known, there's a third cache disposition the earlier runs
+never tried: write `.onnx` but **without** the external-initializer session
+entries. Run 1 ruled out `.onnx` wholesale, so this was never on the table.
+
+`conditional_decoder_loop.onnx`, ORT 1.29.0 / CUDA, best of 3:
+
+| disposition | write | warm load | cache size |
+|---|---:|---:|---:|
+| miss (no cache) | — | 1906 ms | — |
+| `.ort` (**ships today**, PR #59) | 3024 ms | 1550 ms | 577 MB |
+| `.onnx`, no ext-init (**untested until now**) | 1980 ms | **1303 ms** | **168 MB** |
+
+**247 ms faster per warm load than the shipping fallback, and 409 MB
+smaller on disk.** The size collapse is the mechanism: without the
+ext-init entries ORT leaves the optimized graph pointing at the *source*
+model's existing `.onnx_data` sidecar rather than copying 577 MB of
+weights into a new file, so the warm load mmaps weights it was going to
+mmap anyway. `.ort` embeds everything inline, which is exactly the
+lazy-load loss Run 2 measured on the LM graph.
+
+`nemo128.onnx` for completeness: miss 16 ms, `.ort` warm 11 ms, `.onnx`
+warm 10 ms. Real but worthless — a 1 ms graph. The fallback costs nothing
+there and only the Chatterbox graph is worth changing anything for.
+
+Caveat: this measures **load**, not numerical correctness. A
+`ChatterboxSmoke` parity run against the no-ext-init cache is required
+before this ships.
+
+**Why ext-init can't simply be dropped globally:** `language_model.onnx`
+has a 6.1 GB weight sidecar and its optimized cache writes a 2.0 GB one.
+Without ext-init that write hits protobuf's 2 GB message limit. The
+entries are load-bearing for large graphs and merely harmful for
+subgraph-bearing ones.
+
+Suggested shape, if we act on this: insert a tier, so the ladder becomes
+`.onnx` + ext-init → `.onnx` no-ext-init → `.ort` → sentinel. The
+no-ext-init tier catches every subgraph-bearing graph under 2 GB (both
+known cases), and a >2 GB subgraph-bearing graph would fail its write and
+fall through to `.ort` as today.
+
+## Run 11 — 2026-09-08 09:24 — Implementation: inline `.onnx` tier
+
+Added a third rung to `OrtSessionBuilder`'s ladder, between the primary
+and `.ort`: same `.onnx` format, written *without* the two
+external-initializer session entries, marked by a `.no-ext-init` hint.
+
+```
+.onnx + sidecar  →  .onnx inline  →  .ort  →  .cache-disabled
+```
+
+Two safety properties the new rung needs, both implemented:
+
+- **Write can fail on its own terms.** Without the sidecar, a graph whose
+  optimized initializers exceed protobuf's 2 GB message limit can't
+  serialize at all — `language_model.onnx` writes a 2.0 GB sidecar and is
+  exactly that case. The inline write is wrapped so a failure escalates to
+  `.ort` instead of surfacing a cache-write failure as a model-load
+  failure. (`language_model` never reaches the tier — it round-trips fine
+  on tier 1 — but a future >2 GB subgraph-bearing graph would.)
+- **Legacy hint migration.** A `.use-ort` with no `.no-ext-init` beside it
+  was written by the old two-tier ladder. Retried once on the inline tier,
+  costing one cache miss; the hint left behind stops it repeating. Without
+  this, every machine that ran the old code keeps its Chatterbox graph on
+  the slow tier forever, since cache keys only invalidate on ORT upgrade
+  or model change.
+
+Convergence, from a cleared cache (ChatterboxSmoke, CUDA):
+
+| run | what happened | cond-decoder load |
+|---|---|---|
+| 1 | write `.onnx` + sidecar | 2143 ms (miss) |
+| 2 | reload fails → `[cache-format]` → rewrite inline, same call | 2153 ms (miss) |
+| 3+ | **cache HIT** | **1431 ms** |
+
+Seeded a legacy `.use-ort` and confirmed the migration path separately:
+run 1 logs the retry and misses (2012 ms), run 2 HITs (1508 ms).
+
+Steady state, all four graphs — no regression on the three that never
+left tier 1:
+
+```
+speech_encoder.onnx           1057 ms  cache=HIT
+embed_tokens.onnx               30 ms  cache=HIT
+language_model.onnx            408 ms  cache=HIT
+conditional_decoder_loop.onnx 1395 ms  cache=HIT
+Loaded sessions in 2896 ms total
+```
+
+vs **1776 ms** for the same graph on `.ort` in Run 3. Cache on disk for
+that graph: **168 MB, down from 577 MB.**
+
+## Run 12 — 2026-09-08 09:29 — Parity, and the non-determinism floor
+
+Load time proves nothing about numerics, so: 3 runs on the inline cache
+vs 3 cache-bypassed baselines, same voice and text, comparing the output
+waveforms.
+
+First attempt looked alarming — every pair differed, including two
+cache-bypassed runs compared against *each other*. That's the answer,
+not the problem: this pipeline is not bitwise reproducible run to run
+(CUDA non-determinism, and `ScatterND with reduction=='none'` warns about
+exactly this). So the comparison has to be against the floor, not zero.
+
+| comparison | max abs diff | mean abs diff |
+|---|---|---|
+| no-cache vs no-cache (floor) | 7.265e-02 | 6.624e-04 |
+| inline-HIT vs inline-HIT (floor) | 7.395e-02 | 7.757e-04 |
+| **inline-HIT vs no-cache** | 9.249e-02 | 8.574e-04 |
+
+Cross-configuration difference sits in the same order as the pipeline's
+own run-to-run spread, and waveform RMS agrees to 5 significant figures
+(0.046366 / 0.046361 / 0.046363). **The inline cache introduces no
+deviation beyond noise the pipeline already has.** It is not a proof of
+bitwise equivalence, and no such proof is available here.
+
+`dotnet test tests/Vernacula.Tests`: 40/40 pass.
+
+**Status:** shipped in the working tree, not committed. Issue #60 stays
+open — it's about reporting the bug upstream, and the upstream defect
+(missing `clear_initializer()` in `AddExternalInitializersToGraphProtoImpl`,
+Run 8) is untouched by any of this. What changed is that we no longer pay
+for it.

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -130,20 +130,34 @@ public static class OrtSessionBuilder
     /// file, skip optimization (<c>ORT_DISABLE_ALL</c>), and load directly —
     /// typically 5–10× faster for large graphs.
     ///
-    /// <b>Layered cache format.</b> Three states per cache key, advanced by
+    /// <b>Layered cache format.</b> Four states per cache key, advanced by
     /// observed round-trip behavior:
     /// <list type="number">
-    ///   <item><description><b>.onnx</b> (primary). Fast: ORT can lazy-load
-    ///     weights from a <c>_data</c> external-initializer sidecar. Works
-    ///     for almost every graph.</description></item>
-    ///   <item><description><b>.ort</b> (fallback, marked by a
-    ///     <c>.use-ort</c> hint file). Used when the <c>.onnx</c> writer
-    ///     mishandles the graph — currently any graph containing a Loop
-    ///     subgraph (issue #56 — the <c>.onnx</c> serializer duplicates
-    ///     body-scope initializers into the outer scope). The <c>.ort</c>
-    ///     binary writer encodes subgraphs faithfully and round-trips at
-    ///     every opt level, but embeds all initializers inline so loads
-    ///     are slower for large graphs. Only used when needed.</description></item>
+    ///   <item><description><b>.onnx + sidecar</b> (primary). Fast: ORT can
+    ///     lazy-load weights from a <c>_data</c> external-initializer
+    ///     sidecar. Works for almost every graph.</description></item>
+    ///   <item><description><b>.onnx inline</b> (marked by a
+    ///     <c>.no-ext-init</c> hint file). Same format, written without the
+    ///     external-initializer session entries. Used when the primary tier
+    ///     can't round-trip, which happens for any graph carrying a
+    ///     control-flow subgraph (<c>Loop</c>, <c>If</c>): ORT's
+    ///     external-initializer writer appends a subgraph's initializers to
+    ///     that subgraph a second time instead of clearing first, and then
+    ///     rejects its own output with "<c>&lt;name&gt; initializer name is
+    ///     not unique</c>" (issue #60, still open upstream as of ORT 1.29).
+    ///     Dropping the sidecar entries sidesteps it. Counter-intuitively
+    ///     this is also the *fastest* tier for a graph whose source already
+    ///     has a <c>_data</c> sidecar: the cache file keeps pointing at the
+    ///     source's weights instead of copying them, so it's both smaller on
+    ///     disk and quicker to load than tier 1 would have been.</description></item>
+    ///   <item><description><b>.ort</b> (marked by a <c>.use-ort</c> hint
+    ///     file). ORT's binary format — a different serializer that
+    ///     round-trips at every opt level. Reached either when the inline
+    ///     tier also fails to round-trip, or when its write fails outright,
+    ///     which is what a >2 GB graph does once the sidecar is gone
+    ///     (protobuf message limit). Embeds all initializers inline, so
+    ///     loads are slower for large graphs. Only used when
+    ///     needed.</description></item>
     ///   <item><description><b>No cache</b> (last resort, marked by a
     ///     <c>.cache-disabled</c> sentinel). Used when even <c>.ort</c>
     ///     can't round-trip. Stops the broken write→fail→delete cycle.
@@ -152,10 +166,10 @@ public static class OrtSessionBuilder
     /// </list>
     ///
     /// Convergence costs one extra cache miss per state transition: a
-    /// Loop-bearing graph takes 2 runs to reach a steady-state cache hit
-    /// (run 1: write .onnx → run 2: .onnx reload fails, escalate to .ort
-    /// hint, write .ort in the same call → run 3+: .ort cache HIT).
-    /// Most graphs stay on the .onnx path forever.
+    /// subgraph-bearing graph takes 2 runs to reach a steady-state cache hit
+    /// (run 1: write .onnx+sidecar → run 2: reload fails, escalate to the
+    /// inline hint and rewrite .onnx in the same call → run 3+: cache HIT).
+    /// Most graphs stay on tier 1 forever.
     ///
     /// Cache key (in the path stem) embeds EP, ORT version, and source-file
     /// mtime+size, so source changes or ORT upgrades automatically invalidate
@@ -216,12 +230,45 @@ public static class OrtSessionBuilder
         // (if any) exists alongside the actual cache file(s).
         string cachePathOnnx = cacheBase + ".onnx";   // primary cache (with _data sidecar)
         string cacheDataPath = cachePathOnnx + "_data";
-        string cachePathOrt = cacheBase + ".ort";     // fallback for Loop-bearing graphs
-        string useOrtHintPath = cacheBase + ".use-ort";       // ".onnx round-trip failed, escalate to .ort"
+        string cachePathOrt = cacheBase + ".ort";     // last-resort fallback for subgraph-bearing graphs
+        string noExtInitHintPath = cacheBase + ".no-ext-init"; // ".onnx+sidecar round-trip failed, write .onnx inline"
+        string useOrtHintPath = cacheBase + ".use-ort";       // ".onnx round-trip failed both ways, escalate to .ort"
         string cacheDisabledPath = cacheBase + ".cache-disabled"; // "both formats failed, skip caching"
 
         bool cacheDisabled = !bypassCache && File.Exists(cacheDisabledPath);
         bool useOrtFormat = !bypassCache && !cacheDisabled && File.Exists(useOrtHintPath);
+        // .use-ort wins if both hints are somehow present — it's the later
+        // (more conservative) state in the escalation order.
+        bool noExtInit = !bypassCache && !cacheDisabled && !useOrtFormat
+                         && File.Exists(noExtInitHintPath);
+
+        // One-time migration for caches written before issue #60 was
+        // understood. A .use-ort hint with no .no-ext-init beside it was
+        // written by the old two-tier ladder, which jumped straight to .ort on
+        // a failed .onnx round-trip. We now know the sidecar is the trigger and
+        // that the inline tier is both faster and smaller, so retry it once.
+        // Costs one cache miss. A graph that genuinely needs .ort re-escalates
+        // on its own — and the .no-ext-init hint left behind stops this from
+        // firing a second time.
+        if (useOrtFormat && !File.Exists(noExtInitHintPath))
+        {
+            try
+            {
+                File.WriteAllText(noExtInitHintPath, "");
+                File.Delete(useOrtHintPath);
+                useOrtFormat = false;
+                noExtInit = true;
+                try { if (File.Exists(cachePathOrt)) File.Delete(cachePathOrt); } catch { /* best-effort */ }
+                Console.WriteLine(
+                    $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
+                    "retrying inline .onnx in place of the .ort fallback (see issue #60); one cache miss to converge.");
+            }
+            catch
+            {
+                // Couldn't rewrite the hints — leave the .ort path exactly as
+                // it was rather than half-migrating.
+            }
+        }
 
         if (cacheDisabled)
         {
@@ -264,48 +311,103 @@ public static class OrtSessionBuilder
                     try { File.WriteAllText(cacheDisabledPath, ""); } catch { /* best-effort */ }
                     cacheDisabled = true;
                 }
-                else
+                else if (noExtInit)
                 {
-                    // .onnx round-trip failed; escalate to .ort fallback.
-                    // useOrtFormat=true makes the fall-through cache-write
-                    // path emit .ort this run — so by the end of *this* call
-                    // the .ort file is on disk, and the very next call sees
-                    // a cache HIT instead of having to repeat the cycle.
+                    // Inline .onnx ALSO failed to round-trip; escalate to .ort.
+                    // Not observed for any graph we ship — the inline tier
+                    // fixes both known cases — but the rung exists so a new
+                    // graph with some third serializer defect still ends up
+                    // cached rather than re-optimized on every load.
                     Console.WriteLine(
                         $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
-                        ".onnx round-trip failed (likely a Loop-subgraph graph); switching to .ort for this model (see issue #56).");
+                        "inline .onnx round-trip ALSO failed; switching to .ort for this model (see issue #60).");
                     try { File.Delete(cachePathOnnx); } catch { /* best-effort */ }
-                    try { File.Delete(cacheDataPath); } catch { /* best-effort */ }
                     try { File.WriteAllText(useOrtHintPath, ""); } catch { /* best-effort */ }
                     useOrtFormat = true;
+                }
+                else
+                {
+                    // .onnx + external-initializer sidecar failed to round-trip.
+                    // That combination is the actual ORT bug (issue #60): the
+                    // external-initializer writer appends a subgraph's
+                    // initializers to that subgraph a second time instead of
+                    // clearing first, so ORT rejects its own output with
+                    // "<name> initializer name is not unique". Dropping just
+                    // the sidecar entries fixes it — and is *faster* than the
+                    // .ort fallback, because the inline graph keeps pointing at
+                    // the source model's existing _data sidecar instead of
+                    // copying every weight into the cache file.
+                    //
+                    // noExtInit=true makes the fall-through cache-write path
+                    // re-emit .onnx inline this run — so by the end of *this*
+                    // call the usable cache is on disk and the next call HITs.
+                    Console.WriteLine(
+                        $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
+                        ".onnx round-trip failed (subgraph-bearing graph); rewriting without the external-initializer sidecar (see issue #60).");
+                    try { File.Delete(cachePathOnnx); } catch { /* best-effort */ }
+                    try { File.Delete(cacheDataPath); } catch { /* best-effort */ }
+                    try { File.WriteAllText(noExtInitHintPath, ""); } catch { /* best-effort */ }
+                    noExtInit = true;
                 }
             }
         }
 
         // Cache miss (or bypass, or this-model-disabled): load source,
         // optimize, optionally save the result for next time.
-        var opts = Create(ep, optLevel, enableProfiling: false, out var freshUsedCuda, disableTf32);
-        usedCuda = freshUsedCuda;
-        if (!bypassCache && !cacheDisabled)
+        SessionOptions BuildWriteOptions(out bool cudaUsed)
         {
-            opts.OptimizedModelFilePath = useOrtFormat ? cachePathOrt : cachePathOnnx;
+            var o = Create(ep, optLevel, enableProfiling: false, out cudaUsed, disableTf32);
+            if (bypassCache || cacheDisabled)
+                return o;
+            o.OptimizedModelFilePath = useOrtFormat ? cachePathOrt : cachePathOnnx;
             if (useOrtFormat)
             {
                 // .ort embeds all initializers inline; no _data sidecar.
-                opts.AddSessionConfigEntry("session.save_model_format", "ORT");
+                o.AddSessionConfigEntry("session.save_model_format", "ORT");
             }
-            else
+            else if (!noExtInit)
             {
                 // For >2GB graphs, force the optimized weights to an external-data
                 // sidecar; otherwise the serializer hits protobuf's 2GB limit.
-                opts.AddSessionConfigEntry(
+                // Skipped on the inline tier — this sidecar is what trips the
+                // ORT subgraph-initializer bug (issue #60).
+                o.AddSessionConfigEntry(
                     "session.optimized_model_external_initializers_file_name",
                     Path.GetFileName(cacheDataPath));
-                opts.AddSessionConfigEntry(
+                o.AddSessionConfigEntry(
                     "session.optimized_model_external_initializers_min_size_in_bytes",
                     externalInitializersMinBytes.ToString());
             }
+            return o;
         }
+
+        if (noExtInit && !useOrtFormat)
+        {
+            // The inline tier is the one write that can fail on its own terms:
+            // without the sidecar, a graph whose optimized initializers exceed
+            // protobuf's 2 GB message limit can't serialize at all. Catch that
+            // and drop to .ort rather than surfacing a cache-write failure as a
+            // model-load failure.
+            var inlineOpts = BuildWriteOptions(out var inlineUsedCuda);
+            try
+            {
+                usedCuda = inlineUsedCuda;
+                return new InferenceSession(modelPath, inlineOpts);
+            }
+            catch (Exception ex)
+            {
+                inlineOpts.Dispose();
+                Console.WriteLine(
+                    $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
+                    $"inline .onnx write failed ({ex.GetType().Name}); falling back to .ort for this model (see issue #60).");
+                try { File.Delete(cachePathOnnx); } catch { /* best-effort */ }
+                try { File.WriteAllText(useOrtHintPath, ""); } catch { /* best-effort */ }
+                useOrtFormat = true;
+            }
+        }
+
+        var opts = BuildWriteOptions(out var freshUsedCuda);
+        usedCuda = freshUsedCuda;
         return new InferenceSession(modelPath, opts);
     }
 

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -225,7 +225,7 @@ public static class OrtSessionBuilder
 
         bool bypassCache = Environment.GetEnvironmentVariable("VERNACULA_ORT_NO_CACHE") == "1";
         string cacheBase = bypassCache ? "" : ComputeCacheBasePath(modelPath, ep, optLevel);
-        // All cache-key-derived paths. The five files form a small state
+        // All cache-key-derived paths. The six files form a small state
         // machine; the per-key disposition is encoded by which marker
         // (if any) exists alongside the actual cache file(s).
         string cachePathOnnx = cacheBase + ".onnx";   // primary cache (with _data sidecar)
@@ -250,23 +250,35 @@ public static class OrtSessionBuilder
         // Costs one cache miss. A graph that genuinely needs .ort re-escalates
         // on its own — and the .no-ext-init hint left behind stops this from
         // firing a second time.
-        if (useOrtFormat && !File.Exists(noExtInitHintPath))
+        // A .cache-disabled key from that era is migrated too: it means both
+        // old tiers failed, and the inline tier — which neither of them was —
+        // may well work. If it doesn't, the ladder walks the key straight back
+        // to disabled on its own.
+        if ((useOrtFormat || cacheDisabled) && !bypassCache && !File.Exists(noExtInitHintPath))
         {
             try
             {
+                // Order matters: clear the old markers BEFORE writing the new
+                // one. If a delete throws (locked file, EACCES) we're left
+                // with no hints at all, which replays the ladder from tier 1
+                // next run. Writing .no-ext-init first and then failing the
+                // delete would strand the key on .ort permanently, since the
+                // guard above would never be true again.
+                if (File.Exists(useOrtHintPath)) File.Delete(useOrtHintPath);
+                if (File.Exists(cacheDisabledPath)) File.Delete(cacheDisabledPath);
                 File.WriteAllText(noExtInitHintPath, "");
-                File.Delete(useOrtHintPath);
                 useOrtFormat = false;
+                cacheDisabled = false;
                 noExtInit = true;
                 try { if (File.Exists(cachePathOrt)) File.Delete(cachePathOrt); } catch { /* best-effort */ }
                 Console.WriteLine(
                     $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
-                    "retrying inline .onnx in place of the .ort fallback (see issue #60); one cache miss to converge.");
+                    "retrying inline .onnx in place of the older fallback (see issue #60); one cache miss to converge.");
             }
             catch
             {
-                // Couldn't rewrite the hints — leave the .ort path exactly as
-                // it was rather than half-migrating.
+                // Couldn't rewrite the markers. Whatever survived on disk still
+                // describes a valid state, so just carry on with it.
             }
         }
 
@@ -322,6 +334,11 @@ public static class OrtSessionBuilder
                         $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
                         "inline .onnx round-trip ALSO failed; switching to .ort for this model (see issue #60).");
                     try { File.Delete(cachePathOnnx); } catch { /* best-effort */ }
+                    // The inline tier never writes a _data sidecar, but a stale
+                    // one from a tier-1 write whose cleanup failed can still be
+                    // sitting here. Nothing downstream cleans it up once the key
+                    // escalates to .ort, so drop it now.
+                    try { File.Delete(cacheDataPath); } catch { /* best-effort */ }
                     try { File.WriteAllText(useOrtHintPath, ""); } catch { /* best-effort */ }
                     useOrtFormat = true;
                 }
@@ -381,13 +398,14 @@ public static class OrtSessionBuilder
             return o;
         }
 
+        Exception? inlineWriteFailure = null;
         if (noExtInit && !useOrtFormat)
         {
             // The inline tier is the one write that can fail on its own terms:
             // without the sidecar, a graph whose optimized initializers exceed
-            // protobuf's 2 GB message limit can't serialize at all. Catch that
-            // and drop to .ort rather than surfacing a cache-write failure as a
-            // model-load failure.
+            // protobuf's 2 GB message limit can't serialize at all. Retry on
+            // .ort rather than surfacing a cache-write failure as a model-load
+            // failure.
             var inlineOpts = BuildWriteOptions(out var inlineUsedCuda);
             try
             {
@@ -397,22 +415,36 @@ public static class OrtSessionBuilder
             catch (Exception ex)
             {
                 inlineOpts.Dispose();
-                Console.WriteLine(
-                    $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
-                    $"inline .onnx write failed ({ex.GetType().Name}); falling back to .ort for this model (see issue #60).");
+                inlineWriteFailure = ex;
                 try { File.Delete(cachePathOnnx); } catch { /* best-effort */ }
-                try { File.WriteAllText(useOrtHintPath, ""); } catch { /* best-effort */ }
                 useOrtFormat = true;
             }
         }
 
         var opts = BuildWriteOptions(out var freshUsedCuda);
         usedCuda = freshUsedCuda;
-        return new InferenceSession(modelPath, opts);
+        var freshSession = new InferenceSession(modelPath, opts);
+
+        // Only now is the demotion justified. The catch above can't tell a real
+        // serializer limit from something transient and unrelated — CUDA OOM
+        // under memory pressure, a briefly unreadable source sidecar — and the
+        // .use-ort hint is sticky for the life of the cache key. Writing it only
+        // once .ort has demonstrably succeeded where inline failed keeps a bad
+        // afternoon from permanently downgrading a model that was fine.
+        if (inlineWriteFailure is not null)
+        {
+            Console.WriteLine(
+                $"[cache-format] {Path.GetFileName(cachePathOnnx)}: " +
+                $"inline .onnx write failed ({inlineWriteFailure.GetType().Name}), .ort succeeded; " +
+                "using .ort for this model (see issue #60).");
+            try { File.WriteAllText(useOrtHintPath, ""); } catch { /* best-effort */ }
+        }
+        return freshSession;
     }
 
     // Returns the cache-key path STEM (no extension). Caller appends
-    // ".onnx" / ".ort" / ".use-ort" / ".cache-disabled" as needed.
+    // ".onnx" / ".ort" / ".no-ext-init" / ".use-ort" / ".cache-disabled"
+    // as needed.
     private static string ComputeCacheBasePath(
         string modelPath, ExecutionProvider ep, GraphOptimizationLevel optLevel)
     {
@@ -426,8 +458,16 @@ public static class OrtSessionBuilder
             _ => "auto",
         };
         // Include mtime+size in a short hash so source edits invalidate.
+        // The source's external-data sidecar counts as source: the inline tier
+        // writes a cache file that still references it by name rather than
+        // copying the weights, so a sidecar swapped under an untouched .onnx
+        // would otherwise be a silent stale-weights HIT.
+        var sidecar = new FileInfo(modelPath + "_data");
+        var sidecarKey = sidecar.Exists
+            ? $"{sidecar.LastWriteTimeUtc.Ticks}|{sidecar.Length}"
+            : "no-sidecar";
         var keyBytes = Encoding.UTF8.GetBytes(
-            $"{fi.LastWriteTimeUtc.Ticks}|{fi.Length}|{epTag}|{optLevel}|{ortVer}");
+            $"{fi.LastWriteTimeUtc.Ticks}|{fi.Length}|{sidecarKey}|{epTag}|{optLevel}|{ortVer}");
         var hash = SHA256.HashData(keyBytes).AsSpan(0, 6);
         var hashHex = Convert.ToHexString(hash).ToLowerInvariant();
         var dir = fi.DirectoryName ?? ".";


### PR DESCRIPTION
## What this is

While verifying whether the ORT bug behind #56/#59 was still worth reporting upstream (#60), the root cause turned out to be different from what those issues state — and the corrected cause opens a faster cache tier we'd ruled out.

## The bug is not the `.onnx` serializer

It's the optimized-model **external-initializer writer**. `AddExternalInitializersToGraphProtoImpl` appends a subgraph's initializers to that subgraph a second time instead of clearing first:

```
outer initializers:            ['big_w', 'trip_count_const', 'loop_cond_init']
body of the_loop initializers: ['t_now_1d_axes', 'body_bias', 't_now_1d_axes', 'body_bias']
```

ORT then rejects its own output with `<name> initializer name is not unique`. Its sibling `ToGraphProtoWithCustomInitializerHandlingImpl` *does* clear, with a comment explaining exactly why. Confirmed still live on ORT 1.29.0 (the version `Directory.Build.props` pins), on CPU as well as CUDA, at every opt level.

Corrections to the old mental model:

- Nothing is hoisted to the outer scope — the duplication is *within* the subgraph. That's why #56's renaming and Constant-node workarounds could never have worked.
- It isn't Loop-specific. `nemo128.onnx` hits it through an `If` branch, and had silently fallen back too.
- It needs the external-initializer sidecar. Without those session entries the same graphs round-trip fine, which is what this PR exploits.

## The change

A third rung in the ladder — same `.onnx` format, written without the two external-initializer entries, marked by a `.no-ext-init` hint:

```
.onnx + sidecar  →  .onnx inline  →  .ort  →  .cache-disabled
```

Counter-intuitively the inline tier is the *fastest* for a graph whose source already has a `_data` sidecar: the cache keeps pointing at the source's weights instead of copying them, so it's smaller on disk and quicker to load. `.ort` embeds everything inline, which is the lazy-load loss measured back in Run 2.

| | warm load | cache size |
|---|---:|---:|
| `.ort` (before) | 1776 ms | 577 MB |
| `.onnx` inline (after) | **1395 ms** | **168 MB** |

Two details the rung needs:

- **The inline write can fail on its own terms.** Without the sidecar, a graph whose optimized initializers exceed protobuf's 2 GB limit can't serialize — `language_model.onnx` writes a 2.0 GB sidecar and is exactly that shape. The write is wrapped so failure escalates to `.ort` rather than surfacing a cache-write failure as a model-load failure.
- **Legacy hints migrate.** A `.use-ort` with no `.no-ext-init` beside it came from the old two-tier ladder and is retried once on the inline tier. Without it, every machine that ran the old code stays on the slow tier until an ORT upgrade changes the cache key.

## Verification

ChatterboxSmoke on CUDA. Converges in 2 runs from a cleared cache; the migration path also converges in 2 (verified by seeding a legacy `.use-ort`). Steady state, all four graphs HIT, no regression on the three that never leave tier 1.

Parity: 3 inline-cache runs vs 3 cache-bypassed baselines. Worth flagging that this pipeline is **not bitwise reproducible** — two cache-bypassed runs differ from each other — so the comparison is against that floor:

| comparison | max abs diff | mean abs diff |
|---|---|---|
| no-cache vs no-cache (floor) | 7.265e-02 | 6.624e-04 |
| inline-HIT vs inline-HIT (floor) | 7.395e-02 | 7.757e-04 |
| **inline-HIT vs no-cache** | 9.249e-02 | 8.574e-04 |

Same order as the pipeline's own spread; RMS agrees to 5 significant figures. Not a proof of bitwise equivalence — none is available here.

`dotnet test tests/Vernacula.Tests`: 40/40 pass.

## Scope

Runs 4–12 in `docs/ort_loop_cache_investigation.md` carry the full trail, including the dead ends — notably that the reproducer in #60 does not reproduce, because it omits the session entries that actually trigger the bug.

#60 stays open: the upstream defect is unfixed, we just no longer pay for it. A minimal ~4 MB CPU-only reproducer now exists for that report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUD6pAV2iVKg4G45xzzDq