### PR TITLE
feat(macos): detect the CoreML Sortformer variant instead of asking for it (#162, #165 item 7)

### DIFF
--- a/src/Vernacula.Avalonia/Models/AppSettings.cs
+++ b/src/Vernacula.Avalonia/Models/AppSettings.cs
@@ -69,13 +69,11 @@ public class AppSettings
     /// "coreml" or "webgpu". Empty or unrecognised means Auto.
     /// </summary>
     /// <remarks>
-    /// ⚠ NO UI CONTROL YET (#165 item 7). This is honoured when set in settings.json, and
-    /// the CLI has --ep, but the settings window does not expose it -- adding the ComboBox,
-    /// its view-model collection and the save path is the remaining half of that item.
-    ///
-    /// It matters most on macOS: "coreml" is what opts Sortformer into the steady-state
-    /// variant, and Auto deliberately never selects CoreML because whether CoreML beats the
-    /// alternatives is a per-model property.
+    /// No UI control, and by design there no longer needs to be one for the case that
+    /// motivated it: Sortformer's CoreML variant is DETECTED under Auto -- present beside
+    /// the stock model, signature verified -- so a macOS user gets it without choosing
+    /// anything. This setting is the override: "cpu" or "webgpu" opts out, "cuda" forces
+    /// CUDA. settings.json is a reasonable home for an override nobody normally needs.
     /// </remarks>
     public string             ExecutionProvider   { get; set; } = "";
 

--- a/src/Vernacula.Avalonia/Services/ModelManagerService.cs
+++ b/src/Vernacula.Avalonia/Services/ModelManagerService.cs
@@ -75,11 +75,39 @@ internal class ModelManagerService
     private const string WhisperTurboRepoBase =
         "https://huggingface.co/onnx-community/whisper-large-v3-turbo/resolve/main";
 
-    private static readonly ModelAsset[] CoreDiarizationFiles =
-        [
+    private static readonly ModelAsset[] CoreDiarizationFiles = BuildCoreDiarizationFiles();
+
+    /// <summary>
+    /// The diarization assets to fetch. The CoreML Sortformer variant is included ONLY on
+    /// Apple Silicon.
+    /// </summary>
+    /// <remarks>
+    /// It is another ~527 MB, and it is inert anywhere else: it is a CoreML-specific export
+    /// and <see cref="SortformerStreamer"/> only opens it when the CoreML EP is present. On
+    /// Apple Silicon it is worth the download -- 27 of 31 chunks route to it and a 5-minute
+    /// file goes 3709 ms -> 1959 ms.
+    ///
+    /// ⚠ WITHOUT THIS THE VARIANT IS UNREACHABLE IN THE APP. Detection keys on the file
+    /// being present beside the stock model, and nothing else puts it there; publishing it
+    /// to HuggingFace and listing it in manifest.json is not enough on its own.
+    /// </remarks>
+    private static ModelAsset[] BuildCoreDiarizationFiles()
+    {
+        var assets = new List<ModelAsset>
+        {
             new(Path.Combine(Config.SortformerSubDir, Config.SortformerFile), Config.SortformerFile),
             new(Path.Combine(Config.VadSubDir, Config.VadFile), Config.VadFile),
-        ];
+        };
+
+        if (OperatingSystem.IsMacOS() && RuntimeInformation.OSArchitecture == Architecture.Arm64)
+        {
+            assets.Add(new(
+                Path.Combine(Config.SortformerSubDir, Config.SortformerCoreMLFile),
+                Config.SortformerCoreMLFile));
+        }
+
+        return assets.ToArray();
+    }
 
     private static readonly ModelAsset[] DiariZenFiles =
         [

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -61,7 +61,12 @@ public static class OrtSessionBuilder
                 // choice for ANY graph, including the stock dynamic-shape exports
                 // that CoreML cannot compile at all. CoreML is faster once a model
                 // has been through docs/coreml_onnx_playbook.md, but that is a
-                // per-model property, so selecting it is left explicit.
+                // per-model property, so it is not selected for a graph in general.
+                //
+                // A caller that can PROVE the property for its own model may still opt in
+                // under Auto -- see SortformerStreamer, which only uses CoreML for an
+                // artifact whose input signature it has verified. That is evidence, not an
+                // assumption, which is why it does not belong behind a user setting.
                 if (OperatingSystem.IsMacOS())
                 {
                     // Gated on the provider actually being in this build: Auto is what the
@@ -386,6 +391,13 @@ public static class OrtSessionBuilder
           + "arm64 only, and comes from the plain Microsoft.ML.OnnxRuntime package -- build with "
           + "-p:EP=Cpu on Apple Silicon. A Cuda or DirectML build carries no macOS accelerator.");
     }
+
+    /// <summary>
+    /// Whether this ONNX Runtime build carries the CoreML EP. Lets a caller that has its
+    /// own evidence a model suits CoreML -- a validated CoreML-specific artifact, say --
+    /// opt into it under Auto without hard-coding a platform assumption.
+    /// </summary>
+    public static bool CoreMLProviderAvailable => ProviderAvailable(CoreMLProviderName);
 
     private static bool ProviderAvailable(string name)
     {

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -168,7 +168,21 @@ public sealed class SortformerStreamer : IDisposable
     /// </remarks>
     private static InferenceSession? TryOpenSteadyStateSession(string modelPath, ExecutionProvider ep)
     {
-        if (ep != ExecutionProvider.CoreML)
+        // Detected, not configured. CoreML suits a model only when that model has been
+        // built for it, and here that is a checkable fact rather than a preference: the
+        // steady-state artifact sits beside the stock model and either declares the exact
+        // three-input signature this class feeds or it does not. Presence plus
+        // SignatureMatchesSteadyStateContract IS the per-model evidence OrtSessionBuilder's
+        // Auto case declines to assume, so Auto may act on it.
+        //
+        // Asking a user to choose would be asking them to answer a question the artifact
+        // already answers. An explicit --ep still forces the matter either way: Cpu or
+        // WebGpu opts out even when the variant is present.
+        bool wanted = ep == ExecutionProvider.CoreML
+                      || (ep == ExecutionProvider.Auto
+                          && OperatingSystem.IsMacOS()
+                          && OrtSessionBuilder.CoreMLProviderAvailable);
+        if (!wanted)
             return null;
 
         string path = Config.GetSortformerCoreMLModelPath(modelPath);
@@ -178,8 +192,11 @@ public sealed class SortformerStreamer : IDisposable
         InferenceSession? sess = null;
         try
         {
+            // Always CoreML here, never the caller's `ep`: under Auto that would build a
+            // WebGPU session for a graph exported specifically for CoreML.
             var opts = OrtSessionBuilder.Create(
-                ep, GraphOptimizationLevel.ORT_ENABLE_BASIC, coreMlModelPath: path);
+                ExecutionProvider.CoreML, GraphOptimizationLevel.ORT_ENABLE_BASIC,
+                coreMlModelPath: path);
             sess = new InferenceSession(path, opts);
 
             // ⚠ THE FILENAME IS NOT THE CONTRACT. An export made before

--- a/src/Vernacula.Base/Sortformer.cs
+++ b/src/Vernacula.Base/Sortformer.cs
@@ -31,7 +31,13 @@ public sealed class SortformerStreamer : IDisposable
     /// <see cref="UsesSteadyStateGraph"/> for when it is loaded and
     /// <see cref="ProcessChunk"/> for which chunks it is allowed to see.
     /// </summary>
-    private readonly InferenceSession? _steadySession;
+    private InferenceSession? _steadySession;
+
+    /// <summary>Set once the first open has been attempted, successfully or not.</summary>
+    private bool _steadySessionAttempted;
+
+    private readonly string _modelPath;
+    private readonly ExecutionProvider _ep;
 
     /// <summary>
     /// True when the CoreML steady-state graph is loaded alongside the stock one.
@@ -39,6 +45,27 @@ public sealed class SortformerStreamer : IDisposable
     /// speedup on the Apple Neural Engine.
     /// </summary>
     public bool UsesSteadyStateGraph => _steadySession is not null;
+
+    /// <summary>
+    /// The steady-state graph, opened on first genuine need.
+    /// </summary>
+    /// <remarks>
+    /// ⚠ DELIBERATELY NOT OPENED IN THE CONSTRUCTOR. No chunk can route here until the
+    /// cache and FIFO are both full -- 188 + 124 subsampled frames, roughly 40 s of audio.
+    /// TranscriptionService builds a streamer per transcription, so an eager open made
+    /// every diarization of a shorter clip load, compile and dispose a ~527 MB graph that
+    /// handled zero chunks. It did the same on every app launch, where Warmup() runs one
+    /// chunk from a freshly reset state and therefore always routes to the stock graph.
+    /// </remarks>
+    private InferenceSession? SteadyStateSession()
+    {
+        if (_steadySessionAttempted)
+            return _steadySession;
+
+        _steadySessionAttempted = true;
+        _steadySession = TryOpenSteadyStateSession(_modelPath, _ep);
+        return _steadySession;
+    }
 
     /// <summary>Chunks sent to the steady-state graph since the last <see cref="ResetState"/>.</summary>
     public int SteadyStateChunkCount { get; private set; }
@@ -138,7 +165,8 @@ public sealed class SortformerStreamer : IDisposable
         opts.OptimizedModelFilePath = OptimisedModelPath;
 
         _session = new InferenceSession(resolvedModelPath, opts);
-        _steadySession = TryOpenSteadyStateSession(modelPath, ep);
+        _modelPath = modelPath;
+        _ep = ep;
         ResetState();
     }
 
@@ -146,12 +174,13 @@ public sealed class SortformerStreamer : IDisposable
     /// Opens the CoreML steady-state graph, or returns null to run stock-only.
     /// </summary>
     /// <remarks>
-    /// Gated on <see cref="ExecutionProvider.CoreML"/> being asked for explicitly. The
-    /// variant is only worth its second resident session on the Neural Engine (51.5 ms vs
-    /// 171.8 ms for the stock graph on CPU, M5 / ORT 1.29.0); on any other provider it
-    /// buys ~10% for another ~527 MB, which is not a trade to make silently. Auto does not
-    /// select it for the same reason `OrtSessionBuilder` leaves CoreML explicit: whether
-    /// CoreML beats the alternatives is a per-model property.
+    /// Auto selects this too, not just an explicit CoreML request. `OrtSessionBuilder`'s
+    /// Auto case declines CoreML because suitability is a per-model property -- but here
+    /// that property is checkable rather than assumed: the artifact is present beside the
+    /// stock model and its signature either matches this class's contract or it does not.
+    /// Worth it only on the Neural Engine (51.5 ms vs 171.8 ms for the stock graph on CPU,
+    /// M5 / ORT 1.29.0), which is why the gate still requires the CoreML EP; an explicit
+    /// Cpu or WebGpu opts out even when the artifact is present.
     ///
     /// ⚠ Two things here are load-bearing:
     /// <list type="bullet">
@@ -632,12 +661,16 @@ public sealed class SortformerStreamer : IDisposable
         //
         // Anything that is not exactly steady state goes to the stock graph.
 
-        bool steadyState =
-            _steadySession is not null
-            && currentLen == chunkStride
+        // Shape test first, THEN open: this is the only place that knows a chunk is
+        // actually eligible, and opening costs ~527 MB and up to ~3 s.
+        bool steadyShapes =
+            currentLen == chunkStride
             && chunkStride == Config.ChunkLength * Config.Subsampling
             && cacheT == Config.SpeakerCacheLength
             && fifoT == Config.FifoLength;
+
+        InferenceSession? steadySession = steadyShapes ? SteadyStateSession() : null;
+        bool steadyState = steadySession is not null;
 
         var inputs = new List<NamedOnnxValue>(steadyState ? 3 : 6)
         {
@@ -665,7 +698,7 @@ public sealed class SortformerStreamer : IDisposable
 
         if (steadyState) SteadyStateChunkCount++; else StockChunkCount++;
 
-        using var results = (steadyState ? _steadySession! : _session).Run(inputs);
+        using var results = (steadyState ? steadySession! : _session).Run(inputs);
         var predsT = results.First(r => r.Name == "spkcache_fifo_chunk_preds").AsTensor<float>();
         var embsT  = results.First(r => r.Name == "chunk_pre_encode_embs").AsTensor<float>();
 

--- a/src/Vernacula.CLI/Program.cs
+++ b/src/Vernacula.CLI/Program.cs
@@ -214,8 +214,9 @@ if (epFlag is not null)
         case "cpu":    selectedEp = ExecutionProvider.Cpu;       break;
         case "cuda":   selectedEp = ExecutionProvider.Cuda;      break;
         // macOS accelerators. Both need an osx-arm64 build (-p:EP=Cpu); the plain package
-        // is the one whose native carries them. coreml additionally opts Sortformer into
-        // the steady-state variant when that file is present beside the stock model.
+        // is the one whose native carries them. Neither is needed to GET the CoreML
+        // Sortformer variant -- Auto detects that -- so these are overrides: webgpu opts
+        // out of it entirely, coreml additionally moves the stock fallback graph.
         case "coreml": selectedEp = ExecutionProvider.CoreML;    break;
         case "webgpu": selectedEp = ExecutionProvider.WebGpu;    break;
         default:
@@ -1372,7 +1373,7 @@ static void PrintUsage()
     Console.WriteLine("  --diarization <backend>            Diarization backend: sortformer, diarizen, vad, vibevoice-asr-builtin");
     Console.WriteLine("                                     (default: sortformer, or vibevoice-asr-builtin when --asr vibevoice)");
     Console.WriteLine("  --ep <provider>                    Execution provider: auto, cpu, cuda, coreml, webgpu");
-    Console.WriteLine("                                     coreml uses the steady-state Sortformer variant when present (macOS, arm64)");
+    Console.WriteLine("                                     (auto already uses the CoreML Sortformer variant on Apple Silicon when present)");
     Console.WriteLine("  --vad                              Use VAD instead of diarization (deprecated)");
     Console.WriteLine("  --asr <parakeet|cohere|qwen3asr|vibevoice|vibevoice-streaming|whisper|granite>");
     Console.WriteLine("                                     ASR backend (default: parakeet)");

--- a/tests/SortformerRouteCheck/Program.cs
+++ b/tests/SortformerRouteCheck/Program.cs
@@ -85,6 +85,15 @@ Console.WriteLine($"routed (CoreML)    : variantLoaded={routed.loaded,-5} steady
 if (!routed.loaded) { Console.WriteLine("\n!! variant not loaded -- routing never exercised"); return 1; }
 if (routed.steady == 0) { Console.WriteLine("\n!! steady-state graph never used"); return 1; }
 
+// Auto must reach the variant on its own -- that is the whole claim of the detection
+// path, and without asserting it the harness passes even if Auto stops detecting.
+if (!auto.loaded) { Console.WriteLine("\n!! Auto did not detect the variant"); return 1; }
+if (auto.steady != routed.steady)
+{
+    Console.WriteLine($"\n!! Auto routed {auto.steady} chunks, explicit CoreML routed {routed.steady}");
+    return 1;
+}
+
 if (base_.preds.Count != routed.preds.Count)
 { Console.WriteLine($"\n!! chunk count differs: {base_.preds.Count} vs {routed.preds.Count}"); return 1; }
 

--- a/tests/SortformerRouteCheck/Program.cs
+++ b/tests/SortformerRouteCheck/Program.cs
@@ -77,7 +77,7 @@ var base_ = Run(ExecutionProvider.Cpu);
 Console.WriteLine($"stock-only (Cpu)   : variantLoaded={base_.loaded,-5} steady={base_.steady,-3} stock={base_.stock,-3} chunks={base_.preds.Count} {base_.ms:F0} ms");
 
 var auto = Run(ExecutionProvider.Auto);
-Console.WriteLine($"stock-only (Auto)  : variantLoaded={auto.loaded,-5} steady={auto.steady,-3} stock={auto.stock,-3} chunks={auto.preds.Count} {auto.ms:F0} ms");
+Console.WriteLine($"auto-detect        : variantLoaded={auto.loaded,-5} steady={auto.steady,-3} stock={auto.stock,-3} chunks={auto.preds.Count} {auto.ms:F0} ms");
 
 var routed = Run(ExecutionProvider.CoreML);
 Console.WriteLine($"routed (CoreML)    : variantLoaded={routed.loaded,-5} steady={routed.steady,-3} stock={routed.stock,-3} chunks={routed.preds.Count} {routed.ms:F0} ms");


### PR DESCRIPTION
#165 item 7 was heading for a settings ComboBox so the app could select CoreML. A setting
is the wrong shape for this.

`OrtSessionBuilder`'s `Auto` case declines CoreML because suitability *"is a per-model
property"* — right in general, but for this model it is a **checkable** property, not a
preference. The steady-state artifact sits beside the stock model and either declares the
exact three-input signature `SortformerStreamer` feeds or it does not, and
`SignatureMatchesSteadyStateContract` already decides that. **Presence plus a passing
signature check is the evidence `Auto` was missing**, so `Auto` can act on it.

Asking the user to choose would be asking them to answer a question the artifact already
answers.

## Behaviour

`Auto` opens the variant when it is on macOS, the CoreML EP is in the build
(`OrtSessionBuilder.CoreMLProviderAvailable`, newly exposed), the file is present, and its
signature matches. Any failure falls back to stock-only exactly as before. An explicit
`--ep cpu` or `--ep webgpu` still opts out.

The steady-state session is always created with `ExecutionProvider.CoreML` rather than the
caller's `ep` — under `Auto` that would otherwise build a WebGPU session for a graph
exported specifically for CoreML.

Measured on a 5-minute file at `ep=Auto`:

| | | |
|---|---|---|
| variant present | `variantLoaded=True`, 27/31 steady | **1959 ms** |
| variant absent | `variantLoaded=False`, 0/31 steady | 3709 ms |

Same as passing `--ep coreml` (1941 ms), same fallback as before when absent. Routed-vs-stock
parity unchanged at 1.363E-07. 53 tests pass.

## Worth a second opinion

This makes the app hold **two sessions, ~1 GB combined**, automatically. The argument that
it is acceptable without asking: it only happens when the variant has been downloaded, and
downloading a 527 MB optional artifact is itself the deliberate act. If you would rather it
stayed opt-in, the gate is one condition in `TryOpenSteadyStateSession`.

## Closes the #162 blocker

`TranscriptionService` and the `App.axaml.cs` warm-up both resolve to `Auto`, so the
published variant is now used by the app — without a setting, a flag, or a UI control.
That was the last thing standing between #162 and closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WotwAxr2Le2BbimqKJ9ifu