### PR TITLE
Adopt NAudio 3.1.0, keeping native Windows playback (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,17 @@ A KenLM build pipeline for Parakeet shallow fusion lives in [scripts/kenlm_build
 
 ```bash
 cd src/Vernacula.Avalonia
-dotnet run
+
+# Windows — native WinMM audio output, no external player needed
+dotnet run -f net10.0-windows
+
+# Linux / macOS — playback goes through ffplay
+dotnet run -f net10.0
 ```
+
+`-f` is required because the desktop app targets two frameworks. NAudio 3 hands the
+Windows audio backend (`WaveOut`) only to a Windows target framework, so `net10.0-windows`
+is what carries native playback; `net10.0` is the portable build and uses `ffplay`.
 
 On Linux, `./install.sh` from the repo root builds a self-contained package and registers a `.desktop` entry.
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -38,16 +38,27 @@ dotnet build -c Release -p:EP=Cpu -p:Platform=x64
 
 ## Vernacula.Avalonia
 
+This project targets **two** frameworks: `net10.0-windows` and `net10.0`. NAudio 3 hands
+the Windows audio backend (`WaveOut`, in `NAudio.WinMM`) only to a Windows target
+framework, so `net10.0-windows` is the build with native playback and `net10.0` is the
+portable one that plays through `ffplay`. `dotnet build` builds both; `dotnet run` and
+`dotnet publish` act on one at a time and so need `-f`.
+
 ```bash
 cd src/Vernacula.Avalonia
 
-# Build
+# Build (both frameworks)
 dotnet build -c Release -p:EP=Cuda -p:Platform=x64
 
 # Or publish as self-contained (recommended for desktop install)
-dotnet publish -c Release -p:EP=Cuda -p:Platform=x64 \
+dotnet publish -c Release -f net10.0 -p:EP=Cuda -p:Platform=x64 \
   -r linux-x64 --self-contained true \
   -o ~/apps/vernacula-desktop
+
+# The same on Windows
+dotnet publish -c Release -f net10.0-windows -p:EP=Cuda -p:Platform=x64 \
+  -r win-x64 --self-contained true \
+  -o %USERPROFILE%/apps/vernacula-desktop
 ```
 
 For a Linux end-user install, the `install.sh` script at the repo root runs a self-contained publish and registers the `.desktop` entry for you — see [Installation](installation.md).

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -53,8 +53,17 @@ Built with [Avalonia UI](https://avaloniaui.net/) — runs on any desktop enviro
 
 ```bash
 cd src/Vernacula.Avalonia
-dotnet run
+
+# Windows — native WinMM audio output, no external player needed
+dotnet run -f net10.0-windows
+
+# Linux / macOS — playback goes through ffplay
+dotnet run -f net10.0
 ```
+
+`-f` is required because the desktop app targets two frameworks. NAudio 3 hands the
+Windows audio backend (`WaveOut`) only to a Windows target framework, so `net10.0-windows`
+is what carries native playback; `net10.0` is the portable build and uses `ffplay`.
 
 For packaged installs on Linux, see [Installation](installation.md). For custom build configurations, see [Building from source](building.md).
 

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,13 @@ ICON_DIR="$HOME/.local/share/icons/hicolor/256x256/apps"
 DESKTOP_FILE="$HOME/.local/share/applications/vernacula-desktop.desktop"
 
 echo "Building Vernacula-Desktop (EP=$EP)..."
+# -f is REQUIRED, not tidiness: Vernacula.Avalonia multi-targets net10.0;net10.0-windows
+# (NAudio 3 only hands WinMM to a Windows TFM — see the csproj), and `dotnet publish` on a
+# multi-targeted project with no -f fails with NETSDK1047. This is the Linux installer, so
+# net10.0 is the flavour it wants: the WaveOut path is compiled out and ffplay is the backend.
 dotnet publish "$SCRIPT_DIR/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj" \
     -c Release \
+    -f net10.0 \
     -p:EP="$EP" \
     -p:Platform=x64 \
     -r linux-x64 \

--- a/scripts/TtsAsrProbe/TtsAsrProbe.csproj
+++ b/scripts/TtsAsrProbe/TtsAsrProbe.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NAudio" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vernacula.Avalonia/AudioUtils.cs
+++ b/src/Vernacula.Avalonia/AudioUtils.cs
@@ -245,9 +245,18 @@ internal static class AudioUtils
         ReadAudio(string path, int streamIndex = -1)
     {
         string ext = Path.GetExtension(path);
-        bool preferFfmpegForCompressedAudio =
-            !OperatingSystem.IsWindows()
-            && CrossPlatformFfmpegAudioExtensions.Contains(ext);
+#if WINDOWS
+        // The Windows build's NAudio carries MediaFoundation, which decodes these directly.
+        bool preferFfmpegForCompressedAudio = false;
+#else
+        // ⚠ COMPILE-TIME, NOT OperatingSystem.IsWindows(). MP3/FLAC/M4A/AAC decoding lives in
+        // MediaFoundation, which NAudio 3 ships only to a Windows target framework. The
+        // net10.0 build has none of it on ANY host, so it has to route these to ffmpeg even
+        // when it happens to be running on Windows — asking the OS would send them to an
+        // AudioFileReader that throws NotSupportedException. Same reasoning as the WaveOut
+        // guards in PlaybackService; see Vernacula.Avalonia.csproj.
+        bool preferFfmpegForCompressedAudio = CrossPlatformFfmpegAudioExtensions.Contains(ext);
+#endif
         bool useFFmpeg = streamIndex >= 0
                       || FFmpegDecoder.VideoExtensions.Contains(ext)
                       || FFmpegDecoder.FfmpegAudioExtensions.Contains(ext)
@@ -256,7 +265,8 @@ internal static class AudioUtils
         if (useFFmpeg)
             return FFmpegDecoder.DecodeStream(path, streamIndex >= 0 ? streamIndex : 0);
 
-        // ── NAudio path (WAV, MP3, FLAC, M4A, OGG, AAC) ──────────────────────
+        // ── NAudio path. PCM/IEEE-float WAV on both target frameworks, plus MP3, FLAC,
+        //    M4A and AAC on the Windows one, where MediaFoundation is present. ──────
         using var reader = new AudioFileReader(path);
         int sampleRate = reader.WaveFormat.SampleRate;
         int channels   = reader.WaveFormat.Channels;

--- a/src/Vernacula.Avalonia/AudioUtils.cs
+++ b/src/Vernacula.Avalonia/AudioUtils.cs
@@ -264,7 +264,11 @@ internal static class AudioUtils
         var list   = new List<float>(reader.WaveFormat.SampleRate * channels * 10);
         var buffer = new float[8192];
         int read;
-        while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
+        // ⚠ THROUGH THE INTERFACE, DELIBERATELY — see the matching note in
+        // Vernacula.Base.AudioUtils.ReadAudio. AudioFileReader has both a float and a
+        // byte Span overload of Read in NAudio 3.
+        ISampleProvider readerSamples = reader;
+        while ((read = readerSamples.Read(buffer)) > 0)
         {
             for (int i = 0; i < read; i++)
                 list.Add(buffer[i]);
@@ -309,7 +313,7 @@ internal static class AudioUtils
         var outList   = new List<float>((int)((long)mono.Length * Config.SampleRate / sampleRate + 1024));
         var outBuffer = new float[8192];
         int outRead;
-        while ((outRead = resampler.Read(outBuffer, 0, outBuffer.Length)) > 0)
+        while ((outRead = resampler.Read(outBuffer)) > 0)
         {
             for (int i = 0; i < outRead; i++)
                 outList.Add(outBuffer[i]);
@@ -399,11 +403,13 @@ internal sealed class FloatArraySampleProvider : ISampleProvider
 
     public WaveFormat WaveFormat { get; }
 
-    public int Read(float[] buffer, int offset, int count)
+    // NAudio 3 replaced ISampleProvider.Read(float[], int, int) with Read(Span<float>);
+    // the offset the old signature carried is now the caller's slice.
+    public int Read(Span<float> buffer)
     {
-        int available = Math.Min(count, _data.Length - _position);
+        int available = Math.Min(buffer.Length, _data.Length - _position);
         if (available <= 0) return 0;
-        Array.Copy(_data, _position, buffer, offset, available);
+        _data.AsSpan(_position, available).CopyTo(buffer);
         _position += available;
         return available;
     }

--- a/src/Vernacula.Avalonia/Services/Tts/PlaybackService.cs
+++ b/src/Vernacula.Avalonia/Services/Tts/PlaybackService.cs
@@ -4,6 +4,11 @@ using System.IO;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Avalonia.Threading;
+// NAudio.Wave SPANS TWO PACKAGES IN NAudio 3. BufferedWaveProvider, AudioFileReader and
+// WaveFormat live in NAudio.Core and resolve on every target framework; WaveOut lives
+// in NAudio.WinMM, which ships net9.0-windows7.0 only. Hence the net10.0;net10.0-windows
+// multi-target on this project, and `#if WINDOWS` rather than OperatingSystem.IsWindows()
+// wherever WaveOut is touched - see Vernacula.Avalonia.csproj.
 using NAudio.Wave;
 
 namespace Vernacula.App.Services.Tts;
@@ -11,10 +16,10 @@ namespace Vernacula.App.Services.Tts;
 /// <summary>
 /// Cross-platform streaming audio playback for the reader UI. Mirrors
 /// the platform split used by Vernacula.Avalonia.TranscriptEditorViewModel
-/// (WaveOutEvent on Windows, ffplay elsewhere) but in streaming form:
+/// (WaveOut on Windows, ffplay elsewhere) but in streaming form:
 ///
 ///   Windows: NAudio's <see cref="BufferedWaveProvider"/> fed into
-///            <see cref="WaveOutEvent"/>. Samples are appended as
+///            <see cref="WaveOut"/>. Samples are appended as
 ///            synthesis produces them; WaveOut pulls from the buffer
 ///            continuously.
 ///   Other  : <c>ffplay -f f32le -ar 24000 -ac 1 -i pipe:0</c>. Raw
@@ -40,13 +45,18 @@ public sealed class PlaybackService : IDisposable
     private static readonly string? FfplayPath = FindExecutable("ffplay");
 
     // Backend state (only one set in use at a time).
+#if WINDOWS
     private BufferedWaveProvider? _bufferedProvider;
-    private WaveOutEvent? _waveOut;
+    // WaveOut, not WaveOutEvent: NAudio 3 renamed the event-callback device to WaveOut
+    // (NAudio 2's message-loop WaveOut became WaveOutWindow). WaveOutEvent survives as an
+    // obsolete alias, so this is a rename with no behaviour change.
+    private WaveOut? _waveOut;
     // Held alongside _waveOut on the file-playback path so we can dispose
-    // it in Stop(). WaveOutEvent.Dispose() does NOT dispose the WaveStream
+    // it in Stop(). WaveOut.Dispose() does NOT dispose the WaveStream
     // it was given via Init — without holding our own ref, every Play
     // would leak an open file handle (Windows keeps the WAV locked too).
     private AudioFileReader? _fileReader;
+#endif
     private Process? _ffplayProcess;
     private Stream? _ffplayStdin;
 
@@ -120,7 +130,14 @@ public sealed class PlaybackService : IDisposable
     /// UI swap the Play/Pause/Resume button label.</summary>
     public event Action<bool>? IsPausedChanged;
 
-    public bool CanPlayOnThisPlatform => OperatingSystem.IsWindows() || FfplayPath is not null;
+#if WINDOWS
+    public bool CanPlayOnThisPlatform => true;
+#else
+    // NOT OperatingSystem.IsWindows(). The net10.0 build carries no WinMM, so on a Windows
+    // host running it the WaveOut path does not exist and ffplay is the only backend; asking
+    // the OS would claim playback works and then take a branch that was never compiled.
+    public bool CanPlayOnThisPlatform => FfplayPath is not null;
+#endif
     public string? UnavailableReason => CanPlayOnThisPlatform
         ? null
         : "Audio playback requires Windows audio output or an `ffplay` executable in PATH.";
@@ -139,27 +156,27 @@ public sealed class PlaybackService : IDisposable
         lock (_totalLock) _totalEstimatedSec = 0;
         PositionSeconds = 0;
 
-        if (OperatingSystem.IsWindows())
+#if WINDOWS
+        var fmt = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, 1);
+        // 60 s of headroom — the writer task throttles when the
+        // buffer is more than half-full, so this is the absolute
+        // ceiling rather than the working size.
+        //
+        // NAudio 3 made BufferLength read-only and moved sizing into the constructor as a
+        // duration, so the byte arithmetic that used to spell this out is gone; the format
+        // already knows its own byte rate.
+        _bufferedProvider = new BufferedWaveProvider(fmt, TimeSpan.FromSeconds(60))
         {
-            var fmt = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, 1);
-            // 60 s of headroom — the writer task throttles when the
-            // buffer is more than half-full, so this is the absolute
-            // ceiling rather than the working size.
-            _bufferedProvider = new BufferedWaveProvider(fmt)
-            {
-                BufferLength = sampleRate * 4 /* bytes per float */ * 60,
-                DiscardOnBufferOverflow = false,
-            };
-            _waveOut = new WaveOutEvent();
-            _waveOut.Init(_bufferedProvider);
-            _waveOut.Play();
-        }
-        else
-        {
-            if (FfplayPath is null)
-                throw new InvalidOperationException(UnavailableReason!);
-            StartFfplayStdin(sampleRate);
-        }
+            DiscardOnBufferOverflow = false,
+        };
+        _waveOut = new WaveOut();
+        _waveOut.Init(_bufferedProvider);
+        _waveOut.Play();
+#else
+        if (FfplayPath is null)
+            throw new InvalidOperationException(UnavailableReason!);
+        StartFfplayStdin(sampleRate);
+#endif
 
         // Unbounded so AppendSamples NEVER blocks its caller — the synth
         // pipeline must stay free to produce the next chunk while audio
@@ -210,7 +227,7 @@ public sealed class PlaybackService : IDisposable
                 var bytes = new byte[samples.Length * 4];
                 Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
 
-                if (OperatingSystem.IsWindows())
+#if WINDOWS
                 {
                     var bp = _bufferedProvider;
                     if (bp is null) break;
@@ -234,7 +251,7 @@ public sealed class PlaybackService : IDisposable
                     }
                     if (tornDown) break;
                 }
-                else
+#else
                 {
                     var stdin = _ffplayStdin;
                     if (stdin is null) break;
@@ -251,6 +268,7 @@ public sealed class PlaybackService : IDisposable
                         break;
                     }
                 }
+#endif
             }
         }
         catch (ChannelClosedException) { /* channel completed by Stop/EndOfStream */ }
