### PR TITLE
feat(vibevoice-streaming): decode a too-long recording in passes (closes #150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ More screenshots and a feature tour live in [docs/desktop-app.md](docs/desktop-a
 - **Local, private transcription** — audio never leaves your computer
 - **Multi-speaker detection** — identifies and labels up to four concurrent speakers
 - **No audio length limits** — the default pipeline streams and segments, so file length is
-  unbounded. The VibeVoice backends are the exception: they hold the whole recording in
-  context to attribute speakers without a diarizer, which caps them at their context window
-  (about 68 minutes for VibeVoice-ASR Streaming 1.5B, 2 hours for the 7B, less on a card that
-  cannot hold that much context alongside the model). Over-long files are refused up front
-  rather than failing partway.
+  unbounded. The VibeVoice backends hold the whole recording in context to attribute speakers
+  without a diarizer, so anything past their context window (about 68 minutes for VibeVoice-ASR
+  Streaming 1.5B, 2 hours for the 7B, less on a card that cannot hold that much context
+  alongside the model) is decoded in several passes. Each pass gets its own set of speaker
+  labels, since nothing carries identity across the reset — merge them in the editor if the
+  same person appears in more than one.
 - **Transcript editor** with confidence colouring, audio playback, and word-level timestamps
 - **Pluggable ASR backends** — Parakeet TDT v3, Cohere Transcribe, Qwen3-ASR, VibeVoice-ASR, VibeVoice-ASR Streaming, Whisper large-v3-turbo, IndicConformer, Granite Speech 4.1
 - **Shallow KenLM fusion** for domain-specific English (general, medical)

--- a/docs/dev/vibevoice_asr_streaming_investigation.md
+++ b/docs/dev/vibevoice_asr_streaming_investigation.md
@@ -1378,3 +1378,108 @@ The first version of that test checked one card size and passed with either miti
 independently load-bearing: remove either and the sweep fails. The arithmetic now lives in
 `VibeVoiceStreamingBudget`, which the backend and the settings window both call, rather than in
 two copies that had to agree and did not.
+
+
+## Run 36 — 2026-09-09 10:20 — a recording too long for the cache is decoded in passes (issue #150)
+
+The reporter came back with the other half of #150: with the cache now sized to the recording,
+a 28-minute file on their 16 GB card is refused up front — "about N minutes would fit right
+now" — where before the whole thing failed on allocation. Their suggestion was to cut the audio
+with ffmpeg and stitch the pieces back together.
+
+The reason that had not been done is speaker identity. This model attributes speakers *because*
+it keeps the whole recording in context; cut the context and its "Speaker 1" on the far side of
+the cut is a fresh guess with no relationship to the "Speaker 1" before it. Matching them up
+means embedding-based re-identification, which is a diarizer — the component this backend exists
+to avoid.
+
+The question this run answers is whether that matters enough to justify refusing the job. It
+does not: labelling the passes disjointly and letting the user merge them turns a refusal into a
+transcript with a naming chore attached.
+
+### What was built
+
+- The planner no longer refuses a recording that needs more cache than the export ceiling or the
+  card allows. It returns the largest cache that *is* allowed, and the run decodes into it as
+  many times as the file takes. The only refusals left are a package with a baked-in cache length
+  the card cannot hold (ORT rejects a shorter buffer, so there is nothing to split into) and a
+  card with less than `MinKvTokens` to spare, which is not enough to be worth a pass.
+- The pass boundary is decided at run time, not planned: before each window, if `kvPos +
+  worstCaseWindow` exceeds the cache, the position counter resets to 0 and the prompt is
+  re-prefilled. Worst case is the two speech markers, the window's frames, every token the
+  decoder is allowed to emit for it, and the chunk-end token — about 16 seconds of audio's worth
+  of slack on a pass measured in minutes. The cache therefore cannot overflow mid-window, which
+  is what the 2.5x safety factor used to be insuring against, and dense speech shortens a pass
+  instead of failing one.
+- `VibeVoiceStreamingChunk` carries its pass index; `SegmentAssembler` closes the open turn at a
+  boundary and shifts the model's numbering past every label already handed out. Pass 0 keeps the
+  model's own numbers, so nothing changes for a recording that fits.
+
+### Measured, 1.5B on the RTX 3090, 10-minute two-person interview
+
+The card is far too large to force a split honestly, so the cache was pinned with a temporary
+`VERNACULA_KV_TOKENS` env override (removed before commit) at 4096 positions — about 3.4 minutes
+of audio, three passes over this file.
+
+| | chunks | segments | speakers | wall |
+|---|---|---|---|---|
+| one pass (24,000-position cache) | 205 | 155 | `speaker_0` ×155 | 46.5 s |
+| three passes (4,096) | 205 | 163 | `speaker_0` ×65, `speaker_1` ×58, `speaker_2` ×40 | 40.2 s |
+
+Same 205 chunks and the same audio coverage, so nothing is dropped or decoded twice at a
+boundary. The eight extra segments are the turns the resets cut in half. Word-level similarity
+between the two transcripts is 0.925, and the differences are spread through the file rather than
+clustered at the two cuts — comma placement, sentence splits, and near-homophones of the kind
+this decoder varies on between any two runs, not damage from the reset.
+
+At the cut itself:
+
+```
+  [ 234.7s] Speaker 0:<a sentence, running on to the end of the chunk>
+  -- cache reset for pass 2; speaker numbers restart here --
+  [ 237.6s] Speaker 0:<the next words of that same sentence, as a new turn>
+```
+
+(Chunk text abstracted, as above.) The sentence is cut, as it must be — the second pass has no
+idea a sentence was in progress — but the audio is continuous, nothing is repeated or dropped
+across the boundary, and the model re-opens with a speaker marker of its own accord.
+
+This file is the interesting case for labelling: whole, the model calls everyone `speaker_0`;
+split, each pass names its own `speaker_0` and the assembler renumbers them 0, 1, 2. That is
+three labels for what is probably two people — which is exactly the trade being made. The
+alternative on offer was no transcript.
+
+### Negative result: forcing a planner-driven split on a 24 GB card is finicky
+
+Ballast (`run34/ballast.py`) was used to make the card look small. Eight attempts, none of which
+landed on a planner-chosen split:
+
+| ballast | free before the run | file | result |
+|---|---|---|---|
+| 17.4, 17.2 GiB | 4.7, 4.9 GiB | 30 min | refused: nothing left after the working-set reserve |
+| 16.6, 16.3, 16.05 GiB | 5.6, 5.6, 5.9 GiB | 10/30 min | refused |
+| 15.6 GiB | 6.6 GiB | 30 min | refused |
+| 15.5 GiB | 6.7 GiB | 10 min | one pass, 24,000-position cache |
+| 15.0 GiB | 6.1 GiB | 30 min | one pass, 614 chunks, 439 segments, 146 s |
+
+The band between "refuses" and "does not need to split" is only a few hundred MB wide, because a
+cache position is cheap (28 KiB) next to a 1.39 GiB working-set reserve — and the two runs at
+6.6 and 6.1 GiB free came out on opposite sides of it, so where the boundary falls is not even
+stable between runs. Two things worth recording from that:
+
+- With 6.67 GiB free the 10-minute run peaked at 6.12 GiB against a 656 MiB cache, so the fixed
+  cost is about 5.5 GiB where the budget models 4.58 (3.19 weights + 1.39 working set). The
+  reserve is if anything a little *low*, not conservative — the same direction of error as the
+  allocation failure that opened this issue.
+- A 30-minute file — the reporter's case, near enough — transcribes in a single pass on a card
+  with 6.1 GiB free, which is the outcome that matters most: splitting is the fallback, not the
+  normal path.
+
+### What the user sees
+
+The CLI prints `-- cache reset for pass N; speaker numbers restart here --` in the streamed
+output; the app appends `· pass N, new speaker labels` to the progress line. The settings warning
+changed from "fits about N minutes rather than the full 136" to saying that is how much is held
+*at a time*, that longer recordings are still transcribed in passes, and that the same person may
+appear under two labels. The help page and README say the same. The merge itself is the speaker
+rename the editor already has.

--- a/docs/dev/vibevoice_asr_streaming_investigation.md
+++ b/docs/dev/vibevoice_asr_streaming_investigation.md
@@ -1468,12 +1468,41 @@ cache position is cheap (28 KiB) next to a 1.39 GiB working-set reserve — and 
 stable between runs. Two things worth recording from that:
 
 - With 6.67 GiB free the 10-minute run peaked at 6.12 GiB against a 656 MiB cache, so the fixed
-  cost is about 5.5 GiB where the budget models 4.58 (3.19 weights + 1.39 working set). The
-  reserve is if anything a little *low*, not conservative — the same direction of error as the
-  allocation failure that opened this issue.
+  cost is about 5.5 GiB where the *settings picker* models 4.58 (3.19 weights + 1.39 working
+  set). The picker therefore over-promises by nearly a gigabyte's worth of minutes on a card
+  near the line. The runtime planner is not wrong in the same way — it reads free memory after
+  the weights are resident, so its reserve only has to cover growth after that point, measured
+  here at about 0.84 GiB against the 1.39 GiB it holds back.
 - A 30-minute file — the reporter's case, near enough — transcribes in a single pass on a card
   with 6.1 GiB free, which is the outcome that matters most: splitting is the fallback, not the
   normal path.
+
+### Review follow-ups
+
+Three defects came out of reviewing the above, two of them consequences of the split itself.
+
+**The split path spent every byte the memory model called spare.** Below the cap the cache is
+`needed × 2.5`, which usually leaves slack; at the cap — now the normal path for a long file
+rather than a refusal — `want == affordable` exactly, and the arena's own growth had nothing to
+grow into. Given the picker's ~0.9 GiB optimism above, that is the allocation failure this issue
+opened with, moved to an hour into the job. A tenth of the cap is now left unspent when the cap
+comes from memory. The export ceiling is not an estimate and is still spent in full, and a
+recording that fits is still given what it needs, so the picker and the planner still agree.
+
+**Speaker labels have to be dense, not just disjoint.** The first version shifted each pass's
+numbering past the previous pass's highest label. That is disjoint but not gapless — a pass that
+decodes to silence, or a model that does not start its numbering at zero, leaves a hole — and the
+results database keys speakers by row id and derives the tag back from it (`'speaker_' ||
+(speaker_id - 1)`), so a hole makes a segment's tag disagree with its speaker's name. Labels are
+now allocated per `(pass, model number)` in order of first appearance, which is dense by
+construction and still disjoint across passes. The persist loop takes the row id the insert
+returned rather than deriving one, so the two cannot drift apart even if that changes again.
+
+**The live speaker tag did not match the saved one.** The streaming callback showed
+`speaker_{seg.Speaker}` while the persist loop folded the assembler's "attributed to nobody" -1
+onto 0, so an unattributed opening turn was `speaker_-1` in the progress list and `speaker_0`
+after the reload. Pre-existing, but a pass boundary can produce one unattributed turn per pass,
+so it stopped being rare.
 
 ### What the user sees
 

--- a/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
+++ b/src/Vernacula.Avalonia/Help/en/first_steps/settings_window.md
@@ -85,13 +85,21 @@ A speaker in the result is not always a person: the model may give a distinct la
 non-speech source such as an audience, whose segment then reads something like "Applause and
 cheering". Rename or merge it in the editor like any other speaker.
 
-Recording length is capped rather than unlimited. The model keeps its whole context — that is
-how it tracks who is speaking without a separate diarizer — so each package is built with a
-ceiling set to the checkpoint's trained context: about **68 minutes** for the 1.5B and about
-**2 hours** for the 7B. A smaller card lowers that further, because the memory of the
-recording has to fit alongside the model. Either way a file that is too long is refused up
-front with a message naming the length that would fit, instead of failing partway through. Note that speed tapers as the context fills, so the last
-minutes of a very long recording decode more slowly than the first.
+Long recordings are decoded in passes. The model keeps its whole context — that is how it
+tracks who is speaking without a separate diarizer — so how much audio it can hold at once is
+bounded by the checkpoint's trained context, about **68 minutes** for the 1.5B and about **2
+hours** for the 7B, and by how much of your card is free, which on a small card is the lower of
+the two. A recording longer than that is not refused: the model's context is cleared and
+decoding continues, as many times as the file needs.
+
+What that costs is the speaker numbering, not the transcript. Nothing survives the reset, so
+the model starts naming speakers from scratch and there is no reliable way to tell that its
+"Speaker 1" after a reset is the same person as before it. Rather than guess, each pass gets
+its own labels — `speaker_0`, `speaker_1` in the first stretch, then `speaker_2`, `speaker_3`
+in the next — and you merge the ones that are the same person in the editor. The Settings page
+tells you how much audio your card holds at a time, and the progress line says when a new pass
+starts. Note that speed tapers as the context fills, so the last minutes of a pass decode more
+slowly than the first.
 
 ### IndicConformer language selection
 

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -283,7 +283,11 @@ internal class TranscriptionService
                 }, ct).ConfigureAwait(false);
 
                 db.BeginBulkInsert();
