### PR TITLE
sortformer: finish the remaining #165 items (1, 7, 12)

### DIFF
--- a/scripts/nemo_export/benchmark_sortformer_rtf.py
+++ b/scripts/nemo_export/benchmark_sortformer_rtf.py
@@ -232,7 +232,10 @@ class SortformerPipelineBase:
         boost = scale_factor * math.log(0.5)
         total_frames = scores.shape[0]
         for spk in range(scores.shape[1]):
-            order = np.argsort(scores[:, spk])[::-1]
+            # torch.topk keeps the LOWEST indices among ties; argsort()[::-1] reverses
+            # them to the highest. Sort on (-score, index) instead. See Sortformer.cs.
+            col = scores[:, spk]
+            order = sorted(range(len(col)), key=lambda t: (-col[t], t))
             for t_idx in order[: min(n_boost_per_spk, total_frames)]:
                 if not np.isneginf(scores[t_idx, spk]):
                     scores[t_idx, spk] -= boost

--- a/src/Vernacula.Avalonia/App.axaml.cs
+++ b/src/Vernacula.Avalonia/App.axaml.cs
@@ -173,7 +173,10 @@ public partial class App : Application
                 var sortformerDir = Settings.GetSortformerModelsDir();
                 if (Directory.Exists(sortformerDir))
                 {
-                    using var streamer = new SortformerStreamer(sortformerDir);
+                    // Same provider the real transcription will use, or the warm-up
+                    // compiles a graph for a provider nothing goes on to use.
+                    using var streamer = new SortformerStreamer(
+                        sortformerDir, Settings.Current.ResolvedExecutionProvider);
                     streamer.Warmup();
                     Console.WriteLine("[App] Sortformer model warmup complete.");
                 }

--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -63,6 +63,35 @@ public class AppSettings
     public string             IndicConformerLanguage { get; set; } = "hi";
     public PlaybackMode       EditorPlaybackMode  { get; set; } = PlaybackMode.Continuous;
     public string             ModelsDir           { get; set; } = "";
+
+    /// <summary>
+    /// Execution provider for the ASR/diarization models: "", "auto", "cpu", "cuda",
+    /// "coreml" or "webgpu". Empty or unrecognised means Auto.
+    /// </summary>
+    /// <remarks>
+    /// ⚠ NO UI CONTROL YET (#165 item 7). This is honoured when set in settings.json, and
+    /// the CLI has --ep, but the settings window does not expose it -- adding the ComboBox,
+    /// its view-model collection and the save path is the remaining half of that item.
+    ///
+    /// It matters most on macOS: "coreml" is what opts Sortformer into the steady-state
+    /// variant, and Auto deliberately never selects CoreML because whether CoreML beats the
+    /// alternatives is a per-model property.
+    /// </remarks>
+    public string             ExecutionProvider   { get; set; } = "";
+
+    /// <summary>
+    /// <see cref="ExecutionProvider"/> as the enum, falling back to Auto for empty or
+    /// unrecognised values -- a bad settings.json string must not break model loading.
+    /// Accepts the same spellings as the CLI's --ep.
+    /// </summary>
+    public ExecutionProvider ResolvedExecutionProvider => ExecutionProvider?.Trim().ToLowerInvariant() switch
+    {
+        "cpu"    => Vernacula.Base.Models.ExecutionProvider.Cpu,
+        "cuda"   => Vernacula.Base.Models.ExecutionProvider.Cuda,
+        "coreml" => Vernacula.Base.Models.ExecutionProvider.CoreML,
+        "webgpu" => Vernacula.Base.Models.ExecutionProvider.WebGpu,
+        _        => Vernacula.Base.Models.ExecutionProvider.Auto,
+    };
     public string             DiariZenModelsDir   { get; set; } = "";
     public bool               DiariZenNoticeAccepted { get; set; } = false;
 