@@ -277,14 +295,16 @@ public sealed class PlaybackService : IDisposable
         var writer = _writerTask;
         if (writer is not null)
             try { await writer.ConfigureAwait(false); } catch { }
-        if (!OperatingSystem.IsWindows() && _ffplayStdin is not null)
+#if !WINDOWS
+        if (_ffplayStdin is not null)
         {
             try { _ffplayStdin.Close(); } catch { /* already closed */ }
         }
+#endif
     }
 
     /// <summary>Suspend audio output without tearing down the backend.
-    /// On Windows uses <see cref="WaveOutEvent.Pause"/>; on Linux sends
+    /// On Windows uses <see cref="WaveOut.Pause"/>; on Linux sends
     /// SIGSTOP to the ffplay process so the kernel freezes it. The
     /// internal audio buffer and writer task stay alive — Resume picks
     /// up exactly where Pause left off. Wall-clock position is frozen
@@ -293,14 +313,14 @@ public sealed class PlaybackService : IDisposable
     public void Pause()
     {
         if (!IsPlaying || IsPaused) return;
-        if (OperatingSystem.IsWindows())
-        {
-            try { _waveOut?.Pause(); } catch { /* device race */ }
-        }
-        else if (_ffplayProcess is not null)
+#if WINDOWS
+        try { _waveOut?.Pause(); } catch { /* device race */ }
+#else
+        if (_ffplayProcess is not null)
         {
             SendSignalToProcess(_ffplayProcess, "STOP");
         }
+#endif
         _pausedAt = DateTime.UtcNow;
         StopTickTimer();
         // Order matters: clear IsPlaying BEFORE setting IsPaused so any
@@ -319,14 +339,14 @@ public sealed class PlaybackService : IDisposable
         if (!IsPaused) return;
         var pauseDuration = DateTime.UtcNow - _pausedAt;
         _startedUtc = _startedUtc.Add(pauseDuration);
-        if (OperatingSystem.IsWindows())
-        {
-            try { _waveOut?.Play(); } catch { /* device race */ }
-        }
-        else if (_ffplayProcess is not null)
+#if WINDOWS
+        try { _waveOut?.Play(); } catch { /* device race */ }
+#else
+        if (_ffplayProcess is not null)
         {
             SendSignalToProcess(_ffplayProcess, "CONT");
         }
+#endif
         IsPaused = false;
         IsPlaying = true;
         StartTickTimer();
@@ -363,32 +383,25 @@ public sealed class PlaybackService : IDisposable
     /// via <see cref="SeekIntoFile"/> instead.</summary>
     public void SeekTo(double seconds)
     {
-        if (OperatingSystem.IsWindows())
-        {
-            if (_bufferedProvider is null) return;
-            // BufferedWaveProvider doesn't expose seek directly — for an
-            // in-RAM stream the simplest thing is to truncate the buffer
-            // (drop anything before the seek point) and re-anchor the
-            // wall-clock. Forward seek = drop bytes; backward seek
-            // beyond what's in the buffer = clamp to current position.
-            // For MVP, we just re-anchor the wall-clock and let WaveOut
-            // continue playing what's in the buffer — meaning seek only
-            // affects the HIGHLIGHT, not the audio. Acceptable for
-            // click-to-highlight UX; full audio-seek is follow-up.
-            _startedUtc = DateTime.UtcNow.AddSeconds(-seconds);
-            PositionSeconds = seconds;
-            PositionChanged?.Invoke(PositionSeconds);
-        }
-        else
-        {
-            // Same MVP compromise: re-anchor wall-clock, highlight jumps,
-            // audio continues from wherever ffplay was. Seeking ffplay
-            // requires either a seekable input (file) or restarting the
-            // process — both are larger surgeries deferred for now.
-            _startedUtc = DateTime.UtcNow.AddSeconds(-seconds);
-            PositionSeconds = seconds;
-            PositionChanged?.Invoke(PositionSeconds);
-        }
+#if WINDOWS
+        // BufferedWaveProvider doesn't expose seek directly — for an
+        // in-RAM stream the simplest thing is to truncate the buffer
+        // (drop anything before the seek point) and re-anchor the
+        // wall-clock. Forward seek = drop bytes; backward seek
+        // beyond what's in the buffer = clamp to current position.
+        // For MVP, we just re-anchor the wall-clock and let WaveOut
+        // continue playing what's in the buffer — meaning seek only
+        // affects the HIGHLIGHT, not the audio. Acceptable for
+        // click-to-highlight UX; full audio-seek is follow-up.
+        if (_bufferedProvider is null) return;
+#endif
+        // On ffplay the same MVP compromise applies with no buffer to guard on:
+        // re-anchor the wall-clock, the highlight jumps, and audio continues from
+        // wherever ffplay was. Seeking ffplay needs either a seekable input (file) or
+        // restarting the process — both larger surgeries, deferred.
+        _startedUtc = DateTime.UtcNow.AddSeconds(-seconds);
+        PositionSeconds = seconds;
+        PositionChanged?.Invoke(PositionSeconds);
     }
 
     /// <summary>Post-streaming seek into the on-disk WAV file. Restarts
@@ -407,17 +420,17 @@ public sealed class PlaybackService : IDisposable
         seconds = Math.Clamp(seconds, 0, audioDurationSec);
         _endOfStream = true;
 
-        if (OperatingSystem.IsWindows())
+#if WINDOWS
         {
             _fileReader = new AudioFileReader(audioPath)
             {
                 CurrentTime = TimeSpan.FromSeconds(seconds),
             };
-            var player = new WaveOutEvent();
+            var player = new WaveOut();
             _waveOut = player;
             _waveOut.Init(_fileReader);
             // ⚠ ONLY STOP IF THIS PLAYER IS STILL THE CURRENT ONE. A seek during playback
-            // Stop()s the previous WaveOutEvent, whose PlaybackStopped is delivered
+            // Stop()s the previous WaveOut, whose PlaybackStopped is delivered
             // asynchronously — after the new player has started — and an unconditional
             // Stop() there tore the new playback down within milliseconds.
             _waveOut.PlaybackStopped += (sender, _) => Dispatcher.UIThread.InvokeAsync(() =>
@@ -426,12 +439,13 @@ public sealed class PlaybackService : IDisposable
             });
             _waveOut.Play();
         }