-                var seenVibeSpeakers = new HashSet<int>();
+                // The label the model gives a speaker is not a row id: a recording decoded in
+                // several passes carries labels shifted past the previous pass's, and a pass
+                // that never says "Speaker 0" leaves a gap. So each label is inserted on first
+                // sight and the row it actually got is what the segments reference.
+                var vibeSpeakerRows = new Dictionary<int, int>();
                 foreach (var seg in vibeSegs)
                 {
                     // The streaming model can emit text before it names anyone, which the
@@ -291,10 +295,11 @@ internal class TranscriptionService
                     // writing "speaker_-1" and a diarization id of 0, which no consumer expects.
                     int speaker     = Math.Max(0, seg.Speaker);
                     string spkId    = $"speaker_{speaker}";
-                    int diarSpkId   = speaker + 1;
-
-                    if (seenVibeSpeakers.Add(speaker))
-                        db.InsertSpeaker(spkId);
+                    if (!vibeSpeakerRows.TryGetValue(speaker, out int diarSpkId))
+                    {
+                        diarSpkId = db.AddSpeaker(spkId);
+                        vibeSpeakerRows[speaker] = diarSpkId;
+                    }
 
                     // VibeVoice does not emit timestamps, so we synthesize them uniformly over
                     // the segment while preserving the real decoder token ids and logprobs.

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -226,7 +226,11 @@ internal class TranscriptionService
                                 for (; shown < segs.Count; shown++)
                                 {
                                     var seg = segs[shown];
-                                    string sid = $"speaker_{seg.Speaker}";
+                                    // Same fold as the persist loop below: text the model
+                                    // attributed to nobody is speaker -1, and showing
+                                    // "speaker_-1" here and "speaker_0" after the reload would
+                                    // be two names for one turn.
+                                    string sid = $"speaker_{Math.Max(0, seg.Speaker)}";
                                     onSegmentAdded(new SegmentRow
                                     {
                                         SegmentId          = shown,
@@ -283,10 +287,11 @@ internal class TranscriptionService
                 }, ct).ConfigureAwait(false);
 
                 db.BeginBulkInsert();
-                // The label the model gives a speaker is not a row id: a recording decoded in
-                // several passes carries labels shifted past the previous pass's, and a pass
-                // that never says "Speaker 0" leaves a gap. So each label is inserted on first
-                // sight and the row it actually got is what the segments reference.
+                // Row ids are the app's speaker identity — GetSegments derives the tag back
+                // from them — so a segment has to reference the row its speaker actually got
+                // rather than a number derived from the label. The assembler hands out labels
+                // densely in first-appearance order, so the two agree, and taking the id from
+                // the insert keeps them agreeing without relying on that.
                 var vibeSpeakerRows = new Dictionary<int, int>();
                 foreach (var seg in vibeSegs)
                 {

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -240,9 +240,14 @@ internal class TranscriptionService
                                     onSegmentText(segs.Count - 1, segs[^1].Content);
 
                                 double pct = vibeDuration > 0 ? c.End / vibeDuration * 100.0 : 0;
+                                // A recording too long for the cache is decoded in passes, and
+                                // the speaker numbering restarts with each one. Say so while it
+                                // is happening rather than leaving the extra speakers to be
+                                // discovered in the transcript.
+                                string pass = c.Pass > 0 ? $" · pass {c.Pass + 1}, new speaker labels" : "";
                                 progress.Report(new TranscriptionProgress(
                                     TranscriptionPhase.Recognizing, 0, 100,
-                                    $"{c.End:F1}s / {vibeDuration:F1}s",
+                                    $"{c.End:F1}s / {vibeDuration:F1}s{pass}",
                                     Math.Max(0, segs.Count - 1), c.Text, OverridePercent: pct));
                             },
                             ct: ct);

--- a/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
+++ b/src/Vernacula.Avalonia/ViewModels/SettingsViewModel.cs
@@ -180,8 +180,9 @@ internal partial class SettingsViewModel : ObservableObject
     /// <summary>
     /// Says what this card can actually do with the selected checkpoint. The cache is sized to
     /// the recording rather than to the export ceiling (issue #150), so the honest answer is
-    /// not "fits / does not fit" but the length that fits: a 16 GB card runs the 7B for about
-    /// an hour of audio and cannot run it for the full two.
+    /// not "fits / does not fit" but how much audio is decoded at a time: a 16 GB card runs the
+    /// 7B for about an hour before it has to reset the cache and start a new pass, which costs
+    /// the speaker numbering rather than the transcript.
     ///
     /// Reads FREE memory, not total. The runtime decides on what is free when the job starts,
     /// and a card is never entirely yours — the desktop alone is most of a gigabyte. Quoting
@@ -224,8 +225,10 @@ internal partial class SettingsViewModel : ObservableObject
         double capMinutes = VibeVoiceStreamingBudget.CeilingMinutes(shape.Ceiling);
         return fits >= capMinutes
             ? ""
-            : $"This card has {freeGiB:F1} GB of VRAM free, which fits about {fits:F0} minutes "
-            + $"of audio with this checkpoint rather than the full {capMinutes:F0}.";
+            : $"This card has {freeGiB:F1} GB of VRAM free, which holds about {fits:F0} minutes "
+            + $"of audio at a time with this checkpoint rather than the full {capMinutes:F0}. "
+            + "Longer recordings are still transcribed, in passes of about that length; speaker "
+            + "labels are not carried across a pass, so the same person may appear twice.";
     }
 
     public bool ShowVibeVoiceStreamingSizeWarning => VibeVoiceStreamingSizeWarning.Length > 0;
