### PR TITLE
Assert the segments-dir convention instead of a literal path string (#154)

### DIFF
--- a/tests/Vernacula.Tts.Tests/AlignmentSidecarTests.cs
+++ b/tests/Vernacula.Tts.Tests/AlignmentSidecarTests.cs
@@ -138,8 +138,27 @@ public class AlignmentSidecarTests : IDisposable
     [Fact]
     public void SegmentConventionsAreDerivedFromTheSidecarPath()
     {
-        string sidecar = Path.Combine("/jobs", "abc_tts.json");
-        Assert.Equal(Path.Combine("/jobs", "abc_tts_segments"), AlignmentSidecar.SegmentsDirFor(sidecar));
+        // ⚠ ASSERT THE CONVENTION, NOT A LITERAL PATH STRING. This used to compare against
+        // Path.Combine("/jobs", "abc_tts_segments"), which pinned an exact string that only
+        // held where the hard-coded "/" happened to be the platform separator. On Windows
+        // Path.Combine treats a leading "/" as an opaque first component and leaves it alone,
+        // while SegmentsDirFor round-trips through Path.GetDirectoryName, which normalises it
+        // to "\" — so the two sides disagreed at position 0 ("/jobs\…" vs "\jobs\…") even
+        // though both name the same directory and Windows treats the separators as
+        // interchangeable. The code was right; the assertion was over-specified (#154). It
+        // passed on Linux, which is the only platform CI has ever run, so it went unnoticed
+        // until the suite was first run on Windows.
+        //
+        // What SegmentsDirFor actually promises — see its own docstring — is "beside the
+        // sidecar, named {stem}_segments". Asserting those two facts separately says the same
+        // thing without hard-coding a separator, and the stem check still catches the
+        // extension being left on (abc_tts.json_segments).
+        string sidecar  = Path.Combine(_dir, "abc_tts.json");
+        string segments = AlignmentSidecar.SegmentsDirFor(sidecar);
+
+        Assert.Equal(Path.GetDirectoryName(sidecar), Path.GetDirectoryName(segments));
+        Assert.Equal("abc_tts_segments", Path.GetFileName(segments));
+
         Assert.Equal("seg_0000.wav", AlignmentSidecar.SegmentFileName(0));
         Assert.Equal("seg_0042.wav", AlignmentSidecar.SegmentFileName(42));
         // Sorts lexically in index order, which is what a directory listing relies on.


### PR DESCRIPTION
Closes #154.

## The failure

```
Vernacula.Tts.Tests.AlignmentSidecarTests.SegmentConventionsAreDerivedFromTheSidecarPath [FAIL]
  Assert.Equal() Failure: Strings differ
          ↓ (pos 0)
  Expected: "/jobs\abc_tts_segments"
  Actual:   "\jobs\abc_tts_segments"
```

## It's the test, not the code

The two sides built the directory part by different routes, and on Windows those routes disagree about a leading `/`:

- The **expectation** was `Path.Combine("/jobs", "abc_tts_segments")`. `Path.Combine` treats `/jobs` as an opaque first component and leaves it alone → `/jobs\abc_tts_segments`.
- `SegmentsDirFor` round-trips through `Path.GetDirectoryName`, which normalises `/` to the platform separator → `\jobs\abc_tts_segments`.

Both name the same directory — Windows treats `/` and `\` as interchangeable separators — so `SegmentsDirFor` was behaving correctly and the assertion was over-specified: it pinned an exact string that only holds when the separator the test hard-codes happens to be the platform's own. On Linux both sides are `/jobs/abc_tts_segments`, which is why the only platform CI has ever run never saw it.

## The fix

`SegmentsDirFor`'s own docstring states the contract: *"The folder of per-segment WAVs beside a sidecar: `{stem}_segments/`."* That is two facts, and the test now asserts them separately rather than reconstructing the string:

```csharp
string sidecar  = Path.Combine(_dir, "abc_tts.json");
string segments = AlignmentSidecar.SegmentsDirFor(sidecar);

Assert.Equal(Path.GetDirectoryName(sidecar), Path.GetDirectoryName(segments));
Assert.Equal("abc_tts_segments", Path.GetFileName(segments));
```

Off `_dir`, the per-test temp directory the rest of the class already uses, so no separator is hard-coded anywhere and it cannot break this way again on a platform nobody has tried.

**Coverage is not weakened.** A segments dir that stopped being a sibling fails the first assertion; one that kept the extension (`abc_tts.json_segments`) or changed the suffix fails the second — which is what the string comparison was really buying. The `SegmentFileName` and lexical-sort assertions were always separator-free and are untouched.

## Verification

Windows 11, full suite — green for the first time:

| suite | result |
|---|---|
| `Vernacula.Tests` | 40 passed, 0 failed |
| `Vernacula.Tts.Tests` | 175 passed, 0 failed, 7 skipped |
| `AsrBackendCoverage` | 181 passed, 0 failed, 2 skipped |
| `IndicConformerTest` | 23 skipped (asset-gated, as on hosted CI) |

Linux is covered by CI on this PR. Between the two, both separator conventions are exercised — which is the only way this change can be properly checked.

I skipped a formal review pass on this one: it is a four-line assertion change, and running it on both platforms is stronger evidence than a reviewer reading it. Say the word if you'd rather I ran one anyway.

## Not done here

The issue also notes that nothing in CI builds or tests on Windows, which is why both this and the NETSDK1073 failure in #155 were only findable by hand. Adding a `windows-latest` leg is a standing cost decision rather than part of this fix, so I've left it out — happy to add one in a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GAqWdE4wQqAk2L9fVyTdm