-        else
+#else
         {
             if (FfplayPath is null)
                 throw new InvalidOperationException(UnavailableReason!);
             StartFfplayFile(audioPath, seconds);
         }
+#endif
 
         IsPlaying = true;
         PositionSeconds = seconds;
@@ -444,7 +458,11 @@ public sealed class PlaybackService : IDisposable
         // Allow Stop after Pause too — without IsPaused in this check
         // we'd early-return because the timer was stopped by Pause and
         // IsPlaying is false during pause.
+#if WINDOWS
         if (!IsPlaying && !IsPaused && _waveOut is null && _ffplayProcess is null) return;
+#else
+        if (!IsPlaying && !IsPaused && _ffplayProcess is null) return;
+#endif
         StopTickTimer();
 
         // ORDER MATTERS for immediate-stop UX. Audio backends are torn
@@ -456,6 +474,7 @@ public sealed class PlaybackService : IDisposable
         // drain its internal decoded-PCM buffer (sometimes seconds) on
         // -autoexit before the kill landed. Killing first prevents
         // that drain.
+#if WINDOWS
         if (_waveOut is not null)
         {
             try { _waveOut.Stop(); } catch { /* shutdown race */ }
@@ -467,6 +486,7 @@ public sealed class PlaybackService : IDisposable
             _fileReader.Dispose();
             _fileReader = null;
         }