@@ -234,7 +237,7 @@ internal partial class SettingsViewModel : ObservableObject
         : "VibeVoice-ASR Streaming";
     public string VibeVoiceStreamingAsrDescription => VibeVoiceStreamingOnCpu
         ? "Chunked ASR with built-in speaker attribution, in 10 languages. No CUDA provider was found, so this runs on the CPU: the transcript is the same but decoding takes roughly 12x the length of the recording, so a 10-minute file is about two hours. Use the 1.5B, and prefer another backend for anything long."
-        : "Chunked ASR with built-in speaker attribution, in 10 languages. Text appears as the recording is decoded rather than after it finishes. Recording length is capped by the checkpoint's context: about 68 minutes (1.5B) or 2 hours (7B).";
+        : "Chunked ASR with built-in speaker attribution, in 10 languages. Text appears as the recording is decoded rather than after it finishes. Anything longer than the checkpoint's context (about 68 minutes for the 1.5B, 2 hours for the 7B, less on a card with little free memory) is decoded in passes, each with its own set of speaker labels.";
     public string VibeVoiceAsrLabel => CanUseVibeVoiceAsr ? "VibeVoice-ASR" : "VibeVoice-ASR (Unavailable - CUDA Missing)";
     public string VibeVoiceAsrDescription => CanUseVibeVoiceAsr
         ? "Whole-recording ASR with built-in diarization. Downloads into the vibevoice_asr models folder."

--- a/src/Vernacula.Base/VibeVoiceStreamingAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceStreamingAsr.cs
@@ -163,7 +163,17 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         // Below the cap this is "size it to the recording". At the cap — a recording longer than
         // the export's context, or than this card can hold — it is "size it to one pass", and the
         // recording is transcribed in as many passes as it takes.
-        long want = Math.Min((long)(needed * KvSafetyFactor), cap);
+        //
+        // A tenth is left unspent when the cap comes from memory rather than from the export.
+        // `affordable` is what the memory model says is spare, and that model is an estimate
+        // which has been wrong in this direction before (Run 34): spending all of it would put
+        // the arena's own growth over the line partway through a long job — the failure this
+        // issue opened with, except hours in rather than up front. The export ceiling is not an
+        // estimate, so it is spent in full. A recording that fits is given what it needs either
+        // way, so the length the settings window promises is still the length that is allocated.
+        long usable = affordable < maxKvTokens ? cap - cap / 10 : cap;
+        if (needed <= cap) usable = Math.Max(usable, needed);
+        long want = Math.Min((long)(needed * KvSafetyFactor), usable);
         want = Math.Max(want, Math.Min(MinKvTokens, cap));
 
         // The floor is only a floor when the recording has to be split: a short file that fits
