### PR TITLE
macOS: CoreML and WebGPU execution providers, and a CoreML-compilable Sortformer export

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ User and reference documentation for Vernacula. Start with [Installation](instal
 
 ## Getting started
 
+- [CoreML ONNX playbook](coreml_onnx_playbook.md) — making ONNX graphs fast under CoreML on Apple Silicon
 - [Installation](installation.md) — .NET 10, FFmpeg, GPU prerequisites, Linux installer
 - [Desktop app](desktop-app.md) — features, screenshots, walkthrough
 - [CLI reference](cli-reference.md) — invocation, arguments, examples

--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -1,0 +1,317 @@
+# CoreML ONNX playbook
+
+How to make an ONNX model actually fast under ONNX Runtime's **CoreML execution
+provider** on Apple Silicon. Derived from taking Sortformer v2.1 from "fails to
+compile at all" to a single-partition CoreML graph.
+
+CoreML matters because it is the only path to the **Apple Neural Engine**. The
+WebGPU EP (Dawn → Metal) reaches the GPU and nothing else, so on an M-series
+machine WebGPU leaves the ANE idle. WebGPU is also the better default until a
+model has been through this playbook, because an un-tuned graph loses to it.
+
+## What this bought on Sortformer
+
+Measured on an M5, ORT **1.24.4**, chunk=992 / spkcache=188 / fifo=124.
+Inference figures are from an idle machine; load figures are stable.
+
+| stage | partitions | inference | cold load | warm load | `model.mil` |
+|---|---|---|---|---|---|
+| shipped dynamic model | *fails to compile* (`error -14`) | — | — | — | — |
+| `--coreml-static-batch1` | 71 | 166.0 ms | — | — | — |
+| `+ const lengths` | 69 | — | — | — | — |
+| `+ all-False `Where` removed` | 35 | 97.0 ms | — | — | — |
+| `+ `Pad` → `Concat`` | **1** | 51.3 ms | 101.0 s | 20.8 s | 1.49 GB |
+| `+ Gemm pre-transpose` | **1** | 52.3 ms | **2.1 s** | **0.2 s** | **0.00 GB** |
+
+Reference on the same machine: **CPU 163.5 ms, WebGPU 94.0 ms.**
+Outputs match the original dynamic model to `3.6e-07` (preds) and `0.0` (embeddings).
+
+Net: **3.2× vs CPU, 1.8× vs WebGPU, and load went from 101 s to 2.1 s.**
+
+## The core mental model
+
+The CoreML EP fuses only the ops it fully supports. Everything else stays on
+CPU **and splits the graph at that boundary**. Every boundary is a CPU↔CoreML
+copy plus a sync. So the metric that matters is not "percent of nodes
+supported" but **partition count**.
+
+Sortformer at 94% supported (1794/1914 nodes) was still barely faster than CPU,
+because those 120 stragglers sat inside every encoder layer and carved the graph
+into 71 pieces. Getting to 1 partition roughly tripled throughput.
+
+> **Aim for one partition.** Two-thirds supported in one partition beats 95%
+> supported across fifty.
+
+## Technique 1 — Static shapes, and no data-dependent slicing
+
+**Symptom:** `Failed to create MLModel ... error code: -14`, preceded by a wall
+of `E5RT ... has unbounded dimension which is not supported` and sometimes
+`Failed to PropagateInputTensorShapes`.
+
+CoreML's MIL runtime rejects unbounded dimensions outright. Every ASR graph here
+has a dynamic time axis, so this hits all of them.
+
+Fixing the *declared input* shapes is necessary but **not sufficient**. Two
+traps:
+
+1. **The tracer bakes in shape arithmetic.** `torch.onnx.export` with
+   `dynamic_axes` emits `Shape`→`Gather`→`Reshape` chains that compute shapes at
+   runtime. Freezing inputs afterwards (`onnxruntime.tools.make_dynamic_shape_fixed`)
+   removes the "unbounded" errors but leaves those chains, so shape inference
+   still cannot resolve and CoreML still fails. **This must be fixed at export
+   time, not post-hoc.** Verified: post-hoc freezing left 352/352 matmuls with
+   unresolved shapes; adding constant folding only got it to 86/352, and CoreML
+   still refused.
+
+2. **Slicing by a tensor *value* poisons everything downstream.** This pattern:
+
+   ```python
+   spk_len = spkcache_lengths[0].to(torch.int64)
+   spkcache_trimmed = spkcache[:, :spk_len, :]
+   ```
+
+   makes every subsequent shape data-dependent even with fixed input shapes.
+   In Sortformer the trim was a **no-op at runtime** — `Sortformer.cs` always
+   passes `*_lengths` equal to each buffer's own size — so it was destroying
+   compilability for nothing.
+
+**Do:** add an export mode that fixes the input shapes *and* concatenates whole
+buffers with no length-based trimming. See `--coreml-static-batch1` in
+`scripts/nemo_export/export_sortformer_nemo_to_onnx.py`.
+
+**Check first:** are the "dynamic" axes actually constant at runtime? For
+Sortformer they were compile-time constants in `Config.cs`
+(`ChunkLength × Subsampling = 992`, `SpeakerCacheLength = 188`,
+`FifoLength = 124`), so fixing them cost **zero** padding waste. A model whose
+axes genuinely vary needs bucketing, and that trade is real.
+
+## Technique 2 — Bake constant lengths in
+
+If lengths are constant at runtime, make them graph constants
+(`--coreml-const-lengths`). Mask construction then folds instead of building
+`Range`/`Expand` chains from tensor values.
+
+**Worth knowing: on its own this barely helped** (71 → 69 partitions). Its real
+value is enabling Technique 3 — it turns the masks into foldable constants.
+
+## Technique 3 — Delete all-False `Where` masks
+
+**Symptom:** `Where` nodes on CPU, one or more per encoder layer.
+
+With constant lengths and a fully packed sequence, the attention padding mask
+folds to a constant that is **entirely False** (Sortformer: shape
+`(1,1,436,436)`, 436 = 188+124+124 — the tensor is exactly full).
+`Where(false, -10000, x)` is just `x`. These are identities whose only effect is
+fragmenting the graph.
+
+**Do:** rewire consumers to the data input and delete the node. Verify the mask
+really is all-False first — it is a provable property, so assert it rather than
+assuming.
+
+**Trap:** replacing `Where` with `Identity` instead of removing it made things
+*worse* (69 → 157 partitions). Remove the node; do not substitute one.
+
+Sortformer: 51 removed, 69 → 35 partitions, 166 ms → 97 ms.
+
+## Technique 4 — Rewrite `Pad` as `Concat`
+
+**Symptom:** `Pad` nodes on CPU.
+
+The CoreML EP declines `Pad` but supports `Concat`, and a **constant zero-pad is
+exactly a concat against a zero tensor**. Sortformer had two per layer:
+
+| shape | pads | meaning |
+|---|---|---|
+| `[1,8,436,871] → [1,8,436,872]` | 1 at start of axis 3 | relative-position shift in self-attention |
+| `[1,512,436] → [1,512,444]` | 4 each side of axis 2 | depthwise conv, kernel 9 |
+
+**Do:** for constant-mode, zero-value, single-axis pads, emit
+`Concat([zeros, x, zeros], axis)`. Requires static shapes (Technique 1) to size
+the zero tensors. Match the zero constant's **dtype** to the padded tensor or
+`Concat` fails type inference — this bites after an fp16 conversion.
+
+Sortformer: 34 converted, 35 → **1** partition, 97 ms → 51 ms. Biggest
+throughput win of the four.
+
+## Technique 5 — Pre-transpose `Gemm` weights (the load-time fix)
+
+**Symptom:** enormous first-load and warm-load times, and a `model.mil` far
+larger than the model's actual weights.
+
+CoreML's `linear` op wants the weight as `[N, K]`. An ONNX `Gemm` with
+`transB=0` stores it `[K, N]`, so the EP **synthesizes a transposed copy per
+node** — and it writes synthesized constants **inline in `model.mil` as
+hex-float text** (`0x1.d040b6p-6`, ~16 chars per float) rather than into the
+binary weight blob.
+
+On Sortformer that meant **180 Gemm nodes → 179 inline consts → a 1.49 GB
+`model.mil`** holding 0.39 GB of actual weights, re-parsed on every single load.
+Meanwhile the MatMul-with-constant weights (10.1 M params) went to `weight.bin`
+correctly. 75% of all weights were taking the text path.
+
+**Do:** pre-transpose the constant weight and set `transB=1`. Bit-exact — it is
+the same operation. Only do it in place when the initializer has a single
+consumer.
+
+```
+transB=0:  cold 101.0s   warm 20.8s   cache 2.16 GB   model.mil 1.49 GB
+transB=1:  cold   2.2s   warm  0.2s   cache 1.06 GB   model.mil 0.00 GB
+```
+
+**46× faster cold compile, 100× faster warm load, zero numerical change.**
+Inference is unaffected (52.7 → 54.3 ms, within noise).
+
+This is the highest-leverage item in the playbook and it generalizes to **any**
+transformer export, because `transB=0` is what `torch.onnx.export` emits by
+default.
+
+## Technique 6 — `ModelCacheDirectory`
+
+Set the CoreML provider option `ModelCacheDirectory` to persist the compiled
+model across processes. Necessary but not a substitute for Technique 5:
+
+| | cold | warm |
+|---|---|---|
+| cache only | 97.5 s | 18.6 s |
+| cache + pre-transpose | 2.1 s | **0.2 s** |
+
+## Anti-patterns
+
+**Do not use `ORT_ENABLE_EXTENDED` (or `ORT_ENABLE_ALL`) before CoreML.**
+Its fusions produce ops the CoreML EP rejects and it makes partitioning
+dramatically worse:
+
+```
+raw export        : 69 partitions
+ORT_ENABLE_BASIC  : 69 partitions   <- use this
+ORT_ENABLE_EXTENDED: 191 partitions  <- much worse
+```
+
+`ORT_ENABLE_ALL` additionally emits hardware-specific `NhwcFusedConv` that makes
+the saved model **unloadable**. Fold at `BASIC` only.
+
+**Load pre-optimized models with `ORT_DISABLE_ALL`.** Re-optimizing an
+already-optimized graph throws
+`AddInitializedOrtValue Attempt to replace the existing tensor`.
+`OrtSessionBuilder.CreateCachedSession` already does this for cache hits.
+
+**The CoreML provider options do not help load time.** Measured, all identical
+to three significant figures: `SpecializationStrategy=FastPrediction`,
+`RequireStaticInputShapes`, `AllowLowPrecisionAccumulationOnGPU`. Do not go
+looking here — the fix is Technique 5.
+
+**fp16 is not a load-time fix.** It shrank the cache 2.16 → 1.52 GB but made
+warm load *worse* (18.6 → 27.5 s). It is an inference lever, and a
+double-edged one — see below.
+
+## fp16: unresolved
+
+fp16 gave the fastest inference measured — **22.3 ms** on
+`MLComputeUnits=CPUAndGPU` (vs 51 ms fp32) — but at a real accuracy cost:
+
+```
+fp32:  preds max=3.58E-07   embs max=0.00E+00
+fp16:  preds max=1.26E-03   embs max=9.77E-02
+```
+
+`preds` at 1e-3 is likely fine for thresholded diarization logits. `embs` at
+9.8e-2 is not obviously safe, because `chunk_pre_encode_embs` feeds back into
+the spkcache/FIFO for later chunks — a feedback loop, exactly the structure this
+codebase already documents error-compounding through (the TF32/OmniVoice note in
+`OrtSessionBuilder.cs`). **A single-chunk parity check cannot see compounding.**
+Validate with end-to-end DER on real audio before shipping fp16.
+
+Also note `onnxconverter-common` fights graphs containing explicit `Cast` nodes;
+expect to patch mixed-dtype boundaries by hand.
+
+## Should we bypass ONNX and call CoreML directly from C#?
+
+**For a model that reaches 1 partition: no.** Measured on the finished Sortformer
+graph, same machine state:
+
+| path | inference | load |
+|---|---|---|
+| direct CoreML (`ct.models.CompiledMLModel`) | 53.54 ms | 0.16 s |
+| ORT CoreML EP | 55.06 ms | 2.77 s cold / 0.2 s warm |
+
+ORT's overhead is ~1.5 ms (≈3%), within noise. That is the expected result: at
+one partition ORT hands the entire graph to CoreML as a single fused node, so it
+is already a thin wrapper around one CoreML call. A second model format and a
+native interop layer would buy ~3%.
+
+Note this is a *consequence* of the playbook. At 71 partitions ORT was adding
+real overhead in copies and syncs — but the fix was fixing the graph, not
+replacing the runtime.
+
+**Where direct CoreML would genuinely add capability** — all things ORT's CoreML
+EP cannot currently express:
+
+1. **Stateful models** (macOS 14+). CoreML natively supports state tensors held
+   across predictions — the natural fit for KV-cache decoders and for the
+   Parakeet TDT decoder, both of which the CoreML EP handles poorly because they
+   are `Loop` subgraphs. This is the strongest argument.
+2. **Enumerated / flexible shapes.** CoreML accepts a declared *set* of allowed
+   input shapes and compiles for each. That could handle Parakeet's variable
+   audio length better than ONNX-side bucketing, without padding waste.
+3. **`coremltools` compression.** Its fp16, palettization and quantization are
+   better calibrated than `onnxconverter-common`, which fights graphs containing
+   explicit `Cast` nodes (see the fp16 section).
+
+**Costs to weigh:** .NET's CoreML bindings require a macOS-specific target
+framework (`Microsoft.macOS`), which conflicts with the cross-platform Avalonia
+build — it would need a native shim plus P/Invoke. It also means a second model
+artifact per model to build, host and version, and it bypasses the
+`OrtSessionBuilder` abstraction that currently keeps every EP on one code path.
+
+**Recommendation:** stay on ORT for anything that reaches a low partition count.
+Revisit direct CoreML only for the `Loop`-bearing decoders, and treat it as a
+capability question (can we express this at all?) rather than a performance one.
+
+## Diagnostic workflow for a new model
+
+1. **Does it compile?** Load with the CoreML EP. `error -14` → Technique 1.
+2. **Count partitions.** The EP logs it at warning level:
+   ```
+   CoreMLExecutionProvider::GetCapability, number of partitions supported by
+   CoreML: N number of nodes in the graph: M number of nodes supported by CoreML: K
+   ```
+   One partition is the goal. More than ~5 means throughput is being eaten by copies.
+3. **Find what stayed on CPU.** Set `LogSeverityLevel = ORT_LOGGING_LEVEL_VERBOSE`;
+   ORT lists every node and its assigned EP after
+   `Node(s) placed on [CPUExecutionProvider]`. Group by op type — the offenders
+   are usually two or three types repeated per layer.
+4. **Check `model.mil` size** in the cache dir against the model's real weight
+   volume. Much larger → Technique 5.
+5. **Verify parity at every step**, against the *original* model, not the
+   previous step — errors compound quietly otherwise.
+
+## Applying to other models
+
+| model | outlook |
+|---|---|
+| Sortformer | **Done.** Axes constant at runtime; ideal case. |
+| Parakeet encoder | Plausible. Length genuinely varies → needs bucketing, and padding waste is a real cost. Technique 5 applies regardless. |
+| Parakeet TDT decoder | Poor. `Loop` subgraphs are badly handled by the CoreML EP; `OrtSessionBuilder` already carries a `.ort` workaround for Loop graphs (issue #56). Likely stays CPU. |
+| KV-cache decoders (Cohere, Qwen3, VibeVoice, Granite) | Untested. Fixed cache lengths would help; per-step dynamic KV growth is the obstacle. |
+| Conv-heavy (Silero VAD, DeepFilterNet3, WeSpeaker) | Promising — conv is the ANE's strength and these graphs are simpler. Start here for quick wins. |
+
+**Technique 5 is worth applying to every model unconditionally**, including ones
+never going near CoreML — it is bit-exact and costs nothing.
+
+## Tooling
+
+- `scripts/nemo_export/export_sortformer_nemo_to_onnx.py` — `--coreml-static-batch1`,
+  `--coreml-const-lengths` (Techniques 1–2)
+- `scripts/nemo_export/coreml_optimize_sortformer.py` — Techniques 3–5 plus
+  `--verify` against the original model. The graph transforms are model-agnostic;
+  only the verification harness is Sortformer-specific.
+
+## Caveats
+
+- **ORT-version sensitive.** Validated on **1.24.4**. Python ORT 1.29.0
+  partitions the same graph into 194 and diverges at ~1e-2. Re-validate on any
+  ORT upgrade.
+- **Steady-state only.** The static graph assumes full cache/FIFO and a
+  full-length chunk. Warm-up chunks must be zero-padded to full size.
+- **Contract changes.** Folding prunes the now-unused `*_lengths`, so the graph
+  takes three inputs, not six, at fixed shapes. Callers need a variant path.

--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -71,9 +71,11 @@ traps:
    ```
 
    makes every subsequent shape data-dependent even with fixed input shapes.
-   In Sortformer the trim was a **no-op at runtime** — `Sortformer.cs` always
-   passes `*_lengths` equal to each buffer's own size — so it was destroying
-   compilability for nothing.
+   In Sortformer the trim was a **no-op at runtime** for `spkcache` and `fifo` —
+   `Sortformer.cs` always passes those two `*_lengths` equal to each buffer's own
+   size — so it was destroying compilability for nothing. The chunk is the
+   exception, and it survives only because it is concatenated *last*: the summed
+   logical length still masks a short final chunk's padded tail.
 
 **Do:** add an export mode that fixes the input shapes *and* concatenates whole
 buffers with no length-based trimming. See `--coreml-static-batch1` in
@@ -90,6 +92,12 @@ axes genuinely vary needs bucketing, and that trade is real.
 If lengths are constant at runtime, make them graph constants
 (`--coreml-const-lengths`). Mask construction then folds instead of building
 `Range`/`Expand` chains from tensor values.
+
+> ⚠ **Check each length separately.** In Sortformer only `spkcache_lengths` and
+> `fifo_lengths` are genuinely constant. `chunk_lengths` is short for the last
+> chunk of every recording, so baking it would silently change the diarization at
+> the end of every file — a constant that is *usually* right is a correctness bug,
+> not an optimization. Verify against the calling code, not the steady state.
 
 **Worth knowing: on its own this barely helped** (71 → 69 partitions). Its real
 value is enabling Technique 3 — it turns the masks into foldable constants.

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -225,6 +225,60 @@ This candidate keeps logical length inputs but trims the fixed-size cache/fifo
 buffers before concatenation, which is useful when investigating whether a more
 static streaming contract gives ORT or TensorRT a better graph.
 
+### Apple CoreML (single-partition) export
+
+`--static-streaming-batch1` fixes the input shapes but still trims the cache and
+FIFO by a *tensor value*, which makes every downstream shape data-dependent and
+stops CoreML compiling the graph at all. `--coreml-static-batch1` drops that trim
+(it is a no-op at runtime anyway -- Vernacula always passes `*_lengths` equal to
+each buffer's own size), and `--coreml-const-lengths` bakes the steady-state
+lengths in as constants:
+
+```bash
+python scripts/nemo_export/export_sortformer_nemo_to_onnx.py \
+  --nemo ~/models/diar_streaming_sortformer_4spk-v2.1.nemo \
+  --output ~/models/sortformer_coreml.onnx \
+  --opset 17 \
+  --coreml-static-batch1 --coreml-const-lengths \
+  --chunk-frames 992 --fixed-spkcache-frames 188 --fixed-fifo-frames 124 \
+  --overwrite
+```
+
+That alone compiles under CoreML but leaves ~70 partitions, because a `Where`
+(padding mask) and a `Pad` in every encoder layer stay on CPU and split the graph.
+Post-process to collapse them:
+
+```bash
+python scripts/nemo_export/coreml_optimize_sortformer.py \
+  --input ~/models/sortformer_coreml.onnx \
+  --output ~/models/sortformer_coreml_final.onnx \
+  --verify --reference ~/models/diar_streaming_sortformer_4spk-v2.1.onnx
+```
+
+Measured on an M5, ORT 1.24.4, chunk=992 / cache=188 / fifo=124:
+
+| stage | partitions | inference | cold load | warm load |
+|---|---|---|---|---|
+| shipped dynamic model | fails to compile | -- | -- | -- |
+| `--coreml-static-batch1` | 71 | 166.0 ms | -- | -- |
+| `+ --coreml-const-lengths` | 69 | -- | -- | -- |
+| `+ Where removed` | 35 | 97.0 ms | -- | -- |
+| `+ Pad -> Concat` | **1** | 51.3 ms | 101.0 s | 20.8 s |
+| `+ Gemm pre-transpose` | **1** | **52.3 ms** | **2.1 s** | **0.2 s** |
+
+Reference on the same machine: CPU 163.5 ms, WebGPU 94.0 ms. Outputs match the
+original dynamic model to 3.6e-07 (preds) and 0.0 (embeddings).
+
+The Gemm pre-transpose is the load-time fix: ORT's CoreML EP writes the weight
+transposes it synthesizes for `Gemm(transB=0)` as hex-float TEXT inline in
+`model.mil` (1.49 GB for 0.39 GB of weights), and re-parses that on every load.
+See [docs/coreml_onnx_playbook.md](../../docs/coreml_onnx_playbook.md) for the
+full set of techniques and how to apply them to other models.
+
+Caveats: steady-state only (full cache/FIFO, full-length chunk); constant folding
+prunes the unused `*_lengths`, so the graph takes three inputs, not six; and
+CoreML partitioning is ORT-version dependent -- validated on 1.24.4.
+
 For a safer structure-only experiment that keeps dynamic time dimensions but
 specializes the graph to batch size 1, use:
 

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -230,9 +230,10 @@ static streaming contract gives ORT or TensorRT a better graph.
 `--static-streaming-batch1` fixes the input shapes but still trims the cache and
 FIFO by a *tensor value*, which makes every downstream shape data-dependent and
 stops CoreML compiling the graph at all. `--coreml-static-batch1` drops that trim
-(it is a no-op at runtime anyway -- Vernacula always passes `*_lengths` equal to
-each buffer's own size), and `--coreml-const-lengths` bakes the steady-state
-lengths in as constants:
+-- safe because `spkcache` and `fifo` are always full at runtime, and the chunk is
+concatenated **last**, so the summed logical length still masks the padded tail of
+a short final chunk. `--coreml-const-lengths` then bakes the two buffer lengths in
+as constants:
 
 ```bash
 python scripts/nemo_export/export_sortformer_nemo_to_onnx.py \
@@ -275,9 +276,13 @@ transposes it synthesizes for `Gemm(transB=0)` as hex-float TEXT inline in
 See [docs/coreml_onnx_playbook.md](../../docs/coreml_onnx_playbook.md) for the
 full set of techniques and how to apply them to other models.
 
-Caveats: steady-state only (full cache/FIFO, full-length chunk); constant folding
-prunes the unused `*_lengths`, so the graph takes three inputs, not six; and
-CoreML partitioning is ORT-version dependent -- validated on 1.24.4.
+Caveats: the graph assumes a full cache and FIFO, which `Sortformer.cs` always
+supplies; constant folding prunes the two baked `*_lengths`, so the graph takes
+four inputs, not six. `chunk_lengths` stays live on purpose -- `ProcessChunk`
+passes `min(start + chunkStride, totalFrames) - start`, which is **short for the
+final chunk of every recording**, and baking a constant there would let that
+chunk's zero-padded tail be attended to as real audio. CoreML partitioning is
+ORT-version dependent -- validated on 1.24.4.
 
 For a safer structure-only experiment that keeps dynamic time dimensions but
 specializes the graph to batch size 1, use:

--- a/scripts/nemo_export/coreml_optimize_sortformer.py
+++ b/scripts/nemo_export/coreml_optimize_sortformer.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Post-process a --coreml-static-batch1 Sortformer export into a graph the
+CoreML execution provider can compile as a SINGLE partition.
+
+Run this on the output of:
+
+    export_sortformer_nemo_to_onnx.py --coreml-static-batch1 --coreml-const-lengths
+
+Background
+----------
+ORT's CoreML EP only fuses ops it fully supports; everything else stays on CPU
+and splits the graph at that boundary. A conformer export straight out of NeMo
+leaves two op families on CPU, and because they sit inside *every* encoder
+layer they shred the graph into dozens of partitions. Each boundary is a
+CPU<->CoreML copy, which is why a 94%-supported graph was still barely faster
+than pure CPU.
+
+Measured on an M5 (ORT 1.24.4, Sortformer 4spk v2.1, chunk=992/cache=188/fifo=124):
+
+    stage                                partitions   median
+    raw --coreml-static-batch1 export           71    166.0 ms
+      + --coreml-const-lengths                  69         --
+      + all-False Where removed                 35     97.0 ms
+      + Pad -> Concat                            1     51.3 ms
+
+    reference: CPU 164.4 ms, WebGPU 94.2 ms
+
+The two transforms
+------------------
+1. `Where` (51x). With constant lengths the attention padding mask folds to a
+   compile-time constant that is ALL FALSE -- the sequence is fully packed
+   (188 + 124 + 124 = 436). `Where(false, -10000, x)` is exactly `x`, so these
+   are identities that exist only to break up the graph. Removed by rewiring
+   consumers to the data input. Numerically exact.
+
+2. `Pad` (34x). Two single-axis constant zero-pads per layer (the relative
+   position shift in self-attention, and the depthwise-conv padding). The
+   CoreML EP declines Pad but supports Concat, and a constant zero-pad is
+   exactly a Concat against a zero tensor. Numerically exact.
+
+Both rewrites are value-preserving; verify with --verify (compares against the
+original dynamic model on the CPU EP).
+
+Caveats
+-------
+* Constant folding must run at ORT_ENABLE_BASIC. ORT_ENABLE_EXTENDED fuses ops
+  the CoreML EP then rejects and makes partitioning much WORSE (69 -> 191).
+* The result is steady-state only: full cache/fifo and a full-length chunk.
+* Folding prunes the now-unused *_lengths inputs, so the graph takes three
+  inputs (chunk, spkcache, fifo), not six.
+* Partitioning behaviour is ORT-version dependent. Validated on 1.24.4.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper, shape_inference
+
+
+def basic_fold(src: str, dst: str) -> None:
+    """Constant-fold at BASIC level. EXTENDED is deliberately avoided."""
+    import onnxruntime as ort
+
+    so = ort.SessionOptions()
+    so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
+    so.optimized_model_filepath = dst
+    ort.InferenceSession(src, so, providers=["CPUExecutionProvider"])
+
+
+def drop_allfalse_where(g) -> int:
+    init = {i.name: i for i in g.initializer}
+    rewire, drop = {}, set()
+    for idx, n in enumerate(g.node):
+        if n.op_type != "Where" or n.input[0] not in init:
+            continue
+        mask = numpy_helper.to_array(init[n.input[0]])
+        if mask.dtype != np.bool_ or mask.any():
+            continue
+        rewire[n.output[0]] = n.input[2]
+        drop.add(idx)
+
+    def resolve(x):
+        seen = set()
+        while x in rewire and x not in seen:
+            seen.add(x)
+            x = rewire[x]
+        return x
+
+    rewire = {k: resolve(v) for k, v in rewire.items()}
+    for n in g.node:
+        for i, inp in enumerate(n.input):
+            if inp in rewire:
+                n.input[i] = rewire[inp]
+    for o in g.output:
+        if o.name in rewire:
+            o.name = rewire[o.name]
+    kept = [n for i, n in enumerate(g.node) if i not in drop]
+    del g.node[:]
+    g.node.extend(kept)
+    return len(drop)
+
+
+def pad_to_concat(g, shapes: dict, dtypes: dict) -> int:
+    init = {i.name: i for i in g.initializer}
+    zero_cache: dict[tuple, str] = {}
+
+    def zeros(shape, np_dtype):
+        # Must match the padded tensor's dtype or Concat fails type inference
+        # (notably after an fp16 conversion).
+        key = (tuple(shape), np_dtype.str)
+        if key not in zero_cache:
+            name = f"coreml_zeros_{np_dtype.name}_" + "x".join(map(str, shape))
+            g.initializer.append(numpy_helper.from_array(np.zeros(shape, np_dtype), name))
+            zero_cache[key] = name
+        return zero_cache[key]
+
+    converted = 0
+    for idx, n in enumerate(g.node):
+        if n.op_type != "Pad" or len(n.input) < 2 or n.input[1] not in init:
+            continue
+        if next((a.s.decode() for a in n.attribute if a.name == "mode"), "constant") != "constant":
+            continue
+        if len(n.input) > 2 and n.input[2] in init:
+            if float(numpy_helper.to_array(init[n.input[2]]).reshape(-1)[0]) != 0.0:
+                continue
+        ish = shapes.get(n.input[0])
+        if ish is None or any(d is None for d in ish):
+            continue
+        dt = dtypes.get(n.input[0])
+        if dt is None:
+            continue
+        np_dtype = np.dtype(onnx.helper.tensor_dtype_to_np_dtype(dt))
+        pads = numpy_helper.to_array(init[n.input[1]]).astype(int).tolist()
+        r = len(ish)
+        if len(pads) != 2 * r:
+            continue
+        begins, ends = pads[:r], pads[r:]
+        axes = [i for i in range(r) if begins[i] or ends[i]]
+        if len(axes) != 1:
+            continue
+        ax = axes[0]
+        parts = []
+        if begins[ax]:
+            s = list(ish); s[ax] = begins[ax]; parts.append(zeros(s, np_dtype))
+        parts.append(n.input[0])
+        if ends[ax]:
+            s = list(ish); s[ax] = ends[ax]; parts.append(zeros(s, np_dtype))
+        g.node[idx].CopyFrom(helper.make_node(
+            "Concat", inputs=parts, outputs=list(n.output), name=n.name + "_concat", axis=ax))
+        converted += 1
+    return converted
+
+
+def pretranspose_gemm(g) -> int:
+    """Pre-transpose constant Gemm weights and set transB=1.
+
+    THE single biggest load-time lever. CoreML's `linear` op wants the weight as
+    [N, K]; an ONNX Gemm with transB=0 stores it [K, N], so ORT's CoreML EP
+    synthesizes a transposed copy per node -- and it writes those synthesized
+    constants INLINE in model.mil as hex-float TEXT (~16 chars per float)
+    instead of into the binary weight blob. On Sortformer that produced a
+    1.49 GB model.mil for 0.39 GB of actual weights, and CoreML re-parsed it on
+    every load.
+
+    Feeding the weight already transposed removes the synthesized copy, so the
+    weights land in weight.bin. Measured on Sortformer/M5:
+
+        transB=0:  cold 101.0s  warm 20.8s  model.mil 1.49 GB
+        transB=1:  cold   2.2s  warm  0.2s  model.mil 0.00 GB
+
+    Bit-exact: Gemm(A, B, transB=1) with B pre-transposed is the same operation.
+    """
+    init = {i.name: i for i in g.initializer}
+    users: dict[str, int] = {}
+    for n in g.node:
+        for i in n.input:
+            users[i] = users.get(i, 0) + 1
+
+    done = 0
+    for n in g.node:
+        if n.op_type != "Gemm":
+            continue
+        attrs = {a.name: a for a in n.attribute}
+        if "transB" in attrs and int(attrs["transB"].i) == 1:
+            continue
+        w = n.input[1]
+        # Only safe in place when this initializer feeds nothing else.
+        if w not in init or users.get(w, 0) != 1:
+            continue
+        arr = numpy_helper.to_array(init[w])
+        if arr.ndim != 2:
+            continue
+        init[w].CopyFrom(numpy_helper.from_array(np.ascontiguousarray(arr.T), w))
+        if "transB" in attrs:
+            attrs["transB"].i = 1
+        else:
+            n.attribute.append(helper.make_attribute("transB", 1))
+        done += 1
+    return done
+
+
+def restore_folded_outputs(g) -> int:
+    """Folding can turn a graph output into a bare initializer with no producer,
+    which the ONNX checker rejects. Give each one an Identity producer."""
+    init = {i.name: i for i in g.initializer}
+    produced = {o for n in g.node for o in n.output}
+    fixed = 0
+    for o in g.output:
+        if o.name in produced:
+            continue
+        if o.name not in init:
+            raise SystemExit(f"graph output {o.name} has neither producer nor initializer")
+        src = o.name + "_const"
+        init[o.name].name = src
+        g.node.append(helper.make_node("Identity", [src], [o.name], name=o.name + "_id"))
+        fixed += 1
+    return fixed
+
+
+def prune(g) -> None:
+    """Drop initializers nothing references any more, and any graph input that
+    named one of them. Real graph inputs (fed by the caller) are never
+    initializers, so they always survive."""
+    used = {i for n in g.node for i in n.input}
+    dropped = {i.name for i in g.initializer if i.name not in used}
+    keep = [i for i in g.initializer if i.name in used]
+    del g.initializer[:]
+    g.initializer.extend(keep)
+    gi = [v for v in g.input if v.name not in dropped]
+    del g.input[:]
+    g.input.extend(gi)
+    del g.value_info[:]          # let ORT re-infer
+
+
+def verify(original: str, optimized: str, tol: float) -> bool:
+    import onnxruntime as ort
+
+    rng = np.random.default_rng(7)
+    chunk = rng.standard_normal((1, 992, 128)).astype(np.float32)
+    spk = rng.standard_normal((1, 188, 512)).astype(np.float32)
+    fifo = rng.standard_normal((1, 124, 512)).astype(np.float32)
+
+    def run(path, feed, opt=None):
+        so = ort.SessionOptions()
+        if opt is not None:
+            so.graph_optimization_level = opt
+        s = ort.InferenceSession(path, so, providers=["CPUExecutionProvider"])
+        return dict(zip([o.name for o in s.get_outputs()], s.run(None, feed)))
+
+    ref = run(original, {
+        "chunk": chunk, "chunk_lengths": np.array([992], np.int64),
+        "spkcache": spk, "spkcache_lengths": np.array([188], np.int64),
+        "fifo": fifo, "fifo_lengths": np.array([124], np.int64)})
+    import onnx as _onnx
+    om = _onnx.load(optimized, load_external_data=False)
+    itype = {v.name: v.type.tensor_type.elem_type for v in om.graph.input}
+    def cast(name, arr):
+        return arr.astype(np.float16) if itype.get(name) == _onnx.TensorProto.FLOAT16 else arr
+    got = run(optimized, {"chunk": cast("chunk", chunk), "spkcache": cast("spkcache", spk),
+                          "fifo": cast("fifo", fifo)},
+              ort.GraphOptimizationLevel.ORT_DISABLE_ALL)
+    ok = True
+    for k in ("spkcache_fifo_chunk_preds", "chunk_pre_encode_embs"):
+        a, b = ref[k], got[k]
+        if a.shape != b.shape:
+            print(f"  {k:28} SHAPE {a.shape} vs {b.shape}  -> FAIL")
+            ok = False
+            continue
+        d = np.abs(a.astype(np.float32) - b.astype(np.float32))
+        good = d.max() < tol
+        ok &= good
+        print(f"  {k:28} maxAbsDiff={d.max():.3E} rms={np.sqrt((d ** 2).mean()):.3E}"
+              f"  -> {'OK' if good else 'FAIL'}")
+    return ok
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--input", required=True, help="ONNX from --coreml-static-batch1")
+    ap.add_argument("--output", required=True, help="CoreML-optimized ONNX to write")
+    ap.add_argument("--verify", action="store_true",
+                    help="Compare against --reference on the CPU EP")
+    ap.add_argument("--reference", help="Original dynamic ONNX to verify against")
+    ap.add_argument("--tolerance", type=float, default=1e-3)
+    ap.add_argument("--keep-intermediate", action="store_true")
+    args = ap.parse_args()
+
+    src = os.path.expanduser(args.input)
+    dst = os.path.expanduser(args.output)
+    folded = dst + ".basic.tmp.onnx"
+
+    print(f"[1/5] constant-folding at ORT_ENABLE_BASIC  <- {src}")
+    basic_fold(src, folded)
+
+    inferred = folded + ".inferred.onnx"
+    shape_inference.infer_shapes_path(folded, inferred)
+    sm = onnx.load(inferred, load_external_data=False)
+    shapes, dtypes = {}, {}
+    for vi in list(sm.graph.input) + list(sm.graph.value_info) + list(sm.graph.output):
+        d = vi.type.tensor_type.shape.dim
+        shapes[vi.name] = [x.dim_value if x.HasField("dim_value") else None for x in d]
+        dtypes[vi.name] = vi.type.tensor_type.elem_type
+
+    m = onnx.load(folded)
+    g = m.graph
+    print(f"[2/5] removing all-False Where ...      {drop_allfalse_where(g):3d} removed")
+    print(f"[3/5] rewriting Pad -> Concat ...       {pad_to_concat(g, shapes, dtypes):3d} converted")
+    print(f"[4/5] pre-transposing Gemm weights ...  {pretranspose_gemm(g):3d} converted")
+    restore_folded_outputs(g)
+    prune(g)
+
+    onnx.checker.check_model(m, full_check=False)
+    onnx.save(m, dst, save_as_external_data=False)
+    print(f"[5/5] wrote {dst} ({os.path.getsize(dst) / 1e6:.0f} MB), "
+          f"{len(g.node)} nodes, inputs={[v.name for v in g.input]}")
+
+    if not args.keep_intermediate:
+        for f in (folded, inferred):
+            try: os.remove(f)
+            except OSError: pass
+
+    if args.verify:
+        if not args.reference:
+            raise SystemExit("--verify needs --reference <original dynamic .onnx>")
+        print("\nverifying against reference on CPU EP:")
+        if not verify(os.path.expanduser(args.reference), dst, args.tolerance):
+            sys.exit(1)
+        print("PARITY: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemo_export/coreml_optimize_sortformer.py
+++ b/scripts/nemo_export/coreml_optimize_sortformer.py
@@ -71,7 +71,7 @@ def basic_fold(src: str, dst: str) -> None:
     ort.InferenceSession(src, so, providers=["CPUExecutionProvider"])
 
 
-def drop_allfalse_where(g) -> int:
+def drop_allfalse_where(g, shapes: dict) -> int:
     init = {i.name: i for i in g.initializer}
     rewire, drop = {}, set()
     for idx, n in enumerate(g.node):
@@ -79,6 +79,15 @@ def drop_allfalse_where(g) -> int:
             continue
         mask = numpy_helper.to_array(init[n.input[0]])
         if mask.dtype != np.bool_ or mask.any():
+            continue
+        # Where BROADCASTS all three inputs. An all-False Where equals its false
+        # branch only when that branch is already the broadcast shape -- otherwise
+        # rewiring past it drops the broadcast and hands consumers a smaller
+        # tensor, which is a silent numeric change (or a load-time shape error).
+        fs, os_ = shapes.get(n.input[2]), shapes.get(n.output[0])
+        if fs is None or os_ is None or any(d is None for d in fs) or any(d is None for d in os_):
+            continue
+        if list(fs) != list(os_):
             continue
         rewire[n.output[0]] = n.input[2]
         drop.add(idx)
@@ -124,8 +133,15 @@ def pad_to_concat(g, shapes: dict, dtypes: dict) -> int:
             continue
         if next((a.s.decode() for a in n.attribute if a.name == "mode"), "constant") != "constant":
             continue
-        if len(n.input) > 2 and n.input[2] in init:
-            if float(numpy_helper.to_array(init[n.input[2]]).reshape(-1)[0]) != 0.0:
+        # constant_value must be KNOWN zero. A third input that is present and
+        # non-empty but is not a zero initializer (e.g. computed at runtime) is
+        # disqualifying -- rewriting it to a Concat against zeros would silently
+        # change the numerics.
+        if len(n.input) > 2 and n.input[2]:
+            if n.input[2] not in init:
+                continue
+            cv = numpy_helper.to_array(init[n.input[2]]).reshape(-1)
+            if cv.size == 0 or float(cv[0]) != 0.0:
                 continue
         ish = shapes.get(n.input[0])
         if ish is None or any(d is None for d in ish):
@@ -134,11 +150,20 @@ def pad_to_concat(g, shapes: dict, dtypes: dict) -> int:
         if dt is None:
             continue
         np_dtype = np.dtype(onnx.helper.tensor_dtype_to_np_dtype(dt))
+        # Opset 18's optional `axes` input remaps what `pads` refers to. Resolving it
+        # is not worth it here; skip rather than misapply the pads to the wrong axes.
+        if len(n.input) > 3 and n.input[3]:
+            continue
         pads = numpy_helper.to_array(init[n.input[1]]).astype(int).tolist()
         r = len(ish)
         if len(pads) != 2 * r:
             continue
         begins, ends = pads[:r], pads[r:]
+        # ONNX Pad allows NEGATIVE pads, which crop rather than pad. A Concat cannot
+        # express that, and a negative extent would reach np.zeros as a negative
+        # dimension and abort the run.
+        if any(p < 0 for p in pads):
+            continue
         axes = [i for i in range(r) if begins[i] or ends[i]]
         if len(axes) != 1:
             continue
@@ -216,7 +241,11 @@ def restore_folded_outputs(g) -> int:
             raise SystemExit(f"graph output {o.name} has neither producer nor initializer")
         src = o.name + "_const"
         init[o.name].name = src
-        g.node.append(helper.make_node("Identity", [src], [o.name], name=o.name + "_id"))
+        # Must go at the FRONT: the renamed initializer may feed other nodes, which
+        # now read this Identity's output. ONNX requires a node to precede its
+        # consumers, and check_model(full_check=False) does not catch a violation --
+        # ORT rejects the model only at session creation.
+        g.node.insert(0, helper.make_node("Identity", [src], [o.name], name=o.name + "_id"))
         fixed += 1
     return fixed
 
@@ -240,29 +269,54 @@ def verify(original: str, optimized: str, tol: float) -> bool:
     import onnxruntime as ort
 
     rng = np.random.default_rng(7)
-    chunk = rng.standard_normal((1, 992, 128)).astype(np.float32)
-    spk = rng.standard_normal((1, 188, 512)).astype(np.float32)
-    fifo = rng.standard_normal((1, 124, 512)).astype(np.float32)
+    NP = {"tensor(float)": np.float32, "tensor(float16)": np.float16, "tensor(int64)": np.int64}
 
-    def run(path, feed, opt=None):
+    def session(path, opt=None):
         so = ort.SessionOptions()
         if opt is not None:
             so.graph_optimization_level = opt
-        s = ort.InferenceSession(path, so, providers=["CPUExecutionProvider"])
+        return ort.InferenceSession(path, so, providers=["CPUExecutionProvider"])
+
+    def run(s, feed):
         return dict(zip([o.name for o in s.get_outputs()], s.run(None, feed)))
 
-    ref = run(original, {
-        "chunk": chunk, "chunk_lengths": np.array([992], np.int64),
-        "spkcache": spk, "spkcache_lengths": np.array([188], np.int64),
-        "fifo": fifo, "fifo_lengths": np.array([124], np.int64)})
-    import onnx as _onnx
-    om = _onnx.load(optimized, load_external_data=False)
-    itype = {v.name: v.type.tensor_type.elem_type for v in om.graph.input}
-    def cast(name, arr):
-        return arr.astype(np.float16) if itype.get(name) == _onnx.TensorProto.FLOAT16 else arr
-    got = run(optimized, {"chunk": cast("chunk", chunk), "spkcache": cast("spkcache", spk),
-                          "fifo": cast("fifo", fifo)},
-              ort.GraphOptimizationLevel.ORT_DISABLE_ALL)
+    ref_sess = session(original)
+
+    # Build the feed from the model's OWN signature. The frame counts follow
+    # --chunk-frames / --fixed-spkcache-frames / --fixed-fifo-frames at export time,
+    # so hardcoding them here made --verify usable on exactly one configuration.
+    shapes = {i.name: i.shape for i in ref_sess.get_inputs()}
+    feed = {}
+    for i in ref_sess.get_inputs():
+        if any(not isinstance(d, int) for d in i.shape):
+            raise SystemExit(
+                f"--verify needs a static graph; input {i.name} has shape {i.shape}")
+        np_dtype = NP.get(i.type)
+        if np_dtype is None:
+            raise SystemExit(f"--verify cannot synthesize input {i.name} of type {i.type}")
+        if np_dtype == np.int64:
+            # A `<buffer>_lengths` input. Steady state is the buffer's own frame count,
+            # which is what the CoreML graph was specialized for.
+            buf = i.name[: -len("_lengths")] if i.name.endswith("_lengths") else None
+            if buf is None or buf not in shapes:
+                raise SystemExit(f"--verify cannot infer a value for integer input {i.name}")
+            feed[i.name] = np.full(i.shape, shapes[buf][1], np.int64)
+        else:
+            feed[i.name] = rng.standard_normal(i.shape).astype(np_dtype)
+
+    ref = run(ref_sess, feed)
+
+    # Feed the optimized model only what it still declares: --coreml-const-lengths
+    # folds the baked lengths away, and prune() then drops them from the signature.
+    opt_sess = session(optimized, ort.GraphOptimizationLevel.ORT_DISABLE_ALL)
+    opt_feed = {}
+    for i in opt_sess.get_inputs():
+        if i.name not in feed:
+            raise SystemExit(f"optimized model expects input {i.name}, absent from the original")
+        arr = feed[i.name]
+        opt_feed[i.name] = arr.astype(np.float16) if i.type == "tensor(float16)" else arr
+    got = run(opt_sess, opt_feed)
+
     ok = True
     for k in ("spkcache_fifo_chunk_preds", "chunk_pre_encode_embs"):
         a, b = ref[k], got[k]
@@ -308,7 +362,7 @@ def main() -> None:
 
     m = onnx.load(folded)
     g = m.graph
-    print(f"[2/5] removing all-False Where ...      {drop_allfalse_where(g):3d} removed")
+    print(f"[2/5] removing all-False Where ...      {drop_allfalse_where(g, shapes):3d} removed")
     print(f"[3/5] rewriting Pad -> Concat ...       {pad_to_concat(g, shapes, dtypes):3d} converted")
     print(f"[4/5] pre-transposing Gemm weights ...  {pretranspose_gemm(g):3d} converted")
     restore_folded_outputs(g)

--- a/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
+++ b/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
@@ -56,6 +56,31 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--coreml-static-batch1",
+        action="store_true",
+        help=(
+            "Export a fully static batch-1 graph for Apple CoreML. Like "
+            "--static-streaming-batch1 it fixes chunk/spkcache/fifo shapes, but it also drops "
+            "the length-based trimming: the fixed buffers are concatenated whole. That trim is "
+            "a no-op at runtime anyway (Vernacula always passes *_lengths equal to the buffer "
+            "size), yet it slices by a tensor VALUE, which makes every downstream shape "
+            "data-dependent and prevents CoreML from building an execution plan. Callers of "
+            "this graph must pass full-size, zero-padded buffers."
+        ),
+    )
+    parser.add_argument(
+        "--coreml-const-lengths",
+        action="store_true",
+        help=(
+            "With --coreml-static-batch1, replace the three *_lengths inputs with baked-in "
+            "constants (chunk/spkcache/fifo frame counts). The tensors stay in the graph "
+            "signature but are unused, so the caller is unchanged. This lets constant folding "
+            "erase the Range/Expand mask-building ops that otherwise force ~120 nodes back onto "
+            "CPU and fragment the CoreML graph into dozens of partitions. STEADY-STATE ONLY: "
+            "the graph then assumes full cache/fifo and a full-length chunk."
+        ),
+    )
+    parser.add_argument(
         "--dynamic-streaming-batch1",
         action="store_true",
         help=(
@@ -160,6 +185,11 @@ def build_wrapper(
     *,
     static_streaming_batch1: bool = False,
     dynamic_streaming_batch1: bool = False,
+    coreml_static_batch1: bool = False,
+    coreml_const_lengths: bool = False,
+    const_chunk_frames: int = 0,
+    const_spkcache_frames: int = 0,
+    const_fifo_frames: int = 0,
 ) -> Any:
     class SortformerExportWrapper(nn.Module):
         def __init__(self, inner: Any) -> None:
@@ -167,9 +197,28 @@ def build_wrapper(
             self.inner = inner
 
         def forward(self, chunk: Any, chunk_lengths: Any, spkcache: Any, spkcache_lengths: Any, fifo: Any, fifo_lengths: Any) -> tuple[Any, Any, Any]:
+            if coreml_const_lengths:
+                # Bake the steady-state lengths in as graph constants. The runtime always
+                # feeds exactly these values (Sortformer.cs sets *_lengths to each buffer's
+                # own size, and a full chunk is chunk_frames mel frames), so this changes no
+                # numerics in steady state -- but it turns the mask construction into foldable
+                # constants instead of data-dependent Range/Expand chains.
+                chunk_lengths = torch.tensor([const_chunk_frames], dtype=torch.int64)
+                spkcache_lengths = torch.tensor([const_spkcache_frames], dtype=torch.int64)
+                fifo_lengths = torch.tensor([const_fifo_frames], dtype=torch.int64)
             chunk_pre_encode_embs, chunk_pre_encode_lengths = self.inner.encoder.pre_encode(x=chunk, lengths=chunk_lengths)
             chunk_pre_encode_lengths = chunk_pre_encode_lengths.to(torch.int64)
-            if static_streaming_batch1:
+            if coreml_static_batch1:
+                # Fully static: concatenate the whole fixed buffers. No slice bound
+                # depends on a tensor value, so every downstream shape stays inferable
+                # and CoreML can compile the graph. Masking still happens downstream
+                # via the summed logical lengths passed to frontend_encoder.
+                spkcache_fifo_chunk_pre_encode_embs = torch.cat(
+                    [spkcache, fifo, chunk_pre_encode_embs],
+                    dim=1,
+                )
+                spkcache_fifo_chunk_pre_encode_lengths = chunk_pre_encode_lengths + spkcache_lengths + fifo_lengths
+            elif static_streaming_batch1:
                 spk_len = spkcache_lengths[0].to(torch.int64)
                 fifo_len = fifo_lengths[0].to(torch.int64)
                 chunk_len = chunk_pre_encode_lengths[0].to(torch.int64)
@@ -233,9 +282,13 @@ def main() -> None:
         raise SystemExit(f".nemo file not found: {nemo_path}")
     if output_path.exists() and not args.overwrite:
         raise SystemExit(f"Output already exists: {output_path}. Re-run with --overwrite.")
-    if args.static_streaming_batch1 and args.dynamic_streaming_batch1:
-        raise SystemExit("Choose only one of --static-streaming-batch1 or --dynamic-streaming-batch1.")
-    if (args.static_streaming_batch1 or args.dynamic_streaming_batch1) and args.batch_size != 1:
+    if args.coreml_const_lengths and not args.coreml_static_batch1:
+        raise SystemExit("--coreml-const-lengths requires --coreml-static-batch1.")
+    if sum([args.static_streaming_batch1, args.dynamic_streaming_batch1, args.coreml_static_batch1]) > 1:
+        raise SystemExit(
+            "Choose at most one of --static-streaming-batch1, --dynamic-streaming-batch1, --coreml-static-batch1."
+        )
+    if (args.static_streaming_batch1 or args.dynamic_streaming_batch1 or args.coreml_static_batch1) and args.batch_size != 1:
         raise SystemExit("The batch-1 streaming-specialized export modes currently require --batch-size 1.")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -253,6 +306,11 @@ def main() -> None:
         nn,
         model,
         static_streaming_batch1=args.static_streaming_batch1,
+        coreml_static_batch1=args.coreml_static_batch1,
+        coreml_const_lengths=args.coreml_const_lengths,
+        const_chunk_frames=args.chunk_frames,
+        const_spkcache_frames=args.fixed_spkcache_frames,
+        const_fifo_frames=args.fixed_fifo_frames,
         dynamic_streaming_batch1=args.dynamic_streaming_batch1,
     )
     wrapper.eval()
@@ -260,12 +318,19 @@ def main() -> None:
     batch = args.batch_size
     chunk = torch.randn(batch, args.chunk_frames, feature_dim)
     chunk_lengths = torch.full((batch,), args.chunk_frames, dtype=torch.int64)
-    spkcache_frames = args.fixed_spkcache_frames if args.static_streaming_batch1 else 0
-    fifo_frames = args.fixed_fifo_frames if args.static_streaming_batch1 else 0
+    _fixed_shapes = args.static_streaming_batch1 or args.coreml_static_batch1
+    spkcache_frames = args.fixed_spkcache_frames if _fixed_shapes else 0
+    fifo_frames = args.fixed_fifo_frames if _fixed_shapes else 0
     spkcache = torch.zeros(batch, spkcache_frames, emb_dim)
-    spkcache_lengths = torch.zeros((batch,), dtype=torch.int64)
     fifo = torch.zeros(batch, fifo_frames, emb_dim)
-    fifo_lengths = torch.zeros((batch,), dtype=torch.int64)
+    if args.coreml_static_batch1:
+        # Trace with steady-state lengths so any folded constant matches the shape
+        # the runtime actually feeds (lengths always equal the buffer size).
+        spkcache_lengths = torch.full((batch,), spkcache_frames, dtype=torch.int64)
+        fifo_lengths = torch.full((batch,), fifo_frames, dtype=torch.int64)
+    else:
+        spkcache_lengths = torch.zeros((batch,), dtype=torch.int64)
+        fifo_lengths = torch.zeros((batch,), dtype=torch.int64)
     dynamo = resolve_export_bool(args.dynamo, default=False)
     optimize = resolve_export_bool(args.optimize, default=dynamo)
     export_kwargs: dict[str, Any] = {
@@ -277,7 +342,7 @@ def main() -> None:
         "verify": args.verify,
         "do_constant_folding": not args.no_constant_folding,
     }
-    if not args.static_streaming_batch1:
+    if not _fixed_shapes:
         dynamic_axes = {
             "chunk": {1: "time_chunk"} if args.dynamic_streaming_batch1 else {0: "batch", 1: "time_chunk"},
             "spkcache": {1: "time_cache"} if args.dynamic_streaming_batch1 else {0: "batch", 1: "time_cache"},
@@ -328,6 +393,15 @@ def main() -> None:
         )
         metadata.notes.append(
             "The static candidate trims fixed-size cache/fifo buffers using the provided logical lengths before concatenation."
+        )
+    if args.coreml_static_batch1:
+        metadata.notes.append(
+            f"Exported a fully static CoreML batch-1 candidate: chunk={args.chunk_frames}, "
+            f"spkcache={args.fixed_spkcache_frames}, fifo={args.fixed_fifo_frames}."
+        )
+        metadata.notes.append(
+            "No length-based trimming: fixed buffers are concatenated whole so no shape is "
+            "data-dependent. Callers must pass full-size, zero-padded buffers."
         )
     if args.dynamic_streaming_batch1:
         metadata.notes.append(

--- a/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
+++ b/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
@@ -61,23 +61,26 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Export a fully static batch-1 graph for Apple CoreML. Like "
             "--static-streaming-batch1 it fixes chunk/spkcache/fifo shapes, but it also drops "
-            "the length-based trimming: the fixed buffers are concatenated whole. That trim is "
-            "a no-op at runtime anyway (Vernacula always passes *_lengths equal to the buffer "
-            "size), yet it slices by a tensor VALUE, which makes every downstream shape "
-            "data-dependent and prevents CoreML from building an execution plan. Callers of "
-            "this graph must pass full-size, zero-padded buffers."
+            "the length-based trimming: the fixed buffers are concatenated whole. Dropping it "
+            "is safe because spkcache and fifo are always full at runtime, and the chunk is "
+            "concatenated LAST, so the summed logical length still masks the padded tail of a "
+            "short final chunk. The trim itself slices by a tensor VALUE, which makes every "
+            "downstream shape data-dependent and prevents CoreML from building an execution "
+            "plan. Callers of this graph must pass full-size, zero-padded buffers."
         ),
     )
     parser.add_argument(
         "--coreml-const-lengths",
         action="store_true",
         help=(
-            "With --coreml-static-batch1, replace the three *_lengths inputs with baked-in "
-            "constants (chunk/spkcache/fifo frame counts). The tensors stay in the graph "
-            "signature but are unused, so the caller is unchanged. This lets constant folding "
-            "erase the Range/Expand mask-building ops that otherwise force ~120 nodes back onto "
-            "CPU and fragment the CoreML graph into dozens of partitions. STEADY-STATE ONLY: "
-            "the graph then assumes full cache/fifo and a full-length chunk."
+            "With --coreml-static-batch1, replace the spkcache_lengths and fifo_lengths "
+            "inputs with baked-in constants. Those two tensors stay in the graph signature "
+            "but are unused, so the caller is unchanged. This lets constant folding erase the "
+            "Range/Expand mask-building ops that otherwise force nodes back onto CPU and "
+            "fragment the CoreML graph into extra partitions. chunk_lengths is NOT baked: it "
+            "is short for the final chunk of every recording, so a constant there would attend "
+            "to that chunk's zero-padded tail as real audio. The graph does assume a full "
+            "cache and fifo, which Sortformer.cs always supplies."
         ),
     )
     parser.add_argument(
@@ -198,12 +201,18 @@ def build_wrapper(
 
         def forward(self, chunk: Any, chunk_lengths: Any, spkcache: Any, spkcache_lengths: Any, fifo: Any, fifo_lengths: Any) -> tuple[Any, Any, Any]:
             if coreml_const_lengths:
-                # Bake the steady-state lengths in as graph constants. The runtime always
-                # feeds exactly these values (Sortformer.cs sets *_lengths to each buffer's
-                # own size, and a full chunk is chunk_frames mel frames), so this changes no
-                # numerics in steady state -- but it turns the mask construction into foldable
-                # constants instead of data-dependent Range/Expand chains.
-                chunk_lengths = torch.tensor([const_chunk_frames], dtype=torch.int64)
+                # Bake the two BUFFER lengths in as graph constants. Sortformer.cs feeds
+                # spkcache_lengths/fifo_lengths as each buffer's own size on every call, so
+                # folding them away changes no numerics -- it turns their mask construction
+                # into foldable constants instead of data-dependent Range/Expand chains.
+                #
+                # ⚠ chunk_lengths is deliberately NOT baked. It is the one length the runtime
+                # does NOT always set to the buffer size: ProcessChunk passes
+                # min(start + chunkStride, totalFrames) - start, which is SHORT for the final
+                # chunk of every recording. Baking chunk_frames there would let the
+                # zero-padded tail of that last chunk be attended to as real audio, changing
+                # the diarization output at the end of every file. It stays a real input; only
+                # its mask stays data-dependent, which costs a few partitions, not correctness.
                 spkcache_lengths = torch.tensor([const_spkcache_frames], dtype=torch.int64)
                 fifo_lengths = torch.tensor([const_fifo_frames], dtype=torch.int64)
             chunk_pre_encode_embs, chunk_pre_encode_lengths = self.inner.encoder.pre_encode(x=chunk, lengths=chunk_lengths)
@@ -402,6 +411,14 @@ def main() -> None:
         metadata.notes.append(
             "No length-based trimming: fixed buffers are concatenated whole so no shape is "
             "data-dependent. Callers must pass full-size, zero-padded buffers."
+        )
+    if args.coreml_const_lengths:
+        metadata.notes.append(
+            f"spkcache_lengths={args.fixed_spkcache_frames} and fifo_lengths="
+            f"{args.fixed_fifo_frames} are baked in as graph constants; both inputs remain in "
+            "the signature but are ignored, and may be pruned from it after folding. "
+            "chunk_lengths is still a live input. This graph is valid only for a full cache "
+            "and fifo."
         )
     if args.dynamic_streaming_batch1:
         metadata.notes.append(

--- a/src/Vernacula.Avalonia/FFmpegDecoder.cs
+++ b/src/Vernacula.Avalonia/FFmpegDecoder.cs
@@ -54,6 +54,16 @@ internal static unsafe class FFmpegDecoder
         // the system-installed FFmpeg from dlopen when we don't. Force it to
         // empty so Linux/macOS/Windows fall back to ldconfig / DYLD / PATH.
         string? runtimesDir = FindNativeRuntimeDirectory(rootPath);
+
+        // macOS: Homebrew's unversioned `ffmpeg` formula tracks the latest major
+        // (9.x, i.e. libavformat.63) whose sonames FFmpeg.AutoGen cannot bind.
+        // The formula that DOES match (ffmpeg@6 for AutoGen 6.x) is keg-only, so
+        // its libraries are deliberately kept off the default dyld search path.
+        // An empty RootPath therefore resolves nothing, every stub stays unbound,
+        // and the first call throws NotSupportedException. Probe the Homebrew
+        // prefixes for an install whose soname matches this binding.
+        runtimesDir ??= FindMacOsFFmpegDirectory();
+
         ffmpeg.RootPath = runtimesDir ?? string.Empty;
 
         _initialized = true;
@@ -69,6 +79,49 @@ internal static unsafe class FFmpegDecoder
 
             if (Directory.EnumerateFiles(candidate, "*avformat*").Any())
                 return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Locate a macOS FFmpeg installation whose libavformat major version matches
+    /// the one FFmpeg.AutoGen was generated against. FFmpeg.AutoGen binds sonames
+    /// at a fixed major, so a mismatched install is worse than none: it resolves
+    /// nothing and fails later at the call site rather than here.
+    /// Returns null on other platforms, or when no matching install is present.
+    /// </summary>
+    private static string? FindMacOsFFmpegDirectory()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return null;
+
+        string soname = $"libavformat.{ffmpeg.LIBAVFORMAT_VERSION_MAJOR}.dylib";
+
+        // Apple-silicon Homebrew lives at /opt/homebrew, Intel at /usr/local.
+        foreach (string prefix in new[] { "/opt/homebrew", "/usr/local" })
+        {
+            // The unversioned formula, if it happens to be the right major.
+            string libDir = Path.Combine(prefix, "lib");
+            if (File.Exists(Path.Combine(libDir, soname)))
+                return libDir;
+
+            // Otherwise any keg-only ffmpeg@N formula that matches.
+            string optDir = Path.Combine(prefix, "opt");
+            try
+            {
+                if (!Directory.Exists(optDir))
+                    continue;
+
+                foreach (string keg in Directory.EnumerateDirectories(optDir, "ffmpeg*"))
+                {
+                    string kegLib = Path.Combine(keg, "lib");
+                    if (File.Exists(Path.Combine(kegLib, soname)))
+                        return kegLib;
+                }
+            }
+            catch (UnauthorizedAccessException) { /* unreadable prefix: skip */ }
+            catch (IOException)                 { /* unreadable prefix: skip */ }
         }
 
         return null;

--- a/src/Vernacula.Base/DiariZenDiarizer.cs
+++ b/src/Vernacula.Base/DiariZenDiarizer.cs
@@ -1,5 +1,6 @@
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Inference;
 using Vernacula.Base.Models;
 using System.Collections.Concurrent;
 using System.Text.Json;
@@ -954,9 +955,14 @@ public sealed class DiariZenDiarizer : IDisposable
         if (configuredWorkers.HasValue)
             return configuredWorkers.Value;
 
-        if (ep == ExecutionProvider.Cuda || ep == ExecutionProvider.DirectML)
+        // One worker per accelerator: parallel sessions contend for the same device
+        // instead of adding throughput. CoreML and WebGpu count here too.
+        if (ep is ExecutionProvider.Cuda or ExecutionProvider.DirectML
+                or ExecutionProvider.CoreML or ExecutionProvider.WebGpu)
             return 1;
         if (ep == ExecutionProvider.Auto && HardwareInfo.CanProbeCudaExecutionProvider())
+            return 1;
+        if (ep == ExecutionProvider.Auto && OperatingSystem.IsMacOS())
             return 1;
 
         int intraOpThreads = Math.Max(1, Config.GetDiariZenSegmentationIntraOpThreads());
@@ -1139,25 +1145,28 @@ public sealed class DiariZenDiarizer : IDisposable
             IntraOpNumThreads = Config.GetDiariZenSegmentationIntraOpThreads()
         };
 
-        switch (ep)
+        if (!OrtSessionBuilder.TryAppendPlatformAccelerator(opts, ep))
         {
-            case ExecutionProvider.Auto:
-                if (HardwareInfo.CanProbeCudaExecutionProvider())
-                {
-                    try { opts.AppendExecutionProvider_CUDA(0); } catch { }
-                }
-                try { opts.AppendExecutionProvider_DML(0); }  catch { }
-                break;
-            case ExecutionProvider.Cuda:
-                try { opts.AppendExecutionProvider_CUDA(0); }
-                catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
-                break;
-            case ExecutionProvider.DirectML:
-                try { opts.AppendExecutionProvider_DML(0); }
-                catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException("DirectML EP not available."); }
-                break;
+            switch (ep)
+            {
+                case ExecutionProvider.Auto:
+                    if (HardwareInfo.CanProbeCudaExecutionProvider())
+                    {
+                        try { opts.AppendExecutionProvider_CUDA(0); } catch { }
+                    }
+                    try { opts.AppendExecutionProvider_DML(0); }  catch { }
+                    break;
+                case ExecutionProvider.Cuda:
+                    try { opts.AppendExecutionProvider_CUDA(0); }
+                    catch (EntryPointNotFoundException)
+                    { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
+                    break;
+                case ExecutionProvider.DirectML:
+                    try { opts.AppendExecutionProvider_DML(0); }
+                    catch (EntryPointNotFoundException)
+                    { throw new InvalidOperationException("DirectML EP not available."); }
+                    break;
+            }
         }
 
         return new InferenceSession(segmentationModelPath, opts);

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -54,6 +54,18 @@ public static class OrtSessionBuilder
         switch (ep)
         {
             case ExecutionProvider.Auto:
+                // macOS has neither CUDA nor DirectML. The osx-arm64 ORT build
+                // ships CoreML + WebGPU; Auto picks WebGPU because it is the safe
+                // choice for ANY graph, including the stock dynamic-shape exports
+                // that CoreML cannot compile at all. CoreML is faster once a model
+                // has been through docs/coreml_onnx_playbook.md, but that is a
+                // per-model property, so selecting it is left explicit.
+                if (OperatingSystem.IsMacOS())
+                {
+                    try { opts.AppendExecutionProvider("WebGPU", new Dictionary<string, string>()); }
+                    catch { }
+                    break;
+                }
                 if (HardwareInfo.CanProbeCudaExecutionProvider())
                 {
                     try
@@ -98,12 +110,42 @@ public static class OrtSessionBuilder
                 }
                 break;
 
+            case ExecutionProvider.CoreML:
+                try { AppendCoreML(opts); }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        "CoreML EP not available in the current ONNX Runtime build.", ex);
+                }
+                break;
+
+            case ExecutionProvider.WebGpu:
+                try { opts.AppendExecutionProvider("WebGPU", new Dictionary<string, string>()); }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        "WebGPU EP not available in the current ONNX Runtime build.", ex);
+                }
+                break;
+
             case ExecutionProvider.Cpu:
                 break;
         }
 
         return opts;
     }