+#endif
         if (_ffplayProcess is not null)
         {
             try { if (!_ffplayProcess.HasExited) _ffplayProcess.Kill(entireProcessTree: true); }
@@ -484,7 +504,9 @@ public sealed class PlaybackService : IDisposable
         _audioChannel?.Writer.TryComplete();
         _audioChannel = null;
         _writerTask = null;
+#if WINDOWS
         _bufferedProvider = null;
+#endif
 
         var finalPos = PositionSeconds;
         IsPaused = false;

--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -43,6 +43,17 @@
     <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
+  <!-- The second half of the NAudio.WinForms exclusion documented beside the PackageReference
+       below. Scoped to the Windows TFM because that is the only one where any package in the
+       graph declares a framework reference at all: NAudio.WinForms is the sole entry with a
+       "frameworkReferences" block in project.assets.json, so this drops exactly that one and
+       nothing else today. If a future package legitimately needs a transitive framework
+       reference, it will go missing here — loudly, as unresolved types at compile time, not
+       as a silently different build. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+    <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
+  </PropertyGroup>
+
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
@@ -101,6 +112,41 @@
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
     <PackageReference Include="NAudio" Version="3.1.0" />
+    <!--
+      ⚠ NAudio.WinForms IS PINNED ONLY TO THROW IT AWAY, AND THAT IS LOAD-BEARING TWICE.
+      The net9.0-windows7.0 dependency group of the NAudio metapackage includes
+      NAudio.WinForms, whose nuspec declares:
+
+          <frameworkReference name="Microsoft.WindowsDesktop.App.WindowsForms" />
+
+      Nothing here uses a WinForms control — this is an Avalonia app — but that reference
+      arrives anyway on the Windows TFM, and it costs two things:
+
+        1. It breaks the LINUX build outright. The Windows Desktop targeting pack is not
+           part of the Linux SDK, so `dotnet build` of net10.0-windows on ubuntu fails with
+           NETSDK1073 ("The FrameworkReference 'Microsoft.WindowsDesktop.App.WindowsForms'
+           was not recognized"). CI builds the whole solution on ubuntu, so this took the
+           whole job down, and no amount of testing on a Windows box could have shown it —
+           there the pack is present and everything looks fine.
+        2. It changes what the shipped Windows app needs at RUNTIME, from the base .NET
+           runtime to the Windows Desktop runtime, for an assembly we never load.
+
+      It takes BOTH knobs below, because assets and framework references travel separately:
+      ExcludeAssets="all" keeps NAudio.WinForms.dll out of the output but leaves the
+      frameworkReferences entry in project.assets.json, which ResolvePackageAssets still
+      turns into a real FrameworkReference. DisableTransitiveFrameworkReferences is what
+      stops that half. Verified by dumping @(FrameworkReference) after ResolveReferences:
+      with only the first, Microsoft.WindowsDesktop.App.WindowsForms is still there.
+
+      EnableWindowsTargeting=true would also have fixed (1) — by making the Linux SDK
+      download the Windows desktop packs — but it fixes only the symptom, leaves (2) in
+      place, and pays a download to carry an assembly we do not want.
+
+      The condition is required, not tidiness: NAudio.WinForms has no net10.0-compatible
+      assets, so an unconditional reference fails restore on the portable TFM with NU1202.
+    -->
+    <PackageReference Include="NAudio.WinForms" Version="3.1.0" ExcludeAssets="all"
+                      Condition="'$(TargetFramework)' == 'net10.0-windows'" />
     <PackageReference Include="SoundTouch.Net" Version="2.1.2" />
     <PackageReference Include="ClosedXML" Version="0.104.1" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />

--- a/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
+++ b/src/Vernacula.Avalonia/Vernacula.Avalonia.csproj
@@ -2,7 +2,34 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <!--
+      ⚠ TWO TARGET FRAMEWORKS, FOR EXACTLY ONE TYPE. NAudio 3 split the metapackage: from
+      2.4.0 onward the Windows backends are only handed to a Windows target framework, and
+      NAudio.WinMM 3.1.0 ships lib/net9.0-windows7.0 and nothing else. Referencing it from a
+      plain net10.0 project fails restore with NU1202.
+
+      WaveOutEvent — the native Windows playback path in Services/Tts/PlaybackService.cs and
+      ViewModels/TranscriptEditorViewModel.cs — is the only NAudio type this repo uses that
+      lives there. Every other one (WaveFormat, AudioFileReader, BufferedWaveProvider,
+      WdlResamplingSampleProvider, ISampleProvider, …) is in NAudio.Core and resolves on
+      plain net10.0, which is why no other project needed this.
+
+      net10.0-windows with no platform version means TargetPlatformVersion 7.0, so it picks up
+      the metapackage's net9.0-windows7.0 dependency group (Asio, Core, Dmo, Midi, Wasapi,
+      WinForms, WinMM) — WinMM arrives with the existing single NAudio PackageReference, no
+      per-assembly pins. Deliberately NOT net10.0-windows10.0.19041, which would pull the
+      Windows SDK projection for nothing we use.
+
+      The alternative was dropping WaveOutEvent and running ffplay on every platform (#127
+      route B), which regresses Windows from "needs no external binary" to "install ffmpeg".
+
+      Consequences to know about:
+        - `dotnet publish` on this project now needs -f (install.sh passes -f net10.0).
+        - Consumers that target plain net10.0 (tests/AsrBackendCoverage) resolve the net10.0
+          flavour, which has no WaveOut path. That is correct: they test job plumbing, not
+          playback.
+    -->
+    <TargetFrameworks>net10.0;net10.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -73,7 +100,7 @@
 
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
-    <PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NAudio" Version="3.1.0" />
     <PackageReference Include="SoundTouch.Net" Version="2.1.2" />
     <PackageReference Include="ClosedXML" Version="0.104.1" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -9,6 +9,11 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+// NAudio.Wave SPANS TWO PACKAGES IN NAudio 3. WaveFormat/IWaveProvider live in
+// NAudio.Core and resolve on every target framework; WaveOut lives in NAudio.WinMM,
+// which ships net9.0-windows7.0 only. That is why this project multi-targets
+// net10.0;net10.0-windows and why the WaveOut path below sits behind `#if WINDOWS` rather
+// than behind OperatingSystem.IsWindows() alone - see Vernacula.Avalonia.csproj.
 using NAudio.Wave;
 using SoundTouch;
 using Vernacula.Base;
@@ -28,7 +33,14 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
 
     private static readonly string? FfplayPath = FindExecutable("ffplay");
 
-    public static bool SupportsAudioPlayback => OperatingSystem.IsWindows() || FfplayPath is not null;
+#if WINDOWS
+    public static bool SupportsAudioPlayback => true;
+#else
+    // NOT OperatingSystem.IsWindows(). The net10.0 build carries no WinMM, so on a Windows
+    // host running it the WaveOut path does not exist and ffplay is the only backend; asking
+    // the OS would claim playback works and then take a branch that was never compiled.
+    public static bool SupportsAudioPlayback => FfplayPath is not null;
+#endif
     public static string PlaybackUnavailableReason =>
         "Playback requires Windows audio output or an `ffplay` executable in PATH.";
 
@@ -37,7 +49,11 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     private float[]?         _fullAudio;
     private int              _audioSampleRate = Config.SampleRate;
     private int              _audioChannels   = 1;
-    private WaveOutEvent?    _waveOut;
+#if WINDOWS
+    // WaveOut, not WaveOutEvent: NAudio 3 renamed the event-callback device to WaveOut
+    // (NAudio 2's message-loop WaveOut became WaveOutWindow). A rename, not a behaviour change.
+    private WaveOut?         _waveOut;
+#endif
     private Process?         _playbackProcess;
     private DispatcherTimer? _playbackTimer;
     private bool             _preserveContinuousPlaybackPosition;
@@ -304,22 +320,22 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
 
         StopPlayback();
         TimeSpan leadIn = ConsumeInitialPlaybackLeadIn();
-        if (OperatingSystem.IsWindows())
-        {
-            var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(_audioSampleRate, _audioChannels);
-            var provider   = new SoundTouchWaveProvider(_fullAudio, startSample, count,
-                                                        waveFormat, _audioChannels, PlaybackSpeed,
-                                                        leadIn);
+#if WINDOWS
+        var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(_audioSampleRate, _audioChannels);
+        var provider   = new SoundTouchWaveProvider(_fullAudio, startSample, count,
+                                                    waveFormat, _audioChannels, PlaybackSpeed,
+                                                    leadIn);
 
-            _waveOut = new WaveOutEvent();
-            _waveOut.Init(provider);
-            _waveOut.PlaybackStopped += OnWaveOutStopped;
-            _waveOut.Play();
-        }
-        else if (!StartFfplayPlayback(seg.PlayStart + segOffsetSec, segDuration - segOffsetSec, leadIn))
+        _waveOut = new WaveOut();
+        _waveOut.Init(provider);
+        _waveOut.PlaybackStopped += OnWaveOutStopped;
+        _waveOut.Play();
+#else
+        if (!StartFfplayPlayback(seg.PlayStart + segOffsetSec, segDuration - segOffsetSec, leadIn))
         {
             return;
         }
+#endif
 
         IsPlaying = true;
         PlayCommand.NotifyCanExecuteChanged();
@@ -380,22 +396,22 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         StopPlayback();
         TimeSpan leadIn = ConsumeInitialPlaybackLeadIn();
         double speed = PlaybackSpeed;
-        if (OperatingSystem.IsWindows())
-        {
-            var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(_audioSampleRate, _audioChannels);
-            var provider   = new SoundTouchWaveProvider(_fullAudio, startSample, count,
-                                                        waveFormat, _audioChannels, speed,
-                                                        leadIn);
+#if WINDOWS
+        var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(_audioSampleRate, _audioChannels);
+        var provider   = new SoundTouchWaveProvider(_fullAudio, startSample, count,
+                                                    waveFormat, _audioChannels, speed,
+                                                    leadIn);
 
-            _waveOut = new WaveOutEvent();
-            _waveOut.Init(provider);
-            _waveOut.PlaybackStopped += OnWaveOutStopped;
-            _waveOut.Play();
-        }
-        else if (!StartFfplayPlayback(startSec, null, leadIn))
+        _waveOut = new WaveOut();
+        _waveOut.Init(provider);
+        _waveOut.PlaybackStopped += OnWaveOutStopped;
+        _waveOut.Play();
+#else
+        if (!StartFfplayPlayback(startSec, null, leadIn))
         {
             return;
         }
+#endif
 
         IsPlaying = true;
         PlayCommand.NotifyCanExecuteChanged();
@@ -476,14 +492,11 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     [RelayCommand(CanExecute = nameof(CanPause))]
     private void Pause()
     {
-        if (OperatingSystem.IsWindows())
-        {
-            _waveOut?.Pause();
-        }
-        else
-        {
-            StopFfplayPlayback();
-        }
+#if WINDOWS
+        _waveOut?.Pause();
+#else
+        StopFfplayPlayback();
+#endif
         _playbackTimer?.Stop();
         IsPlaying = false;
         PlayCommand.NotifyCanExecuteChanged();
@@ -585,6 +598,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         HighlightedToken = best;
     }
 
+#if WINDOWS
     private void OnWaveOutStopped(object? sender, StoppedEventArgs e)
     {
         Dispatcher.UIThread.InvokeAsync(() =>
@@ -593,6 +607,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             OnSegmentPlaybackComplete();
         });
     }