--- a/src/Vernacula.Avalonia/Services/TranscriptionService.cs
+++ b/src/Vernacula.Avalonia/Services/TranscriptionService.cs
@@ -432,7 +432,7 @@ internal class TranscriptionService
             var (streamer, melSpec, totalFrames, chunkStride, numChunks) =
                 await Task.Run(() =>
                 {
-                    var s = new SortformerStreamer(sortformerModelsDir);
+                    var s = new SortformerStreamer(sortformerModelsDir, _settings.Current.ResolvedExecutionProvider);
                     var m = AudioUtils.LogMelSpectrogram(audio);
                     var p = s.GetPredParams(m);
                     return (s, m, p.totalFrames, p.chunkStride, p.numChunks);

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -412,7 +412,19 @@ public sealed class SortformerStreamer : IDisposable
         {
             var col = new (float score, int t)[T];
             for (int t = 0; t < T; t++) col[t] = (scores[t, s], t);
-            Array.Sort(col, (a, b) => b.score.CompareTo(a.score));
+
+            // NeMo picks which frames to boost with torch.topk(scores, k, dim=1), which on
+            // CPU is deterministic and keeps the LOWEST indices among equal values
+            // (verified: 12 tied values, k=5 -> indices 0..4). Without the same rule the
+            // boosted SET differs whenever scores tie -- and they tie constantly, because
+            // float32 sigmoid saturates to exactly 1.0 above ~16.6 logits, so confident
+            // frames produce bit-identical preds and bit-identical scores. A different
+            // boosted set then changes the final selection.
+            Array.Sort(col, (a, b) =>
+            {
+                int byScore = b.score.CompareTo(a.score);
+                return byScore != 0 ? byScore : a.t.CompareTo(b.t);
+            });
 
             for (int i = 0; i < Math.Min(nBoostPerSpk, T); i++)
             {

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -204,6 +204,26 @@ if (runLid)
     return RunLidAction(audioPath, modelsRoot);
 }
 
+// --ep, resolved once, for every model this CLI loads (#165 item 1).
+ExecutionProvider selectedEp = ExecutionProvider.Auto;
+if (epFlag is not null)
+{
+    switch (epFlag)
+    {
+        case "auto":   selectedEp = ExecutionProvider.Auto;      break;
+        case "cpu":    selectedEp = ExecutionProvider.Cpu;       break;
+        case "cuda":   selectedEp = ExecutionProvider.Cuda;      break;
+        // macOS accelerators. Both need an osx-arm64 build (-p:EP=Cpu); the plain package
+        // is the one whose native carries them. coreml additionally opts Sortformer into
+        // the steady-state variant when that file is present beside the stock model.
+        case "coreml": selectedEp = ExecutionProvider.CoreML;    break;
+        case "webgpu": selectedEp = ExecutionProvider.WebGpu;    break;
+        default:
+            Console.Error.WriteLine($"--ep must be auto, cpu, cuda, coreml or webgpu (got \"{epFlag}\").");
+            return 2;
+    }
+}
+
 if (runWhisperCheck)
 {
     if (audioPath is null)
@@ -211,7 +231,7 @@ if (runWhisperCheck)
         Console.Error.WriteLine("Error: --whisper-check requires --audio <file>.");
         return 1;
     }
-    return RunWhisperCheckAction(audioPath, modelsRoot);
+    return RunWhisperCheckAction(audioPath, modelsRoot, selectedEp);
 }
 
 if (audioPath is null)
@@ -223,27 +243,6 @@ if (audioPath is null)
 
 // Resolve diarization default based on ASR backend
 diarization ??= asrBackend is "vibevoice" or "vibevoice-streaming" ? "vibevoice-asr-builtin" : "sortformer";
-
-// --ep, resolved once. Diarization is the only consumer today; the ASR backends still
-// take Auto (#165 item 1 asks for the flag, this is the diarization half of it).
-ExecutionProvider diarizationEp = ExecutionProvider.Auto;
-if (epFlag is not null)
-{
-    switch (epFlag)
-    {
-        case "auto":   diarizationEp = ExecutionProvider.Auto;      break;
-        case "cpu":    diarizationEp = ExecutionProvider.Cpu;       break;
-        case "cuda":   diarizationEp = ExecutionProvider.Cuda;      break;
-        // macOS accelerators. Both need an osx-arm64 build (-p:EP=Cpu); the plain package
-        // is the one whose native carries them. coreml additionally opts Sortformer into
-        // the steady-state variant when that file is present beside the stock model.
-        case "coreml": diarizationEp = ExecutionProvider.CoreML;    break;
-        case "webgpu": diarizationEp = ExecutionProvider.WebGpu;    break;
-        default:
-            Console.Error.WriteLine($"--ep must be auto, cpu, cuda, coreml or webgpu (got \"{epFlag}\").");
-            return 2;
-    }
-}
 
 // Validate that vibevoice-asr-builtin is only used with vibevoice ASR
 if (diarization == "vibevoice-asr-builtin" && asrBackend is not ("vibevoice" or "vibevoice-streaming"))
@@ -429,7 +428,7 @@ try
 
             var sw1 = Stopwatch.StartNew();
             Console.Write("Loading Sortformer model... ");
-            using var sortformer = new SortformerStreamer(modelsRoot, diarizationEp);
+            using var sortformer = new SortformerStreamer(modelsRoot, selectedEp);
             Console.WriteLine($"DONE ({sw1.ElapsedMilliseconds,6} ms)");
 
             var sw2 = Stopwatch.StartNew();
@@ -482,7 +481,7 @@ try
         else
         {
             Console.Write("Diarizing (Sortformer)... ");
-            using var sortformer = new SortformerStreamer(modelsRoot, diarizationEp);
+            using var sortformer = new SortformerStreamer(modelsRoot, selectedEp);
             segs = sortformer.Diarize(audio,
                 (idx, total) => Console.Write($"\r  Diarizing chunk {idx}/{total}..."));
             swDiar.Stop();
@@ -520,7 +519,7 @@ try
         // In built-in whole-recording mode the encoder is created and disposed
         // inside each Transcribe() call so its VRAM is freed before the long decode.
         bool persistEncoder = diarization != "vibevoice-asr-builtin";
-        using var vibevoice = new VibeVoiceAsr(vibevoiceDir, persistEncoder: persistEncoder,
+        using var vibevoice = new VibeVoiceAsr(vibevoiceDir, ep: selectedEp, persistEncoder: persistEncoder,
             profileOutputDir: profileOutputDir);
 
         if (diarization == "vibevoice-asr-builtin")
@@ -654,7 +653,7 @@ try
             Console.WriteLine($"Hotwords: {hotwords} ({hotwordIds.Length} token(s))");
         }
 
-        using var streaming = new VibeVoiceStreamingAsr(dir);
+        using var streaming = new VibeVoiceStreamingAsr(dir, selectedEp);
         Console.WriteLine($"Transcribing (VibeVoice-ASR-Streaming, {streaming.HopSamples / (double)streaming.SampleRate:F2}s chunks)...");
         // Print each chunk as the model emits it: this backend is meant to produce text while
         // the audio is still arriving, and hiding that until the end would misrepresent it.
@@ -757,7 +756,7 @@ try
             return 1;
         }
 
-        using var granite = new GraniteSpeech(graniteDir);
+        using var granite = new GraniteSpeech(graniteDir, selectedEp);
         int totalSegs = segs.Count;
         int completed = 0;
 
@@ -796,6 +795,7 @@ try
                                     File.Exists(Path.Combine(qwen3AsrDir, Qwen3Asr.DecoderInitBatchedFile)));
             using var qwen3Asr = new Qwen3Asr(
                 qwen3AsrDir,
+                ep: selectedEp,
                 preferBatched: hasBatchedFiles,
                 optimizationLevel: qwen3AsrOrtOptLevel);
             int totalSegs = segs.Count;
@@ -864,7 +864,7 @@ try
             }
         }
 