+
+    // Append the CoreML EP. Uses the ML Program format (CoreML's current IR --
+    // the legacy NeuralNetwork format is frozen) and lets CoreML pick among CPU,
+    // GPU and ANE. Note that CoreML silently declines any node whose shape has an
+    // unbounded dimension, so graphs with a dynamic time axis end up heavily
+    // partitioned; measure before preferring this over CPU.
+    private static void AppendCoreML(SessionOptions opts)
+        => opts.AppendExecutionProvider("CoreML", new Dictionary<string, string>
+        {
+            ["ModelFormat"] = "MLProgram",
+            ["MLComputeUnits"] = "ALL",
+        });
 
     // Append the CUDA EP, optionally forcing full-fp32 matmul (use_tf32=0). TF32's ~1e-2
     // error is fine for one-shot models but COMPOUNDS catastrophically through OmniVoice's
@@ -453,8 +495,14 @@ public static class OrtSessionBuilder
         var epTag = ep switch
         {
             ExecutionProvider.Cpu => "cpu",
-            ExecutionProvider.Cuda or ExecutionProvider.Auto => "cuda",
+            // Auto resolves to a different provider per platform, so its tag has to
+            // follow -- otherwise a macOS Auto run and an explicit WebGpu run build
+            // two copies of the same optimised graph under different keys.
+            ExecutionProvider.Auto => OperatingSystem.IsMacOS() ? "webgpu" : "cuda",
+            ExecutionProvider.Cuda => "cuda",
             ExecutionProvider.DirectML => "dml",
+            ExecutionProvider.CoreML => "coreml",
+            ExecutionProvider.WebGpu => "webgpu",
             _ => "auto",
         };
         // Include mtime+size in a short hash so source edits invalidate.

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -62,8 +62,14 @@ public static class OrtSessionBuilder
                 // per-model property, so selecting it is left explicit.
                 if (OperatingSystem.IsMacOS())
                 {
-                    try { opts.AppendExecutionProvider("WebGPU", new Dictionary<string, string>()); }
-                    catch { }
+                    // Gated on the provider actually being in this build: Auto is what the
+                    // desktop app uses everywhere and it has no EP setting, so a throw here
+                    // would break every model load with no way out. See ProviderAvailable.
+                    if (ProviderAvailable(WebGpuProviderName))
+                    {
+                        try { AppendWebGpu(opts); }
+                        catch { }
+                    }
                     break;
                 }
                 if (HardwareInfo.CanProbeCudaExecutionProvider())