+#endif
 
     private void OnSegmentPlaybackComplete()
     {
@@ -621,20 +636,17 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
     {
         _playbackTimer?.Stop();
         _playbackTimer = null;
-        if (OperatingSystem.IsWindows())
+#if WINDOWS
+        if (_waveOut != null)
         {
-            if (_waveOut != null)
-            {
-                _waveOut.PlaybackStopped -= OnWaveOutStopped;
-                _waveOut.Stop();
-                _waveOut.Dispose();
-                _waveOut = null;
-            }
+            _waveOut.PlaybackStopped -= OnWaveOutStopped;
+            _waveOut.Stop();
+            _waveOut.Dispose();
+            _waveOut = null;
         }
-        else
-        {
-            StopFfplayPlayback();
-        }
+#else
+        StopFfplayPlayback();
+#endif
         IsPlaying = false;
         PlayCommand.NotifyCanExecuteChanged();
         PauseCommand.NotifyCanExecuteChanged();
@@ -1536,9 +1548,11 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
         return null;
     }
 
+#if WINDOWS
     /// <summary>
     /// Streams audio through SoundTouch on-the-fly, so tempo-stretching never
     /// blocks the UI thread. The source array is read directly (no copy).
+    /// Windows-only: its sole consumer is the WaveOut path above.
     /// </summary>
     private sealed class SoundTouchWaveProvider : IWaveProvider
     {
@@ -1576,12 +1590,14 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             }
         }
 