@@ -401,14 +411,18 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         private double _start, _end;
         private bool   _started;
         private int    _pass;
-        /// <summary>Added to the model's own numbering, so this pass cannot reuse a label.</summary>
-        private int    _speakerBase;
         /// <summary>
-        /// Highest label handed out so far. Starts at 0 rather than -1 because 0 is spoken for
-        /// even before a marker: text the model attributes to nobody is reported as speaker -1
-        /// and folded onto 0 downstream, and a later pass must not land on top of it.
+        /// Labels, in order of first appearance, keyed by the pass that produced them: the same
+        /// "Speaker 1" either side of a cache reset is two different people and gets two labels.
+        ///
+        /// The model's own numbering cannot be handed out as-is. It restarts at every boundary,
+        /// and consumers count on labels being dense and ascending — the results database keys
+        /// speakers by row id and derives the tag back from it, so a gap makes the tag and the
+        /// name disagree. Entries are created when a turn is first built, which is also when the
+        /// <see cref="Segments"/> preview builds the open turn: the open turn is always the
+        /// newest one, so previewing it assigns the label it was going to get anyway.
         /// </summary>
-        private int    _maxSpeaker;
+        private readonly Dictionary<(int Pass, int Speaker), int> _labels = [];
 
         /// <summary>Every turn so far. The last entry is still open and may grow.</summary>
         public IReadOnlyList<VibeVoiceSegment> Segments
@@ -429,13 +443,9 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
                 // The cache was reset here, so the turn in progress cannot continue across the
                 // boundary and the numbering on the far side means something else.
                 Close(chunk.Start);
-                _pass        = chunk.Pass;
-                _speakerBase = _maxSpeaker + 1;
-                // Claimed immediately: a pass that never names anyone still occupies its base,
-                // and the pass after it has to start above that.
-                _maxSpeaker  = _speakerBase;
-                _speaker     = -1;
-                _start       = chunk.Start;
+                _pass    = chunk.Pass;
+                _speaker = -1;
+                _start   = chunk.Start;
             }
             int pos = 0;
             foreach (Match m in SpeakerMarker.Matches(chunk.Text))
@@ -444,7 +454,6 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
                 double at = At(chunk, m.Index);
                 Close(at);
                 _speaker = int.Parse(m.Groups[1].Value);
-                _maxSpeaker = Math.Max(_maxSpeaker, Label);
                 _start   = at;
                 // The marker's own tokens belong to no turn: they are structure, not speech.
                 pos = m.Index + m.Length;
@@ -478,17 +487,24 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         }
 
         /// <summary>
-        /// The label the open turn gets: the model's own number in the first pass, shifted past
-        /// every label already used in a later one. Text the model attributed to nobody keeps
-        /// its -1 in the first pass — callers already fold that onto 0 — and takes the base in a
-        /// later one, which is where speaker 0 of that pass would land anyway.
+        /// The label for the turn being built, allocating one if this speaker has not been seen
+        /// in this pass before. Text the model attributed to nobody keeps the -1 callers already
+        /// fold onto 0 in the first pass, but still consumes its label, so the first speaker of
+        /// a later pass cannot land on top of it.
         /// </summary>
-        private int Label => _speaker < 0
-            ? (_speakerBase == 0 ? -1 : _speakerBase)
-            : _speakerBase + _speaker;
+        private int Label()
+        {
+            var key = (_pass, _speaker);
+            if (!_labels.TryGetValue(key, out int label))
+            {
+                label = _labels.Count;
+                _labels[key] = label;
+            }
+            return _speaker < 0 && _pass == 0 ? -1 : label;
+        }
 
         private VibeVoiceSegment Build(string text, double end) =>
