### PR TITLE
export: the flag that actually reaches a single CoreML partition, and the runbook to validate it on Apple Silicon (#162)

### DIFF
--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -18,7 +18,7 @@ Inference figures are from an idle machine; load figures are stable.
 |---|---|---|---|---|---|
 | shipped dynamic model | *fails to compile* (`error -14`) | — | — | — | — |
 | `--coreml-static-batch1` | 71 | 166.0 ms | — | — | — |
-| `+ const lengths` | 69 | — | — | — | — |
+| `+ const lengths` (all three — see Technique 2) | 69 | — | — | — | — |
 | `+ all-False `Where` removed` | 35 | 97.0 ms | — | — | — |
 | `+ `Pad` → `Concat`` | **1** | 51.3 ms | 101.0 s | 20.8 s | 1.49 GB |
 | `+ Gemm pre-transpose` | **1** | 52.3 ms | **2.1 s** | **0.2 s** | **0.00 GB** |
@@ -27,6 +27,9 @@ Reference on the same machine: **CPU 163.5 ms, WebGPU 94.0 ms.**
 Outputs match the original dynamic model to `3.6e-07` (preds) and `0.0` (embeddings).
 
 Net: **3.2× vs CPU, 1.8× vs WebGPU, and load went from 101 s to 2.1 s.**
+
+⚠ **On ORT 1.24.4 — which is not the ORT the macOS build ships.** Read the first
+caveat at the bottom before treating any of this as a shipped speedup.
 
 ## The core mental model
 
@@ -95,12 +98,27 @@ If lengths are constant at runtime, make them graph constants
 
 > ⚠ **Check each length separately.** In Sortformer only `spkcache_lengths` and
 > `fifo_lengths` are genuinely constant. `chunk_lengths` is short for the last
-> chunk of every recording, so baking it would silently change the diarization at
-> the end of every file — a constant that is *usually* right is a correctness bug,
-> not an optimization. Verify against the calling code, not the steady state.
+> chunk of every recording, so baking it *does* silently change the diarization at
+> the end of every file — measured on the shipped model, up to **0.54** (rms 0.24)
+> on `preds`' 0..1 scale, enough to flip speaker assignments. Verify against the
+> calling code, not the steady state.
 
 **Worth knowing: on its own this barely helped** (71 → 69 partitions). Its real
 value is enabling Technique 3 — it turns the masks into foldable constants.
+
+> ⚠ **And that is the trap, because the two halves of this technique conflict.**
+> The attention mask is a function of **all three** lengths, so leaving the one
+> non-constant length live keeps the mask data-dependent and **Technique 3 removes
+> nothing at all** — 0 of 51 `Where` nodes, four inputs instead of three, and no
+> path past 69 partitions. There is no middle setting: you either bake a length
+> that is sometimes wrong, or you keep the whole mask. Sortformer's resolution is
+> to bake all three behind an explicit opt-in
+> (`--coreml-const-chunk-length`) and give the resulting steady-state graph a
+> **caller obligation**: route the final, short chunk of each recording to the
+> unspecialized graph. Every other chunk is full-length, so that costs one
+> inference per recording and keeps the output exact. Expect to find this shape
+> wherever "the axes are constant at runtime" turns out to mean "constant except
+> at the edges".
 
 ## Technique 3 — Delete all-False `Where` masks
 
@@ -111,6 +129,12 @@ folds to a constant that is **entirely False** (Sortformer: shape
 `(1,1,436,436)`, 436 = 188+124+124 — the tensor is exactly full).
 `Where(false, -10000, x)` is just `x`. These are identities whose only effect is
 fragmenting the graph.
+
+**Precondition:** *every* length feeding the mask must be a graph constant
+(Technique 2, including the awkward one). While any of them is a live input the
+mask cannot fold, the condition is not an initializer, and this technique is a
+no-op — a silent one, since the transform simply reports 0 removed and the
+pipeline continues to a graph that looks finished.
 
 **Do:** rewire consumers to the data input and delete the node. Verify the mask
 really is all-False first — it is a provable property, so assert it rather than
@@ -198,10 +222,22 @@ ORT_ENABLE_EXTENDED: 191 partitions  <- much worse
 `ORT_ENABLE_ALL` additionally emits hardware-specific `NhwcFusedConv` that makes
 the saved model **unloadable**. Fold at `BASIC` only.
 
-**Load pre-optimized models with `ORT_DISABLE_ALL`.** Re-optimizing an
-already-optimized graph throws
+**Load pre-optimized models with `ORT_DISABLE_ALL` — or `ORT_ENABLE_BASIC`, but
+never higher.** Re-optimizing an already-optimized graph throws
 `AddInitializedOrtValue Attempt to replace the existing tensor`.
-`OrtSessionBuilder.CreateCachedSession` already does this for cache hits.
+`OrtSessionBuilder.CreateCachedSession` already does this for cache hits, but
+`Create` defaults to `ORT_ENABLE_ALL`, so a *fresh* session on a pre-optimized
+file — which is exactly what the shipped CoreML variant is — has to pass the level
+explicitly or it throws at load.
+
+Bisected on ORT 1.26.0 with `disabled_optimizers`: the thrower is
+**`MatMulAddFusion`**, an EXTENDED-level pass. It reshapes >2D `MatMul` inputs so
+it can emit a `Gemm`, and the already-folded graph is full of the initializers it
+generates (`gemm_input_shape_token_N`, `gemm_output_reshape_token_N_new_shape`)
+because the fold pass already ran it. Renaming all 340 of those out of the way does
+**not** fix it, so it collides on something the fusion mints fresh — treat it as an
+ORT defect to route around, not a graph to reshape. The four transforms here are
+innocent: a BASIC-folded graph with *none* of them applied fails identically.
 
 **The CoreML provider options do not help load time.** Measured, all identical
 to three significant figures: `SpecializationStrategy=FastPrediction`,
@@ -309,17 +345,28 @@ never going near CoreML — it is bit-exact and costs nothing.
 ## Tooling
 
 - `scripts/nemo_export/export_sortformer_nemo_to_onnx.py` — `--coreml-static-batch1`,
-  `--coreml-const-lengths` (Techniques 1–2)
+  `--coreml-const-lengths`, `--coreml-const-chunk-length` (Techniques 1–2). All three
+  are needed to reach one partition; the first two alone stop at 69.
 - `scripts/nemo_export/coreml_optimize_sortformer.py` — Techniques 3–5 plus
   `--verify` against the original model. The graph transforms are model-agnostic;
   only the verification harness is Sortformer-specific.
 
 ## Caveats
 
-- **ORT-version sensitive.** Validated on **1.24.4**. Python ORT 1.29.0
-  partitions the same graph into 194 and diverges at ~1e-2. Re-validate on any
-  ORT upgrade.
+- **⚠ Every number here was measured on ORT 1.24.4, which the macOS build does not
+  ship.** `Directory.Build.props` pins 1.24.4 only for DirectML; an Apple Silicon
+  build is `-p:EP=Cpu` and takes the default, **1.29.0** — where the one data point
+  we have says this same graph splits into **194** partitions and diverges at
+  **~1e-2**. Until that is re-run on 1.29.0, the speedup below is a property of a
+  runtime no user of the shipped build is holding. This is the open question, and it
+  gates shipping the variant at all; see
+  `docs/investigations/sortformer_coreml_publish_investigation.md`.
 - **Steady-state only.** The static graph assumes full cache/FIFO and a
-  full-length chunk. Warm-up chunks must be zero-padded to full size.
+  full-length chunk. Warm-up chunks must be zero-padded to full size — free, since
+  the runtime already reports those two lengths as the full buffer size — but the
+  final short chunk of each recording must go to the unspecialized graph instead
+  (Technique 2's warning).
 - **Contract changes.** Folding prunes the now-unused `*_lengths`, so the graph
   takes three inputs, not six, at fixed shapes. Callers need a variant path.
+- **Load level is part of the contract**, not a tuning knob: `ORT_ENABLE_BASIC` or
+  lower, or the file does not open. See the anti-patterns above.

--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -353,19 +353,19 @@ never going near CoreML — it is bit-exact and costs nothing.
 
 ## Caveats
 
-- **⚠ Every number here was measured on ORT 1.24.4, which the macOS build does not
-  ship.** `Directory.Build.props` pins 1.24.4 only for DirectML; an Apple Silicon
-  build is `-p:EP=Cpu` and takes the default, **1.29.0** — where the one data point
-  we have says this same graph splits into **194** partitions and diverges at
-  **~1e-2**. Until that is re-run on 1.29.0, the speedup below is a property of a
-  runtime no user of the shipped build is holding. This is the open question, and it
-  gates shipping the variant at all; see
+- **The numbers in the table below were measured on ORT 1.24.4; 1.29.0 is what ships
+  and has since been measured too.** `Directory.Build.props` pins 1.24.4 only for
+  DirectML; an Apple Silicon build is `-p:EP=Cpu` and takes the default, **1.29.0**. It
+  was once believed 1.29.0 split this graph into 194 partitions and diverged at ~1e-2 —
+  **that does not reproduce.** On an M5 under 1.29.0 the graph reaches **1 partition**
+  and `4.470E-07` against the stock model, at **51.5 ms** vs 171.8 ms for stock-on-CPU.
+  The variant shipped on that basis; see
   `docs/investigations/sortformer_coreml_publish_investigation.md`.
-- **Steady-state only.** The static graph assumes full cache/FIFO and a
-  full-length chunk. Warm-up chunks must be zero-padded to full size — free, since
-  the runtime already reports those two lengths as the full buffer size — but the
-  final short chunk of each recording must go to the unspecialized graph instead
-  (Technique 2's warning).
+- **Steady-state only.** The static graph assumes a genuinely full cache/FIFO and a
+  full-length chunk. Zero-padding a partly-filled buffer is **not** free: the baked
+  lengths claim every frame is real, so padding gets attended to as audio. Both the
+  warm-up chunks (cache/FIFO still filling) and the final short chunk of each recording
+  must go to the unspecialized graph instead (Technique 2's warning).
 - **Contract changes.** Folding prunes the now-unused `*_lengths`, so the graph
   takes three inputs, not six, at fixed shapes. Callers need a variant path.
 - **Load level is part of the contract**, not a tuning knob: `ORT_ENABLE_BASIC` or

--- a/docs/investigations/sortformer_coreml_publish_investigation.md
+++ b/docs/investigations/sortformer_coreml_publish_investigation.md
@@ -344,3 +344,118 @@ the PR body carries the same list with the commands filled in. In order:
    passed, and add the `manifest.json` entry by extending the published manifest rather than
    regenerating it (the live one deliberately omits `sortformer/`, the int8 variants and
    `silero_vad.onnx`, so `--all` would silently change what the app validates).
+
+## Run 7 — 2026-09-09 — the Mac. The 1.29.0 blocker does not reproduce
+
+Environment: MacBook Air (Apple Silicon), macOS 25.6.0, export venv rebuilt here on
+python 3.12.14 / **onnxruntime 1.29.0** (the version an `EP=Cpu` osx-arm64 build takes,
+per Run 6). Source checkpoint downloaded fresh from `nvidia/diar_streaming_sortformer_4spk-v2.1`;
+reference dynamic model `~/models/diar_streaming_sortformer_4spk-v2.1.onnx`, md5
+`647a22cef31f59dc2c314fa783b2581d` — the same file Run 1 used.
+
+### Build reproduces the Linux run
+
+Same two commands as Runs 1 and 4. Transform counts are identical:
+
+```
+[2/5] removing all-False Where ...       51 removed
+[3/5] rewriting Pad -> Concat ...        34 converted
+[4/5] pre-transposing Gemm weights ...  180 converted
+[5/5] wrote diar_streaming_sortformer_4spk-v2.1.coreml.onnx (527 MB), 1788 nodes,
+      inputs=['chunk', 'spkcache', 'fifo']
+```
+
+Artifact: 526,897,872 B, md5 `890c59cc71dedfff9f1c3d7f10924422` — 42 bytes off the Linux
+build, as expected from folding under a different ORT.
+
+`verify()` against the shipped dynamic model, CPU EP, seed 7:
+
+| | this Mac (ORT 1.29.0) | Linux (Run 4, ORT 1.26.0) | #162 (ORT 1.24.4) |
+|---|---|---|---|
+| `preds` maxAbs | 3.576E-07 | 3.278E-07 | 3.576E-07 |
+| `embs` maxAbs | **0.000E+00** | 3.052E-05 | 0.0 |
+
+The `embs` figure confirms Run 4's diagnosis: the Linux `3.052E-05` was reference-side
+`ORT_ENABLE_ALL` fusion, not the variant. It is exactly zero when both sides match.
+
+### Checklist step 1 — CoreML EP on ORT 1.29.0. **GO.**
+
+```
+partitions      1 (1751/1751 nodes on the EP)  <- single partition
+All nodes placed on [CoreMLExecutionProvider]
+```
+
+| | #162's caveat for 1.29.0 | measured here on 1.29.0 |
+|---|---|---|
+| partitions | 194 | **1** |
+| CoreML-vs-CPU `preds` | ~1e-2 | **4.470E-07** (rms 7.616E-08) |
+| inference | — | **51.5 ms** (min/max 51.3/51.7) |
+| cold / warm load | — | **2.2 s / 0.16 s** |
+
+CPU EP on this machine, same graph: **154.0 ms**, so **2.99× vs CPU**. WebGPU could not be
+compared — it is not in the pip `onnxruntime` wheel, only in the C# package's natives.
+
+**The Run 6 blocker is retired.** Whatever produced "194 partitions / ~1e-2" in #162, it is
+not what 1.29.0 does with the artifact this pipeline builds. Pinning macOS to 1.24.4
+(Run 6, option 2) is unnecessary.
+
+The 1751 node count also resolves a loose end: `coreml_optimize_sortformer.py` writes 1788,
+and ORT's BASIC fold trims it to 1751 at load. #162's "1751 nodes" was the post-load count,
+so Run 4's "1788 vs 1751, expected from a different ORT" was explaining a difference that
+was never there.
+
+### Checklist step 3 — the load-level constraint is gone on 1.29.0
+
+Run 5 found `ORT_ENABLE_EXTENDED` and above throwing
+`AddInitializedOrtValue Attempt to replace the existing tensor` (`MatMulAddFusion`). That
+does not reproduce here. All four levels load, hold one partition, and stay correct:
+
+| level | loads | partitions | inference |
+|---|---|---|---|
+| `ORT_DISABLE_ALL` | yes | 1 (1788/1788) | 83.9 ms |
+| `ORT_ENABLE_BASIC` | yes | 1 (1751/1751) | 51.6 ms |
+| `ORT_ENABLE_EXTENDED` | yes | 1 (1751/1751) | 52.0 ms |
+| `ORT_ENABLE_ALL` | yes | 1 (1751/1751) | 51.9 ms |
+
+At `ORT_ENABLE_ALL` — what `OrtSessionBuilder.Create` actually defaults to — parity is
+unchanged at `4.470E-07`. So it was an ORT 1.26.0 re-optimization defect, and the model
+card should **not** carry the `ORT_ENABLE_BASIC`-only contract term as an unconditional
+rule. Note the playbook's separate claim that EXTENDED worsens CoreML partitioning
+(69 → 191) was measured on 1.24.4 against the `chunk_lengths`-live graph; it does not hold
+for this artifact on 1.29.0.
+
+### The probe could not have reported any of this
+
+`coreml_partition_probe.py` printed `partitions  not reported` on a graph that was at one
+partition — a no-go reading on a go. Three defects, all fixed in this commit:
+
+* `make_session` read the captured stderr *inside* the `with` block, while the `seek(0)`
+  sat in the context manager's `finally`. `dup2` makes fd 2 share the file offset, so the
+  read happened at end-of-writes and returned `""`, always. Reproduced standalone.
+* The `GetCapability` summary is WARNING **only when partitions > 1**; at one partition it
+  is INFO. Both the session logger (`SessionOptions.log_severity_level`, was 2) and the
+  default logger gate it, so both had to drop to INFO. The comment at `PARTITION_RE`
+  claiming "logs this at warning level" was the root of it.
+* The "requested EP did not take the graph" guard tested `get_providers()[0]`, which is the
+  *registration* list, not the assignment list — an EP that registers and claims zero nodes
+  still sits at index 0. It now checks the supported-node count, and correctly caught the
+  absent WebGPU EP during this run.
+
+(Also `--runs 0` left `got` unbound, crashing the parity block with `NameError`.)
+
+### Where that leaves the publish
+
+Steps 1–3 pass on the runtime the macOS build actually ships. Step 4 — HF upload and the
+`manifest.json` entry — is still **not done**, and now has two blockers of its own:
+
+1. `make_manifest.py` has no merge mode (`--files` and `--all` are exclusive and the result
+   is written wholesale to `<model-dir>/manifest.json`), so step 4 as written destroys the
+   live manifest with a one-entry file — the same failure the step's own warning attributes
+   only to `--all`. The published manifest has to be hand-extended, or the tool needs a
+   merge flag.
+2. **The tail-chunk routing does not exist.** `Sortformer.cs` has no CoreML path at all;
+   `ProcessChunk` still passes `min(start + chunkStride, totalFrames) - start` for every
+   chunk. Publishing the steady-state artifact before a caller can route the final short
+   chunk to the dynamic graph ships a file that silently degrades the end of every
+   recording by up to 0.54 on `preds` (Run 3). The routing is the precondition for the
+   51.5 ms being usable at all.

--- a/docs/investigations/sortformer_coreml_publish_investigation.md
+++ b/docs/investigations/sortformer_coreml_publish_investigation.md
@@ -459,3 +459,45 @@ Steps 1–3 pass on the runtime the macOS build actually ships. Step 4 — HF up
    chunk to the dynamic graph ships a file that silently degrades the end of every
    recording by up to 0.54 on `preds` (Run 3). The routing is the precondition for the
    51.5 ms being usable at all.
+
+## Published — 2026-09-09
+
+`diar_streaming_sortformer_4spk-v2.1.coreml.onnx` is live in
+`christopherthompson81/sortformer_parakeet_onnx`: 526,897,872 B, md5
+`890c59cc71dedfff9f1c3d7f10924422` — the artifact built and measured in Run 7.
+
+The manifest was **extended, not regenerated**. `make_manifest.py` has no merge mode
+(`--files`/`--all` are exclusive and the result is written wholesale to
+`<model-dir>/manifest.json`), so running step 4 as originally written would have replaced
+the published 9-entry manifest with a 1-entry file. Instead the live manifest was pulled,
+the new entry inserted, and every original entry checked byte-identical before upload:
+9 → 10 files, `version: 2` preserved, none removed. **`make_manifest.py` still needs a
+merge flag before anyone runs step 4 literally.**
+
+The model card was corrected before syncing rather than published as-is. It carried three
+claims that Run 7 disproved or superseded:
+
+* the headline and perf table were ORT 1.24.4 (52.3 ms vs 196.3 ms CPU / 113.0 ms WebGPU);
+  now leads with the 1.29.0 measurements — 51.5 ms vs 171.8 ms CPU, **3.34×**, single
+  partition, `4.470E-07`.
+* `ORT_ENABLE_BASIC or lower` was stated as an unconditional contract term; it is a 1.26.0
+  defect and is now scoped to that version.
+* the "1.29.0 splits into 194 partitions and diverges at ~1e-2" caveat is marked as not
+  reproducing.
+
+The 1.24.4 CPU/WebGPU baselines (196.3 / 113.0) still disagree with the figures recorded
+elsewhere for the same machine and ORT (163.5 / 94.0). That is unresolved and the card now
+says so; this machine measured **171.8 ms** for the stock graph on CPU under 1.29.0, which
+does not settle which 1.24.4 figure was right. Both the playbook and
+`scripts/nemo_export/README.md` still carry the older numbers.
+
+Also confirmed on 1.29.0: the **stock** dynamic graph still fails to compile under CoreML
+(`Input: _ConstantOfShape_1_output_0 has unbounded dimension which is not supported`), so
+the variant's reason to exist is intact on the shipped runtime.
+
+**Still not consumable from the app.** `Sortformer.cs` gained CoreML/WebGPU selectability
+in `b3410d6` (it was the one call site #164 missed, so macOS diarization had been on the
+CPU EP regardless of the requested provider), but the tail-chunk routing does not exist:
+`ProcessChunk` sends a short `chunk_lengths` on the last chunk of every recording, and this
+graph bakes it to 992. Until a caller routes that one chunk to the stock graph, the
+published file must not be wired in as a drop-in — see Run 3 for the 0.54 error it causes.

--- a/docs/investigations/sortformer_coreml_publish_investigation.md
+++ b/docs/investigations/sortformer_coreml_publish_investigation.md
@@ -325,17 +325,22 @@ Done on this machine (all machine-independent, all committed):
 pending — publishing a 527 MB file whose only measured win is on an ORT the app does not
 ship would be advertising a benefit no user of the shipped build receives.
 
-To run on the MacBook Air, in order:
+`scripts/nemo_export/coreml_partition_probe.py` exists so each of these is one command;
+the PR body carries the same list with the commands filled in. In order:
 
-1. `pip install onnxruntime==1.29.0`, then load
-   `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` on the CoreML EP and log the partition
-   count and CoreML-vs-CPU diffs. **This one answers the go/no-go**; everything below is
-   moot if 1.29.0 cannot be made to behave.
-2. Repeat on 1.24.4 to confirm this box's ORT-1.26.0-folded file reproduces the 1-partition
-   result at all — if it does not, the artifact has to be *built* on the Mac (fold under the
-   ORT it will run on) and this box only ever cross-checks numerics.
-3. Confirm the file loads at `ORT_ENABLE_BASIC` and fails at `ORT_ENABLE_ALL` on the Mac's
-   ORT too (Run 5 found this on 1.26.0 and traced it to `MatMulAddFusion`). If it fails at
-   BASIC as well, the whole artifact needs rebuilding without the ORT fold round-trip.
-4. Only then: `scripts/make_manifest.py` / `scripts/upload_to_hf.py --sync-readme`, from
-   whichever machine built the file that passed.
+1. On **ORT 1.29.0** (what an Apple Silicon build ships), probe the variant on the CoreML EP
+   and read the partition count and the CoreML-vs-CPU diffs. **This answers the go/no-go**;
+   everything below is moot if 1.29.0 cannot be made to behave.
+2. Repeat on 1.24.4, to learn whether a file folded under a *different* ORT (1.26.0, on the
+   Linux box) reproduces the 1-partition result at all. If it does not, the shippable
+   artifact has to be **built** on the Mac — fold under the ORT it will run on — and the
+   Linux box only ever cross-checks numerics.
+3. Confirm the load-level constraint holds there too: loads at `ORT_ENABLE_BASIC`, throws at
+   `ORT_ENABLE_ALL` (Run 5, traced to `MatMulAddFusion`). If it throws at BASIC as well, the
+   artifact needs rebuilding without the ORT fold round-trip and this whole approach needs
+   rethinking.
+4. Only then publish: `scripts/make_manifest.py` then
+   `scripts/upload_to_hf.py --sync-readme`, from whichever machine built the file that
+   passed, and add the `manifest.json` entry by extending the published manifest rather than
+   regenerating it (the live one deliberately omits `sortformer/`, the int8 variants and
+   `silero_vad.onnx`, so `--all` would silently change what the app validates).

--- a/docs/investigations/sortformer_coreml_publish_investigation.md
+++ b/docs/investigations/sortformer_coreml_publish_investigation.md
@@ -404,25 +404,40 @@ and ORT's BASIC fold trims it to 1751 at load. #162's "1751 nodes" was the post-
 so Run 4's "1788 vs 1751, expected from a different ORT" was explaining a difference that
 was never there.
 
-### Checklist step 3 — the load-level constraint is gone on 1.29.0
+### Checklist step 3 — the load-level constraint holds, and the CoreML EP hides it
 
-Run 5 found `ORT_ENABLE_EXTENDED` and above throwing
-`AddInitializedOrtValue Attempt to replace the existing tensor` (`MatMulAddFusion`). That
-does not reproduce here. All four levels load, hold one partition, and stay correct:
+**Corrected 2026-09-09, after the first pass got this wrong.** The probe defaults to
+`--ep coreml`, so the level matrix was only ever run with the CoreML EP registered:
 
-| level | loads | partitions | inference |
+| level | loads (coreml) | partitions | inference |
 |---|---|---|---|
 | `ORT_DISABLE_ALL` | yes | 1 (1788/1788) | 83.9 ms |
 | `ORT_ENABLE_BASIC` | yes | 1 (1751/1751) | 51.6 ms |
 | `ORT_ENABLE_EXTENDED` | yes | 1 (1751/1751) | 52.0 ms |
 | `ORT_ENABLE_ALL` | yes | 1 (1751/1751) | 51.9 ms |
 
-At `ORT_ENABLE_ALL` — what `OrtSessionBuilder.Create` actually defaults to — parity is
-unchanged at `4.470E-07`. So it was an ORT 1.26.0 re-optimization defect, and the model
-card should **not** carry the `ORT_ENABLE_BASIC`-only contract term as an unconditional
-rule. Note the playbook's separate claim that EXTENDED worsens CoreML partitioning
-(69 → 191) was measured on 1.24.4 against the `chunk_lengths`-live graph; it does not hold
-for this artifact on 1.29.0.
+That reads as "Run 5's constraint is a 1.26.0 defect". It is not. Loading the same file on
+the **CPU EP alone** on the same ORT 1.29.0:
+
+| level | CPU EP | CoreML EP registered |
+|---|---|---|
+| `ORT_DISABLE_ALL` | loads | loads |
+| `ORT_ENABLE_BASIC` | loads | loads |
+| `ORT_ENABLE_EXTENDED` | **fails** | loads |
+| `ORT_ENABLE_ALL` | **fails** | loads |
+
+Same `AddInitializedOrtValue Attempt to replace the existing tensor` from
+`MatMulAddFusion`. CoreML claims the whole graph in `GetCapability` before the CPU-side
+fusions get to run, so the fusion never fires and the defect is invisible — on the one EP
+this artifact is built for. **Run 5 was right; `ORT_ENABLE_BASIC` or lower is a real,
+version-independent contract term**, and it matters most in exactly the case the CoreML EP
+cannot cover: a fallback to CPU when CoreML is absent or declines the graph.
+
+The lesson for the probe: `--ep` selects what you measure *and* what you can see. A
+load-level matrix is only meaningful per-EP.
+
+(The playbook's separate claim that EXTENDED worsens CoreML partitioning, 69 → 191, was
+measured on 1.24.4 against the `chunk_lengths`-live graph and is untested here.)
 
 ### The probe could not have reported any of this
 
@@ -480,8 +495,8 @@ claims that Run 7 disproved or superseded:
 * the headline and perf table were ORT 1.24.4 (52.3 ms vs 196.3 ms CPU / 113.0 ms WebGPU);
   now leads with the 1.29.0 measurements — 51.5 ms vs 171.8 ms CPU, **3.34×**, single
   partition, `4.470E-07`.
-* `ORT_ENABLE_BASIC or lower` was stated as an unconditional contract term; it is a 1.26.0
-  defect and is now scoped to that version.
+* `ORT_ENABLE_BASIC or lower` was briefly and wrongly scoped to 1.26.0 on the basis of a
+  CoreML-EP-only matrix; corrected the same day. It is unconditional — see step 3 above.
 * the "1.29.0 splits into 194 partitions and diverges at ~1e-2" caveat is marked as not
   reproducing.
 

--- a/docs/investigations/sortformer_coreml_publish_investigation.md
+++ b/docs/investigations/sortformer_coreml_publish_investigation.md
@@ -1,0 +1,341 @@
+# Sortformer CoreML variant — publish investigation (issue #162)
+
+Goal: produce `diar_streaming_sortformer_4spk-v2.1.coreml.onnx`, verify it against
+the shipped dynamic model, and publish it to
+`christopherthompson81/sortformer_parakeet_onnx` with a `manifest.json` entry.
+
+The techniques and the M5 measurements are already recorded in
+`docs/coreml_onnx_playbook.md` (landed with #164). This log covers only the
+*build and publish* of the artifact.
+
+## Environment (Linux workstation, not the Mac)
+
+- repo: the local working tree at `631a88c` (`$WORK` below is a scratch model dir)
+- export venv: `.venv-nemo-export` (python 3.12.3) — `nemo-toolkit 2.7.1`,
+  `torch 2.11.0+cu128`, `onnx 1.21.0`, `onnxruntime 1.26.0`
+- source checkpoint: HF cache snapshot of `nvidia/diar_streaming_sortformer_4spk-v2.1`
+- reference dynamic model: `~/.local/share/Vernacula/models/sortformer/diar_streaming_sortformer_4spk-v2.1.onnx`
+  (492,268,840 B, md5 `647a22cef31f59dc2c314fa783b2581d` — matches the published manifest)
+
+**Known gap up front:** this box has no CoreML. Partition count and the CoreML-EP
+numbers in #162 cannot be re-measured here, and the playbook warns partitioning is
+ORT-version dependent. The build ORT here is 1.26.0, not the 1.24.4 used for the
+issue's measurements — the constant-folding step (`basic_fold`) runs under ORT, so
+the folded graph is not guaranteed byte-identical to the one measured on the Mac.
+What *is* verifiable here: numeric parity vs the shipped dynamic model on CPU, the
+input/output contract, and the file size.
+
+## Run 1 — 2026-09-09 — export the static CoreML-shaped graph
+
+Question: does `--coreml-static-batch1 --coreml-const-lengths` export cleanly in
+this venv, and what does the raw graph look like?
+
+Command:
+
+```bash
+./.venv-nemo-export/bin/python scripts/nemo_export/export_sortformer_nemo_to_onnx.py \
+  --nemo <hf-cache>/diar_streaming_sortformer_4spk-v2.1.nemo \
+  --output $WORK/sortformer_coreml.onnx \
+  --opset 17 --coreml-static-batch1 --coreml-const-lengths \
+  --chunk-frames 992 --fixed-spkcache-frames 188 --fixed-fifo-frames 124 --overwrite
+```
+
+Result: **clean export**, 502,241,105 B, in ~40 s.
+`sortformer_coreml.onnx.report.json` records the expected notes, including:
+
+> `spkcache_lengths=188` and `fifo_lengths=124` are baked in as graph constants … **`chunk_lengths` is still a live input.**
+
+That last clause is the thread this whole investigation pulls on.
+
+## Run 2 — 2026-09-09 — graph transforms
+
+Question: do the four transforms reproduce the counts #162/#164 report
+(51 `Where` removed, 34 `Pad`, 180 `Gemm`, 3 inputs, 1751 nodes)?
+
+```bash
+./.venv-nemo-export/bin/python scripts/nemo_export/coreml_optimize_sortformer.py \
+  --input  $WORK/sortformer_coreml.onnx \
+  --output $WORK/diar_streaming_sortformer_4spk-v2.1.coreml.onnx \
+  --verify --reference ~/.local/share/Vernacula/models/sortformer/diar_streaming_sortformer_4spk-v2.1.onnx
+```
+
+Raw output:
+
+```
+[1/5] constant-folding at ORT_ENABLE_BASIC
+[2/5] removing all-False Where ...        0 removed
+[3/5] rewriting Pad -> Concat ...        34 converted
+[4/5] pre-transposing Gemm weights ...  180 converted
+[5/5] wrote ... (484 MB), 1914 nodes, inputs=['chunk', 'chunk_lengths', 'spkcache', 'fifo']
+
+verifying against reference on CPU EP:
+--verify needs a static graph; input chunk has shape ['batch', 'time_chunk', 128]
+```
+
+Three findings, in increasing order of importance:
+
+1. `--verify --reference <shipped dynamic model>` **cannot work as documented.**
+   `verify()` builds its feed from the *reference* model's signature and bails on any
+   non-int dimension, so the one reference the docstring and #162's repro command name
+   is the one reference it rejects. It only works against another static graph
+   (i.e. `--input`). Cosmetic; parity can be checked with a hand-written feed instead.
+
+2. `Pad` and `Gemm` match (34, 180). `Where` is **0 removed, not 51**, and the graph
+   keeps **4 inputs, not 3** (1914 nodes, not 1751).
+
+3. The 51 `Where` nodes are all still there — `drop_allfalse_where` skips them because
+   their condition is not a constant initializer. Tracing the ancestry of one:
+
+   ```
+   /encoder/layers.0/self_attn/Where.cond
+     <- Unsqueeze <- Not <- And <- And <- Tile <- Unsqueeze <- Less
+        <- chunk_pre_encode_lengths <- Cast <- ... <- chunk_lengths   [GRAPH INPUT]
+   ```
+
+   The attention padding mask is a function of `chunk_lengths`, which is a live input,
+   so it cannot fold to a constant, so it is not all-False, so none of the 51 can be
+   removed. `chunk_lengths` has exactly one consumer in the folded graph
+   (`/pre_encode/conv/Cast`) — that mask chain.
+
+**So the pipeline on `main` cannot produce the graph #162 measured.** The measurement
+predates a review fix. `gh pr view 164 --json commits` shows two commits, the second
+being "macOS: fix review findings in the CoreML/WebGPU change", and the surviving
+comment in `export_sortformer_nemo_to_onnx.py` states the reasoning:
+
+> ⚠ `chunk_lengths` is deliberately NOT baked. […] Baking `chunk_frames` there would let
+> the zero-padded tail of that last chunk be attended to as real audio, changing the
+> diarization output at the end of every file. It stays a real input; only its mask stays
+> data-dependent, **which costs a few partitions, not correctness.**
+
+"A few partitions" is the part that is wrong. Per the playbook's own table, removing the
+`Where` nodes is what takes partitions 69 → 35, and `Pad` → `Concat` only reaches 1
+partition *after* that (replacing `Where` with `Identity` instead of deleting it made it
+worse, 69 → 157 — so the nodes are load-bearing for partitioning, not incidental). The
+best available without them is the 69-partition / 166.0 ms row, i.e. **level with the CPU
+EP (163.5 ms) and worse than WebGPU (94.0 ms)**. Keeping `chunk_lengths` live does not
+cost a few partitions; it costs the entire reason for the variant to exist.
+
+Both `docs/coreml_onnx_playbook.md` and the #164 PR body still advertise the pre-fix
+numbers (1 partition / 52.3 ms / "removes 51 all-False `Where` masks") against a pipeline
+that no longer produces them.
+
+## Run 3 — 2026-09-09 — is the review fix *right*? Quantify the tail chunk
+
+Question: #162's stated contract is "steady-state only … the final short chunk needs
+padding", i.e. bake `chunk_lengths` and let the caller zero-pad. The #164 review called
+that a correctness bug. Who is right, and by how much?
+
+This is measurable on the **shipped dynamic model alone** — no graph transform involved.
+`Sortformer.cs:330-372` already sends a full-size zero-padded `chunk` buffer and varies
+only `chunk_lengths` (`currentLen`, short on the last chunk of every recording), while
+`spkcache_lengths`/`fifo_lengths` are always the buffers' own sizes. So run the same
+padded input twice, once with the honest `chunk_lengths` and once with 992, and diff the
+outputs over the **valid** frames only.
+
+`scratchpad/tail_chunk_effect.py`, random-normal chunk/cache/fifo, seed 7:
+
+| `chunk_lengths` | valid frames | `preds[chunk_valid]` maxAbs | rms | `preds[fifo]` maxAbs | `embs` |
+|---|---|---|---|---|---|
+| 992 | 124/124 | 0.0000 | 0.0000 | 0.0000 | 0.0 |
+| 800 | 100/124 | 0.1549 | 0.0626 | 0.0056 | 0.0 |
+| 400 |  50/124 | 0.2240 | 0.0792 | 0.0063 | 0.0 |
+| 200 |  25/124 | 0.4863 | 0.1859 | 0.0172 | 0.0 |
+|  64 |   8/124 | 0.5426 | 0.2364 | 0.0035 | 0.0 |
+
+`preds` are per-speaker probabilities on 0..1. **The review was right and #162's contract
+is not viable:** baking `chunk_lengths` moves the final chunk's speaker probabilities by
+up to 0.54 and an rms of 0.24 — enough to flip speaker assignments outright, not a
+tolerance question. (Random input is a pessimistic stand-in for speech, but two orders of
+magnitude of headroom is not going to appear.) `chunk_pre_encode_embs` is unaffected
+(0.0 everywhere) because `pre_encode` is a convolution over the padded buffer and never
+sees the mask; the damage is entirely in the encoder's self-attention over the packed
+436-frame sequence.
+
+Note also that the steady-state assumption for the *other* two buffers is genuinely free:
+the warm-up chunks #162 flags as needing padding already work, because the shipped runtime
+always passes `spkcache_lengths`/`fifo_lengths` as the full buffer sizes even while those
+buffers are still zero-filled.
+
+## Where that leaves issue #162
+
+The artifact #162 asks to publish is reachable — but only as a **steady-state graph that
+must not be fed the final chunk of a recording**. It cannot be a whole-recording
+replacement for the shipped model at any accuracy anyone would accept. So the publish
+needs a decision (see the conversation): the exportable choices are
+
+* **A. Bake all three lengths** (new opt-in flag) → 1 partition / 52.3 ms as measured, and
+  the runtime routes the one short tail chunk per recording to the shipped dynamic model
+  on CPU or WebGPU. Exact, since every other chunk is full-length; costs a second loaded
+  session for one inference per file.
+* **B. Ship what `main` produces** (`chunk_lengths` live, 4 inputs, 51 `Where`) → correct
+  for every chunk, ~69 partitions, no measurable CoreML win. Publishes a 480 MB file that
+  buys the 13% CPU / 10% WebGPU improvement from the static shapes and nothing else.
+
+Result: pending decision.
+
+
+**Decision (2026-09-09): option A.** Bake all three lengths behind an opt-in flag, publish
+the steady-state graph, and make the tail-chunk fallback part of the documented contract.
+
+## Run 4 — 2026-09-09 — build the steady-state graph
+
+Added `--coreml-const-chunk-length` (requires `--coreml-const-lengths`, which requires
+`--coreml-static-batch1`) and re-exported. Also fixed `verify()`, which could never run
+against the reference its own docstring and #162's repro command name: it built the feed
+from the *reference* signature and bailed on any dynamic dimension. It now takes the
+buffer shapes from `--input` (the static export) and synthesizes each input by name for
+the union of what the two graphs declare — needed because the baked lengths are gone from
+`--input`'s signature too.
+
+```
+[1/5] constant-folding at ORT_ENABLE_BASIC
+[2/5] removing all-False Where ...       51 removed
+[3/5] rewriting Pad -> Concat ...        34 converted
+[4/5] pre-transposing Gemm weights ...  180 converted
+[5/5] wrote diar_streaming_sortformer_4spk-v2.1.coreml.onnx (527 MB), 1788 nodes,
+      inputs=['chunk', 'spkcache', 'fifo']
+```
+
+Matches #162: 51 / 34 / 180, three inputs, 527 MB. Node count is 1788 vs the 1751 reported
+there — expected, since the graph is folded by whatever ORT the build box has (1.26.0 here,
+1.24.4 there).
+
+Parity against the shipped dynamic model on the CPU EP, full chunk, seed 7:
+
+```
+spkcache_fifo_chunk_preds   maxAbsDiff = 3.278E-07   rms = 6.151E-08
+chunk_pre_encode_embs       maxAbsDiff = 3.052E-05   rms = 3.441E-06
+```
+
+`preds` reproduces #162 (3.576E-07). `embs` does not — #162 reports exactly 0.0. Chased it:
+comparing the reference against the **pre-transform** static export gives the identical
+`3.052E-05`, so none of it comes from the four transforms (they are value-preserving to the
+bit here). It is the reference session running at ORT's default `ORT_ENABLE_ALL` while the
+candidate runs at `ORT_DISABLE_ALL` — ORT's own fusions on the reference side. Not
+attributable to the variant.
+
+## Run 5 — 2026-09-09 — the artifact will not load at ORT_ENABLE_ALL
+
+Question (not on anyone's list, which is why it nearly shipped): does the finished file
+load the way `OrtSessionBuilder` actually loads models?
+
+```python
+ort.InferenceSession(coreml_variant, providers=["CPUExecutionProvider"])   # default = ORT_ENABLE_ALL
+```
+
+```
+FAIL : graph.cc:3864 AddInitializedOrtValue Attempt to replace the existing tensor
+```
+
+| level | loads |
+|---|---|
+| `ORT_DISABLE_ALL` | yes |
+| `ORT_ENABLE_BASIC` | yes |
+| `ORT_ENABLE_EXTENDED` | **no** |
+| `ORT_ENABLE_ALL` | **no** |
+
+`OrtSessionBuilder.Create` defaults `optLevel` to `ORT_ENABLE_ALL`, and `verify()` happens
+to use `ORT_DISABLE_ALL`, so the parity check passes on a file the app cannot open.
+
+Isolated it. Not our transforms — applying **none** of them still fails, and the raw
+pre-fold static export loads fine at every level:
+
+| graph | BASIC | EXTENDED | ALL |
+|---|---|---|---|
+| raw static export | ok | ok | ok |
+| BASIC-folded, no transforms | ok | **fail** | **fail** |
+| + any subset of the 4 transforms | ok | **fail** | **fail** |
+| shipped dynamic model | ok | ok | ok |
+
+So `basic_fold`'s ORT round-trip is what does it: ORT cannot re-optimize its own saved
+optimized graph above BASIC. Bisecting with `disabled_optimizers`:
+
+```
+disable MatMulAddFusion   -> loads at EXTENDED
+disable <11 others>       -> still fails
+```
+
+`MatMulAddFusion` reshapes >2D MatMul inputs so it can emit a `Gemm`, and the folded graph
+already contains 340 of the initializers it generates (`gemm_input_shape_token_N`,
+`gemm_output_reshape_token_N_new_shape`) because the fold pass already ran it. Renaming all
+340 out of the way does **not** fix it, so the collision is on something the fusion mints
+fresh rather than on those names; it is an ORT re-optimization defect, not something the
+graph can be shaped around from here.
+
+**Not a blocker, but it is a hard contract term.** `ORT_ENABLE_BASIC` is the level this
+variant has to run at anyway — the playbook already found EXTENDED makes CoreML
+partitioning much worse (69 → 191), so the required level and the optimal level are the
+same one. It has to be written down in the model card and enforced at the call site, since
+the builder's default is the level that throws.
+
+## Run 6 — 2026-09-09 — the 52.3 ms was measured on an ORT the app does not ship
+
+Not a run, a read. Prompted by the reminder that the 1-partition / 52.3 ms result came off
+the Apple Silicon MacBook Air, so this issue has to bounce between the two machines
+anyway — which raised the question of *which ORT* each side is actually holding.
+
+`Directory.Build.props:21-24`:
+
+```xml
+<EP Condition="'$(EP)' == ''">Cuda</EP>
+<OnnxRuntimeVersion Condition="'$(EP)' == 'DirectML'">1.24.4</OnnxRuntimeVersion>
+<OnnxRuntimeVersion Condition="'$(OnnxRuntimeVersion)' == ''">1.29.0</OnnxRuntimeVersion>
+```
+
+Only a **DirectML** build pins 1.24.4. An Apple Silicon build is `-p:EP=Cpu` (per #164 — the
+plain `osx-arm64` package is the one carrying the CoreML and WebGPU natives), so it takes
+the default: **ORT 1.29.0**.
+
+Every CoreML number in #162, #164 and the playbook was measured on **1.24.4**. And #162's
+own caveat says what 1.29.0 does to this graph:
+
+> python ORT 1.29.0 partitions the same graph into **194** and diverges at **~1e-2**.
+
+So the variant's entire benefit is measured on a runtime the macOS build does not use, and
+the one data point we have on the runtime it *does* use says the benefit is absent and the
+outputs are wrong by 1e-2. That is the blocker for publishing, ahead of anything about the
+graph itself. Three ways out, in preference order:
+
+1. **Make it work on 1.29.0.** Re-run the partition survey there and find which op families
+   1.29.0 declines that 1.24.4 accepted — same method as the playbook, new ORT. The 1e-2
+   divergence needs its own root-cause; at 194 partitions it is probably a CPU↔CoreML fp
+   boundary rather than a bad rewrite, but that is a guess until measured.
+2. **Pin macOS to 1.24.4** the way DirectML is pinned. Cheap to write, but it forks the
+   stack on a third axis and 1.24.4 does not necessarily have the osx-arm64 fixes 1.29.0 has.
+3. **Don't ship the variant.** macOS stays on WebGPU (113.0 ms), which #164 already made the
+   `Auto` choice there. Costs nothing that exists today.
+
+Nothing here is decidable from this machine.
+
+## What is done, and the Mac-side checklist
+
+Done on this machine (all machine-independent, all committed):
+
+* `--coreml-const-chunk-length`, the opt-in that actually reaches the all-False mask, with
+  the correctness obligation it creates written into the flag help and the export report.
+* `verify()` fixed so `--reference <the shipped dynamic model>` works — the documented
+  usage, previously the one usage that could not run.
+* An artifact built here, from the ungated upstream checkpoint, ORT 1.26.0 folding:
+  `diar_streaming_sortformer_4spk-v2.1.coreml.onnx`, 526,897,914 B,
+  md5 `94cc7392ea9358e22b479fac146e9595`, 1788 nodes, inputs `[chunk, spkcache, fifo]`,
+  parity `3.278E-07` on `preds` vs the shipped model at a full chunk.
+* Docs corrected to describe the pipeline that exists rather than the pre-review one.
+
+**Not published.** The HF upload and the `manifest.json` entry are deliberately still
+pending — publishing a 527 MB file whose only measured win is on an ORT the app does not
+ship would be advertising a benefit no user of the shipped build receives.
+
+To run on the MacBook Air, in order:
+
+1. `pip install onnxruntime==1.29.0`, then load
+   `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` on the CoreML EP and log the partition
+   count and CoreML-vs-CPU diffs. **This one answers the go/no-go**; everything below is
+   moot if 1.29.0 cannot be made to behave.
+2. Repeat on 1.24.4 to confirm this box's ORT-1.26.0-folded file reproduces the 1-partition
+   result at all — if it does not, the artifact has to be *built* on the Mac (fold under the
+   ORT it will run on) and this box only ever cross-checks numerics.
+3. Confirm the file loads at `ORT_ENABLE_BASIC` and fails at `ORT_ENABLE_ALL` on the Mac's
+   ORT too (Run 5 found this on 1.26.0 and traced it to `MatMulAddFusion`). If it fails at
+   BASIC as well, the whole artifact needs rebuilding without the ORT fold round-trip.
+4. Only then: `scripts/make_manifest.py` / `scripts/upload_to_hf.py --sync-readme`, from
+   whichever machine built the file that passed.

--- a/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
+++ b/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
@@ -33,6 +33,7 @@ co-located here so a single download brings up the full pipeline.
 
 - **DFT-basis mel frontend replaces `torch.stft`.** ORT's STFT op diverged from NeMo (cosine ≈ 0.23 on first inspection); the replacement uses precomputed cos/sin basis matrices as Conv1D weights, with center-padded windows and standard ops only. Restored bit-for-bit parity to the NeMo reference.
 - **Streaming Sortformer 6→3 ONNX contract.** NeMo's `concat_and_pad()` isn't ONNX-traceable; the custom exporter replaces dynamic per-batch slicing with fixed-shape ops at 992 chunk frames (124 subsampled at 8× downsampling). Inputs: `chunk, chunk_lengths, spkcache, spkcache_lengths, fifo, fifo_lengths`. Outputs: `spkcache_fifo_chunk_preds, chunk_pre_encode_embs, chunk_pre_encode_lengths`.
+- **CoreML-compilable Sortformer variant for Apple Silicon.** The stock diarization graph cannot be compiled by ONNX Runtime's CoreML EP at all (`Failed to create MLModel … error code: -14`), so the Neural Engine was unreachable on macOS. `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` is a fully static re-export plus four value-preserving graph rewrites that compile as a **single** CoreML partition — 52.3 ms/chunk vs 196.3 ms on CPU and 113.0 ms on WebGPU (M5, ORT 1.24.4). It is a **steady-state-only** graph with a different input contract; read [Sortformer CoreML variant](#sortformer-coreml-variant) before using it.
 - **Dynamic-batch encoder + dynamic-batch joint decoder** for Parakeet TDT (preprocessor still batch-1 post-export). INT8 variants of encoder, decoder-joint, and Sortformer ship for CPU-only inference.
 - **Chunk-by-chunk parity diagnostic** ([`compare_sortformer_chunk_outputs.py`](https://github.com/christopherthompson81/vernacula/blob/main/scripts/nemo_export/compare_sortformer_chunk_outputs.py)) compares NeMo vs ONNX state evolution across streaming chunks to localise drift to either model output or carry-state.
 - **Preprocessor export sweep** ([`tune_nemo128_export.py`](https://github.com/christopherthompson81/vernacula/blob/main/scripts/nemo_export/tune_nemo128_export.py)) scores wrapper / custom / DFT modes against a legacy reference with feature-level and encoder-output deltas — the tooling that picked the DFT path in the first bullet.
@@ -49,9 +50,84 @@ co-located here so a single download brings up the full pipeline.
 | `nemo128.onnx` | NeMo preprocessor | 80-mel log-FBANK frontend (128-dim hop config) |
 | `diar_streaming_sortformer_4spk-v2.1.onnx` | [`nvidia/diar_streaming_sortformer_4spk-v2.1`](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) | Streaming 4-speaker diarization |
 | `diar_streaming_sortformer_4spk-v2.1_int8.onnx` | (quantized) | INT8-quantized diarization |
+| `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` | Sortformer | Static steady-state diarization graph for the CoreML EP — **different contract**, see below |
 | `sortformer/diar_streaming_sortformer_4spk-v2.1.onnx` | Sortformer | Same graph in subdir layout for legacy clients |
 | `silero_vad.onnx` | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) | Voice activity detection |
 | `config.json`, `manifest.json` | Vernacula | Runtime config + per-file MD5 hashes |
+
+## Sortformer CoreML variant
+
+`diar_streaming_sortformer_4spk-v2.1.coreml.onnx` exists because ONNX Runtime's CoreML
+execution provider is the only route to the Apple Neural Engine, and the stock graph
+cannot be compiled by it at all — it slices by tensor *values*, which makes every
+downstream shape data-dependent, and CoreML's MIL runtime rejects unbounded dimensions
+outright. The variant fixes the shapes at export time and applies four rewrites (delete
+51 all-False `Where` masks, rewrite 34 constant zero `Pad`s as `Concat`s, pre-transpose
+180 `Gemm` weights) to reach a single CoreML partition instead of 71.
+
+Measured on an M5, ORT 1.24.4, chunk=992 / spkcache=188 / fifo=124:
+
+| model | EP | inference | cold load | warm load |
+|---|---|---|---|---|
+| stock dynamic | CPU | 196.3 ms | 0.53 s | — |
+| stock dynamic | WebGPU | 113.0 ms | 0.45 s | — |
+| stock dynamic | CoreML | *fails to compile* | — | — |
+| CoreML variant | CPU | 170.3 ms | 0.15 s | — |
+| CoreML variant | WebGPU | 101.7 ms | 0.13 s | — |
+| **CoreML variant** | **CoreML** | **52.3 ms** | **2.1 s** | **0.2 s** |
+
+Outputs match the stock graph on the CPU EP to `3.3e-07` (`preds`) for a full chunk. The
+static shapes alone also make it ~13% faster on CPU and ~10% faster on WebGPU, so it is
+not purely a macOS artifact.
+
+**This is not a drop-in replacement.** Four things differ:
+
+| | stock | CoreML variant |
+|---|---|---|
+| inputs | 6 (`chunk`, `spkcache`, `fifo` + 3 `*_lengths`) | **3** (`chunk`, `spkcache`, `fifo`) |
+| shapes | dynamic | fixed `[1,992,128]` / `[1,188,512]` / `[1,124,512]` |
+| `spkcache_fifo_chunk_preds` | `[batch, time_out, 4]` | `[1, 436, 4]` |
+| graph optimization level | any | **`ORT_ENABLE_BASIC` or lower** |
+
+1. **All three lengths are baked in, so this graph is steady-state only.** Pass full-size,
+   zero-padded buffers. Zero-filled `spkcache`/`fifo` during warm-up are fine — the stock
+   runtime already passes those two lengths as the full buffer size on every call.
+2. **Never feed it the final, short chunk of a recording.** With `chunk_lengths` baked to
+   992 the graph attends to that chunk's zero-padded tail as real audio, which moves its
+   speaker probabilities by up to **0.54** (rms 0.24) on a 0..1 scale — enough to flip
+   speaker assignments. Route that one chunk per recording to the stock dynamic graph,
+   which is in this same repo.
+3. **Create the session at `ORT_ENABLE_BASIC` or lower.** At `ORT_ENABLE_EXTENDED` and
+   above ORT 1.26.0 fails to load the file outright (`AddInitializedOrtValue Attempt to
+   replace the existing tensor`, from `MatMulAddFusion` re-running over an
+   already-optimized graph). BASIC is the right level regardless: EXTENDED also shatters
+   CoreML partitioning (69 → 191).
+4. **CoreML partitioning is ORT-version dependent.** Validated on **1.24.4**; ORT 1.29.0
+   splits the same graph into 194 partitions and diverges at ~1e-2. Re-validate on any ORT
+   upgrade. Set the CoreML EP's `ModelCacheDirectory` or every load pays the 2.1 s compile
+   instead of 0.2 s.
+
+`fp16` was measured faster still (22.3 ms) but is **not** shipped: `chunk_pre_encode_embs`
+diverges to 9.8e-02 there and those embeddings feed back into the speaker cache and FIFO,
+so it needs an end-to-end DER check rather than a single-chunk comparison.
+
+Reproduce it with:
+
+```bash
+python scripts/nemo_export/export_sortformer_nemo_to_onnx.py \
+  --nemo <path>/diar_streaming_sortformer_4spk-v2.1.nemo \
+  --output sortformer_coreml.onnx --opset 17 \
+  --coreml-static-batch1 --coreml-const-lengths --coreml-const-chunk-length \
+  --chunk-frames 992 --fixed-spkcache-frames 188 --fixed-fifo-frames 124 --overwrite
+
+python scripts/nemo_export/coreml_optimize_sortformer.py \
+  --input sortformer_coreml.onnx \
+  --output diar_streaming_sortformer_4spk-v2.1.coreml.onnx \
+  --verify --reference diar_streaming_sortformer_4spk-v2.1.onnx
+```
+
+The techniques generalize; see
+[`docs/coreml_onnx_playbook.md`](https://github.com/christopherthompson81/vernacula/blob/main/docs/coreml_onnx_playbook.md).
 
 ## Export provenance
 

--- a/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
+++ b/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
@@ -61,9 +61,10 @@ co-located here so a single download brings up the full pipeline.
 execution provider is the only route to the Apple Neural Engine, and the stock graph
 cannot be compiled by it at all — it slices by tensor *values*, which makes every
 downstream shape data-dependent, and CoreML's MIL runtime rejects unbounded dimensions
-outright. The variant fixes the shapes at export time and applies four rewrites (delete
-51 all-False `Where` masks, rewrite 34 constant zero `Pad`s as `Concat`s, pre-transpose
-180 `Gemm` weights) to reach a single CoreML partition instead of 71.
+outright. The variant fixes the shapes at export time and applies four rewrites
+(constant-fold at `ORT_ENABLE_BASIC`, delete 51 all-False `Where` masks, rewrite 34
+constant zero `Pad`s as `Concat`s, pre-transpose 180 `Gemm` weights) to reach a single
+CoreML partition instead of 71.
 
 Measured on an M5 (Mac17,3, macOS 26.6.2), **ORT 1.29.0** — the version Vernacula builds
 against — chunk=992 / spkcache=188 / fifo=124:
@@ -76,7 +77,8 @@ against — chunk=992 / spkcache=188 / fifo=124:
 | **CoreML variant** | **CoreML** | **51.5 ms** | **2.2 s** | **0.16 s** |
 
 **3.34× vs the stock graph on CPU.** The CoreML EP takes the whole graph as a single
-partition (1751 of 1751 nodes), measured at `ORT_ENABLE_BASIC` (see note 3). Outputs match the stock graph to `4.470E-07` (`preds`,
+partition (1751 of 1751 nodes -- the file holds 1788, and ORT's BASIC fold trims it to
+1751 at load), measured at `ORT_ENABLE_BASIC` (see note 3). Outputs match the stock graph to `4.470E-07` (`preds`,
 rms 7.616E-08) running CoreML against stock-on-CPU, and to `3.576E-07` CPU-to-CPU. The
 static shapes alone also make it ~10% faster on plain CPU, so it is not purely a macOS
 artifact.
@@ -101,9 +103,15 @@ only in the packaged app.
 | `spkcache_fifo_chunk_preds` | `[batch, time_out, 4]` | `[1, 436, 4]` |
 | graph optimization level | any | **`ORT_ENABLE_BASIC` or lower** |
 
-1. **All three lengths are baked in, so this graph is steady-state only.** Pass full-size,
-   zero-padded buffers. Zero-filled `spkcache`/`fifo` during warm-up are fine — the stock
-   runtime already passes those two lengths as the full buffer size on every call.
+1. **All three lengths are baked in, so this graph is steady-state only.** Pass full-size
+   buffers whose real content fills them: `spkcache` genuinely 188 frames, `fifo` genuinely
+   124, `chunk` genuinely 992.
+
+   ⚠ **Warm-up is NOT safe to send here**, contrary to what an earlier version of this note
+   said. A streaming runtime builds the cache and FIFO up from empty, and the baked lengths
+   claim all 188 / 124 frames are real, so zero-padding them makes the graph attend to
+   padding as audio — the same failure as note 2, in a different input. Vernacula's own
+   caller routes every chunk to the stock graph until both buffers are genuinely full.
 2. **Never feed it the final, short chunk of a recording.** With `chunk_lengths` baked to
    992 the graph attends to that chunk's zero-padded tail as real audio, which moves its
    speaker probabilities by up to **0.54** (rms 0.24) on a 0..1 scale — enough to flip

--- a/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
+++ b/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
@@ -76,7 +76,7 @@ against — chunk=992 / spkcache=188 / fifo=124:
 | **CoreML variant** | **CoreML** | **51.5 ms** | **2.2 s** | **0.16 s** |
 
 **3.34× vs the stock graph on CPU.** The CoreML EP takes the whole graph as a single
-partition (1751 of 1751 nodes). Outputs match the stock graph to `4.470E-07` (`preds`,
+partition (1751 of 1751 nodes), measured at `ORT_ENABLE_BASIC` (see note 3). Outputs match the stock graph to `4.470E-07` (`preds`,
 rms 7.616E-08) running CoreML against stock-on-CPU, and to `3.576E-07` CPU-to-CPU. The
 static shapes alone also make it ~10% faster on plain CPU, so it is not purely a macOS
 artifact.
@@ -99,7 +99,7 @@ only in the packaged app.
 | inputs | 6 (`chunk`, `spkcache`, `fifo` + 3 `*_lengths`) | **3** (`chunk`, `spkcache`, `fifo`) |
 | shapes | dynamic | fixed `[1,992,128]` / `[1,188,512]` / `[1,124,512]` |
 | `spkcache_fifo_chunk_preds` | `[batch, time_out, 4]` | `[1, 436, 4]` |
-| graph optimization level | any | any on ORT 1.29.0; **`ORT_ENABLE_BASIC` or lower** on 1.26.0 (see note 3) |
+| graph optimization level | any | **`ORT_ENABLE_BASIC` or lower** |
 
 1. **All three lengths are baked in, so this graph is steady-state only.** Pass full-size,
    zero-padded buffers. Zero-filled `spkcache`/`fifo` during warm-up are fine — the stock
@@ -109,14 +109,26 @@ only in the packaged app.
    speaker probabilities by up to **0.54** (rms 0.24) on a 0..1 scale — enough to flip
    speaker assignments. Route that one chunk per recording to the stock dynamic graph,
    which is in this same repo.
-3. **Check the graph optimization level against your ORT.** On **1.29.0 this is a
-   non-issue**: all four levels load, hold the single partition, and give identical
-   outputs (`4.470E-07`). On **1.26.0**, `ORT_ENABLE_EXTENDED` and above fail to load the
-   file outright (`AddInitializedOrtValue Attempt to replace the existing tensor`, from
-   `MatMulAddFusion` re-running over an already-optimized graph), so pin to
-   `ORT_ENABLE_BASIC` there. A separate 1.24.4 measurement found EXTENDED shattering
-   CoreML partitioning (69 → 191) on the earlier four-input graph; that does not reproduce
-   on 1.29.0 with this artifact.
+3. **Create the session at `ORT_ENABLE_BASIC` or lower.** At `ORT_ENABLE_EXTENDED` and
+   above, ORT fails to load the file outright — `AddInitializedOrtValue Attempt to replace
+   the existing tensor`, from `MatMulAddFusion` re-running over an already-optimized graph.
+   Confirmed on both 1.26.0 and 1.29.0.
+
+   ⚠ **This is masked when the CoreML EP is registered.** CoreML claims the whole graph
+   before the CPU fusions run, so on macOS all four levels appear to load — but the moment
+   the graph falls back to the CPU EP (CoreML absent from the build, a non-Apple machine,
+   or `MLComputeUnits` declining it) the same session options throw. Pin BASIC regardless
+   of platform; it costs nothing, since the file is already an optimized graph.
+
+   | level | CPU EP | CoreML EP registered |
+   |---|---|---|
+   | `ORT_DISABLE_ALL` | loads | loads |
+   | `ORT_ENABLE_BASIC` | loads | loads |
+   | `ORT_ENABLE_EXTENDED` | **fails** | loads |
+   | `ORT_ENABLE_ALL` | **fails** | loads |
+
+   A separate 1.24.4 measurement found EXTENDED also shattering CoreML partitioning
+   (69 → 191) on the earlier four-input graph.
 4. **CoreML partitioning is ORT-version dependent — re-validate on any ORT upgrade.**
    Validated on **1.24.4** and **1.29.0**, which both reach a single partition. An earlier
    note here claimed 1.29.0 split the graph into 194 partitions and diverged at ~1e-2;

--- a/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
+++ b/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
@@ -33,7 +33,7 @@ co-located here so a single download brings up the full pipeline.
 
 - **DFT-basis mel frontend replaces `torch.stft`.** ORT's STFT op diverged from NeMo (cosine ≈ 0.23 on first inspection); the replacement uses precomputed cos/sin basis matrices as Conv1D weights, with center-padded windows and standard ops only. Restored bit-for-bit parity to the NeMo reference.
 - **Streaming Sortformer 6→3 ONNX contract.** NeMo's `concat_and_pad()` isn't ONNX-traceable; the custom exporter replaces dynamic per-batch slicing with fixed-shape ops at 992 chunk frames (124 subsampled at 8× downsampling). Inputs: `chunk, chunk_lengths, spkcache, spkcache_lengths, fifo, fifo_lengths`. Outputs: `spkcache_fifo_chunk_preds, chunk_pre_encode_embs, chunk_pre_encode_lengths`.
-- **CoreML-compilable Sortformer variant for Apple Silicon.** The stock diarization graph cannot be compiled by ONNX Runtime's CoreML EP at all (`Failed to create MLModel … error code: -14`), so the Neural Engine was unreachable on macOS. `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` is a fully static re-export plus four value-preserving graph rewrites that compile as a **single** CoreML partition — 52.3 ms/chunk vs 196.3 ms on CPU and 113.0 ms on WebGPU (M5, ORT 1.24.4). It is a **steady-state-only** graph with a different input contract; read [Sortformer CoreML variant](#sortformer-coreml-variant) before using it.
+- **CoreML-compilable Sortformer variant for Apple Silicon.** The stock diarization graph cannot be compiled by ONNX Runtime's CoreML EP at all (`Failed to create MLModel … error code: -14`), so the Neural Engine was unreachable on macOS. `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` is a fully static re-export plus four value-preserving graph rewrites that compile as a **single** CoreML partition — 51.5 ms/chunk vs 171.8 ms on CPU (M5, ORT 1.29.0). It is a **steady-state-only** graph with a different input contract; read [Sortformer CoreML variant](#sortformer-coreml-variant) before using it.
 - **Dynamic-batch encoder + dynamic-batch joint decoder** for Parakeet TDT (preprocessor still batch-1 post-export). INT8 variants of encoder, decoder-joint, and Sortformer ship for CPU-only inference.
 - **Chunk-by-chunk parity diagnostic** ([`compare_sortformer_chunk_outputs.py`](https://github.com/christopherthompson81/vernacula/blob/main/scripts/nemo_export/compare_sortformer_chunk_outputs.py)) compares NeMo vs ONNX state evolution across streaming chunks to localise drift to either model output or carry-state.
 - **Preprocessor export sweep** ([`tune_nemo128_export.py`](https://github.com/christopherthompson81/vernacula/blob/main/scripts/nemo_export/tune_nemo128_export.py)) scores wrapper / custom / DFT modes against a legacy reference with feature-level and encoder-output deltas — the tooling that picked the DFT path in the first bullet.
@@ -65,20 +65,32 @@ outright. The variant fixes the shapes at export time and applies four rewrites 
 51 all-False `Where` masks, rewrite 34 constant zero `Pad`s as `Concat`s, pre-transpose
 180 `Gemm` weights) to reach a single CoreML partition instead of 71.
 
-Measured on an M5, ORT 1.24.4, chunk=992 / spkcache=188 / fifo=124:
+Measured on an M5 (Mac17,3, macOS 26.6.2), **ORT 1.29.0** — the version Vernacula builds
+against — chunk=992 / spkcache=188 / fifo=124:
 
 | model | EP | inference | cold load | warm load |
 |---|---|---|---|---|
-| stock dynamic | CPU | 196.3 ms | 0.53 s | — |
-| stock dynamic | WebGPU | 113.0 ms | 0.45 s | — |
+| stock dynamic | CPU | 171.8 ms | 0.50 s | — |
 | stock dynamic | CoreML | *fails to compile* | — | — |
-| CoreML variant | CPU | 170.3 ms | 0.15 s | — |
-| CoreML variant | WebGPU | 101.7 ms | 0.13 s | — |
-| **CoreML variant** | **CoreML** | **52.3 ms** | **2.1 s** | **0.2 s** |
+| CoreML variant | CPU | 154.0 ms | — | — |
+| **CoreML variant** | **CoreML** | **51.5 ms** | **2.2 s** | **0.16 s** |
 
-Outputs match the stock graph on the CPU EP to `3.3e-07` (`preds`) for a full chunk. The
-static shapes alone also make it ~13% faster on CPU and ~10% faster on WebGPU, so it is
-not purely a macOS artifact.
+**3.34× vs the stock graph on CPU.** The CoreML EP takes the whole graph as a single
+partition (1751 of 1751 nodes). Outputs match the stock graph to `4.470E-07` (`preds`,
+rms 7.616E-08) running CoreML against stock-on-CPU, and to `3.576E-07` CPU-to-CPU. The
+static shapes alone also make it ~10% faster on plain CPU, so it is not purely a macOS
+artifact.
+
+The stock graph's CoreML failure reproduces on 1.29.0 exactly as described above —
+`Input: _ConstantOfShape_1_output_0 has unbounded dimension which is not supported`.
+
+An earlier round on **ORT 1.24.4** measured 52.3 ms for the variant on CoreML, alongside
+196.3 ms (CPU) and 113.0 ms (WebGPU) for the stock graph and 101.7 ms for the variant on
+WebGPU. Those CPU/WebGPU baselines disagree with other figures recorded for the same
+machine and ORT (163.5 ms / 94.0 ms) and have not been reconciled; treat the 1.29.0 table
+above as authoritative and the 1.24.4 baselines as indicative only. WebGPU was not
+re-measured on 1.29.0 — the provider is absent from the `onnxruntime` PyPI wheel and ships
+only in the packaged app.
 
 **This is not a drop-in replacement.** Four things differ:
 
@@ -87,7 +99,7 @@ not purely a macOS artifact.
 | inputs | 6 (`chunk`, `spkcache`, `fifo` + 3 `*_lengths`) | **3** (`chunk`, `spkcache`, `fifo`) |
 | shapes | dynamic | fixed `[1,992,128]` / `[1,188,512]` / `[1,124,512]` |
 | `spkcache_fifo_chunk_preds` | `[batch, time_out, 4]` | `[1, 436, 4]` |
-| graph optimization level | any | **`ORT_ENABLE_BASIC` or lower** |
+| graph optimization level | any | any on ORT 1.29.0; **`ORT_ENABLE_BASIC` or lower** on 1.26.0 (see note 3) |
 
 1. **All three lengths are baked in, so this graph is steady-state only.** Pass full-size,
    zero-padded buffers. Zero-filled `spkcache`/`fifo` during warm-up are fine — the stock
@@ -97,15 +109,20 @@ not purely a macOS artifact.
    speaker probabilities by up to **0.54** (rms 0.24) on a 0..1 scale — enough to flip
    speaker assignments. Route that one chunk per recording to the stock dynamic graph,
    which is in this same repo.
-3. **Create the session at `ORT_ENABLE_BASIC` or lower.** At `ORT_ENABLE_EXTENDED` and
-   above ORT 1.26.0 fails to load the file outright (`AddInitializedOrtValue Attempt to
-   replace the existing tensor`, from `MatMulAddFusion` re-running over an
-   already-optimized graph). BASIC is the right level regardless: EXTENDED also shatters
-   CoreML partitioning (69 → 191).
-4. **CoreML partitioning is ORT-version dependent.** Validated on **1.24.4**; ORT 1.29.0
-   splits the same graph into 194 partitions and diverges at ~1e-2. Re-validate on any ORT
-   upgrade. Set the CoreML EP's `ModelCacheDirectory` or every load pays the 2.1 s compile
-   instead of 0.2 s.
+3. **Check the graph optimization level against your ORT.** On **1.29.0 this is a
+   non-issue**: all four levels load, hold the single partition, and give identical
+   outputs (`4.470E-07`). On **1.26.0**, `ORT_ENABLE_EXTENDED` and above fail to load the
+   file outright (`AddInitializedOrtValue Attempt to replace the existing tensor`, from
+   `MatMulAddFusion` re-running over an already-optimized graph), so pin to
+   `ORT_ENABLE_BASIC` there. A separate 1.24.4 measurement found EXTENDED shattering
+   CoreML partitioning (69 → 191) on the earlier four-input graph; that does not reproduce
+   on 1.29.0 with this artifact.
+4. **CoreML partitioning is ORT-version dependent — re-validate on any ORT upgrade.**
+   Validated on **1.24.4** and **1.29.0**, which both reach a single partition. An earlier
+   note here claimed 1.29.0 split the graph into 194 partitions and diverged at ~1e-2;
+   that was measured against a different build of the graph and **does not reproduce** —
+   1.29.0 gives 1 partition and `4.470E-07`. Set the CoreML EP's `ModelCacheDirectory` or
+   every load pays the 2.2 s compile instead of 0.16 s.
 
 `fp16` was measured faster still (22.3 ms) but is **not** shipped: `chunk_pre_encode_embs`
 diverges to 9.8e-02 there and those embeddings feed back into the speaker cache and FIFO,

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -288,10 +288,12 @@ full set of techniques and how to apply them to other models.
 
 Caveats:
 
-* The graph assumes a full cache and FIFO, which `Sortformer.cs` always supplies,
-  and constant folding prunes the baked `*_lengths` from the signature -- so with
-  all three baked the graph takes **three** inputs (`chunk`, `spkcache`, `fifo`),
-  not six. Without `--coreml-const-chunk-length` it takes four.
+* The graph assumes a genuinely full cache and FIFO. `Sortformer.cs` does NOT always
+  supply that -- `ResetState` starts both buffers at length 0 and they grow -- so the
+  caller has to route warm-up chunks to the stock graph too, not just the short tail
+  chunk. Constant folding prunes the baked `*_lengths` from the signature, so with all
+  three baked the graph takes **three** inputs (`chunk`, `spkcache`, `fifo`), not six.
+  Without `--coreml-const-chunk-length` it takes four.
 * **The steady-state graph must never see the final chunk of a recording.**
   `ProcessChunk` passes `min(start + chunkStride, totalFrames) - start`, which is
   short for the last chunk of every file, and a baked `chunk_lengths` lets that
@@ -303,9 +305,11 @@ Caveats:
   `AddInitializedOrtValue Attempt to replace the existing tensor`
   (`MatMulAddFusion`). `OrtSessionBuilder.Create` defaults to `ORT_ENABLE_ALL`.
 * **CoreML partitioning is ORT-version dependent, and the table above is 1.24.4.**
-  An Apple Silicon build of Vernacula ships **1.29.0**, where the same graph is
-  reported to split into 194 partitions and diverge at ~1e-2. Re-validate there
-  before relying on any of these numbers; see
+  An Apple Silicon build of Vernacula ships **1.29.0**. That was once believed to split
+  this graph into 194 partitions and diverge at ~1e-2; **it does not** -- measured on an
+  M5 under 1.29.0 the graph reaches **1 partition** and `4.470E-07` against the stock
+  model, at 51.5 ms vs 171.8 ms for stock-on-CPU. Re-validate on any further ORT change;
+  see
   [docs/investigations/sortformer_coreml_publish_investigation.md](../../docs/investigations/sortformer_coreml_publish_investigation.md).
 
 For a safer structure-only experiment that keeps dynamic time dimensions but

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -14,6 +14,7 @@ It now covers both models in your pipeline:
 - `export_sortformer_nemo_to_onnx.py`: exports streaming Sortformer `.nemo` to the same six-input / three-output ONNX contract used by Vernacula's inference code.
 - `export_silero_vad_to_onnx.py`: exports Silero VAD to ONNX.
 - `benchmark_sortformer_rtf.py`: benchmarks Sortformer NeMo-vs-ONNX diarization RTF on CPU or CUDA.
+- `coreml_partition_probe.py`: reports what an execution provider does with a static Sortformer graph — partition count, load and inference time, parity against the dynamic graph. This is the measurement that decides whether a CoreML variant is worth shipping, and it has to run on Apple Silicon.
 - `compare_sortformer_chunk_outputs.py`: compares two Sortformer backends chunk-by-chunk to locate streaming parity drift.
 - `tune_nemo128_export.py`: runs multiple preprocessor export candidates and scores them against a legacy reference — use this if the default export mode needs tuning.
 - `setup_nemo_export_env.py`: creates the Python export venv.

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -233,17 +233,25 @@ stops CoreML compiling the graph at all. `--coreml-static-batch1` drops that tri
 -- safe because `spkcache` and `fifo` are always full at runtime, and the chunk is
 concatenated **last**, so the summed logical length still masks the padded tail of
 a short final chunk. `--coreml-const-lengths` then bakes the two buffer lengths in
-as constants:
+as constants, and `--coreml-const-chunk-length` bakes the third:
 
 ```bash
 python scripts/nemo_export/export_sortformer_nemo_to_onnx.py \
   --nemo ~/models/diar_streaming_sortformer_4spk-v2.1.nemo \
   --output ~/models/sortformer_coreml.onnx \
   --opset 17 \
-  --coreml-static-batch1 --coreml-const-lengths \
+  --coreml-static-batch1 --coreml-const-lengths --coreml-const-chunk-length \
   --chunk-frames 992 --fixed-spkcache-frames 188 --fixed-fifo-frames 124 \
   --overwrite
 ```
+
+**All three flags are required to reach one partition, and the third one carries a
+correctness obligation** -- read the caveats below before using it. The attention
+padding mask is a function of all three lengths, so with `chunk_lengths` still live
+the mask never folds to a constant and the `Where` removal below finds **0 of 51**
+nodes, leaving four inputs and ~69 partitions. Drop
+`--coreml-const-chunk-length` and you get a graph that is correct for every chunk
+and no faster under CoreML than the CPU EP.
 
 That alone compiles under CoreML but leaves ~70 partitions, because a `Where`
 (padding mask) and a `Pad` in every encoder layer stay on CPU and split the graph.
@@ -268,7 +276,8 @@ Measured on an M5, ORT 1.24.4, chunk=992 / cache=188 / fifo=124:
 | `+ Gemm pre-transpose` | **1** | **52.3 ms** | **2.1 s** | **0.2 s** |
 
 Reference on the same machine: CPU 163.5 ms, WebGPU 94.0 ms. Outputs match the
-original dynamic model to 3.6e-07 (preds) and 0.0 (embeddings).
+original dynamic model to 3.6e-07 (preds) for a full chunk (independently
+reproduced at 3.3e-07 on a Linux rebuild under ORT 1.26.0).
 
 The Gemm pre-transpose is the load-time fix: ORT's CoreML EP writes the weight
 transposes it synthesizes for `Gemm(transB=0)` as hex-float TEXT inline in
@@ -276,13 +285,27 @@ transposes it synthesizes for `Gemm(transB=0)` as hex-float TEXT inline in
 See [docs/coreml_onnx_playbook.md](../../docs/coreml_onnx_playbook.md) for the
 full set of techniques and how to apply them to other models.
 
-Caveats: the graph assumes a full cache and FIFO, which `Sortformer.cs` always
-supplies; constant folding prunes the two baked `*_lengths`, so the graph takes
-four inputs, not six. `chunk_lengths` stays live on purpose -- `ProcessChunk`
-passes `min(start + chunkStride, totalFrames) - start`, which is **short for the
-final chunk of every recording**, and baking a constant there would let that
-chunk's zero-padded tail be attended to as real audio. CoreML partitioning is
-ORT-version dependent -- validated on 1.24.4.
+Caveats:
+
+* The graph assumes a full cache and FIFO, which `Sortformer.cs` always supplies,
+  and constant folding prunes the baked `*_lengths` from the signature -- so with
+  all three baked the graph takes **three** inputs (`chunk`, `spkcache`, `fifo`),
+  not six. Without `--coreml-const-chunk-length` it takes four.
+* **The steady-state graph must never see the final chunk of a recording.**
+  `ProcessChunk` passes `min(start + chunkStride, totalFrames) - start`, which is
+  short for the last chunk of every file, and a baked `chunk_lengths` lets that
+  chunk's zero-padded tail be attended to as real audio. Measured on the shipped
+  model: up to **0.54** (rms 0.24) on `preds`' 0..1 scale -- enough to flip speaker
+  assignments. A caller must route that one chunk to the unspecialized graph.
+* **Create the session at `ORT_ENABLE_BASIC` or lower.** The post-processed file is
+  an already-optimized graph, and re-optimizing one at EXTENDED or above throws
+  `AddInitializedOrtValue Attempt to replace the existing tensor`
+  (`MatMulAddFusion`). `OrtSessionBuilder.Create` defaults to `ORT_ENABLE_ALL`.
+* **CoreML partitioning is ORT-version dependent, and the table above is 1.24.4.**
+  An Apple Silicon build of Vernacula ships **1.29.0**, where the same graph is
+  reported to split into 194 partitions and diverge at ~1e-2. Re-validate there
+  before relying on any of these numbers; see
+  [docs/investigations/sortformer_coreml_publish_investigation.md](../../docs/investigations/sortformer_coreml_publish_investigation.md).
 
 For a safer structure-only experiment that keeps dynamic time dimensions but
 specializes the graph to batch size 1, use:

--- a/scripts/nemo_export/coreml_optimize_sortformer.py
+++ b/scripts/nemo_export/coreml_optimize_sortformer.py
@@ -327,7 +327,12 @@ def verify(original: str, optimized: str, static_src: str, tol: float) -> bool:
 
     feed = {i.name: synth(i) for i in src_sess.get_inputs()}
     for i in ref_sess.get_inputs():
-        feed.setdefault(i.name, synth(i))
+        # NOT setdefault: its argument is evaluated eagerly, so every shared input
+        # (chunk / spkcache / fifo -- the three big ones) would be synthesized a second
+        # time and thrown away. Values stay correct either way; the waste is ~500 MB of
+        # transient allocation on a script already holding two 527 MB sessions.
+        if i.name not in feed:
+            feed[i.name] = synth(i)
 
     ref = run(ref_sess, {i.name: feed[i.name] for i in ref_sess.get_inputs()})
 

--- a/scripts/nemo_export/coreml_optimize_sortformer.py
+++ b/scripts/nemo_export/coreml_optimize_sortformer.py
@@ -4,7 +4,13 @@ CoreML execution provider can compile as a SINGLE partition.
 
 Run this on the output of:
 
-    export_sortformer_nemo_to_onnx.py --coreml-static-batch1 --coreml-const-lengths
+    export_sortformer_nemo_to_onnx.py --coreml-static-batch1 --coreml-const-lengths \
+        --coreml-const-chunk-length
+
+All three flags matter. Without --coreml-const-chunk-length the padding mask stays
+a function of the live chunk_lengths input, transform 1 below finds 0 of 51 nodes,
+and the graph stops at ~69 partitions. See that flag's help for the correctness
+obligation it puts on the caller.
 
 Background
 ----------
@@ -27,8 +33,8 @@ Measured on an M5 (ORT 1.24.4, Sortformer 4spk v2.1, chunk=992/cache=188/fifo=12
 
 The two transforms
 ------------------
-1. `Where` (51x). With constant lengths the attention padding mask folds to a
-   compile-time constant that is ALL FALSE -- the sequence is fully packed
+1. `Where` (51x). With ALL THREE lengths constant the attention padding mask folds
+   to a compile-time constant that is ALL FALSE -- the sequence is fully packed
    (188 + 124 + 124 = 436). `Where(false, -10000, x)` is exactly `x`, so these
    are identities that exist only to break up the graph. Removed by rewiring
    consumers to the data input. Numerically exact.
@@ -48,6 +54,10 @@ Caveats
 * The result is steady-state only: full cache/fifo and a full-length chunk.
 * Folding prunes the now-unused *_lengths inputs, so the graph takes three
   inputs (chunk, spkcache, fifo), not six.
+* The result is an already-optimized graph: create its session at
+  ORT_ENABLE_BASIC or lower. EXTENDED and above throw
+  `AddInitializedOrtValue Attempt to replace the existing tensor` from
+  MatMulAddFusion, and OrtSessionBuilder.Create defaults to ORT_ENABLE_ALL.
 * Partitioning behaviour is ORT-version dependent. Validated on 1.24.4.
 """
 from __future__ import annotations
@@ -265,7 +275,7 @@ def prune(g) -> None:
     del g.value_info[:]          # let ORT re-infer
 
 
-def verify(original: str, optimized: str, tol: float) -> bool:
+def verify(original: str, optimized: str, static_src: str, tol: float) -> bool:
     import onnxruntime as ort
 
     rng = np.random.default_rng(7)
@@ -282,29 +292,44 @@ def verify(original: str, optimized: str, tol: float) -> bool:
 
     ref_sess = session(original)
 
-    # Build the feed from the model's OWN signature. The frame counts follow
-    # --chunk-frames / --fixed-spkcache-frames / --fixed-fifo-frames at export time,
-    # so hardcoding them here made --verify usable on exactly one configuration.
-    shapes = {i.name: i.shape for i in ref_sess.get_inputs()}
-    feed = {}
-    for i in ref_sess.get_inputs():
+    # Take the buffer shapes from --input, the pre-transform static export, and derive
+    # every input from those. Reading them off the reference instead made the documented
+    # usage (--reference <the shipped DYNAMIC model>) the one case that could never
+    # work: a dynamic graph has no shapes to read. Hardcoding them, the version before
+    # that, made --verify usable on exactly one frame configuration.
+    #
+    # Baked lengths are dropped from the signature at export time, so --input does not
+    # necessarily declare all six inputs either -- hence synthesize by NAME, for the
+    # union of what the two graphs ask for, rather than iterating one signature.
+    src_sess = session(static_src)
+    shapes = {i.name: i.shape for i in src_sess.get_inputs()}
+    for i in src_sess.get_inputs():
         if any(not isinstance(d, int) for d in i.shape):
             raise SystemExit(
-                f"--verify needs a static graph; input {i.name} has shape {i.shape}")
+                f"--verify needs a static --input; input {i.name} has shape {i.shape}")
+
+    def synth(i):
         np_dtype = NP.get(i.type)
         if np_dtype is None:
             raise SystemExit(f"--verify cannot synthesize input {i.name} of type {i.type}")
-        if np_dtype == np.int64:
-            # A `<buffer>_lengths` input. Steady state is the buffer's own frame count,
-            # which is what the CoreML graph was specialized for.
-            buf = i.name[: -len("_lengths")] if i.name.endswith("_lengths") else None
-            if buf is None or buf not in shapes:
-                raise SystemExit(f"--verify cannot infer a value for integer input {i.name}")
-            feed[i.name] = np.full(i.shape, shapes[buf][1], np.int64)
-        else:
-            feed[i.name] = rng.standard_normal(i.shape).astype(np_dtype)
+        if np_dtype != np.int64:
+            if i.name not in shapes:
+                raise SystemExit(
+                    f"--verify cannot synthesize {i.name}: --input does not declare it")
+            return rng.standard_normal(shapes[i.name]).astype(np_dtype)
+        # A `<buffer>_lengths` input. Steady state is the buffer's own frame count, which
+        # is the value the CoreML graph was specialized for -- and the value that makes
+        # the reference compute the same thing this graph has baked in.
+        buf = i.name[: -len("_lengths")] if i.name.endswith("_lengths") else None
+        if buf is None or buf not in shapes:
+            raise SystemExit(f"--verify cannot infer a value for integer input {i.name}")
+        return np.full([1], shapes[buf][1], np.int64)
 
-    ref = run(ref_sess, feed)
+    feed = {i.name: synth(i) for i in src_sess.get_inputs()}
+    for i in ref_sess.get_inputs():
+        feed.setdefault(i.name, synth(i))
+
+    ref = run(ref_sess, {i.name: feed[i.name] for i in ref_sess.get_inputs()})
 
     # Feed the optimized model only what it still declares: --coreml-const-lengths
     # folds the baked lengths away, and prune() then drops them from the signature.
@@ -312,7 +337,7 @@ def verify(original: str, optimized: str, tol: float) -> bool:
     opt_feed = {}
     for i in opt_sess.get_inputs():
         if i.name not in feed:
-            raise SystemExit(f"optimized model expects input {i.name}, absent from the original")
+            raise SystemExit(f"optimized model expects input {i.name}, absent from --input")
         arr = feed[i.name]
         opt_feed[i.name] = arr.astype(np.float16) if i.type == "tensor(float16)" else arr
     got = run(opt_sess, opt_feed)
@@ -382,7 +407,7 @@ def main() -> None:
         if not args.reference:
             raise SystemExit("--verify needs --reference <original dynamic .onnx>")
         print("\nverifying against reference on CPU EP:")
-        if not verify(os.path.expanduser(args.reference), dst, args.tolerance):
+        if not verify(os.path.expanduser(args.reference), dst, src, args.tolerance):
             sys.exit(1)
         print("PARITY: PASS")
 

--- a/scripts/nemo_export/coreml_partition_probe.py
+++ b/scripts/nemo_export/coreml_partition_probe.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Measure what an execution provider actually does with a Sortformer graph:
+partition count, load time, inference time, and parity against a reference model.
+
+The partition count is the number that matters for CoreML (see
+docs/coreml_onnx_playbook.md) and ONNX Runtime only reports it as a log line from
+inside the C++ EP, so this script captures the EP's stderr rather than trying to
+read it off the session.
+
+Typical use -- the go/no-go for issue #162, on Apple Silicon:
+
+    python scripts/nemo_export/coreml_partition_probe.py \\
+        --model diar_streaming_sortformer_4spk-v2.1.coreml.onnx \\
+        --ep coreml --cache-dir ~/.cache/vernacula-coreml \\
+        --reference diar_streaming_sortformer_4spk-v2.1.onnx
+
+Run it once per EP (`--ep cpu`, `--ep webgpu`, `--ep coreml`) and once per ORT
+version to compare. Nothing here is macOS-specific except which EPs exist.
+
+Inputs are synthesized from the model's own signature: float buffers get
+seeded random-normal values, and a `<buffer>_lengths` input gets that buffer's
+own frame count -- the steady state both graphs are specialized for. A short
+final chunk is deliberately NOT exercised here; the steady-state graph is not
+valid for one, which is the whole point of the contract.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import re
+import statistics
+import sys
+import tempfile
+import time
+
+import numpy as np
+
+LEVELS = {
+    "disable": "ORT_DISABLE_ALL",
+    "basic": "ORT_ENABLE_BASIC",
+    "extended": "ORT_ENABLE_EXTENDED",
+    "all": "ORT_ENABLE_ALL",
+}
+
+# CoreMLExecutionProvider::GetCapability logs this at warning level.
+PARTITION_RE = re.compile(
+    r"number of partitions supported by \w+:\s*(\d+)"
+    r".*?number of nodes in the graph:\s*(\d+)"
+    r".*?number of nodes supported by \w+:\s*(\d+)",
+    re.S,
+)
+
+
+@contextlib.contextmanager
+def capture_native_stderr():
+    """Redirect fd 2 to a temp file so the EP's C++ logging is readable.
+
+    Reassigning sys.stderr does not work -- the log line is written by the native
+    library, which holds the file descriptor directly.
+    """
+    with tempfile.TemporaryFile(mode="w+") as tmp:
+        saved = os.dup(2)
+        sys.stderr.flush()
+        os.dup2(tmp.fileno(), 2)
+        try:
+            yield tmp
+        finally:
+            sys.stderr.flush()
+            os.dup2(saved, 2)
+            os.close(saved)
+            tmp.seek(0)
+
+
+def build_options(ort, level: str, verbose: bool):
+    so = ort.SessionOptions()
+    so.graph_optimization_level = getattr(ort.GraphOptimizationLevel, LEVELS[level])
+    # Partition counts are logged at WARNING; node placement needs VERBOSE.
+    so.log_severity_level = 0 if verbose else 2
+    if verbose:
+        so.log_verbosity_level = 1
+    return so
+
+
+def providers_for(ep: str, cache_dir: str | None):
+    if ep == "cpu":
+        return ["CPUExecutionProvider"]
+    if ep == "webgpu":
+        return ["WebGpuExecutionProvider", "CPUExecutionProvider"]
+    opts = {
+        # ML Program is CoreML's current IR; the legacy NeuralNetwork format is frozen.
+        "ModelFormat": "MLProgram",
+        "MLComputeUnits": "ALL",
+    }
+    if cache_dir:
+        opts["ModelCacheDirectory"] = os.path.expanduser(cache_dir)
+    return [("CoreMLExecutionProvider", opts), "CPUExecutionProvider"]
+
+
+def make_session(ort, model: str, ep: str, level: str, cache_dir: str | None, verbose: bool):
+    """Returns (session, seconds, captured EP log)."""
+    so = build_options(ort, level, verbose)
+    with capture_native_stderr() as log:
+        t0 = time.perf_counter()
+        sess = ort.InferenceSession(model, so, providers=providers_for(ep, cache_dir))
+        elapsed = time.perf_counter() - t0
+        text = log.read()
+    return sess, elapsed, text
+
+
+def synth_feed(sess, seed: int) -> dict:
+    rng = np.random.default_rng(seed)
+    shapes = {i.name: i.shape for i in sess.get_inputs()}
+    feed = {}
+    for i in sess.get_inputs():
+        if i.type == "tensor(int64)":
+            if not i.name.endswith("_lengths"):
+                raise SystemExit(f"cannot synthesize integer input {i.name}")
+            buf = i.name[: -len("_lengths")]
+            if buf not in shapes:
+                raise SystemExit(f"cannot infer a length for {i.name}: no input named {buf}")
+            feed[i.name] = np.full([1], shapes[buf][1], np.int64)
+        else:
+            if any(not isinstance(d, int) for d in i.shape):
+                raise SystemExit(
+                    f"--model must be static; input {i.name} has shape {i.shape}. "
+                    "Point --model at the CoreML variant and the dynamic graph at "
+                    "--reference, not the other way round."
+                )
+            dtype = np.float16 if i.type == "tensor(float16)" else np.float32
+            feed[i.name] = rng.standard_normal(i.shape).astype(dtype)
+    return feed
+
+
+def report_placement(log: str) -> None:
+    m = PARTITION_RE.search(log)
+    if m:
+        parts, total, supported = (int(x) for x in m.groups())
+        note = "  <- single partition" if parts == 1 else "  <- every extra partition is a copy + sync"
+        print(f"  partitions      {parts} ({supported}/{total} nodes on the EP){note}")
+    else:
+        print("  partitions      not reported (the CPU and WebGPU EPs do not log this)")
+    fell_back = re.findall(r"Node\(s\) placed on \[CPUExecutionProvider\][^\n]*", log)
+    for line in fell_back[:1]:
+        print(f"  {line.strip()}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model", required=True, help="Static Sortformer graph to probe")
+    ap.add_argument("--ep", default="coreml", choices=["coreml", "cpu", "webgpu"])
+    ap.add_argument("--opt-level", default="basic", choices=sorted(LEVELS),
+                    help="Session graph optimization level (default basic -- the only "
+                         "level a post-processed graph reliably loads at)")
+    ap.add_argument("--cache-dir", help="CoreML ModelCacheDirectory; enables the warm-load "
+                                       "measurement by loading a second time")
+    ap.add_argument("--reference", help="Dynamic graph to check outputs against, on the CPU EP")
+    ap.add_argument("--runs", type=int, default=20)
+    ap.add_argument("--warmup", type=int, default=3)
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--verbose", action="store_true",
+                    help="VERBOSE ORT logging, so per-node EP placement is listed")
+    args = ap.parse_args()
+
+    import onnxruntime as ort
+
+    model = os.path.expanduser(args.model)
+    print(f"onnxruntime     {ort.__version__}")
+    print(f"available EPs   {', '.join(ort.get_available_providers())}")
+    print(f"model           {model} ({os.path.getsize(model) / 1e6:.0f} MB)")
+    print(f"ep / opt level  {args.ep} / {LEVELS[args.opt_level]}")
+
+    try:
+        sess, cold, log = make_session(ort, model, args.ep, args.opt_level, args.cache_dir, args.verbose)
+    except Exception as exc:
+        # A load failure IS a result -- ORT_ENABLE_EXTENDED and above are expected to
+        # throw on a post-processed graph, and CoreML rejects a graph with unbounded dims.
+        print(f"\nLOAD FAILED at {LEVELS[args.opt_level]}: {str(exc).strip().splitlines()[-1]}")
+        sys.exit(1)
+
+    print(f"\nload")
+    print(f"  cold            {cold:.2f} s")
+    if args.cache_dir:
+        _, warm, _ = make_session(ort, model, args.ep, args.opt_level, args.cache_dir, False)
+        print(f"  warm            {warm:.2f} s")
+    actually_used = sess.get_providers()
+    print(f"  providers used  {', '.join(actually_used)}")
+    if args.ep != "cpu" and actually_used[0] == "CPUExecutionProvider":
+        print("  ⚠ the requested EP did not take the graph -- numbers below are CPU numbers")
+    report_placement(log)
+
+    feed = synth_feed(sess, args.seed)
+    out_names = [o.name for o in sess.get_outputs()]
+    for _ in range(args.warmup):
+        sess.run(None, feed)
+    times = []
+    for _ in range(args.runs):
+        t0 = time.perf_counter()
+        got = sess.run(None, feed)
+        times.append((time.perf_counter() - t0) * 1e3)
+    print(f"\ninference over {args.runs} runs")
+    print(f"  median          {statistics.median(times):.1f} ms")
+    print(f"  min / max       {min(times):.1f} / {max(times):.1f} ms")
+
+    if args.reference:
+        ref_sess = ort.InferenceSession(
+            os.path.expanduser(args.reference), build_options(ort, "basic", False),
+            providers=["CPUExecutionProvider"])
+        ref_feed = {}
+        for i in ref_sess.get_inputs():
+            if i.name in feed:
+                ref_feed[i.name] = feed[i.name]
+            else:
+                # The reference declares inputs the specialized graph baked away.
+                ref_feed.update(synth_feed_missing(i, feed))
+        ref = dict(zip([o.name for o in ref_sess.get_outputs()], ref_sess.run(None, ref_feed)))
+        mine = dict(zip(out_names, got))
+        print(f"\nparity vs {os.path.basename(args.reference)} (CPU EP, steady state)")
+        for k in ("spkcache_fifo_chunk_preds", "chunk_pre_encode_embs"):
+            if k not in ref or k not in mine:
+                continue
+            a, b = ref[k].astype(np.float32), mine[k].astype(np.float32)
+            if a.shape != b.shape:
+                print(f"  {k:26} SHAPE {a.shape} vs {b.shape}")
+                continue
+            d = np.abs(a - b)
+            print(f"  {k:26} maxAbs={d.max():.3E}  rms={np.sqrt((d ** 2).mean()):.3E}")
+
+
+def synth_feed_missing(inp, feed: dict) -> dict:
+    """A `<buffer>_lengths` the specialized graph no longer declares. Its steady-state
+    value is the buffer's own frame count, which is what was baked in."""
+    if not inp.name.endswith("_lengths"):
+        raise SystemExit(f"reference wants {inp.name}, which --model does not provide")
+    buf = inp.name[: -len("_lengths")]
+    if buf not in feed:
+        raise SystemExit(f"reference wants {inp.name} but --model has no {buf} input")
+    return {inp.name: np.full([1], feed[buf].shape[1], np.int64)}
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nemo_export/coreml_partition_probe.py
+++ b/scripts/nemo_export/coreml_partition_probe.py
@@ -75,8 +75,11 @@ def capture_native_stderr():
 def build_options(ort, level: str, verbose: bool):
     so = ort.SessionOptions()
     so.graph_optimization_level = getattr(ort.GraphOptimizationLevel, LEVELS[level])
-    # Partition counts are logged at WARNING; node placement needs VERBOSE.
-    so.log_severity_level = 0 if verbose else 2
+    # The GetCapability partition summary is INFO when it is a single partition, so
+    # WARNING (2) drops the one outcome worth detecting. The session logger gates it
+    # first, the default logger second -- both have to be lowered (see make_session).
+    # Costs nothing on the console: this all lands in the captured temp file.
+    so.log_severity_level = 0 if verbose else 1
     if verbose:
         so.log_verbosity_level = 1
     return so
@@ -100,11 +103,22 @@ def providers_for(ep: str, cache_dir: str | None):
 def make_session(ort, model: str, ep: str, level: str, cache_dir: str | None, verbose: bool):
     """Returns (session, seconds, captured EP log)."""
     so = build_options(ort, level, verbose)
-    with capture_native_stderr() as log:
-        t0 = time.perf_counter()
-        sess = ort.InferenceSession(model, so, providers=providers_for(ep, cache_dir))
-        elapsed = time.perf_counter() - t0
-        text = log.read()
+    # The CoreML EP emits its GetCapability summary at WARNING only when it produced
+    # more than one partition; the single-partition case -- the outcome this probe
+    # exists to detect -- goes out at INFO. It is also written through the *default*
+    # logger, which SessionOptions.log_severity_level does not lower.
+    ort.set_default_logger_severity(0 if verbose else 1)
+    try:
+        with capture_native_stderr() as log:
+            t0 = time.perf_counter()
+            sess = ort.InferenceSession(model, so, providers=providers_for(ep, cache_dir))
+            elapsed = time.perf_counter() - t0
+            # dup2 makes fd 2 share this file's offset, so it already sits at
+            # end-of-writes: without the seek, read() returns "".
+            log.seek(0)
+            text = log.read()
+    finally:
+        ort.set_default_logger_severity(2)
     return sess, elapsed, text
 
 
@@ -132,7 +146,9 @@ def synth_feed(sess, seed: int) -> dict:
     return feed
 
 
-def report_placement(log: str) -> None:
+def report_placement(log: str):
+    """Prints the partition summary. Returns (partitions, total, supported), or None
+    if the EP did not log one (the CPU and WebGPU EPs never do)."""
     m = PARTITION_RE.search(log)
     if m:
         parts, total, supported = (int(x) for x in m.groups())
@@ -143,6 +159,7 @@ def report_placement(log: str) -> None:
     fell_back = re.findall(r"Node\(s\) placed on \[CPUExecutionProvider\][^\n]*", log)
     for line in fell_back[:1]:
         print(f"  {line.strip()}")
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
 
 
 def main() -> None:
@@ -186,15 +203,22 @@ def main() -> None:
         print(f"  warm            {warm:.2f} s")
     actually_used = sess.get_providers()
     print(f"  providers used  {', '.join(actually_used)}")
-    if args.ep != "cpu" and actually_used[0] == "CPUExecutionProvider":
-        print("  ⚠ the requested EP did not take the graph -- numbers below are CPU numbers")
-    report_placement(log)
+    placement = report_placement(log)
+    # get_providers() is the *registration* list, in priority order -- it says nothing
+    # about which EP was actually assigned nodes. An EP that registers and then claims
+    # zero nodes still sits at index 0, so the node count is the real check.
+    if args.ep != "cpu":
+        if actually_used[0] == "CPUExecutionProvider":
+            print("  ⚠ the requested EP is not present in this build -- numbers below are CPU numbers")
+        elif placement is not None and placement[2] == 0:
+            print("  ⚠ the requested EP registered but claimed 0 nodes -- numbers below are CPU numbers")
 
     feed = synth_feed(sess, args.seed)
     out_names = [o.name for o in sess.get_outputs()]
     for _ in range(args.warmup):
         sess.run(None, feed)
     times = []
+    got = None
     for _ in range(args.runs):
         t0 = time.perf_counter()
         got = sess.run(None, feed)
@@ -204,8 +228,13 @@ def main() -> None:
     print(f"  min / max       {min(times):.1f} / {max(times):.1f} ms")
 
     if args.reference:
+        ref_so = build_options(ort, "basic", False)
+        # The reference session is created outside the stderr capture, so keep it at
+        # WARNING -- build_options lowers to INFO for the partition summary we only
+        # want from the probed session.
+        ref_so.log_severity_level = 2
         ref_sess = ort.InferenceSession(
-            os.path.expanduser(args.reference), build_options(ort, "basic", False),
+            os.path.expanduser(args.reference), ref_so,
             providers=["CPUExecutionProvider"])
         ref_feed = {}
         for i in ref_sess.get_inputs():
@@ -215,6 +244,8 @@ def main() -> None:
                 # The reference declares inputs the specialized graph baked away.
                 ref_feed.update(synth_feed_missing(i, feed))
         ref = dict(zip([o.name for o in ref_sess.get_outputs()], ref_sess.run(None, ref_feed)))
+        if got is None:          # --runs 0: nothing timed, but parity was still asked for
+            got = sess.run(None, feed)
         mine = dict(zip(out_names, got))
         print(f"\nparity vs {os.path.basename(args.reference)} (CPU EP, steady state)")
         for k in ("spkcache_fifo_chunk_preds", "chunk_pre_encode_embs"):

--- a/scripts/nemo_export/coreml_partition_probe.py
+++ b/scripts/nemo_export/coreml_partition_probe.py
@@ -223,9 +223,13 @@ def main() -> None:
         t0 = time.perf_counter()
         got = sess.run(None, feed)
         times.append((time.perf_counter() - t0) * 1e3)
-    print(f"\ninference over {args.runs} runs")
-    print(f"  median          {statistics.median(times):.1f} ms")
-    print(f"  min / max       {min(times):.1f} / {max(times):.1f} ms")
+    if times:
+        print(f"\ninference over {args.runs} runs")
+        print(f"  median          {statistics.median(times):.1f} ms")
+        print(f"  min / max       {min(times):.1f} / {max(times):.1f} ms")
+    else:
+        # --runs 0 is a legitimate way to ask only for the partition count.
+        print("\ninference skipped (--runs 0)")
 
     if args.reference:
         ref_so = build_options(ort, "basic", False)

--- a/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
+++ b/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
@@ -450,12 +450,18 @@ def main() -> None:
             "data-dependent. Callers must pass full-size, zero-padded buffers."
         )
     if args.coreml_const_lengths:
+        # The "chunk_lengths is still a live input" clause is only true WITHOUT
+        # --coreml-const-chunk-length; with it, the next note says the opposite. This
+        # report is the artifact's authoritative contract, so it must not say both.
+        chunk_len_clause = (
+            "chunk_lengths is still a live input. "
+            if not args.coreml_const_chunk_length else ""
+        )
         metadata.notes.append(
             f"spkcache_lengths={args.fixed_spkcache_frames} and fifo_lengths="
             f"{args.fixed_fifo_frames} are baked in as graph constants; both inputs remain in "
             "the signature but are ignored, and may be pruned from it after folding. "
-            "chunk_lengths is still a live input. This graph is valid only for a full cache "
-            "and fifo."
+            f"{chunk_len_clause}This graph is valid only for a full cache and fifo."
         )
     if args.coreml_const_chunk_length:
         metadata.notes.append(

--- a/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
+++ b/scripts/nemo_export/export_sortformer_nemo_to_onnx.py
@@ -84,6 +84,27 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--coreml-const-chunk-length",
+        action="store_true",
+        help=(
+            "With --coreml-const-lengths, ALSO bake chunk_lengths in as a constant, "
+            "producing a graph specialized for a FULL chunk. This is what turns the "
+            "attention padding mask into an all-False constant, which is the "
+            "precondition for coreml_optimize_sortformer.py to delete its 51 Where "
+            "nodes and reach a single CoreML partition -- without it the mask stays a "
+            "function of chunk_lengths, none of the Where nodes can be removed, and the "
+            "graph fragments into ~69 partitions with no CoreML win at all. "
+            "⚠ The resulting graph is WRONG for a short chunk: it attends to the "
+            "zero-padded tail as real audio, which moves that chunk's speaker "
+            "probabilities by up to 0.54 on a 0..1 scale (measured; see "
+            "docs/investigations/sortformer_coreml_publish_investigation.md). Since "
+            "Sortformer.cs sends a short chunk_lengths for the final chunk of EVERY "
+            "recording, a caller of this graph must route that one chunk to a "
+            "non-specialized graph instead. Opt in only when building the CoreML "
+            "steady-state variant, never for a general-purpose export."
+        ),
+    )
+    parser.add_argument(
         "--dynamic-streaming-batch1",
         action="store_true",
         help=(
@@ -190,6 +211,7 @@ def build_wrapper(
     dynamic_streaming_batch1: bool = False,
     coreml_static_batch1: bool = False,
     coreml_const_lengths: bool = False,
+    coreml_const_chunk_length: bool = False,
     const_chunk_frames: int = 0,
     const_spkcache_frames: int = 0,
     const_fifo_frames: int = 0,
@@ -206,15 +228,27 @@ def build_wrapper(
                 # folding them away changes no numerics -- it turns their mask construction
                 # into foldable constants instead of data-dependent Range/Expand chains.
                 #
-                # ⚠ chunk_lengths is deliberately NOT baked. It is the one length the runtime
-                # does NOT always set to the buffer size: ProcessChunk passes
-                # min(start + chunkStride, totalFrames) - start, which is SHORT for the final
-                # chunk of every recording. Baking chunk_frames there would let the
-                # zero-padded tail of that last chunk be attended to as real audio, changing
-                # the diarization output at the end of every file. It stays a real input; only
-                # its mask stays data-dependent, which costs a few partitions, not correctness.
+                # ⚠ chunk_lengths is NOT baked unless --coreml-const-chunk-length says so.
+                # It is the one length the runtime does NOT always set to the buffer size:
+                # ProcessChunk passes min(start + chunkStride, totalFrames) - start, which is
+                # SHORT for the final chunk of every recording, and baking chunk_frames there
+                # lets that chunk's zero-padded tail be attended to as real audio. Measured on
+                # the shipped dynamic model, that moves the final chunk's speaker
+                # probabilities by up to 0.54 (rms 0.24) on a 0..1 scale -- enough to flip
+                # speaker assignments, not a tolerance question. See
+                # docs/investigations/sortformer_coreml_publish_investigation.md.
+                #
+                # It is nonetheless the ONLY way to a single CoreML partition: the attention
+                # padding mask is a function of chunk_lengths, so while that input is live the
+                # mask cannot fold to the all-False constant that lets
+                # coreml_optimize_sortformer.py delete its 51 Where nodes (69 partitions and
+                # ~no CoreML win, vs 1 partition and 3.2x over CPU). Hence the opt-in flag,
+                # and hence the obligation it puts on the caller: the steady-state graph must
+                # never see the final chunk of a recording.
                 spkcache_lengths = torch.tensor([const_spkcache_frames], dtype=torch.int64)
                 fifo_lengths = torch.tensor([const_fifo_frames], dtype=torch.int64)
+                if coreml_const_chunk_length:
+                    chunk_lengths = torch.tensor([const_chunk_frames], dtype=torch.int64)
             chunk_pre_encode_embs, chunk_pre_encode_lengths = self.inner.encoder.pre_encode(x=chunk, lengths=chunk_lengths)
             chunk_pre_encode_lengths = chunk_pre_encode_lengths.to(torch.int64)
             if coreml_static_batch1:
@@ -293,6 +327,8 @@ def main() -> None:
         raise SystemExit(f"Output already exists: {output_path}. Re-run with --overwrite.")
     if args.coreml_const_lengths and not args.coreml_static_batch1:
         raise SystemExit("--coreml-const-lengths requires --coreml-static-batch1.")
+    if args.coreml_const_chunk_length and not args.coreml_const_lengths:
+        raise SystemExit("--coreml-const-chunk-length requires --coreml-const-lengths.")
     if sum([args.static_streaming_batch1, args.dynamic_streaming_batch1, args.coreml_static_batch1]) > 1:
         raise SystemExit(
             "Choose at most one of --static-streaming-batch1, --dynamic-streaming-batch1, --coreml-static-batch1."
@@ -317,6 +353,7 @@ def main() -> None:
         static_streaming_batch1=args.static_streaming_batch1,
         coreml_static_batch1=args.coreml_static_batch1,
         coreml_const_lengths=args.coreml_const_lengths,
+        coreml_const_chunk_length=args.coreml_const_chunk_length,
         const_chunk_frames=args.chunk_frames,
         const_spkcache_frames=args.fixed_spkcache_frames,
         const_fifo_frames=args.fixed_fifo_frames,
@@ -419,6 +456,15 @@ def main() -> None:
             "the signature but are ignored, and may be pruned from it after folding. "
             "chunk_lengths is still a live input. This graph is valid only for a full cache "
             "and fifo."
+        )
+    if args.coreml_const_chunk_length:
+        metadata.notes.append(
+            f"chunk_lengths={args.chunk_frames} is ALSO baked in as a graph constant. This is "
+            "a STEADY-STATE-ONLY graph: it attends to a short chunk's zero-padded tail as "
+            "real audio, so the caller must route the final (short) chunk of every recording "
+            "to a graph that still takes chunk_lengths as an input. In exchange the attention "
+            "padding mask folds to an all-False constant, which is what lets "
+            "coreml_optimize_sortformer.py reach a single CoreML partition."
         )
     if args.dynamic_streaming_batch1:
         metadata.notes.append(

--- a/src/Vernacula.Base/Config.cs
+++ b/src/Vernacula.Base/Config.cs
@@ -13,6 +13,15 @@ public static class Config
     // ── Diarization (Sortformer) ─────────────────────────────────────────────
     public const string SortformerSubDir = "sortformer";
     public const string SortformerFile = "diar_streaming_sortformer_4spk-v2.1.onnx";
+
+    /// <summary>
+    /// The CoreML steady-state Sortformer graph. Optional: present only if the user has
+    /// downloaded it. Fixed shapes and three inputs (all three `*_lengths` are baked in),
+    /// so it is valid ONLY for a full-length chunk over a full cache and FIFO --
+    /// <see cref="SortformerStreamer.ProcessChunk"/> routes every other chunk to
+    /// <see cref="SortformerFile"/>.
+    /// </summary>
+    public const string SortformerCoreMLFile = "diar_streaming_sortformer_4spk-v2.1.coreml.onnx";
     public const string SortformerDataFile = "diar_streaming_sortformer_4spk-v2.1.onnx.data";
     public const string SortformerModelOverrideEnvVar = "VERNACULA_SORTFORMER_MODEL_FILE";
     /// <summary>
@@ -304,6 +313,20 @@ public static class Config
         return File.Exists(subDirPath)
             ? subDirPath
             : Path.Combine(modelDir, SortformerFile);
+    }
+
+    /// <summary>
+    /// The CoreML steady-state variant beside whatever <see cref="GetSortformerModelPath"/>
+    /// resolved, so a subdirectory layout or a <c>VERNACULA_SORTFORMER_MODEL_FILE</c>
+    /// override finds its sibling. The file is optional; callers check existence.
+    /// </summary>
+    public static string GetSortformerCoreMLModelPath(string modelDir)
+    {
+        string stock = GetSortformerModelPath(modelDir);
+        string? dir  = Path.GetDirectoryName(stock);
+        return string.IsNullOrEmpty(dir)
+            ? SortformerCoreMLFile
+            : Path.Combine(dir, SortformerCoreMLFile);
     }
 
     public static int GetDiariZenSegmentationIntraOpThreads()

--- a/src/Vernacula.Base/Config.cs
+++ b/src/Vernacula.Base/Config.cs
@@ -324,9 +324,19 @@ public static class Config
     {
         string stock = GetSortformerModelPath(modelDir);
         string? dir  = Path.GetDirectoryName(stock);
-        return string.IsNullOrEmpty(dir)
-            ? SortformerCoreMLFile
-            : Path.Combine(dir, SortformerCoreMLFile);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            string beside = Path.Combine(dir, SortformerCoreMLFile);
+            if (File.Exists(beside))
+                return beside;
+        }
+
+        // ⚠ BESIDE THE STOCK MODEL IS NOT ENOUGH. GetSortformerModelPath prefers
+        // <modelDir>/sortformer/, but the HuggingFace bundle publishes the variant at the
+        // repo ROOT -- so someone who pulls the whole repo into a layout with the
+        // subdirectory resolves the stock model from there and would never find the
+        // variant beside it. Fall back to the root before giving up.
+        return Path.Combine(modelDir, SortformerCoreMLFile);
     }
 
     public static int GetDiariZenSegmentationIntraOpThreads()

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -26,6 +26,27 @@ public sealed class SortformerStreamer : IDisposable
 {
     private readonly InferenceSession _session;
 
+    /// <summary>
+    /// The CoreML steady-state graph, or null when it is not in use. See
+    /// <see cref="UsesSteadyStateGraph"/> for when it is loaded and
+    /// <see cref="ProcessChunk"/> for which chunks it is allowed to see.
+    /// </summary>
+    private readonly InferenceSession? _steadySession;
+
+    /// <summary>
+    /// True when the CoreML steady-state graph is loaded alongside the stock one.
+    /// Both stay resident (~1 GB combined), which is the cost of the ~3.3x chunk
+    /// speedup on the Apple Neural Engine.
+    /// </summary>
+    public bool UsesSteadyStateGraph => _steadySession is not null;
+
+    /// <summary>Chunks sent to the steady-state graph since the last <see cref="ResetState"/>.</summary>
+    public int SteadyStateChunkCount { get; private set; }
+
+    /// <summary>Chunks sent to the stock graph since the last <see cref="ResetState"/> --
+    /// warm-up, the short tail chunk, and everything when the variant is not loaded.</summary>
+    public int StockChunkCount { get; private set; }
+
     // ── Reusable buffers for chunk processing (eliminates per-chunk allocations) ──
     private float[]? _chunkDataBuffer;
     private float[]? _predsFlatBuffer;
@@ -59,14 +80,26 @@ public sealed class SortformerStreamer : IDisposable
     {
         var opts = new SessionOptions();
 
+        // ⚠ THE STOCK GRAPH CAN NEVER RUN ON THE CoreML EP. It slices by tensor value, so
+        // every downstream shape is data-dependent, and CoreML's MIL runtime rejects
+        // unbounded dimensions outright -- session creation throws
+        // "Failed to create MLModel ... error code: -14" rather than falling back. That
+        // incompatibility is the entire reason the steady-state variant exists.
+        //
+        // So asking this class for CoreML means "use the CoreML variant where it is valid",
+        // and the stock graph it falls back to for warm-up and the tail chunk has to run
+        // somewhere else. Auto picks the best remaining provider (WebGPU on macOS, else CPU)
+        // and never throws.
+        ExecutionProvider stockEp = ep == ExecutionProvider.CoreML ? ExecutionProvider.Auto : ep;
+
         // CoreML / WebGpu / macOS-Auto are handled centrally -- this class is the one
         // ORT call site #164 did not route through the shared helper, so until now
         // ExecutionProvider.CoreML and .WebGpu fell through the switch below with no
         // matching case and Auto appended nothing on macOS, silently running every
         // diarization on the CPU EP. See OrtSessionBuilder.TryAppendPlatformAccelerator.
-        if (!OrtSessionBuilder.TryAppendPlatformAccelerator(opts, ep))
+        if (!OrtSessionBuilder.TryAppendPlatformAccelerator(opts, stockEp))
         {
-            switch (ep)
+            switch (stockEp)
             {
                 case ExecutionProvider.Auto:
                     if (HardwareInfo.CanProbeCudaExecutionProvider())
@@ -105,7 +138,54 @@ public sealed class SortformerStreamer : IDisposable
         opts.OptimizedModelFilePath = OptimisedModelPath;
 
         _session = new InferenceSession(resolvedModelPath, opts);
+        _steadySession = TryOpenSteadyStateSession(modelPath, ep);
         ResetState();
+    }
+
+    /// <summary>
+    /// Opens the CoreML steady-state graph, or returns null to run stock-only.
+    /// </summary>
+    /// <remarks>
+    /// Gated on <see cref="ExecutionProvider.CoreML"/> being asked for explicitly. The
+    /// variant is only worth its second resident session on the Neural Engine (51.5 ms vs
+    /// 171.8 ms for the stock graph on CPU, M5 / ORT 1.29.0); on any other provider it
+    /// buys ~10% for another ~527 MB, which is not a trade to make silently. Auto does not
+    /// select it for the same reason `OrtSessionBuilder` leaves CoreML explicit: whether
+    /// CoreML beats the alternatives is a per-model property.
+    ///
+    /// ⚠ Two things here are load-bearing:
+    /// <list type="bullet">
+    /// <item><c>ORT_ENABLE_BASIC</c> -- the file is already an optimized graph, and
+    /// re-optimizing one at EXTENDED or above throws `AddInitializedOrtValue Attempt to
+    /// replace the existing tensor` (`MatMulAddFusion`). The CoreML EP hides this by
+    /// claiming the whole graph before the CPU fusions run, so it only surfaces on a
+    /// fallback to CPU -- which is exactly what happens when CoreML declines.</item>
+    /// <item>No <c>OptimizedModelFilePath</c> -- the stock session writes one, and pointing
+    /// both at the same file would have them overwrite each other. Re-saving an already
+    /// optimized graph is also the round-trip that causes the throw above.</item>
+    /// </list>
+    /// A failure to open is not fatal: the stock graph handles every chunk on its own.
+    /// </remarks>
+    private static InferenceSession? TryOpenSteadyStateSession(string modelPath, ExecutionProvider ep)
+    {
+        if (ep != ExecutionProvider.CoreML)
+            return null;
+
+        string path = Config.GetSortformerCoreMLModelPath(modelPath);
+        if (!File.Exists(path))
+            return null;
+
+        try
+        {
+            var opts = OrtSessionBuilder.Create(ep, GraphOptimizationLevel.ORT_ENABLE_BASIC);
+            return new InferenceSession(path, opts);
+        }
+        catch
+        {
+            // Missing provider, a graph this ORT will not take, anything: fall back to
+            // stock-only rather than failing diarization outright.
+            return null;
+        }
     }
 
     /// <summary>
@@ -120,6 +200,8 @@ public sealed class SortformerStreamer : IDisposable
         _fifoPreds     = new float[1, 0, Config.NumSpeakers];
         _meanSilEmb    = new float[Config.EmbeddingDimension];
         _nSilFrames    = 0;
+        SteadyStateChunkCount = 0;
+        StockChunkCount       = 0;
 
         // Clear reusable buffers so they reallocate to the right size for the new run
         _chunkDataBuffer = null;
@@ -363,26 +445,53 @@ public sealed class SortformerStreamer : IDisposable
         int cacheT = spkcache.GetLength(1);
         int fifoT  = fifo.GetLength(1);
 
-        var inputs = new List<NamedOnnxValue>
+        // ── Which graph gets this chunk ──────────────────────────────────────
+        // The steady-state graph has all three *_lengths baked in as constants, so it is
+        // correct ONLY when the real lengths equal the baked ones. Two cases fail that:
+        //
+        //   * the LAST chunk of every recording, where `currentLen` is short. Its
+        //     zero-padded tail would be attended to as real audio, moving that chunk's
+        //     speaker probabilities by up to 0.54 (rms 0.24) on a 0..1 scale -- enough to
+        //     flip speaker assignments outright. This is the whole reason for the routing.
+        //   * WARM-UP, where the cache and FIFO have not filled yet. ResetState starts
+        //     both at length 0 and they grow, so the fixed [1,188,512] / [1,124,512]
+        //     inputs do not even match until steady state is reached.
+        //
+        // Anything that is not exactly steady state goes to the stock graph.
+        bool steadyState =
+            _steadySession is not null
+            && currentLen == chunkStride
+            && chunkStride == Config.ChunkLength * Config.Subsampling
+            && cacheT == Config.SpeakerCacheLength
+            && fifoT == Config.FifoLength;
+
+        var inputs = new List<NamedOnnxValue>(steadyState ? 3 : 6)
         {
             NamedOnnxValue.CreateFromTensor("chunk",
                 new DenseTensor<float>(chunkData,
                     new[] { 1, chunkStride, Config.NMels })),
-            NamedOnnxValue.CreateFromTensor("chunk_lengths",
-                new DenseTensor<long>(new long[] { currentLen }, new[] { 1 })),
             NamedOnnxValue.CreateFromTensor("spkcache",
                 new DenseTensor<float>(Flatten3D(spkcache, 1, cacheT, D),
                     new[] { 1, cacheT, D })),
-            NamedOnnxValue.CreateFromTensor("spkcache_lengths",
-                new DenseTensor<long>(new long[] { cacheT }, new[] { 1 })),
             NamedOnnxValue.CreateFromTensor("fifo",
                 new DenseTensor<float>(Flatten3D(fifo, 1, fifoT, D),
                     new[] { 1, fifoT, D })),
-            NamedOnnxValue.CreateFromTensor("fifo_lengths",
-                new DenseTensor<long>(new long[] { fifoT }, new[] { 1 })),
         };
+        if (!steadyState)
+        {
+            // The steady-state graph does not declare these -- they were folded out of its
+            // signature when they became constants, so passing them would be an error.
+            inputs.Add(NamedOnnxValue.CreateFromTensor("chunk_lengths",
+                new DenseTensor<long>(new long[] { currentLen }, new[] { 1 })));
+            inputs.Add(NamedOnnxValue.CreateFromTensor("spkcache_lengths",
+                new DenseTensor<long>(new long[] { cacheT }, new[] { 1 })));
+            inputs.Add(NamedOnnxValue.CreateFromTensor("fifo_lengths",
+                new DenseTensor<long>(new long[] { fifoT }, new[] { 1 })));
+        }
 
-        using var results = _session.Run(inputs);
+        if (steadyState) SteadyStateChunkCount++; else StockChunkCount++;
+
+        using var results = (steadyState ? _steadySession! : _session).Run(inputs);
         var predsT = results.First(r => r.Name == "spkcache_fifo_chunk_preds").AsTensor<float>();
         var embsT  = results.First(r => r.Name == "chunk_pre_encode_embs").AsTensor<float>();
 
@@ -818,5 +927,9 @@ public sealed class SortformerStreamer : IDisposable
 
     // ── IDisposable ───────────────────────────────────────────────────────────
 
-    public void Dispose() => _session.Dispose();
+    public void Dispose()
+    {
+        _session.Dispose();
+        _steadySession?.Dispose();
+    }
 }

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -1,5 +1,6 @@
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
+using Vernacula.Base.Inference;
 using Vernacula.Base.Models;
 
 // ── Buffer pooling for median filter ──────────────────────────────────────────
@@ -57,27 +58,36 @@ public sealed class SortformerStreamer : IDisposable
     public SortformerStreamer(string modelPath, ExecutionProvider ep = ExecutionProvider.Auto)
     {
         var opts = new SessionOptions();
-        switch (ep)
+
+        // CoreML / WebGpu / macOS-Auto are handled centrally -- this class is the one
+        // ORT call site #164 did not route through the shared helper, so until now
+        // ExecutionProvider.CoreML and .WebGpu fell through the switch below with no
+        // matching case and Auto appended nothing on macOS, silently running every
+        // diarization on the CPU EP. See OrtSessionBuilder.TryAppendPlatformAccelerator.
+        if (!OrtSessionBuilder.TryAppendPlatformAccelerator(opts, ep))
         {
-            case ExecutionProvider.Auto:
-                if (HardwareInfo.CanProbeCudaExecutionProvider())
-                {
-                    try { opts.AppendExecutionProvider_CUDA(0); } catch { }
-                }
-                try { opts.AppendExecutionProvider_DML(0);  } catch { }
-                break;
-            case ExecutionProvider.Cuda:
-                try { opts.AppendExecutionProvider_CUDA(0); }
-                catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
-                break;
-            case ExecutionProvider.DirectML:
-                try { opts.AppendExecutionProvider_DML(0); }
-                catch (EntryPointNotFoundException)
-                { throw new InvalidOperationException("DirectML EP not available. Build with -p:EP=DirectML (Windows only)."); }
-                break;
-            case ExecutionProvider.Cpu:
-                break;
+            switch (ep)
+            {
+                case ExecutionProvider.Auto:
+                    if (HardwareInfo.CanProbeCudaExecutionProvider())
+                    {
+                        try { opts.AppendExecutionProvider_CUDA(0); } catch { }
+                    }
+                    try { opts.AppendExecutionProvider_DML(0);  } catch { }
+                    break;
+                case ExecutionProvider.Cuda:
+                    try { opts.AppendExecutionProvider_CUDA(0); }
+                    catch (EntryPointNotFoundException)
+                    { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
+                    break;
+                case ExecutionProvider.DirectML:
+                    try { opts.AppendExecutionProvider_DML(0); }
+                    catch (EntryPointNotFoundException)
+                    { throw new InvalidOperationException("DirectML EP not available. Build with -p:EP=DirectML (Windows only)."); }
+                    break;
+                case ExecutionProvider.Cpu:
+                    break;
+            }
         }
 
         string resolvedModelPath = Config.GetSortformerModelPath(modelPath);

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -175,17 +175,63 @@ public sealed class SortformerStreamer : IDisposable
         if (!File.Exists(path))
             return null;
 
+        InferenceSession? sess = null;
         try
         {
             var opts = OrtSessionBuilder.Create(ep, GraphOptimizationLevel.ORT_ENABLE_BASIC);
-            return new InferenceSession(path, opts);
+            sess = new InferenceSession(path, opts);
+
+            // ⚠ THE FILENAME IS NOT THE CONTRACT. An export made before
+            // --coreml-const-chunk-length existed lands at this exact path with FOUR
+            // inputs (chunk_lengths still live), and one made with different
+            // --fixed-*-frames has the wrong fixed dims. Both load fine and then throw
+            // out of ProcessChunk on the first steady chunk -- turning a graceful
+            // fall-back into a failed run. Check the signature, not the name.
+            if (!SignatureMatchesSteadyStateContract(sess))
+            {
+                sess.Dispose();
+                return null;
+            }
+            return sess;
         }
         catch
         {
             // Missing provider, a graph this ORT will not take, anything: fall back to
             // stock-only rather than failing diarization outright.
+            sess?.Dispose();
             return null;
         }
+    }
+
+    /// <summary>
+    /// Whether a candidate graph is the steady-state variant this class knows how to feed:
+    /// exactly the three tensors <see cref="ProcessChunk"/> sends, at exactly the shapes it
+    /// sends them, with every <c>*_lengths</c> input folded away.
+    /// </summary>
+    private static bool SignatureMatchesSteadyStateContract(InferenceSession sess)
+    {
+        var expected = new (string Name, int[] Dims)[]
+        {
+            ("chunk",    new[] { 1, Config.ChunkLength * Config.Subsampling, Config.NMels }),
+            ("spkcache", new[] { 1, Config.SpeakerCacheLength,               Config.EmbeddingDimension }),
+            ("fifo",     new[] { 1, Config.FifoLength,                       Config.EmbeddingDimension }),
+        };
+
+        var meta = sess.InputMetadata;
+        if (meta.Count != expected.Length)
+            return false;
+
+        foreach (var (name, dims) in expected)
+        {
+            if (!meta.TryGetValue(name, out var m))
+                return false;
+            if (m.Dimensions.Length != dims.Length)
+                return false;
+            for (int i = 0; i < dims.Length; i++)
+                if (m.Dimensions[i] != dims[i])   // a dynamic axis is negative here, so it fails too
+                    return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -458,6 +504,15 @@ public sealed class SortformerStreamer : IDisposable
         //     inputs do not even match until steady state is reached.
         //
         // Anything that is not exactly steady state goes to the stock graph.
+        //
+        // ⚠ In practice this fires on only every OTHER chunk, not on all of them after
+        // warm-up. The FIFO pop below clamps popLen to the whole FIFO -- it computes
+        // (newFifoT - FifoLength) + newFifoT, which always exceeds newFifoT -- so _fifo
+        // is drained to 0 on every pop and fifoT alternates 124, 0, 124, 0. The measured
+        // routing over a 5-minute file is "...S.S.S.S..." Correct, but it leaves roughly
+        // half the available speedup on the table. That formula predates this change and
+        // altering it would move diarization output for every backend, so it is tracked
+        // separately rather than fixed here.
         bool steadyState =
             _steadySession is not null
             && currentLen == chunkStride

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -11,6 +11,7 @@ using ParakeetAsr = Vernacula.Base.Parakeet;
 string? audioPath       = null;
 string? modelDir        = null;         // legacy --model: a models ROOT, or a flat Parakeet bundle
 string? modelsDirFlag   = null;         // --models-dir: the models root, as the desktop app means it
+string? epFlag          = null;         // --ep: execution provider for diarization (#165)
 string? outputPath      = null;
 string? segmentsPath    = null;
 string  exportFormat    = "md";
@@ -55,6 +56,7 @@ for (int i = 0; i < args.Length; i++)
         case "--audio":         audioPath    = args[++i]; break;
         case "--model":         modelDir     = args[++i]; break;
         case "--models-dir":    modelsDirFlag = args[++i]; break;
+        case "--ep":            epFlag       = args[++i].ToLowerInvariant(); break;
         case "--output":        outputPath   = args[++i]; break;
         case "--segments":      segmentsPath = args[++i]; break;
         case "--export-format": exportFormat = args[++i].ToLowerInvariant(); break;
@@ -223,6 +225,27 @@ if (audioPath is null)
 diarization ??= asrBackend is "vibevoice" or "vibevoice-streaming" ? "vibevoice-asr-builtin" : "sortformer";
 
 // Validate that vibevoice-asr-builtin is only used with vibevoice ASR
+// --ep, resolved once. Diarization is the only consumer today; the ASR backends still
+// take Auto (#165 item 1 asks for the flag, this is the diarization half of it).
+ExecutionProvider diarizationEp = ExecutionProvider.Auto;
+if (epFlag is not null)
+{
+    switch (epFlag)
+    {
+        case "auto":   diarizationEp = ExecutionProvider.Auto;      break;
+        case "cpu":    diarizationEp = ExecutionProvider.Cpu;       break;
+        case "cuda":   diarizationEp = ExecutionProvider.Cuda;      break;
+        // macOS accelerators. Both need an osx-arm64 build (-p:EP=Cpu); the plain package
+        // is the one whose native carries them. coreml additionally opts Sortformer into
+        // the steady-state variant when that file is present beside the stock model.
+        case "coreml": diarizationEp = ExecutionProvider.CoreML;    break;
+        case "webgpu": diarizationEp = ExecutionProvider.WebGpu;    break;
+        default:
+            Console.Error.WriteLine($"--ep must be auto, cpu, cuda, coreml or webgpu (got \"{epFlag}\").");
+            return 2;
+    }
+}
+
 if (diarization == "vibevoice-asr-builtin" && asrBackend is not ("vibevoice" or "vibevoice-streaming"))
 {
     Console.Error.WriteLine("Error: --diarization vibevoice-asr-builtin requires --asr vibevoice or vibevoice-streaming.");
@@ -406,7 +429,7 @@ try
 
             var sw1 = Stopwatch.StartNew();
             Console.Write("Loading Sortformer model... ");
-            using var sortformer = new SortformerStreamer(modelsRoot);
+            using var sortformer = new SortformerStreamer(modelsRoot, diarizationEp);
             Console.WriteLine($"DONE ({sw1.ElapsedMilliseconds,6} ms)");
 
             var sw2 = Stopwatch.StartNew();
@@ -459,7 +482,7 @@ try
         else
         {
             Console.Write("Diarizing (Sortformer)... ");
-            using var sortformer = new SortformerStreamer(modelsRoot);
+            using var sortformer = new SortformerStreamer(modelsRoot, diarizationEp);
             segs = sortformer.Diarize(audio,
                 (idx, total) => Console.Write($"\r  Diarizing chunk {idx}/{total}..."));
             swDiar.Stop();
@@ -1348,6 +1371,8 @@ static void PrintUsage()
     Console.WriteLine("  --output <path>                    Override output file path");
     Console.WriteLine("  --diarization <backend>            Diarization backend: sortformer, diarizen, vad, vibevoice-asr-builtin");
     Console.WriteLine("                                     (default: sortformer, or vibevoice-asr-builtin when --asr vibevoice)");
+    Console.WriteLine("  --ep <provider>                    Execution provider for diarization: auto, cpu, cuda, coreml, webgpu");
+    Console.WriteLine("                                     coreml uses the steady-state Sortformer variant when present (macOS, arm64)");
     Console.WriteLine("  --vad                              Use VAD instead of diarization (deprecated)");
     Console.WriteLine("  --asr <parakeet|cohere|qwen3asr|vibevoice|vibevoice-streaming|whisper|granite>");
     Console.WriteLine("                                     ASR backend (default: parakeet)");

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -224,7 +224,6 @@ if (audioPath is null)
 // Resolve diarization default based on ASR backend
 diarization ??= asrBackend is "vibevoice" or "vibevoice-streaming" ? "vibevoice-asr-builtin" : "sortformer";
 
-// Validate that vibevoice-asr-builtin is only used with vibevoice ASR
 // --ep, resolved once. Diarization is the only consumer today; the ASR backends still
 // take Auto (#165 item 1 asks for the flag, this is the diarization half of it).
 ExecutionProvider diarizationEp = ExecutionProvider.Auto;
@@ -246,6 +245,7 @@ if (epFlag is not null)
     }
 }
 
+// Validate that vibevoice-asr-builtin is only used with vibevoice ASR
 if (diarization == "vibevoice-asr-builtin" && asrBackend is not ("vibevoice" or "vibevoice-streaming"))
 {
     Console.Error.WriteLine("Error: --diarization vibevoice-asr-builtin requires --asr vibevoice or vibevoice-streaming.");

--- a/tests/SortformerRouteCheck/Program.cs
+++ b/tests/SortformerRouteCheck/Program.cs
@@ -21,7 +21,9 @@
 using Vernacula.Base;
 using Vernacula.Base.Models;
 
-string modelsRoot = Path.Combine(
+// Optional arg: models root (default ~/models). Used to point at a deliberately
+// mismatched variant when checking that the signature guard rejects it.
+string modelsRoot = args.Length > 0 ? args[0] : Path.Combine(
     Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "models");
 
 // ~5 minutes of structured synthetic audio: alternating tone pairs over noise, so the
@@ -48,6 +50,7 @@ var mel = AudioUtils.LogMelSpectrogram(audio);
     sload.Stop();
     var (totalFrames, chunkStride, numChunks) = s.GetPredParams(mel);
     var all = new List<float[,]>();
+    var pattern  = new System.Text.StringBuilder();
     var steadyMs = new List<double>();
     var stockMs  = new List<double>();
     int prevSteady = 0;
@@ -55,7 +58,9 @@ var mel = AudioUtils.LogMelSpectrogram(audio);
     foreach (var (_, idx, p) in s.GetPreds(mel, totalFrames, chunkStride, numChunks))
     {
         double el = sw.Elapsed.TotalMilliseconds;
-        (s.SteadyStateChunkCount > prevSteady ? steadyMs : stockMs).Add(el);
+        bool wasSteady = s.SteadyStateChunkCount > prevSteady;
+        (wasSteady ? steadyMs : stockMs).Add(el);
+        pattern.Append(wasSteady ? 'S' : '.');
         prevSteady = s.SteadyStateChunkCount;
         sw.Restart();
         all.Add(p);
@@ -63,6 +68,7 @@ var mel = AudioUtils.LogMelSpectrogram(audio);
     static double Med(List<double> v)
     { if (v.Count == 0) return 0; var c = new List<double>(v); c.Sort(); return c[c.Count / 2]; }
     Console.WriteLine($"   load {sload.Elapsed.TotalSeconds:F2} s | per-chunk median: steady {Med(steadyMs):F1} ms, stock {Med(stockMs):F1} ms");
+    Console.WriteLine($"   routing (S=steady . =stock): {pattern}");
     return (all, s.SteadyStateChunkCount, s.StockChunkCount, s.UsesSteadyStateGraph,
             steadyMs.Sum() + stockMs.Sum());
 }

--- a/tests/SortformerRouteCheck/Program.cs
+++ b/tests/SortformerRouteCheck/Program.cs
@@ -1,0 +1,102 @@
+// Sortformer CoreML steady-state routing check (#162).
+//
+// Proves two things about SortformerStreamer's dual-graph routing, end to end over a
+// full streaming run rather than a single chunk:
+//
+//   1. the routing engages at all (steady-state chunk count > 0), and
+//   2. routing through the CoreML variant gives the same answer as the stock graph
+//      alone, after 30-odd chunks of accumulating spkcache/FIFO state.
+//
+// A single-chunk parity check cannot show (2): the risk in this design is that a
+// mis-routed chunk corrupts the streaming state and the error compounds silently.
+//
+// MANUAL TOOL -- not in Vernacula.slnx and not run by CI, like the other tests/*Smoke
+// harnesses. It needs both model files present in ~/models:
+//
+//   diar_streaming_sortformer_4spk-v2.1.onnx          (stock, required)
+//   diar_streaming_sortformer_4spk-v2.1.coreml.onnx   (variant, else the CoreML run is a no-op)
+//
+// Run:  dotnet run --project tests/SortformerRouteCheck -p:EP=Cpu
+
+using Vernacula.Base;
+using Vernacula.Base.Models;
+
+string modelsRoot = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "models");
+
+// ~5 minutes of structured synthetic audio: alternating tone pairs over noise, so the
+// diarizer sees changing content rather than stationary hiss. Identical for both runs.
+const int sr = 16000, seconds = 300;
+var audio = new float[sr * seconds];
+var rng = new Random(7);
+for (int i = 0; i < audio.Length; i++)
+{
+    double t = (double)i / sr;
+    int spk = ((int)(t / 3.7)) % 2;               // switch "speaker" every 3.7 s
+    double f = spk == 0 ? 180.0 : 320.0;
+    audio[i] = (float)(0.35 * Math.Sin(2 * Math.PI * f * t)
+                     + 0.15 * Math.Sin(2 * Math.PI * f * 2.5 * t)
+                     + 0.02 * (rng.NextDouble() - 0.5));
+}
+
+var mel = AudioUtils.LogMelSpectrogram(audio);
+
+(List<float[,]> preds, int steady, int stock, bool loaded, double ms) Run(ExecutionProvider ep)
+{
+    var sload = System.Diagnostics.Stopwatch.StartNew();
+    using var s = new SortformerStreamer(modelsRoot, ep);
+    sload.Stop();
+    var (totalFrames, chunkStride, numChunks) = s.GetPredParams(mel);
+    var all = new List<float[,]>();
+    var steadyMs = new List<double>();
+    var stockMs  = new List<double>();
+    int prevSteady = 0;
+    var sw = System.Diagnostics.Stopwatch.StartNew();
+    foreach (var (_, idx, p) in s.GetPreds(mel, totalFrames, chunkStride, numChunks))
+    {
+        double el = sw.Elapsed.TotalMilliseconds;
+        (s.SteadyStateChunkCount > prevSteady ? steadyMs : stockMs).Add(el);
+        prevSteady = s.SteadyStateChunkCount;
+        sw.Restart();
+        all.Add(p);
+    }
+    static double Med(List<double> v)
+    { if (v.Count == 0) return 0; var c = new List<double>(v); c.Sort(); return c[c.Count / 2]; }
+    Console.WriteLine($"   load {sload.Elapsed.TotalSeconds:F2} s | per-chunk median: steady {Med(steadyMs):F1} ms, stock {Med(stockMs):F1} ms");
+    return (all, s.SteadyStateChunkCount, s.StockChunkCount, s.UsesSteadyStateGraph,
+            steadyMs.Sum() + stockMs.Sum());
+}
+
+var base_ = Run(ExecutionProvider.Cpu);
+Console.WriteLine($"stock-only (Cpu)   : variantLoaded={base_.loaded,-5} steady={base_.steady,-3} stock={base_.stock,-3} chunks={base_.preds.Count} {base_.ms:F0} ms");
+
+var auto = Run(ExecutionProvider.Auto);
+Console.WriteLine($"stock-only (Auto)  : variantLoaded={auto.loaded,-5} steady={auto.steady,-3} stock={auto.stock,-3} chunks={auto.preds.Count} {auto.ms:F0} ms");
+
+var routed = Run(ExecutionProvider.CoreML);
+Console.WriteLine($"routed (CoreML)    : variantLoaded={routed.loaded,-5} steady={routed.steady,-3} stock={routed.stock,-3} chunks={routed.preds.Count} {routed.ms:F0} ms");
+
+if (!routed.loaded) { Console.WriteLine("\n!! variant not loaded -- routing never exercised"); return 1; }
+if (routed.steady == 0) { Console.WriteLine("\n!! steady-state graph never used"); return 1; }
+
+if (base_.preds.Count != routed.preds.Count)
+{ Console.WriteLine($"\n!! chunk count differs: {base_.preds.Count} vs {routed.preds.Count}"); return 1; }
+
+double worst = 0; int worstIdx = -1; double sum = 0; long n = 0;
+for (int c = 0; c < base_.preds.Count; c++)
+{
+    var a = base_.preds[c]; var b = routed.preds[c];
+    if (a.GetLength(0) != b.GetLength(0) || a.GetLength(1) != b.GetLength(1))
+    { Console.WriteLine($"\n!! chunk {c} shape {a.GetLength(0)}x{a.GetLength(1)} vs {b.GetLength(0)}x{b.GetLength(1)}"); return 1; }
+    for (int i = 0; i < a.GetLength(0); i++)
+        for (int j = 0; j < a.GetLength(1); j++)
+        {
+            double d = Math.Abs(a[i, j] - b[i, j]);
+            sum += d * d; n++;
+            if (d > worst) { worst = d; worstIdx = c; }
+        }
+}
+Console.WriteLine($"\npreds vs stock-only over {base_.preds.Count} chunks ({n} values)");
+Console.WriteLine($"  maxAbsDiff = {worst:E3}  (chunk {worstIdx})");
+Console.WriteLine($"  rms        = {Math.Sqrt(sum / n):E3}");
+return 0;

--- a/tests/SortformerRouteCheck/SortformerRouteCheck.csproj
+++ b/tests/SortformerRouteCheck/SortformerRouteCheck.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>sortformer-routecheck</AssemblyName>
+    <RootNamespace>SortformerRouteCheck</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Vernacula.Base/Vernacula.Base.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/SortformerRouteCheck/SortformerRouteCheck.csproj
+++ b/tests/SortformerRouteCheck/SortformerRouteCheck.csproj
@@ -1,16 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
     <AssemblyName>sortformer-routecheck</AssemblyName>
-    <RootNamespace>SortformerRouteCheck</RootNamespace>
+    <RootNamespace>Vernacula.Tests.SortformerRouteCheck</RootNamespace>
+    <!-- CPU-only harness: it references the plain ONNX Runtime on purpose, so the
+         Directory.Build.targets guard against the CPU package under a GPU EP does not
+         apply. Without this, `dotnet run` without -p:EP=Cpu trips the guard, because
+         EP defaults to Cuda in Directory.Build.props. -->
+    <AllowCpuOnnxRuntime>true</AllowCpuOnnxRuntime>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="$(OnnxRuntimeVersion)" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="../../src/Vernacula.Base/Vernacula.Base.csproj" />
+    <ProjectReference Include="..\..\src\Vernacula.Base\Vernacula.Base.csproj">
+      <Private>true</Private>
+      <!-- This harness is CPU-only (AllowCpuOnnxRuntime above), so Base must be built for
+           the CPU provider or its GPU native would land here and the build guard in
+           Directory.Build.targets would reject it. -->
+      <SetConfiguration>EP=Cpu</SetConfiguration>
+    </ProjectReference>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Groundwork for #162. Lands the export-side half, which is finished and verifiable on Linux,
and leaves the HuggingFace publish gated on a measurement only the Apple Silicon machine can
make. **Instructions for that side are at the bottom.**

## What went wrong with the pipeline on `main`

#164 landed in two commits, and the second ("fix review findings") made `chunk_lengths` a
live input. The attention padding mask is a function of all three lengths, so with one live
it never folds to a constant:

```
[2/5] removing all-False Where ...        0 removed      <- not 51
[5/5] ... 1914 nodes, inputs=['chunk', 'chunk_lengths', 'spkcache', 'fifo']
```

That is the playbook's 69-partition / 166.0 ms row — level with the CPU EP (163.5 ms), slower
than WebGPU (94.0 ms). The comment left behind says keeping the length live "costs a few
partitions, not correctness". It costs the entire reason for the variant to exist, and both
the playbook and #164's own body still advertise `51 Where removed` / 1 partition / 52.3 ms
against a pipeline that cannot produce them.

## Why the review was right anyway

#162's contract is "steady-state only … the final short chunk needs padding". That is
measurable on the **shipped dynamic model alone**, no graph transform involved:
`Sortformer.cs:330-372` already sends a full-size zero-padded `chunk` and varies only
`chunk_lengths`. So run the same padded input twice, once honest and once baked, and diff
the valid frames.

| `chunk_lengths` | valid frames | `preds[chunk_valid]` maxAbs | rms | `embs` |
|---|---|---|---|---|
| 992 | 124/124 | 0.0000 | 0.0000 | 0.0 |
| 800 | 100/124 | 0.1549 | 0.0626 | 0.0 |
| 400 | 50/124 | 0.2240 | 0.0792 | 0.0 |
| 200 | 25/124 | 0.4863 | 0.1859 | 0.0 |
| 64 | 8/124 | 0.5426 | 0.2364 | 0.0 |

`preds` are per-speaker probabilities on 0..1, so baking flips speaker assignments at the end
of every recording. Not a tolerance question. (`embs` is untouched — `pre_encode` is a
convolution and never sees the mask; the damage is all in encoder self-attention.)

## So the fix is a contract, not a default

`--coreml-const-chunk-length` is opt-in, requires `--coreml-const-lengths`, and states the
obligation it creates in its `--help`, in the wrapper comment, and in the export report
written beside the artifact: **the steady-state graph must never see the final chunk of a
recording.** A caller routes that one chunk to the unspecialized graph — every other chunk is
full-length, so the output stays exact for the cost of one inference per file.

With all three baked, the pipeline reproduces #162:

```
[2/5] removing all-False Where ...       51 removed
[3/5] rewriting Pad -> Concat ...        34 converted
[4/5] pre-transposing Gemm weights ...  180 converted
[5/5] wrote diar_streaming_sortformer_4spk-v2.1.coreml.onnx (527 MB), 1788 nodes,
      inputs=['chunk', 'spkcache', 'fifo']

spkcache_fifo_chunk_preds   maxAbsDiff = 3.278E-07   (#162 reports 3.576E-07)
```

## Also in here

- **`verify()` could never run against the reference its own docstring and #162's repro
  command name.** It built the feed from the *reference* signature and bailed on any dynamic
  dimension, so the shipped dynamic model was the one reference it rejected. It now takes
  shapes from `--input` and synthesizes by name over the union of both signatures — needed
  because the baked lengths are gone from `--input`'s signature too.
- **The finished file does not load above `ORT_ENABLE_BASIC`**
  (`AddInitializedOrtValue Attempt to replace the existing tensor`). The playbook already
  warned about re-optimizing an optimized graph; bisecting with `disabled_optimizers` names
  the pass — `MatMulAddFusion` — and clears the four transforms: a BASIC-folded graph with
  *none* of them applied fails identically. BASIC is the right level regardless (EXTENDED
  also shatters partitioning, 69 → 191), but `OrtSessionBuilder.Create` defaults to
  `ORT_ENABLE_ALL`, so it is a contract term now rather than a tuning note.
- **`coreml_partition_probe.py`**, so the Apple Silicon measurements are one command instead
  of an ad-hoc script each time. Captures the partition count by redirecting fd 2, since ORT
  emits it from the native library.
- Docs corrected to describe this pipeline rather than the pre-review one.

## ⚠ What blocks the publish

`Directory.Build.props:21-24` pins ORT 1.24.4 **only for DirectML**. An Apple Silicon build is
`-p:EP=Cpu` (per #164 — the plain `osx-arm64` package is the one carrying the CoreML and
WebGPU natives), so it takes the default: **1.29.0**. Every CoreML number in #162, #164 and
the playbook was measured on **1.24.4**, and #162's own caveat says what 1.29.0 does to this
graph: **194 partitions, diverging at ~1e-2**.

The variant's entire benefit is therefore measured on a runtime no user of the shipped build
is holding, and the one data point we have on the runtime they *do* hold says the benefit is
absent and the outputs are wrong. Publishing 527 MB on that basis would advertise a speedup
nobody receives, so the HF upload and the `manifest.json` entry are deliberately **not** in
this PR.

---

## Instructions for the Apple Silicon side

Prereqs: this branch checked out, and the artifact. Either copy the Linux build
(526,897,914 B, md5 `94cc7392ea9358e22b479fac146e9595`) or rebuild it locally:

```bash
python scripts/nemo_export/export_sortformer_nemo_to_onnx.py \
  --nemo ~/models/diar_streaming_sortformer_4spk-v2.1.nemo \
  --output ~/models/sortformer_coreml.onnx --opset 17 \
  --coreml-static-batch1 --coreml-const-lengths --coreml-const-chunk-length \
  --chunk-frames 992 --fixed-spkcache-frames 188 --fixed-fifo-frames 124 --overwrite

python scripts/nemo_export/coreml_optimize_sortformer.py \
  --input  ~/models/sortformer_coreml.onnx \
  --output ~/models/diar_streaming_sortformer_4spk-v2.1.coreml.onnx \
  --verify --reference ~/models/diar_streaming_sortformer_4spk-v2.1.onnx
```

Expect `51 removed / 34 converted / 180 converted`, three inputs, and `PARITY: PASS`. If the
`Where` count is not 51, the third flag did not take.

### Step 1 — the go/no-go: does it work on the ORT the app ships?

```bash
pip install --force-reinstall onnxruntime==1.29.0

python scripts/nemo_export/coreml_partition_probe.py \
  --model ~/models/diar_streaming_sortformer_4spk-v2.1.coreml.onnx \
  --ep coreml --cache-dir ~/.cache/vernacula-coreml \
  --reference ~/models/diar_streaming_sortformer_4spk-v2.1.onnx
```

Then the two baselines on the same ORT, for a like-for-like comparison:

```bash
python scripts/nemo_export/coreml_partition_probe.py --model ~/models/diar_streaming_sortformer_4spk-v2.1.coreml.onnx --ep cpu
python scripts/nemo_export/coreml_partition_probe.py --model ~/models/diar_streaming_sortformer_4spk-v2.1.coreml.onnx --ep webgpu
```

What each outcome means:

- **1 partition and diffs ≲1e-4** — the caveat was pessimistic or version-specific; proceed
  to step 3, then publish.
- **194 partitions** — reproduces the caveat. Find what 1.29.0 declines that 1.24.4 accepted:
  re-run with `--verbose` and group the `Node(s) placed on [CPUExecutionProvider]` list by op
  type, same method as playbook Techniques 3–4. Two or three op families repeated per layer
  is the expected shape.
- **Diffs ~1e-2 at a low partition count** — that is a numerics bug, not a partitioning one,
  and it matters more than the speed: `chunk_pre_encode_embs` feeds back into the speaker
  cache and FIFO, so a single-chunk diff understates it. Needs end-to-end DER before anything
  ships.

If 1.29.0 can't be made to behave, the live options are pinning macOS to 1.24.4 the way
DirectML is pinned, or leaving macOS on WebGPU (which #164 already made the `Auto` choice
there) and not shipping the variant at all.

### Step 2 — is a graph folded on the wrong ORT even usable?

```bash
pip install --force-reinstall onnxruntime==1.24.4
python scripts/nemo_export/coreml_partition_probe.py \
  --model ~/models/diar_streaming_sortformer_4spk-v2.1.coreml.onnx \
  --ep coreml --cache-dir ~/.cache/vernacula-coreml-1244 \
  --reference ~/models/diar_streaming_sortformer_4spk-v2.1.onnx
```

`coreml_optimize_sortformer.py` constant-folds through ORT, so the file carries whatever ORT
built it. If the Linux-built file (ORT 1.26.0) does not reach 1 partition here but a
locally-rebuilt one does, then the publishable artifact must be **built on the Mac** and the
Linux box only ever cross-checks numerics. Worth knowing before we pick which file to upload.

### Step 3 — confirm the load-level constraint

```bash
python scripts/nemo_export/coreml_partition_probe.py --model ~/... --ep coreml --opt-level basic
python scripts/nemo_export/coreml_partition_probe.py --model ~/... --ep coreml --opt-level all
```

Expected: BASIC loads, ALL reports `LOAD FAILED`. If BASIC *also* fails on the Mac's ORT, the
artifact needs rebuilding without the ORT fold round-trip and the approach needs rethinking.

### Step 4 — only then, publish

From whichever machine built the file that passed:

```bash
python scripts/make_manifest.py --model-dir <dir> --files diar_streaming_sortformer_4spk-v2.1.coreml.onnx
python scripts/upload_to_hf.py --model-dir <dir> \
  --repo-id christopherthompson81/sortformer_parakeet_onnx --sync-readme
```

⚠ **Extend the published `manifest.json`, do not regenerate it.** The live manifest
deliberately omits `sortformer/…`, both int8 variants and `silero_vad.onnx`; `--all` would
quietly change the set of files `ModelManagerService` validates. The model card in
`scripts/hf_readmes/sortformer_parakeet_onnx/README.md` is already written for the variant and
`--sync-readme` will push it — re-read its measurement table first and correct it to whatever
step 1 actually found.

Then post the numbers into #162 and the run log, and the follow-ups there (the `Sortformer.cs`
variant path, `ModelCacheDirectory` through `OrtSessionBuilder`, macOS model selection) can be
opened knowing the tail-chunk fallback is part of the contract.

Full run log, including the dead ends: `docs/investigations/sortformer_coreml_publish_investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012REYzas6iF1tQXmfRuin6b