@@ -146,6 +152,111 @@ public static class OrtSessionBuilder
             ["ModelFormat"] = "MLProgram",
             ["MLComputeUnits"] = "ALL",
         });
+
+    // The short names AppendExecutionProvider takes, and the long names
+    // GetAvailableProviders reports. They are not the same strings.
+    private const string WebGpuProviderName = "WebGpuExecutionProvider";
+    private const string CoreMLProviderName = "CoreMLExecutionProvider";
+
+    private static void AppendWebGpu(SessionOptions opts)
+        => opts.AppendExecutionProvider("WebGPU", new Dictionary<string, string>());
+
+    /// <summary>
+    /// Whether this ONNX Runtime build actually carries the named provider.
+    /// </summary>
+    /// <remarks>
+    /// ⚠ A Lazy for the same reason as HardwareInfo's CUDA probe: this is asked at every
+    /// model-init site and those run in parallel.
+    ///
+    /// This matters most for Auto. Registering an absent provider throws, which the Auto path
+    /// swallows -- but on macOS the desktop app has no EP setting (every service defaults to
+    /// Auto), so anything Auto cannot recover from takes down every model load with no way for
+    /// the user to opt out. Asking ORT what it has is cheaper and more honest than registering
+    /// blind and catching. Notably the macOS-x64 pin (ORT 1.19.2) predates the WebGPU EP
+    /// entirely, and a Windows/Linux EP=DirectML or EP=Cuda build has no WebGPU either.
+    ///
+    /// It answers "is the provider IN this build", not "will a device be found". A build that
+    /// has the provider but no usable Metal adapter still fails at session creation.
+    /// </remarks>
+    private static readonly Lazy<HashSet<string>> _availableProviders = new(
+        () =>
+        {
+            try
+            {
+                return new HashSet<string>(
+                    OrtEnv.Instance().GetAvailableProviders(), StringComparer.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                // Never let a probe failure be worse than not probing.
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+        },
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Fail an explicitly requested provider with the reason, rather than letting
+    /// AppendExecutionProvider throw something that does not say what to do about it.
+    /// </summary>
+    private static void RequireProvider(string providerName, string display)
+    {
+        if (ProviderAvailable(providerName))
+            return;
+
+        string built = string.Join(", ", _availableProviders.Value.OrderBy(p => p));
+        throw new InvalidOperationException(
+            $"{display} is not in this ONNX Runtime build (it has: {built}). {display} is macOS "
+          + "arm64 only, and comes from the plain Microsoft.ML.OnnxRuntime package -- build with "
+          + "-p:EP=Cpu on Apple Silicon. A Cuda or DirectML build carries no macOS accelerator.");
+    }
+
+    private static bool ProviderAvailable(string name)
+    {
+        var have = _availableProviders.Value;
+        // An empty set means the probe itself failed; fall back to trying, which is the
+        // pre-probe behaviour.
+        return have.Count == 0 || have.Contains(name);
+    }
+
+    /// <summary>
+    /// Append the macOS accelerator implied by <paramref name="ep"/>, returning true when one
+    /// was actually registered.
+    /// </summary>
+    /// <remarks>
+    /// The DiariZen-family backends (WeSpeakerEmbedder, VoxLinguaLid, DiariZenDiarizer) build
+    /// their own <see cref="SessionOptions"/> because each sets its own thread counts, so they
+    /// cannot route through <see cref="Create(ExecutionProvider)"/>. They still have to agree
+    /// with it about what Auto/CoreML/WebGpu mean, and three hand-rolled switches had already
+    /// drifted once. This is the shared tail they call instead of growing a fourth copy.
+    /// A false return means "nothing macOS-specific applies" -- the caller should run its
+    /// ordinary CUDA/DirectML path, which lands on CPU here.
+    /// </remarks>
+    public static bool TryAppendPlatformAccelerator(SessionOptions opts, ExecutionProvider ep)
+    {
+        switch (ep)
+        {
+            case ExecutionProvider.CoreML:
+                RequireProvider(CoreMLProviderName, "CoreML");
+                AppendCoreML(opts);
+                return true;
+
+            case ExecutionProvider.WebGpu:
+                RequireProvider(WebGpuProviderName, "WebGPU");
+                AppendWebGpu(opts);
+                return true;
+
+            // Auto prefers WebGPU on macOS (see the Auto case in Create). Best effort:
+            // if the provider is not in this ORT build, fall back rather than throw.
+            case ExecutionProvider.Auto when OperatingSystem.IsMacOS():
+                if (!ProviderAvailable(WebGpuProviderName))
+                    return false;
+                try { AppendWebGpu(opts); return true; }
+                catch { return false; }
+
+            default:
+                return false;
+        }
+    }
 
     // Append the CUDA EP, optionally forcing full-fp32 matmul (use_tf32=0). TF32's ~1e-2
     // error is fine for one-shot models but COMPOUNDS catastrophically through OmniVoice's

--- a/src/Vernacula.Base/Models/CoreModels.cs
+++ b/src/Vernacula.Base/Models/CoreModels.cs
@@ -1,5 +1,8 @@
 namespace Vernacula.Base.Models;
 
-public enum ExecutionProvider { Auto, Cuda, DirectML, Cpu }
+// CoreML / WebGpu are macOS-only accelerator paths (the osx-arm64 ORT build
+// reports CoreMLExecutionProvider + WebGpuExecutionProvider). Appended at the
+// end so previously-serialized ordinals keep their meaning.
+public enum ExecutionProvider { Auto, Cuda, DirectML, Cpu, CoreML, WebGpu }
 public enum ModelPrecision    { Int8, Fp32 }
 public enum SegmentationMode  { SileroVad, Sortformer, DiariZen, VibeVoiceBuiltin }

--- a/src/Vernacula.Base/VoxLinguaLid.cs
+++ b/src/Vernacula.Base/VoxLinguaLid.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Inference;
 using Vernacula.Base.Models;
 
 namespace Vernacula.Base;
@@ -289,27 +290,30 @@ public sealed class VoxLinguaLid : IDisposable
             IntraOpNumThreads = Math.Min(8, Math.Max(1, Environment.ProcessorCount)),
         };
 
-        switch (ep)
+        if (!OrtSessionBuilder.TryAppendPlatformAccelerator(opts, ep))
         {
-            case ExecutionProvider.Auto:
-                if (HardwareInfo.CanProbeCudaExecutionProvider())
-                {
+            switch (ep)
+            {
+                case ExecutionProvider.Auto:
+                    if (HardwareInfo.CanProbeCudaExecutionProvider())
+                    {
+                        try { opts.AppendExecutionProvider_CUDA(0); }
+                        catch { /* fall through to CPU */ }
+                    }
+                    try { opts.AppendExecutionProvider_DML(0); }
+                    catch { /* not available */ }
+                    break;
+                case ExecutionProvider.Cuda:
                     try { opts.AppendExecutionProvider_CUDA(0); }
-                    catch { /* fall through to CPU */ }
-                }
-                try { opts.AppendExecutionProvider_DML(0); }
-                catch { /* not available */ }
-                break;
-            case ExecutionProvider.Cuda:
-                try { opts.AppendExecutionProvider_CUDA(0); }
-                catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
-                break;
-            case ExecutionProvider.DirectML:
-                try { opts.AppendExecutionProvider_DML(0); }
-                catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException("DirectML EP not available."); }
-                break;
+                    catch (EntryPointNotFoundException)
+                    { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
+                    break;
+                case ExecutionProvider.DirectML:
+                    try { opts.AppendExecutionProvider_DML(0); }
+                    catch (EntryPointNotFoundException)
+                    { throw new InvalidOperationException("DirectML EP not available."); }
+                    break;
+            }
         }
 
         return new InferenceSession(modelPath, opts);

--- a/src/Vernacula.Base/WeSpeakerEmbedder.cs
+++ b/src/Vernacula.Base/WeSpeakerEmbedder.cs
@@ -2,6 +2,7 @@ using System.Numerics;
 using MathNet.Numerics.IntegralTransforms;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Inference;
 using Vernacula.Base.Models;
 
 namespace Vernacula.Base;
@@ -129,21 +130,24 @@ public sealed class WeSpeakerEmbedder : IDisposable
         // Keep per-session threading low and use outer parallelism across
         // multiple embedding jobs instead of oversubscribing CPU cores.
         opts.IntraOpNumThreads = Config.GetDiariZenEmbeddingIntraOpThreads();
-        switch (ep)
+        if (!OrtSessionBuilder.TryAppendPlatformAccelerator(opts, ep))
         {
-            case ExecutionProvider.Auto:
-                if (HardwareInfo.CanProbeCudaExecutionProvider())
-                {
-                    try { opts.AppendExecutionProvider_CUDA(0); } catch { }
-                }
-                try { opts.AppendExecutionProvider_DML(0); }  catch { }
-                break;
-            case ExecutionProvider.Cuda:
-                opts.AppendExecutionProvider_CUDA(0);
-                break;
-            case ExecutionProvider.DirectML:
-                opts.AppendExecutionProvider_DML(0);
-                break;
+            switch (ep)
+            {
+                case ExecutionProvider.Auto:
+                    if (HardwareInfo.CanProbeCudaExecutionProvider())
+                    {
+                        try { opts.AppendExecutionProvider_CUDA(0); } catch { }
+                    }
+                    try { opts.AppendExecutionProvider_DML(0); }  catch { }
+                    break;
+                case ExecutionProvider.Cuda:
+                    opts.AppendExecutionProvider_CUDA(0);
+                    break;
+                case ExecutionProvider.DirectML:
+                    opts.AppendExecutionProvider_DML(0);
+                    break;
+            }
         }
         _session = new InferenceSession(modelPath, opts);
         var inputNames = _session.InputMetadata.Keys.ToArray();

--- a/src/Vernacula.Tts.Backends.CLI/Program.cs
+++ b/src/Vernacula.Tts.Backends.CLI/Program.cs
@@ -174,8 +174,13 @@ switch (ep)
     case "cuda":     epEnum = ExecutionProvider.Cuda;     break;
     case "cpu":      epEnum = ExecutionProvider.Cpu;      break;
     case "directml": epEnum = ExecutionProvider.DirectML; break;
+    // macOS accelerators. Both need an osx-arm64 build (-p:EP=Cpu); the plain
+    // package is the one whose native carries them.
+    case "coreml":   epEnum = ExecutionProvider.CoreML;   break;
+    case "webgpu":   epEnum = ExecutionProvider.WebGpu;   break;
     default:
-        Console.Error.WriteLine($"Unknown EP: {ep}. Choose cpu, cuda, directml, or auto.");
+        Console.Error.WriteLine(
+            $"Unknown EP: {ep}. Choose cpu, cuda, directml, coreml, webgpu, or auto.");
         return 2;
 }
 
@@ -656,9 +661,12 @@ static void PrintUsage()
         Optional:
           --out <wav>              Output WAV path. Default: chatterbox_out.wav
           --ep <name>              Execution provider, one of:
-                                     auto      — CUDA, fall back to DirectML (default)
+                                     auto      — CUDA, fall back to DirectML; WebGPU
+                                                 on macOS (default)
                                      cuda      — CUDA only, fail if unavailable
                                      directml  — DirectML only, fail if unavailable
+                                     coreml    — CoreML only (macOS), fail if unavailable
+                                     webgpu    — WebGPU only (macOS), fail if unavailable
                                      cpu       — CPU only
                                    The csproj's `-p:EP=...` build flag must include
                                    the runtime you ask for here (cuda needs OnnxRuntime.Gpu,

--- a/src/Vernacula.Tts.CLI/Program.cs
+++ b/src/Vernacula.Tts.CLI/Program.cs
@@ -252,8 +252,13 @@ internal static class Program
                 case "cpu": epEnum = ExecutionProvider.Cpu; break;
                 case "cuda": epEnum = ExecutionProvider.Cuda; break;
                 case "auto": epEnum = ExecutionProvider.Auto; break;
+                // macOS accelerators. Both need an osx-arm64 build (-p:EP=Cpu); the plain
+                // package is the one whose native carries them.
+                case "coreml": epEnum = ExecutionProvider.CoreML; break;
+                case "webgpu": epEnum = ExecutionProvider.WebGpu; break;
                 default:
-                    Console.Error.WriteLine($"--ep must be cpu, cuda or auto (got \"{ep}\").");
+                    Console.Error.WriteLine(
+                        $"--ep must be cpu, cuda, coreml, webgpu or auto (got \"{ep}\").");
                     return 2;
             }
         }