-            new(_start, end, Label, text)
+            new(_start, end, Label(), text)
             {
                 TokenIds      = _openTokens.ToArray(),
                 TokenLogprobs = _openLogprobs.Count == _openTokens.Count ? _openLogprobs.ToArray() : [],

--- a/src/Vernacula.Base/VibeVoiceStreamingAsr.cs
+++ b/src/Vernacula.Base/VibeVoiceStreamingAsr.cs
@@ -24,12 +24,17 @@ namespace Vernacula.Base;
 /// present_key_i are bound to the SAME device tensor, allocated once, and the kernel updates
 /// it in place. Attention costs only the filled length, so VRAM is flat in recording length
 /// and throughput does not decay (docs/dev/vibevoice_asr_streaming_investigation.md, Run 12).
-/// The buffer ceiling bounds job length; exceeding it raises before any work is done.
 ///
-/// Loop: prefill the prompt once; then for every window feed
+/// Loop: prefill the prompt; then for every window feed
 /// [speech_start] + frames + [speech_end], greedy-decode until &lt;|text_chunk_end|&gt; or EOS,
 /// then feed &lt;|text_chunk_end|&gt; itself so the cache always ends on it. The KV cache lives
-/// on the device and grows for the whole recording; upstream never evicts.
+/// on the device and grows for the whole pass; upstream never evicts.
+///
+/// A recording that needs more cache than the export or the card allows is decoded in several
+/// such passes: the cache is reset and the prompt re-prefilled, which bounds VRAM by the pass
+/// rather than by the recording. Nothing survives a reset, so the model renumbers its speakers
+/// from scratch and <see cref="SegmentAssembler"/> keeps the passes' labels disjoint rather
+/// than pretending they line up (issue #150).
 /// </summary>
 public sealed class VibeVoiceStreamingAsr : IDisposable
 {
@@ -54,7 +59,10 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
     /// </summary>
     private readonly int _fixedKvTokens;
 
-    /// <summary>Longest recording this package can transcribe, from its cache ceiling.</summary>
+    /// <summary>
+    /// Longest stretch this package decodes as one pass, from its cache ceiling. Recordings
+    /// longer than this are decoded in several passes rather than refused.
+    /// </summary>
     public double MaxAudioSeconds => _maxKvTokens / PositionsPerSecond;
 
     /// <inheritdoc cref="VibeVoiceStreamingBudget.PositionsPerSecond"/>
@@ -92,8 +100,12 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
     /// one-minute file (issue #150). So the buffer is sized to the recording in hand and only
     /// then clamped to what the card has free.
     ///
+    /// When the recording needs more than the clamp allows, the answer is the clamp rather than
+    /// a refusal: <see cref="Transcribe"/> resets the cache and re-prefills the prompt when the
+    /// next window would not fit, so a recording of any length runs in passes that do fit.
+    ///
     /// The estimate is <see cref="PositionsPerSecond"/>, an average; <see cref="KvSafetyFactor"/>
-    /// covers speech denser than average, and running out anyway is reported by <see cref="Step"/>.
+    /// covers speech denser than average, and speech denser still only shortens a pass.
     /// </summary>
     private int ChooseKvTokens(double audioSeconds, bool onDevice)
     {
@@ -120,44 +132,52 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         double audioSeconds, int maxKvTokens, int fixedKvTokens, long kvBytesPerPosition,
         long workingSetBytes, long freeBytes)
     {
+        // Free device memory, less what a run needs beyond the cache. long.MaxValue when NVML
+        // could not say: an unknown card is not a reason to allocate the ceiling, but it is no
+        // reason to refuse either, so only the recording and the export decide.
+        long budget     = freeBytes > 0 ? freeBytes - workingSetBytes : long.MaxValue;
+        long affordable = freeBytes <= 0 ? long.MaxValue
+                        : budget > 0     ? budget / kvBytesPerPosition
+                        : 0;
+
+        // A graph with a baked-in length has to have all of it, whatever the recording needs,
+        // and there is nothing to plan: ORT rejects any other size.
+        if (fixedKvTokens > 0)
+        {
+            if (affordable < fixedKvTokens)
+                throw new InvalidOperationException(
+                    $"Not enough free GPU memory for this package: its cache needs about " +
+                    $"{fixedKvTokens * kvBytesPerPosition / (double)(1L << 30):F1} GiB and " +
+                    $"{Math.Max(0, budget) / (double)(1L << 30):F1} GiB is free once the model and " +
+                    "its working set are accounted for. This package was exported with a fixed " +
+                    "cache length, so it pays for its whole context on every run; re-download it " +
+                    "to have the cache sized to the recording instead.");
+            return fixedKvTokens;
+        }
+
         // The prompt, its hotwords, and the rounding on the last partial window all sit outside
         // the per-second estimate.
         long needed = (long)Math.Ceiling(audioSeconds * PositionsPerSecond) + PromptPositionSlack;
-        if (needed > maxKvTokens)
-            throw new InvalidOperationException(
-                $"Recording is about {audioSeconds / 60:F1} minutes, which is estimated to need " +
-                $"more than this model's {maxKvTokens}-position cache (about " +
-                $"{maxKvTokens / PositionsPerSecond / 60:F0} minutes of audio). Re-export with a " +
-                "larger --max-tokens, or split the recording.");
+        long cap    = Math.Min(maxKvTokens, affordable);
 
-        long want = fixedKvTokens > 0
-            ? fixedKvTokens
-            // Math.Min on the floor as well: a package exported with a ceiling below the floor
-            // would otherwise reach Math.Clamp with min above max, which throws.
-            : Math.Clamp((long)(needed * KvSafetyFactor), Math.Min(MinKvTokens, maxKvTokens), maxKvTokens);
-        if (freeBytes <= 0)
-            return (int)want;   // No NVML answer: size to the recording and let ORT complain.
+        // Below the cap this is "size it to the recording". At the cap — a recording longer than
+        // the export's context, or than this card can hold — it is "size it to one pass", and the
+        // recording is transcribed in as many passes as it takes.
+        long want = Math.Min((long)(needed * KvSafetyFactor), cap);
+        want = Math.Max(want, Math.Min(MinKvTokens, cap));
 
-        long budget     = freeBytes - workingSetBytes;
-        long affordable = budget > 0 ? budget / kvBytesPerPosition : 0;
-        // A graph with a baked-in length has to have all of it; one that lets us choose only
-        // has to cover the recording.
-        long required = fixedKvTokens > 0 ? fixedKvTokens : needed;
-        if (affordable < required)
+        // The floor is only a floor when the recording has to be split: a short file that fits
+        // in less than the floor is one pass and costs what it costs. Below the floor there is
+        // nothing worth splitting into, and passes that short would spend most of their cache
+        // re-reading the prompt.
+        if (want < Math.Min(MinKvTokens, needed))
             throw new InvalidOperationException(
-                $"Not enough free GPU memory for a {audioSeconds / 60:F1}-minute recording: its " +
-                $"cache needs about {required * kvBytesPerPosition / (double)(1L << 30):F1} GiB and " +
+                "Not enough free GPU memory to transcribe with this checkpoint: " +
                 $"{Math.Max(0, budget) / (double)(1L << 30):F1} GiB is free once the model and its " +
-                "working set are accounted for. " +
-                (fixedKvTokens > 0
-                    ? "This package was exported with a fixed cache length, so it pays for its "
-                    + "whole context on every run; re-download it to have the cache sized to the "
-                    + "recording instead."
-                    : $"About {affordable / PositionsPerSecond / 60:F0} minutes would fit right "
-                    + "now — close other GPU applications, use the 1.5B checkpoint, or split the "
-                    + "recording."));
+                "working set are accounted for, which is not enough cache to be worth decoding a " +
+                "pass into. Close other GPU applications, or use the 1.5B checkpoint.");
 
-        return (int)Math.Min(want, affordable);
+        return (int)want;
     }
 
     // Streaming constants from export-report.json["streaming"]
@@ -281,18 +301,36 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         var window  = new float[WindowSamples];
         var emptyAudio = Array.Empty<Float16>();
         var emptyIds   = Array.Empty<long>();
+        // The most one window can cost: its two speech markers, its frames, every token the
+        // decoder is allowed to generate for it, and the chunk-end token fed back afterwards.
+        // A pass ends before a window that would not fit, so the cache never overflows and the
+        // planner's average-based estimate only decides how long a pass tends to be.
+        long worstCaseWindow = 2 + FramesPerWindow + maxNewTokensPerChunk + 1;
+
         try
         {
-            // 1 — prompt prefill
             long[] prompt = hotwordTokenIds is { Length: > 0 }
                 ? [.. _promptHotwordsHeadIds, .. hotwordTokenIds, .. _promptTailIds]
                 : _promptTokenIds;
-            Step(prompt, emptyAudio, 0, emptyIds, kvBuffers, kvTokens, ref kvPos, binding, runOptions, false);
 
-            // 2 — one window per hop, zero-padded at the end of the recording
+            // One window per hop, zero-padded at the end of the recording, in as many passes as
+            // the cache takes: the first window of a pass prefills the prompt at position 0, and
+            // a pass ends as soon as the next window would not fit (issue #150).
+            int pass = -1;
             for (int ci = 0; ci < totalChunks; ci++)
             {
                 ct.ThrowIfCancellationRequested();
+                if (pass < 0 || kvPos + worstCaseWindow > kvTokens)
+                {
+                    kvPos = 0;
+                    pass++;
+                    Step(prompt, emptyAudio, 0, emptyIds, kvBuffers, kvTokens, ref kvPos, binding, runOptions, false);
+                    if (kvPos + worstCaseWindow > kvTokens)
+                        throw new InvalidOperationException(
+                            $"A {kvTokens}-position cache does not hold the prompt and one window " +
+                            $"({kvPos} + {worstCaseWindow} positions). Free GPU memory, or use the " +
+                            "1.5B checkpoint.");
+                }
                 int start = ci * HopSamples;
                 int n = Math.Min(WindowSamples, audio.Length - start);
                 Array.Copy(audio, start, window, 0, n);
@@ -320,6 +358,7 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
                 var (chunkText, tokenCharEnds) = DecodeWithOffsets(ids);
                 var chunk = new VibeVoiceStreamingChunk(
                     Index: ci,
+                    Pass:  pass,
                     Start: start / (double)SampleRate,
                     End:   Math.Min(start + HopSamples, audio.Length) / (double)SampleRate,
                     Text:  chunkText,
@@ -345,6 +384,12 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
     /// marker, so the newest segment stays open and grows with each chunk. Callers should
     /// re-read <see cref="Segments"/> after every <see cref="Add"/>: entries beyond what they
     /// have already shown are new turns, and the last entry's text may have changed.
+    ///
+    /// A long recording is decoded in passes with an empty cache between them, so the model's
+    /// numbering restarts and its "Speaker 1" after a boundary is not the one before it. The
+    /// numbering is therefore shifted past everything already used: the passes get disjoint
+    /// labels, and deciding that two of them are the same person is left to whoever can
+    /// actually tell (issue #150).
     /// </summary>
     public sealed class SegmentAssembler
     {
@@ -355,6 +400,15 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         private int    _speaker = -1;
         private double _start, _end;
         private bool   _started;
+        private int    _pass;
+        /// <summary>Added to the model's own numbering, so this pass cannot reuse a label.</summary>
+        private int    _speakerBase;
+        /// <summary>
+        /// Highest label handed out so far. Starts at 0 rather than -1 because 0 is spoken for
+        /// even before a marker: text the model attributes to nobody is reported as speaker -1
+        /// and folded onto 0 downstream, and a later pass must not land on top of it.
+        /// </summary>
+        private int    _maxSpeaker;
 
         /// <summary>Every turn so far. The last entry is still open and may grow.</summary>
         public IReadOnlyList<VibeVoiceSegment> Segments
@@ -370,6 +424,19 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
         public void Add(VibeVoiceStreamingChunk chunk)
         {
             if (!_started) { _start = chunk.Start; _started = true; }
+            if (chunk.Pass != _pass)
+            {
+                // The cache was reset here, so the turn in progress cannot continue across the
+                // boundary and the numbering on the far side means something else.
+                Close(chunk.Start);
+                _pass        = chunk.Pass;
+                _speakerBase = _maxSpeaker + 1;
+                // Claimed immediately: a pass that never names anyone still occupies its base,
+                // and the pass after it has to start above that.
+                _maxSpeaker  = _speakerBase;
+                _speaker     = -1;
+                _start       = chunk.Start;
+            }
             int pos = 0;
             foreach (Match m in SpeakerMarker.Matches(chunk.Text))
             {
@@ -377,6 +444,7 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
                 double at = At(chunk, m.Index);
                 Close(at);
                 _speaker = int.Parse(m.Groups[1].Value);
+                _maxSpeaker = Math.Max(_maxSpeaker, Label);
                 _start   = at;
                 // The marker's own tokens belong to no turn: they are structure, not speech.
                 pos = m.Index + m.Length;
@@ -409,8 +477,18 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
             }
         }
 
+        /// <summary>
+        /// The label the open turn gets: the model's own number in the first pass, shifted past
+        /// every label already used in a later one. Text the model attributed to nobody keeps
+        /// its -1 in the first pass — callers already fold that onto 0 — and takes the base in a
+        /// later one, which is where speaker 0 of that pass would land anyway.
+        /// </summary>
+        private int Label => _speaker < 0
+            ? (_speakerBase == 0 ? -1 : _speakerBase)
+            : _speakerBase + _speaker;
+
         private VibeVoiceSegment Build(string text, double end) =>
-            new(_start, end, _speaker, text)
+            new(_start, end, Label, text)
             {
                 TokenIds      = _openTokens.ToArray(),
                 TokenLogprobs = _openLogprobs.Count == _openTokens.Count ? _openLogprobs.ToArray() : [],
@@ -507,13 +585,12 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
     {
         int seqLen = prefixIds.Length + audioCount + suffixIds.Length;
         long total = kvPos + seqLen;
+        // A backstop. Transcribe ends a pass before a window that would not fit, so reaching
+        // this means a single window cost more than its worst case — not that the recording is
+        // too long, which is no longer a way to fail.
         if (total > kvCapacity)
             throw new InvalidOperationException(
-                $"KV cache full: {total} positions needed, {kvCapacity} allocated. This recording " +
-                $"holds more speech than the {PositionsPerSecond:F0}-positions-per-second estimate " +
-                (kvCapacity < _maxKvTokens
-                    ? "and the free GPU memory allowed for; close other GPU applications or split the recording."
-                    : $"allowed for; this package handles about {MaxAudioSeconds / 60:F0} minutes of audio."));
+                $"KV cache full: {total} positions needed, {kvCapacity} allocated.");
 
         binding.ClearBoundInputs();
         binding.ClearBoundOutputs();
@@ -656,6 +733,11 @@ public sealed class VibeVoiceStreamingAsr : IDisposable
 /// not currently carried onto the segments <see cref="VibeVoiceStreamingAsr.ToSegments"/>
 /// produces, so the editor shows no per-word confidence for this backend yet.</para>
 /// </summary>
+/// <param name="Pass">
+///   Which decoding pass produced this chunk. A recording longer than the cache is decoded in
+///   passes, each starting from an empty cache, so nothing — least of all speaker identity —
+///   carries from one pass to the next. Zero for a recording that fits in one.
+/// </param>
 public sealed record VibeVoiceStreamingChunk(
     int Index, double Start, double End, string Text, long[] TokenIds, float[] TokenLogprobs,
-    int[] TokenCharEnds);
+    int[] TokenCharEnds, int Pass = 0);

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -636,12 +636,21 @@ try
         // Print each chunk as the model emits it: this backend is meant to produce text while
         // the audio is still arriving, and hiding that until the end would misrepresent it.
         int chunkCount = 0;
+        int lastPass   = 0;
         var chunks = streaming.Transcribe(rawSamples, sampleRate, channels,
             hotwordTokenIds: hotwordIds,
             computeLogprobs: true,
             onChunk: c =>
             {
                 chunkCount++;
+                if (c.Pass != lastPass)
+                {
+                    // Say it where it happens: the speaker numbers below the line are a fresh
+                    // set, and nothing knows whether they are the same people as above it.
+                    lastPass = c.Pass;
+                    Console.WriteLine(
+                        $"  -- cache reset for pass {c.Pass + 1}; speaker numbers restart here --");
+                }
                 if (!string.IsNullOrWhiteSpace(c.Text))
                     Console.WriteLine($"  [{c.End,6:F1}s] {c.Text.Replace("\n", " ").Trim()}");
             },

--- a/tests/AsrBackendCoverage/VibeVoiceStreamingAssemblerTests.cs
+++ b/tests/AsrBackendCoverage/VibeVoiceStreamingAssemblerTests.cs
@@ -194,6 +194,35 @@ public class VibeVoiceStreamingAssemblerTests
     }
 
     [Fact]
+    public void LabelsAreDenseEvenWhenTheModelsNumbersAreNot()
+    {
+        // The results database keys speakers by row id and derives the tag back from it, so a
+        // gap in the labels makes a segment's tag and its speaker's name disagree. The model is
+        // under no obligation to count from zero, and a pass boundary shifts whatever it does.
+        var segs = VibeVoiceStreamingAsr.ToSegments(
+        [
+            InPass(0, 0, " \n Speaker 3:Third. \n Speaker 7:Seventh."),
+            InPass(1, 1, " \n Speaker 2:Second."),
+        ]);
+        Assert.Equal([0, 1, 2], segs.Select(s => s.Speaker));
+    }
+
+    [Fact]
+    public void APassWithNothingToSayConsumesNoLabel()
+    {
+        // Labels are handed out to turns, not to passes: a stretch of silence must not leave a
+        // hole in the numbering.
+        var segs = VibeVoiceStreamingAsr.ToSegments(
+        [
+            InPass(0, 0, " \n Speaker 0:Before."),
+            InPass(1, 1, "   "),
+            InPass(2, 2, " \n Speaker 0:After."),
+        ]);
+        Assert.Equal([0, 1], segs.Select(s => s.Speaker));
+        Assert.Equal(["Before.", "After."], segs.Select(s => s.Content));
+    }
+
+    [Fact]
     public void ChunksWithNoSpeakerMarkerStillProduceText()
     {
         // A recording whose speaker never changes emits no markers at all; the text must not

--- a/tests/AsrBackendCoverage/VibeVoiceStreamingAssemblerTests.cs
+++ b/tests/AsrBackendCoverage/VibeVoiceStreamingAssemblerTests.cs
@@ -137,6 +137,62 @@ public class VibeVoiceStreamingAssemblerTests
         Assert.Equal(2, segs[1].TokenIds.Count);
     }
 
+    private static VibeVoiceStreamingChunk InPass(int pass, int i, string text) =>
+        new(i, i * 2.933, (i + 1) * 2.933, text, [], [], [], pass);
+
+    [Fact]
+    public void ASecondPassGetsItsOwnSpeakerLabels()
+    {
+        // A recording too long for the cache is decoded in passes, and the model renumbers from
+        // scratch after each reset. Its "Speaker 0" on the far side is not the same person, so
+        // the labels must not collide — deciding they are the same person is the user's call.
+        var segs = VibeVoiceStreamingAsr.ToSegments(
+        [
+            InPass(0, 0, " \n Speaker 0:Hello. \n Speaker 1:Hi."),
+            InPass(1, 1, " \n Speaker 0:Later on. \n Speaker 1:Indeed."),
+        ]);
+
+        Assert.Equal(4, segs.Count);
+        Assert.Equal([0, 1, 2, 3], segs.Select(s => s.Speaker));
+        Assert.Equal(["Hello.", "Hi.", "Later on.", "Indeed."], segs.Select(s => s.Content));
+    }
+
+    [Fact]
+    public void ATurnDoesNotRunAcrossAPassBoundary()
+    {
+        // Nothing survives the cache reset, so text either side of it belongs to two turns even
+        // when the model names nobody in either.
+        var segs = VibeVoiceStreamingAsr.ToSegments([InPass(0, 0, "before"), InPass(1, 1, "after")]);
+        Assert.Equal(2, segs.Count);
+        Assert.Equal("before", segs[0].Content);
+        Assert.Equal("after", segs[1].Content);
+        Assert.NotEqual(segs[0].Speaker, segs[1].Speaker);
+    }
+
+    [Fact]
+    public void PassesThatNameNobodyStillDoNotShareALabel()
+    {
+        // The unnamed opening turn folds onto speaker 0 downstream, so a later pass has to start
+        // above it — and a pass with no markers at all still consumes a label of its own.
+        var segs = VibeVoiceStreamingAsr.ToSegments(
+        [
+            InPass(0, 0, "one"),
+            InPass(1, 1, "two"),
+            InPass(2, 2, " \n Speaker 0:three"),
+        ]);
+        var labels = segs.Select(s => System.Math.Max(0, s.Speaker)).ToList();
+        Assert.Equal(3, segs.Count);
+        Assert.Equal(labels.Count, labels.Distinct().Count());
+    }
+
+    [Fact]
+    public void ASinglePassKeepsTheModelsOwnNumbering()
+    {
+        // The common case must be untouched by any of the above: no pass boundary, no shift.
+        var segs = VibeVoiceStreamingAsr.ToSegments(Conversation);
+        Assert.Equal([0, 1, 0], segs.Select(s => s.Speaker));
+    }
+
     [Fact]
     public void ChunksWithNoSpeakerMarkerStillProduceText()
     {

--- a/tests/AsrBackendCoverage/VibeVoiceStreamingSizeWarningTests.cs
+++ b/tests/AsrBackendCoverage/VibeVoiceStreamingSizeWarningTests.cs
@@ -39,6 +39,10 @@ public class VibeVoiceStreamingSizeWarningTests
         string w = Warn(VibeVoiceStreamingSize.Large7B, 15.3);
         Assert.Contains("rather than the full", w);
         Assert.Contains("136", w);   // the package's own ceiling, not a rounded "120"
+        // And it is a limit on one pass, not on the file: saying otherwise would send someone
+        // away from a recording the app now transcribes (issue #150).
+        Assert.Contains("at a time", w);
+        Assert.Contains("passes", w);
     }
 
     [Fact]

--- a/tests/Vernacula.Tests/VibeVoiceStreamingCacheBudgetTests.cs
+++ b/tests/Vernacula.Tests/VibeVoiceStreamingCacheBudgetTests.cs
@@ -60,6 +60,21 @@ public class VibeVoiceStreamingCacheBudgetTests
     }
 
     [Fact]
+    public void ACacheBoundedByMemoryLeavesTheCardSomeHeadroom()
+    {
+        // The memory model is an estimate. Spending every byte it calls spare would leave the
+        // arena's own growth nothing to grow into — and on the split path that failure lands
+        // partway through a long job rather than before it starts.
+        long free   = Work7B + 10 * 60 * 16 * Kv7B;
+        int  tokens = Plan(30 * 60, freeBytes: free);
+        Assert.True(tokens * Kv7B < free - Work7B,
+            "a memory-bounded cache should not claim the whole budget");
+
+        // The export ceiling is not an estimate, so it is spent in full.
+        Assert.Equal(Max7B, Plan(Max7B / 16.0 + 600, freeBytes: 40L * GiB));
+    }
+
+    [Fact]
     public void AFreeVramShortfallTakesWhatTheCardHasInsteadOfRefusing()
     {
         // The reported case: room for the working set and about ten minutes of cache, asked for
@@ -67,7 +82,7 @@ public class VibeVoiceStreamingCacheBudgetTests
         // answer is now ten minutes of cache and three passes through it.
         long free   = Work7B + 10 * 60 * 16 * Kv7B;
         int  tokens = Plan(30 * 60, freeBytes: free);
-        Assert.InRange(tokens, (int)(9 * 60 * 16), (int)(10 * 60 * 16));
+        Assert.InRange(tokens, (int)(8 * 60 * 16), (int)(10 * 60 * 16));
         Assert.True(tokens * Kv7B <= free - Work7B, "the cache must still fit in what is free");
     }
 

--- a/tests/Vernacula.Tests/VibeVoiceStreamingCacheBudgetTests.cs
+++ b/tests/Vernacula.Tests/VibeVoiceStreamingCacheBudgetTests.cs
@@ -7,8 +7,11 @@ namespace Vernacula.Tests;
 /// <summary>
 /// How large a KV cache a run allocates. The old answer was "the export's ceiling, always",
 /// which cost 7.0 GiB on the 7B for a one-minute file and put the checkpoint out of reach of a
-/// 16 GB card (issue #150). These drive the arithmetic directly, because every branch in it is
-/// otherwise only reachable with a particular card and a particular recording in front of you.
+/// 16 GB card (issue #150). The second half of that issue is the other direction: a recording
+/// too long for the cache is no longer refused, it is decoded in passes, so the planner's job
+/// at the limit is to size one pass rather than to say no. These drive the arithmetic directly,
+/// because every branch in it is otherwise only reachable with a particular card and a
+/// particular recording in front of you.
 /// </summary>
 public class VibeVoiceStreamingCacheBudgetTests
 {
@@ -39,11 +42,11 @@ public class VibeVoiceStreamingCacheBudgetTests
         => Assert.Equal(Max7B, Plan((Max7B - 512) / 16.0, freeBytes: 20L * GiB));
 
     [Fact]
-    public void ARecordingLongerThanTheContextIsRefusedBeforeAnyWork()
+    public void ARecordingLongerThanTheContextTakesTheCeilingAndIsSplit()
     {
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => Plan(Max7B / 16.0 + 600, freeBytes: 40L * GiB));
-        Assert.Contains("131072-position cache", ex.Message);
+        // It used to be refused. A cache that cannot hold the recording holds one pass of it,
+        // and the run resets between passes (issue #150).
+        Assert.Equal(Max7B, Plan(Max7B / 16.0 + 600, freeBytes: 40L * GiB));
     }
 
     [Fact]
@@ -57,13 +60,36 @@ public class VibeVoiceStreamingCacheBudgetTests
     }
 
     [Fact]
-    public void AFreeVramShortfallIsRefusedWithTheLengthThatWouldFit()
+    public void AFreeVramShortfallTakesWhatTheCardHasInsteadOfRefusing()
     {
-        // Room for the working set and about ten minutes of cache, asked for thirty.
-        long free = Work7B + 10 * 60 * 16 * Kv7B;
+        // The reported case: room for the working set and about ten minutes of cache, asked for
+        // thirty. Refusing this is what made a 28-minute file impossible on a 16 GB card; the
+        // answer is now ten minutes of cache and three passes through it.
+        long free   = Work7B + 10 * 60 * 16 * Kv7B;
+        int  tokens = Plan(30 * 60, freeBytes: free);
+        Assert.InRange(tokens, (int)(9 * 60 * 16), (int)(10 * 60 * 16));
+        Assert.True(tokens * Kv7B <= free - Work7B, "the cache must still fit in what is free");
+    }
+
+    [Fact]
+    public void ACardWithNoRoomForACacheAtAllIsStillRefused()
+    {
+        // Splitting has a floor: below a cache that holds a couple of minutes there is nothing
+        // useful to split into, and the run should say so rather than thrash.
+        long free = Work7B + 600 * Kv7B;
         var ex = Assert.Throws<InvalidOperationException>(() => Plan(30 * 60, freeBytes: free));
         Assert.Contains("Not enough free GPU memory", ex.Message);
-        Assert.Contains("10 minutes would fit", ex.Message);
+    }
+
+    [Fact]
+    public void AVeryLongRecordingOnASmallCardIsSizedByTheCardNotTheRecording()
+    {
+        // Both limits bite at once: the card affords less than the ceiling, and the recording
+        // needs more than either. The card wins, and neither is a refusal.
+        long free   = Work7B + 20L * 60 * 16 * Kv7B;
+        int  tokens = Plan(4 * 60 * 60, freeBytes: free);
+        Assert.True(tokens < Max7B, "the ceiling is not affordable here");
+        Assert.True(tokens * Kv7B <= free - Work7B, "the cache must fit in what is free");
     }
 
     [Fact]
@@ -82,6 +108,8 @@ public class VibeVoiceStreamingCacheBudgetTests
         // rejects any other size, so they keep paying for the whole ceiling.
         Assert.Equal(Max7B, Plan(60, freeBytes: 20L * GiB, fixedTokens: Max7B));
 
+        // Nothing can be split out of a fixed length either: ORT rejects a shorter buffer, so
+        // this stays the one length-related refusal.
         var ex = Assert.Throws<InvalidOperationException>(
             () => Plan(60, freeBytes: 6L * GiB, fixedTokens: Max7B));
         Assert.Contains("re-download", ex.Message);


### PR DESCRIPTION
Sizing the KV cache to the recording (#153/#151) turned a 7.0 GiB allocation failure into a refusal: a 28-minute file on a 16 GB card is told how many minutes would fit and sent away. Nothing about the model requires that.

The cache is now reset and the prompt re-prefilled whenever the next window would not fit, so a recording of any length is decoded in as many passes as the card and the export ceiling allow.

## The speaker-identity trade

This backend attributes speakers *because* it keeps the whole recording in context. After a reset its "Speaker 1" has no relationship to the one before it, and matching them up would mean the embedding re-ID this backend exists to avoid. So rather than pretend they line up, the passes get **disjoint labels** — the model's own numbering in the first pass, shifted past every label already used in the rest — and merging the ones that are the same person is left to the editor's speaker rename.

## Changes

- `PlanKvTokens` returns the largest cache allowed instead of refusing when the recording needs more. The only refusals left are a package with a baked-in cache length the card cannot hold (ORT rejects a shorter buffer, so there is nothing to split into) and a card with too little free to be worth a pass.
- The pass boundary is decided at run time against the worst case for one window, so the cache cannot overflow mid-window and dense speech shortens a pass rather than failing one.
- `VibeVoiceStreamingChunk` carries its pass index; `SegmentAssembler` closes the open turn at a boundary and shifts the numbering. Pass 0 is untouched, so a recording that fits behaves exactly as before.
- The CLI prints the reset, the app appends it to the progress line, and the settings warning, help page and README change from "caps length" to "holds this much at a time".

## Measured

1.5B on an RTX 3090, 10-minute two-person interview, cache pinned to 4096 positions to force three passes:

| | chunks | segments | speakers |
|---|---|---|---|
| one pass (24,000-position cache) | 205 | 155 | `speaker_0` ×155 |
| three passes (4,096) | 205 | 163 | 65 / 58 / 40 across `speaker_0..2` |

Same chunk count and the same audio coverage, so nothing is dropped or decoded twice at a boundary; the eight extra segments are the turns the resets cut in half. Word similarity 0.925, with the differences spread through the file rather than clustered at the cuts.

Run 36 in `docs/dev/vibevoice_asr_streaming_investigation.md` has the detail, including the negative result that forcing a planner-chosen split on a 24 GB card is finicky, and that a 30-minute file still runs in a single pass on a card with 6.1 GiB free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7ieUVzfTn5Ljd8fBGbFyW