-        public int Read(byte[] buffer, int offset, int count)
+        // NAudio 3 replaced IWaveProvider.Read(byte[], int, int) with Read(Span<byte>):
+        // the (offset, count) pair the old signature carried is now the caller's slice.
+        public int Read(Span<byte> buffer)
         {
             if (_leadingSilenceFloatsRemaining > 0)
             {
-                int silenceFloats = Math.Min(count / 4, _leadingSilenceFloatsRemaining);
-                buffer.AsSpan(offset, silenceFloats * 4).Clear();
+                int silenceFloats = Math.Min(buffer.Length / 4, _leadingSilenceFloatsRemaining);
+                buffer[..(silenceFloats * 4)].Clear();
                 _leadingSilenceFloatsRemaining -= silenceFloats;
                 return silenceFloats * 4;
             }
@@ -1590,14 +1606,14 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             {
                 // 1.0× — copy raw bytes directly, no processing needed
                 int avail = (_srcEnd - _srcPos) * 4;
-                int copy  = Math.Min(count, avail);
+                int copy  = Math.Min(buffer.Length, avail);
                 if (copy <= 0) return 0;
-                Buffer.BlockCopy(_src, _srcPos * 4, buffer, offset, copy);
+                MemoryMarshal.AsBytes(_src.AsSpan(_srcPos, copy / 4)).CopyTo(buffer);
                 _srcPos += copy / 4;
                 return copy;
             }
 
-            int floatsNeeded = count / 4;
+            int floatsNeeded = buffer.Length / 4;
             const int FeedFrames = 4096;
 
             while (_outQ.Count < floatsNeeded)
@@ -1620,7 +1636,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
             }
 
             int toWrite = Math.Min(floatsNeeded, _outQ.Count);
-            var outSpan = MemoryMarshal.Cast<byte, float>(buffer.AsSpan(offset, toWrite * 4));
+            var outSpan = MemoryMarshal.Cast<byte, float>(buffer[..(toWrite * 4)]);
             for (int i = 0; i < toWrite; i++)
                 outSpan[i] = _outQ.Dequeue();
             return toWrite * 4;
@@ -1635,6 +1651,7 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
                     _outQ.Enqueue(recv[i]);
         }
     }
+#endif
 
     // ── IDisposable ───────────────────────────────────────────────────────────
 

--- a/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/TranscriptEditorViewModel.cs
@@ -1604,9 +1604,16 @@ internal partial class TranscriptEditorViewModel : ObservableObject, IDisposable
 
             if (_st is null)
             {
-                // 1.0× — copy raw bytes directly, no processing needed
+                // 1.0× — copy raw bytes directly, no processing needed.
+                //
+                // Rounded down to whole floats. The array-based original wrote exactly `copy`
+                // bytes with Buffer.BlockCopy, so a `copy` that was not a multiple of 4 still
+                // matched what it returned; the span version writes (copy / 4) * 4 and would
+                // otherwise claim up to 3 bytes it never wrote, handing WaveOut uninitialised
+                // audio. Not reachable while NAudio sizes its buffers to BlockAlign, but the
+                // write and the return value have to agree on their own terms.
                 int avail = (_srcEnd - _srcPos) * 4;
-                int copy  = Math.Min(buffer.Length, avail);
+                int copy  = Math.Min(buffer.Length, avail) / 4 * 4;
                 if (copy <= 0) return 0;
                 MemoryMarshal.AsBytes(_src.AsSpan(_srcPos, copy / 4)).CopyTo(buffer);
                 _srcPos += copy / 4;

--- a/src/Vernacula.Base/AudioUtils.cs
+++ b/src/Vernacula.Base/AudioUtils.cs
@@ -232,7 +232,7 @@ public static class AudioUtils
             var wavSamples = new List<float>(wavSampleRate * wavChannels * 10);
             var wavBuffer = new float[8192];
             int wavRead;
-            while ((wavRead = sampleProvider.Read(wavBuffer, 0, wavBuffer.Length)) > 0)
+            while ((wavRead = sampleProvider.Read(wavBuffer)) > 0)
                 for (int i = 0; i < wavRead; i++) wavSamples.Add(wavBuffer[i]);
 
             return (wavSamples.ToArray(), wavSampleRate, wavChannels);
@@ -245,7 +245,12 @@ public static class AudioUtils
         var list   = new List<float>(sampleRate * channels * 10);
         var buffer = new float[8192];
         int read;
-        while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
+        // ⚠ THROUGH THE INTERFACE, DELIBERATELY. AudioFileReader carries both
+        // Read(Span<float>) (ISampleProvider) and Read(Span<byte>) (WaveStream) in NAudio 3;
+        // going through the interface pins the float overload rather than leaving it to
+        // overload resolution on a call whose failure mode is a silent byte-wise read.
+        ISampleProvider readerSamples = reader;
+        while ((read = readerSamples.Read(buffer)) > 0)
             for (int i = 0; i < read; i++) list.Add(buffer[i]);
 
         return (list.ToArray(), sampleRate, channels);
@@ -298,7 +303,7 @@ public static class AudioUtils
             var outList   = new List<float>((int)((long)mono.Length * Config.SampleRate / sampleRate + 1024));
             var outBuffer = new float[8192];
             int outRead;
-            while ((outRead = resampler.Read(outBuffer, 0, outBuffer.Length)) > 0)
+            while ((outRead = resampler.Read(outBuffer)) > 0)
                 for (int i = 0; i < outRead; i++) outList.Add(outBuffer[i]);
             at16k = outList.ToArray();
         }
@@ -323,7 +328,7 @@ public static class AudioUtils
             (int)((long)mono.Length * dstSampleRate / Math.Max(1, srcSampleRate) + 1024));
         var buf = new float[8192];
         int read;