-        using var whisper = new WhisperTurbo(whisperDir);
+        using var whisper = new WhisperTurbo(whisperDir, selectedEp);
         int totalSegs = segs.Count;
         int completed = 0;
 
@@ -1223,7 +1223,7 @@ static int RunLidAction(string audioPath, string modelsRoot)
 /// the ONNX export loads and produces sensible activations before building
 /// out the decode loop.
 /// </summary>
-static int RunWhisperCheckAction(string audioPath, string modelsRoot)
+static int RunWhisperCheckAction(string audioPath, string modelsRoot, ExecutionProvider selectedEp)
 {
     string whisperDir = Path.Combine(modelsRoot, Config.WhisperTurboSubDir);
 
@@ -1252,7 +1252,7 @@ static int RunWhisperCheckAction(string audioPath, string modelsRoot)
 
     Console.WriteLine($"[whisper-check] loading whisper-turbo from {whisperDir}");
     var swLoad = Stopwatch.StartNew();
-    using var whisper = new WhisperTurbo(whisperDir);
+    using var whisper = new WhisperTurbo(whisperDir, selectedEp);
     swLoad.Stop();
     Console.WriteLine($"[whisper-check] loaded in {swLoad.ElapsedMilliseconds} ms");
 
@@ -1371,7 +1371,7 @@ static void PrintUsage()
     Console.WriteLine("  --output <path>                    Override output file path");
     Console.WriteLine("  --diarization <backend>            Diarization backend: sortformer, diarizen, vad, vibevoice-asr-builtin");
     Console.WriteLine("                                     (default: sortformer, or vibevoice-asr-builtin when --asr vibevoice)");
-    Console.WriteLine("  --ep <provider>                    Execution provider for diarization: auto, cpu, cuda, coreml, webgpu");
+    Console.WriteLine("  --ep <provider>                    Execution provider: auto, cpu, cuda, coreml, webgpu");
     Console.WriteLine("                                     coreml uses the steady-state Sortformer variant when present (macOS, arm64)");
     Console.WriteLine("  --vad                              Use VAD instead of diarization (deprecated)");
     Console.WriteLine("  --asr <parakeet|cohere|qwen3asr|vibevoice|vibevoice-streaming|whisper|granite>");


### PR DESCRIPTION
The rest of #165 in one branch rather than a PR per item.

## Item 1 — `--ep` now reaches every model

The flag only reached diarization. Every ASR backend already accepts an
`ExecutionProvider` — `VibeVoiceAsr`, `VibeVoiceStreamingAsr`, `GraniteSpeech`,
`Qwen3Asr`, `WhisperTurbo` — the CLI just never passed one, so they all ran `Auto`.

Resolution had to move ahead of the `--whisper-check` dispatch, which runs earlier and
calls a static local function that cannot capture the variable; it is threaded in as a
parameter.

## Item 7 — the app honours a provider setting (**half done, deliberately**)

`AppSettings.ExecutionProvider` plus a `ResolvedExecutionProvider` that falls back to
`Auto` on empty or unrecognised values, so a bad `settings.json` cannot break model
loading. `TranscriptionService` and the `App.axaml.cs` warm-up both use it — the warm-up
matters, or it compiles a graph for a provider nothing then uses.

⚠ **No UI control.** The setting works from `settings.json`, but the settings window does
not expose it; the ComboBox, its view-model collection and the save path are the remaining
half. Writing UI I cannot visually verify seemed worse than leaving it explicitly unbuilt,
and the code comment says so.

## Tie-breaking — improved here, tracked in #171

NeMo picks boost targets with `torch.topk`, deterministic on CPU and keeping the **lowest**
indices among ties (verified: 12 tied values, k=5 → 0..4). The port had no tie rule in C#
and `argsort()[::-1]` in Python, which reverses ties to the highest. Fixed in both.

It does not close the divergence — an 85%-saturated fixture still differs from NeMo in
152/188 rows (was 158), unsaturated control 0/188 — and it is **not a CoreML concern**, so
the remainder is now **#171** rather than an item on this issue. Real speech does not reach
that regime: fidelity DER stays 0.000%.

## Item 4 — fp16, still blocked (not in this PR)

`onnxconverter-common` converts the graph in 3 s but produces an invalid model with and
without shape inference: *"Type parameter (T) of Optype (Mul) bound to different types
(tensor(float16) and tensor(float)) in node (/pre_encode/conv/Mul_3)"*. A valid fp16 export
needs `op_block_list` tuning — export work, not a conversion call. The invalid artifact was
deleted rather than left in `~/models`. The DER harness is ready the moment a valid model
exists.

## Item 11 — closed as out of scope

Tier-1 fidelity DER is the standard for this port; replicating an external benchmark inside
our testing is not our job. An `--reference-rttm` mode was written and then reverted rather
than left as unused surface.

53 tests pass; fidelity DER unchanged at 0.000%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WotwAxr2Le2BbimqKJ9ifu