@@ -513,7 +518,8 @@ internal static class Program
           --out <wav>             Output path (24 kHz mono float32 WAV). Required.
           --num-step <n>          Diffusion steps (default 32).
           --target-tokens <n>     Override the duration estimate (25 tokens ≈ 1 s).
-          --ep cpu|cuda|auto      Execution provider (default auto). CUDA runs full fp32; TF32 is
+          --ep <name>             Execution provider (default auto): cpu, cuda, auto, or on
+                                  macOS coreml | webgpu. CUDA runs full fp32; TF32 is
                                   disabled because the diffusion loop degrades into noise under it.
                                   The IPA diff works on every provider (it is a graph rewrite, not a
                                   weight fold), so CUDA needs no pre-merged model.


### PR DESCRIPTION
macOS ran CPU-only on Apple Silicon: the osx-arm64 ONNX Runtime build ships two
accelerators — CoreML and WebGPU — and neither was reachable from Vernacula.

## Runtime

- `ExecutionProvider` gains `CoreML` and `WebGpu`, **appended last** so previously
  serialized ordinals keep their meaning.
- `OrtSessionBuilder` registers both, gives each its own optimized-graph cache tag,
  and `Auto` takes the WebGPU path on macOS — WebGPU because it is the safe choice
  for *any* graph, including the stock dynamic-shape exports CoreML cannot compile
  at all.