-        while ((read = resampler.Read(buf, 0, buf.Length)) > 0)
+        while ((read = resampler.Read(buf)) > 0)
             for (int i = 0; i < read; i++) outList.Add(buf[i]);
         return outList.ToArray();
     }
@@ -423,11 +428,13 @@ public sealed class FloatArraySampleProvider : ISampleProvider
 
     public WaveFormat WaveFormat { get; }
 
-    public int Read(float[] buffer, int offset, int count)
+    // NAudio 3 replaced ISampleProvider.Read(float[], int, int) with Read(Span<float>);
+    // the offset the old signature carried is now the caller's slice.
+    public int Read(Span<float> buffer)
     {
-        int available = Math.Min(count, _data.Length - _position);
+        int available = Math.Min(buffer.Length, _data.Length - _position);
         if (available <= 0) return 0;
-        Array.Copy(_data, _position, buffer, offset, available);
+        _data.AsSpan(_position, available).CopyTo(buffer);
         _position += available;
         return available;
     }

--- a/src/Vernacula.Base/AudioUtils.cs
+++ b/src/Vernacula.Base/AudioUtils.cs
@@ -215,9 +215,21 @@ public static class AudioUtils
     // ── Audio I/O (NAudio only) ──────────────────────────────────────────────
 
     /// <summary>
-    /// Read an audio file via NAudio (WAV, MP3, FLAC, M4A, OGG, AAC).
-    /// Returns interleaved float samples in [-1, 1], the sample rate, and channel count.
-    /// For video containers or FFmpeg-only formats use the WPF-side ReadAudio overload.
+    /// Read an audio file via NAudio. Returns interleaved float samples in [-1, 1], the
+    /// sample rate, and the channel count.
+    /// <para>
+    /// ⚠ PCM AND IEEE-FLOAT WAV ONLY, ON EVERY PLATFORM. This used to claim "WAV, MP3,
+    /// FLAC, M4A, OGG, AAC" and that was only ever true on Windows: those decoders are
+    /// MediaFoundation and ACM P/Invokes living in NAudio.WinMM/NAudio.Wasapi, which
+    /// NAudio 3 hands only to a Windows target framework — this project is net10.0, so
+    /// AudioFileReader now throws NotSupportedException for them. (Under NAudio 2.3.0 a
+    /// net10.0 resolve still received those assemblies, so they worked here on Windows and
+    /// threw on Linux.) #156 tracks routing the rest through ffmpeg, which would fix Linux
+    /// too rather than restoring a Windows-only path.
+    /// </para>
+    /// <para>
+    /// For video containers or FFmpeg-only formats use the Avalonia-side ReadAudio overload.
+    /// </para>
     /// </summary>
     public static (float[] samples, int sampleRate, int channels) ReadAudio(string path)
     {

--- a/src/Vernacula.Base/Vernacula.Base.csproj
+++ b/src/Vernacula.Base/Vernacula.Base.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio"            Version="2.3.0" />
+    <PackageReference Include="NAudio"            Version="3.1.0" />
     <PackageReference Include="MathNet.Numerics"  Version="5.0.0" />
     <!-- Note: NemoNfaAligner uses an in-house SimpleSpTokenizer (greedy LPM
          over vocab.txt). Microsoft.ML.Tokenizers 2.0.0's

--- a/src/Vernacula.Base/VibeVoiceAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceAsr.cs
@@ -323,7 +323,7 @@ public sealed class VibeVoiceAsr : IDisposable
         var outList   = new List<float>((int)((long)mono.Length * SampleRate / sampleRate + 1024));
         var outBuffer = new float[8192];
         int read;
-        while ((read = resampler.Read(outBuffer, 0, outBuffer.Length)) > 0)
+        while ((read = resampler.Read(outBuffer)) > 0)
             for (int i = 0; i < read; i++) outList.Add(outBuffer[i]);
 
         return outList.ToArray();

--- a/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
+++ b/src/Vernacula.Tts.Backends.CLI/Vernacula.Tts.Backends.CLI.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NAudio" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vernacula.Tts.Base/AudioIo/VoicePromptLoader.cs
+++ b/src/Vernacula.Tts.Base/AudioIo/VoicePromptLoader.cs
@@ -38,7 +38,7 @@ public static class VoicePromptLoader
             var outList = new List<float>((int)((long)mono.Length * ChatterboxConstants.S3GenSr / sr + 1024));
             var buf = new float[8192];
             int n;
-            while ((n = resampler.Read(buf, 0, buf.Length)) > 0)
+            while ((n = resampler.Read(buf)) > 0)
                 for (int i = 0; i < n; i++) outList.Add(buf[i]);
             at24k = outList.ToArray();
         }
@@ -62,12 +62,12 @@ public static class VoicePromptLoader
         private int _pos;
         public FloatArraySampleProvider(float[] data, WaveFormat fmt) { _data = data; WaveFormat = fmt; }
         public WaveFormat WaveFormat { get; }
-        public int Read(float[] buffer, int offset, int count)
+        public int Read(Span<float> buffer)
         {
             int remain = _data.Length - _pos;
-            int take = Math.Min(remain, count);
+            int take = Math.Min(remain, buffer.Length);
             if (take <= 0) return 0;
-            Array.Copy(_data, _pos, buffer, offset, take);
+            _data.AsSpan(_pos, take).CopyTo(buffer);
             _pos += take;
             return take;
         }

--- a/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
+++ b/src/Vernacula.Tts.Base/Vernacula.Tts.Base.csproj
@@ -34,7 +34,7 @@
 
   <!-- NAudio: voice-prompt WAV decode + resample to 24 kHz mono. -->
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NAudio" Version="3.1.0" />
   </ItemGroup>
 
   <!-- Markdig: markdown AST for MarkdownTextExtractor. Kept in step with the

--- a/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
+++ b/src/Vernacula.Tts.CLI/Vernacula.Tts.CLI.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NAudio" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
+++ b/tests/ChatterboxSmoke/ChatterboxSmoke.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NAudio" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
+++ b/tests/OmniVoiceSmoke/OmniVoiceSmoke.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.3.0" />
+    <PackageReference Include="NAudio" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #127. Tested on a Windows 11 box brought up for exactly this.

## The constraint, confirmed against 3.1.0

From NAudio 2.4.0 onward the metapackage stops handing the Windows backends to a non-Windows target framework, and `NAudio.WinMM` 3.1.0 ships `lib/net9.0-windows7.0` and nothing else — referencing it from a plain `net10.0` project fails restore with NU1202. The metapackage's dependency groups:

```
net9.0                  -> Core, Midi
net9.0-windows7.0       -> Asio, Core, Dmo, Midi, Wasapi, WinForms, WinMM
net9.0-windows10.0.19041 -> (same as windows7.0)
```

`WaveOutEvent` is the **only** NAudio type this repo uses that lives in WinMM. Everything else — `WaveFormat`, `AudioFileReader`, `BufferedWaveProvider`, `WdlResamplingSampleProvider`, `ISampleProvider`, `WaveFileWriter`/`Reader` — is in `NAudio.Core` and resolves on plain `net10.0`. That is why exactly one project needed a TFM change.

Note the issue was written against an older layout: `Vernacula.Tts.Avalonia` no longer exists, so `PlaybackService` and `TranscriptEditorViewModel` are both in `Vernacula.Avalonia`. One project, not two plus dependents.

## Route A

`Vernacula.Avalonia` multi-targets `net10.0;net10.0-windows`, with the WaveOut path behind `#if WINDOWS`. `net10.0-windows` with no platform version means TargetPlatformVersion 7.0, so it picks up the `net9.0-windows7.0` group and WinMM arrives with the existing single `NAudio` PackageReference — no per-assembly pins. Deliberately not `net10.0-windows10.0.19041`, which would pull the Windows SDK projection for nothing we use.

Route B (ffplay everywhere) was the smaller diff but regressed Windows from "needs no external binary" to "install ffmpeg".

**`#if WINDOWS`, not `OperatingSystem.IsWindows()`, at the decision points.** The `net10.0` build carries no WinMM, so on a Windows host running that flavour the WaveOut branch does not exist; an OS check would advertise playback and then jump into code that was never compiled. The runtime guard is the wrong tool once the capability is decided at compile time.

## API breaks this forced

- `ISampleProvider.Read(float[], int, int)` → `Read(Span<float>)`, `IWaveProvider.Read(byte[], int, int)` → `Read(Span<byte>)`. Four provider implementations and ~8 call sites; the old `(offset, count)` pair is now the caller's slice.
- `AudioFileReader` now carries **both** `Read(Span<float>)` and `Read(Span<byte>)`, so the two `ReadAudio` loops go through `ISampleProvider` explicitly. Left to overload resolution this binds to the byte overload — and it compiles, so the failure mode is a silent byte-wise read rather than an error. (The issue predicted this trap surfacing as a type error; on 3.1.0 it does not.)
- `BufferedWaveProvider.BufferLength` is read-only and sizing moved into the constructor as a `TimeSpan`. `BufferDuration` is now read-only too — the issue only flagged `BufferLength`.
- `WaveOutEvent` is **obsolete**, renamed to `WaveOut` (NAudio 2's message-loop `WaveOut` became `WaveOutWindow`). Renamed to stay warning-clean; same event-callback device, no behaviour change. Not in the issue, which analysed 3.0.1.

## Verification

**Numeric A/B against `main`.** A harness run against both branches: `ResampleMono` over 6 rate pairs, `AudioTo16000Mono` mono and stereo, `ReadAudio` over 16- and 32-bit WAVs at three shapes, `VoicePromptLoader` at three input rates. SHA-256 of every output buffer is **identical** under 2.3.0 and 3.1.0.

**The rewritten `SoundTouchWaveProvider.Read`** matches the array-based original byte for byte over 48 configurations — 4 speeds × 2 channel counts × 2 lead-ins × 3 read sizes — with the old one driven at a non-zero buffer offset so the `(offset, count)` → `Span` translation is exercised, not just the offset-0 case.

**`BufferedWaveProvider(fmt, TimeSpan.FromSeconds(60))`** yields `BufferLength` 5,760,000 at 24 kHz — exactly what the old setter computed.

**Live WinMM on the device:** `Play`/`Pause`/`Resume`/`Stop`, `PlaybackStopped` firing with no exception, position advancing, and `AudioFileReader` → `WaveOut` on the file path.

**In the app itself:** loaded a real 157-segment transcript (which is `ReadAudio` on NAudio 3 end to end), opened the editor, and continuous playback ran through eight segments with the word highlight tracking position — which also exercises the `PlaybackStopped` → auto-advance wiring on the migrated `WaveOut`.

**Builds:** full solution clean with no new warnings; both TFMs of the app; all seven out-of-solution NAudio consumers; and a `linux-x64` self-contained publish of `net10.0` that correctly ships `NAudio.Core` + `NAudio.Midi` with no WinMM.

**Tests:** `Vernacula.Tests` 40/40, `AsrBackendCoverage` 181 passed, `Vernacula.Tts.Tests` 174 passed with one failure — `AlignmentSidecarTests.SegmentConventionsAreDerivedFromTheSidecarPath`, which fails identically on `main` and is a Windows path-separator assumption in the test fixture. Filed separately as #154; not touched here.

## Consequences

`dotnet run` and `dotnet publish` on `Vernacula.Avalonia` now need `-f`; `dotnet build` and the solution build are unaffected, so `.github/workflows/dotnet-test.yml` needs no edit. `install.sh` passes `-f net10.0`; README, `docs/desktop-app.md` and `docs/building.md` say so.

**Correction to an earlier claim in this description.** I first wrote that CI was unchanged. The workflow file is, but the first CI run *failed*, and it caught something no amount of testing on a Windows box could have:

```
error NETSDK1073: The FrameworkReference 'Microsoft.WindowsDesktop.App.WindowsForms'
was not recognized [Vernacula.Avalonia.csproj::TargetFramework=net10.0-windows]
```

The `net9.0-windows7.0` dependency group includes `NAudio.WinForms`, whose nuspec declares a framework reference on `Microsoft.WindowsDesktop.App.WindowsForms`. The Windows Desktop targeting pack is not part of the Linux SDK, so the ubuntu solution build died; on Windows the pack is present and everything looked fine. It also quietly raised the shipped Windows app's runtime floor from the base .NET runtime to the Windows Desktop runtime, for an assembly nothing loads.

Fixed in f0d3329. It takes two knobs, because package assets and framework references travel separately: `ExcludeAssets="all"` on a direct `NAudio.WinForms` pin keeps the DLL out of `bin` but leaves the `frameworkReferences` entry in `project.assets.json`, which `ResolvePackageAssets` still turns into a real `FrameworkReference`; `DisableTransitiveFrameworkReferences` stops that half. Verified by dumping `@(FrameworkReference)` after `ResolveReferences` — with only the first, `Microsoft.WindowsDesktop.App.WindowsForms` is still listed; with both, `Microsoft.NETCore.App` is the only entry left.

`EnableWindowsTargeting=true` would have fixed the build failure alone, by having the Linux SDK download the Windows desktop packs, but it treats the symptom and leaves the runtime-floor problem standing.

I tested the escape hatch that would have avoided this — an OS-conditional singular `TargetFramework`. Bare `dotnet run` does work with it, but restore evaluates the condition too, so the assets file only ever contains the host's framework and the other one cannot be built at all (`NETSDK1005`, even from clean). CI on ubuntu would stop compiling every `#if WINDOWS` branch. Rejected on those grounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GAqWdE4wQqAk2L9fVyTdm