## FFmpeg

Homebrew's unversioned formula is now FFmpeg 9 (`libavformat.63`), which
FFmpeg.AutoGen 6.1 cannot bind, and the matching `ffmpeg@6` is keg-only so it is off
the default dyld path. The decoder now probes the Homebrew prefixes for an install
whose soname matches `LIBAVFORMAT_VERSION_MAJOR`. Without this the desktop app throws
`NotSupportedException` on first decode.

## Export

The shipped Sortformer graph cannot be compiled by the CoreML EP at all (error -14)
because it slices by tensor values, making every downstream shape data-dependent.
`--coreml-static-batch1` drops that trim (a no-op at runtime, since `Sortformer.cs`
always passes `*_lengths` equal to each buffer's size) and `--coreml-const-lengths`
bakes the steady-state lengths in. `coreml_optimize_sortformer.py` then removes 51
all-False `Where` masks, rewrites 34 constant `Pad`s as `Concat`s, and pre-transposes
180 `Gemm` weights.

Measured on an M5, ORT 1.24.4:

| stage | partitions | inference | cold load | warm load |
|---|---|---|---|---|
| shipped dynamic | fails | - | - | - |
| `--coreml-static-batch1` | 71 | 166.0 ms | - | - |
| + const lengths | 69 | - | - | - |
| + Where removed | 35 | 97.0 ms | - | - |
| + Pad → Concat | 1 | 51.3 ms | 101.0 s | 20.8 s |
| + Gemm pre-transpose | 1 | 52.3 ms | 2.1 s | 0.2 s |

Reference: CPU 163.5 ms, WebGPU 94.0 ms. Outputs match the original model to 3.6e-07
(preds) and 0.0 (embeddings).

The Gemm pre-transpose is the load-time fix: ORT's CoreML EP writes the weight
transposes it synthesizes for `Gemm(transB=0)` as hex-float **text** inline in
`model.mil` — 1.49 GB for 0.39 GB of weights — and re-parses it on every load.

`docs/coreml_onnx_playbook.md` generalizes all of this to the other models.

## Note on the build

This work predates `RejectCudaOffX64` in `Directory.Build.props`. That guard already
fails an `EP=Cuda` build on any non-x64 target and points at `-p:EP=Cpu`, superseding
the per-csproj OS conditions this branch originally carried — so they were dropped and
the csprojs are left exactly as `main` has them, preserving *one ONNX Runtime version,
decided once*. On Apple Silicon, build with `-p:EP=Cpu`: the plain osx-arm64 package is
the one carrying the CoreML and WebGPU natives, and none of the new code is behind an
`#if`, so both providers are reachable from that build.

⚠️ **Not built locally** — there is no .NET SDK on the machine this was rebased on, so
CI is the first real build of this rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR93dNe2n9Qh83PJmNR9f
