### PR TITLE
sortformer: a valid fp16 export, and the end-to-end check it was waiting on (#172)

### DIFF
--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -248,25 +248,47 @@ looking here — the fix is Technique 5.
 warm load *worse* (18.6 → 27.5 s). It is an inference lever, and a
 double-edged one — see below.
 
-## fp16: unresolved
+## fp16: the accuracy question is answered, the speed question is per-EP
 
 fp16 gave the fastest inference measured — **22.3 ms** on
-`MLComputeUnits=CPUAndGPU` (vs 51 ms fp32) — but at a real accuracy cost:
+`MLComputeUnits=CPUAndGPU` (vs 51 ms fp32) — at an apparent accuracy cost:
 
 ```
 fp32:  preds max=3.58E-07   embs max=0.00E+00
 fp16:  preds max=1.26E-03   embs max=9.77E-02
 ```
 
-`preds` at 1e-3 is likely fine for thresholded diarization logits. `embs` at
-9.8e-2 is not obviously safe, because `chunk_pre_encode_embs` feeds back into
-the spkcache/FIFO for later chunks — a feedback loop, exactly the structure this
-codebase already documents error-compounding through (the TF32/OmniVoice note in
-`OrtSessionBuilder.cs`). **A single-chunk parity check cannot see compounding.**
-Validate with end-to-end DER on real audio before shipping fp16.
+`embs` at 9.8e-2 looked unsafe because `chunk_pre_encode_embs` feeds back into the
+spkcache/FIFO for later chunks — a feedback loop, exactly the structure this codebase
+already documents error-compounding through (the TF32/OmniVoice note in
+`OrtSessionBuilder.cs`) — and a single-chunk parity check cannot see compounding.
 
-Also note `onnxconverter-common` fights graphs containing explicit `Cast` nodes;
-expect to patch mixed-dtype boundaries by hand.
+**Measured end to end (#172): it does not compound.** Fidelity DER against NeMo is
+**0.000%** on three 90 s real-speech samples. The error does grow through the feedback path
+— 6.7e-04 on one chunk becomes 1.1e-02 to 3.4e-02 over a recording — but the per-chunk trace
+wanders rather than trending, and only 3 frames in 3378 flip their binarized speaker set,
+all isolated enough for the median filter to absorb. So the caveat was right to demand the
+check and wrong about the outcome.
+
+**What decides fp16 now is throughput, and it is not uniform:**
+
+| EP | fp32 | fp16 |
+|---|---|---|
+| CPU (x86-64) | 333.0 ms | **415.3 ms** — 25% slower |
+| CUDA (3090) | 17.6 ms | **10.6 ms** — 1.66× faster |
+| CoreML (M-series) | 51 ms | 22.3 ms *(unre-measured; see below)* |
+
+There are no native fp16 CPU kernels, so ORT casts up and back around every op. fp16 is an
+**EP-gated variant**, never a replacement — shipping it as the default slows down every CPU
+user. The CoreML figure predates the reproducible converter and should be re-measured before
+it is relied on.
+
+`scripts/nemo_export/fp16_convert_sortformer.py` produces the model. Note that a bare
+`convert_float_to_float16` call does not: the graph needs its length arithmetic held in
+fp32 (it is a frame count, not an activation), its explicit `Cast` nodes reconciled (the
+converter rewrites tensor types but not `to` attributes), internal consumers of
+`keep_io_types`-cast outputs rewired, and `ScatterElements` held back because the CPU EP has
+no fp16 kernel for it. See `docs/investigations/sortformer_fp16_investigation.md`.
 
 ## Should we bypass ONNX and call CoreML directly from C#?
 

--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -265,7 +265,7 @@ already documents error-compounding through (the TF32/OmniVoice note in
 
 **Measured end to end (#172): it does not compound.** Fidelity DER against NeMo is
 **0.000%** on three 90 s real-speech samples. The error does grow through the feedback path
-— 6.7e-04 on one chunk becomes 1.1e-02 to 3.4e-02 over a recording — but the per-chunk trace
+— 9.8e-04 on one chunk becomes 1.1e-02 to 3.4e-02 over a recording — but the per-chunk trace
 wanders rather than trending, and only 3 frames in 3378 flip their binarized speaker set,
 all isolated enough for the median filter to absorb. So the caveat was right to demand the
 check and wrong about the outcome.

--- a/docs/investigations/sortformer_fp16_investigation.md
+++ b/docs/investigations/sortformer_fp16_investigation.md
@@ -204,6 +204,37 @@ half the size.
 So fp16 is not a replacement for the fp32 model; it is an **execution-provider-gated
 variant**. Shipping it as the default would slow down every CPU user.
 
+## Review pass — 2026-09-09
+
+A `/code-review high` pass confirmed the shipped graph is structurally clean — 0 nodes with
+mixed float input types, 0 `Cast.to` vs `value_info` disagreements, `chunk_pre_encode_embs`
+with no internal consumers left, all three `ScatterElements` in fp32 with converter-inserted
+casts either side — and reproduced the headline numbers exactly. Six findings on the script
+around it, all fixed:
+
+* **`--io-fp16` made both verification modes unusable.** `--compare` built one fp32 feed and
+  handed it to both sessions, so the fp16-io graph threw `Unexpected input data type`. Each
+  session is now fed the dtype it declares. `--drift` cannot work under `--io-fp16` at all —
+  it runs through `OnnxSortformerPipeline`, which builds float32 buffers exactly as
+  `Sortformer.cs` does — so it now says that instead of throwing from inside ORT.
+* **`check_loads` absolved by the *presence* of a baseline failure, not its cause.** Any
+  level where the fp32 source also failed was waved through, so an fp16-introduced type
+  error surfacing only at `ORT_ENABLE_ALL` on the CoreML variant would have been reported as
+  inherited. It now compares the normalized error text and says "identically to the fp32
+  source", or flags a differing failure.
+* **`length_path_nodes` silently dropped unnamed nodes.** `node_block_list` matches on name,
+  so an unnamed length-path node would have had its frame-count arithmetic converted while
+  the caller was told N nodes were protected — the exact failure the pass exists to prevent.
+  `torch.onnx.export` names everything today, but the exporter has a `--dynamo` path and
+  onnxscript makes no such guarantee. It now refuses rather than under-protecting.
+* **`--max-seconds 0`** (or a negative) fell through to "decode the whole file" rather than
+  erroring. Validated; `inf` is the explicit way to ask for whole files.
+* **`--compare`/`--drift` ran even after the load check had declared a regression**, burying
+  the diagnostic under an ORT traceback, and their outcome never reached the exit code.
+  Gated.
+* **`--drift` on a sub-chunk recording** died inside `np.concatenate` without naming the
+  file. Skipped with a message.
+
 ## Where this leaves #172
 
 1. **A valid fp16 export exists.** `fp16_convert_sortformer.py`, three graph passes plus one
@@ -219,7 +250,10 @@ rather than work:
 * **The CoreML number needs re-measuring on the Apple Silicon machine**, against the fp16
   build of the CoreML variant (the converter handles it — verified, 264 MB, loads at
   `ORT_DISABLE_ALL` and `ORT_ENABLE_BASIC`; its `ORT_ENABLE_ALL` failure is the
-  `MatMulAddFusion` one that variant already has, not an fp16 problem). If 22.3 ms holds
+  failure that variant already has -- the message is `AddInitializedOrtValue Attempt to
+  replace the existing tensor`, thrown by `MatMulAddFusion` re-running over an
+  already-optimized graph, bisected in #171 -- and not an fp16 problem; the load check
+  confirms it by matching the fp32 source's error text, not merely by seeing one). If 22.3 ms holds
   there, fp16-on-CoreML is the fastest path on that platform by a wide margin.
 * **Shipping it means EP-gated model selection** — CUDA and possibly CoreML get the fp16
   file, CPU keeps fp32 — which is the same shape of runtime work as the CoreML variant's

--- a/docs/investigations/sortformer_fp16_investigation.md
+++ b/docs/investigations/sortformer_fp16_investigation.md
@@ -1,0 +1,220 @@
+# Sortformer fp16 — issue #172
+
+#172: the model card records fp16 as the fastest Sortformer variant measured (22.3 ms/chunk)
+but not shipped, because `chunk_pre_encode_embs` diverged to 9.8e-02 and those embeddings
+feed back into the speaker cache and FIFO — so it needed an end-to-end check rather than a
+single-chunk comparison. That check now exists (`sortformer_fidelity_der.py`, #169). What
+did not exist was a **loadable fp16 model to measure**.
+
+## Environment
+
+- `.venv-nemo-export`, python 3.12.3, torch 2.11.0+cu128, onnx 1.21.0, **onnxruntime 1.26.0**,
+  onnxconverter-common 1.16.0 (installed for this work), Linux x86-64, RTX 3090
+- `main` @ `4e3d13b`
+
+## Run 1 — 2026-09-09 — reproduce the failure
+
+```python
+float16.convert_float_to_float16(onnx.load(SRC), keep_io_types=True)
+```
+
+Converts in ~3 s, 492 MB → 247 MB, and will not load:
+
+```
+Type Error: Type (tensor(float16)) of output arg (/pre_encode/conv/Cast_output_0)
+of node (/pre_encode/conv/Cast) does not match expected type (tensor(float))
+```
+
+Slightly different node from the one #172 records (`/pre_encode/conv/Mul_3`), same region.
+
+## Run 2 — 2026-09-09 — what is actually in that region?
+
+Question: #172 calls it "mixed precision surviving in the pre-encode convolution stack" and
+suggests `op_block_list` tuning. Which ops, and why those?
+
+Walked the graph back from the `chunk_pre_encode_lengths` output:
+
+```
+nodes feeding chunk_pre_encode_lengths: 39
+  ops: Constant x15, Cast x9, Add x9, Div x3, Sub x3
+nodes feeding chunk_pre_encode_embs: 514  (37 shared with the length path)
+```
+
+**Not activations at all.** That is `floor((L + 2p - k)/s) + 1` — the conv output-length
+formula — emitted by the tracer as float arithmetic, once per pre-encode conv layer. So the
+first fix is not a tuning knob but a correctness point: **a frame count must not be rounded
+through fp16.** fp16 represents integers exactly only to 2048, and the intermediate divisions
+are not integers. Held in fp32 by walking the graph rather than by hardcoding names, so it
+survives the exporter renaming nodes.
+
+That alone does not fix it — the next failure is a different `Cast`.
+
+## Run 3 — 2026-09-09 — the converter does not update `Cast` nodes
+
+Question: with the length path protected, why is a `Cast` still wrong?
+
+Compared every `Cast`'s `to` attribute against the converted graph's own `value_info`:
+
+| | Cast nodes | `to=` | disagreements |
+|---|---|---|---|
+| source | 141 | FLOAT×31, INT64×53, BOOL×57 | **0** |
+| naive fp16 | 188 | FLOAT×52, INT64×53, BOOL×57, FLOAT16×26 | **27** |
+
+`onnxconverter-common` rewrites tensor types but leaves each explicit `Cast` declaring
+`to=FLOAT`, so 27 of them claim to produce fp32 while the graph types their output fp16.
+This is the concrete mechanism behind the playbook's vaguer note that the converter "fights
+graphs containing explicit `Cast` nodes". Fixed by trusting the converted types and
+reconciling `to`.
+
+## Run 4 — 2026-09-09 — one boundary left, and it is not what it looks like
+
+After the reconciliation, exactly one node has mixed float inputs — and it is the `Mul`
+#172 originally reported:
+
+```
+nodes with MIXED float input types: 1
+  /Mul_7   Mul   inputs=['FLOAT', 'FLOAT16']
+
+node: /Mul_7 -> out FLOAT16
+  input chunk_pre_encode_embs   type=FLOAT     produced_by Cast(/pre_encode/out/Add_cast_to_chunk_pre_encode_embs)
+  input /Cast_6_output_0        type=FLOAT16
+```
+
+The fp32 input is `chunk_pre_encode_embs` — **a graph output**. It is also consumed
+internally, feeding onward into the encoder. `keep_io_types=True` appends a `Cast` so the
+caller still receives fp32, and the internal consumer then reads that fp32 tensor while
+expecting fp16.
+
+So the fix is not to cast the input (an fp16→fp32→fp16 round trip); it is to rewire internal
+consumers back to the **pre-cast** fp16 tensor and let the cast serve only the graph output.
+Lossless, and it generalizes to any tensor that is both an output and an input.
+
+`keep_io_types` is kept deliberately: `Sortformer.cs` feeds float32 and reads float32, so an
+fp32-io fp16 model is a drop-in and the runtime needs no variant path.
+
+## Run 5 — 2026-09-09 — loads, then dies on the first inference
+
+All three passes applied: loads at `ORT_DISABLE_ALL`, `ORT_ENABLE_BASIC` and
+`ORT_ENABLE_ALL`. Then:
+
+```
+RUNTIME_EXCEPTION : Non-zero status code returned while running ScatterElements node.
+CPU execution provider: MLFloat16 data type is not supported with ScatterElements
+opset 16 when reduction is 'add'.
+```
+
+A model that loads is not a model that runs. `ScatterElements` is held in fp32 too — one
+node, cast on each side. Other EPs may have the kernel, but the model has to run on CPU as
+well and a per-EP artifact is not worth one op.
+
+Result: `scripts/nemo_export/fp16_convert_sortformer.py`, 492 MB → 247 MB, loading at every
+optimization level and running. Single-chunk parity against fp32 on the CPU EP:
+
+```
+spkcache_fifo_chunk_preds  maxAbs=6.711E-04  rms=1.395E-04
+chunk_pre_encode_embs      maxAbs=9.766E-02  rms=8.630E-03
+```
+
+`embs` at **9.766e-02** reproduces the model card's 9.8e-02 to three digits, so this is the
+same artifact the original caveat was about — the card's number is now reproducible rather
+than folklore.
+
+## Run 6 — 2026-09-09 — the go/no-go: end-to-end DER
+
+```bash
+python scripts/nemo_export/sortformer_fidelity_der.py \
+  --audio <three 90 s en-US samples> --max-seconds 90 \
+  --nemo <checkpoint> --onnx diar_streaming_sortformer_4spk-v2.1.fp16.onnx
+```
+
+```
+  en-US_sample_01   90.0s  ref 29 seg / 2 spk   hyp 29 seg / 2 spk
+  en-US_sample_02   90.0s  ref 25 seg / 2 spk   hyp 25 seg / 2 spk
+  en-US_sample_03   90.0s  ref 22 seg / 2 spk   hyp 22 seg / 2 spk
+
+fidelity DER vs NeMo: DER 0.000 %  confusion 0.000 %  FA 0.000 %  missed 0.000 %
+```
+
+**Passes.** Segment and speaker counts match NeMo exactly on all three.
+
+## Run 7 — 2026-09-09 — but does the error compound? (DER is too coarse to say)
+
+DER applies a median filter, a collar and binarization, so 0.000% is consistent with real
+per-frame drift being absorbed. The worry on file is specifically *compounding* through the
+spkcache/FIFO feedback, which needs the raw posteriors. `fp16_convert_sortformer.py --drift`
+runs the ported loop twice on the same audio — fp32 model and fp16 model — and diffs per
+chunk:
+
+| sample | per-frame `preds` maxAbs | rms | frames whose binarized speaker set differs |
+|---|---|---|---|
+| en-US_sample_01 | 2.168E-02 | 1.356E-03 | 0 / 1126 |
+| en-US_sample_02 | 1.080E-02 | 4.627E-04 | 0 / 1126 |
+| en-US_sample_03 | 3.363E-02 | 1.573E-03 | **3** / 1126 |
+
+Per-chunk maxAbs, sample 01: `7.6E-4  4.7E-3  3.9E-3  1.3E-3  9.3E-3  4.6E-3  1.5E-2  2.2E-2  9.6E-3  8.9E-3`
+
+Two things worth separating. The error **does** grow through the feedback path — 6.7e-04 on
+a single chunk becomes 1.1e-02 to 3.4e-02 over a recording, a factor of 30-50. But it
+**wanders rather than accumulating**: the per-chunk trace rises and falls, and does not
+trend. Bounded, not compounding.
+
+And it is not entirely invisible: 3 frames of 3378 flip their binarized speaker set. All
+three are isolated, so the median filter absorbs them and DER stays at 0.000%. That is the
+honest form of the result — "0.000%" alone would overstate it.
+
+## Run 8 — 2026-09-09 — a latent bug in the rewiring pass
+
+Self-review before committing: `rewire_output_casts` keyed on "this graph output is produced
+by a `Cast`", which is not the same thing as "the converter added this cast". Sortformer's
+`chunk_pre_encode_lengths` output is produced by a legitimate `Cast(to=INT64)` the model
+itself contains — and it *is* consumed internally, since the attention mask is built from
+it. So the pass was rewiring the mask's frame-count input to the pre-cast float tensor: a
+silent semantic change dressed as a dtype tidy-up.
+
+Restricted to casts that are fp16 → fp32, which is the `keep_io_types` signature. Rewired
+edges drop 4 → 2, i.e. **two of the four were the int64 lengths output.**
+
+Every measured number is byte-identical before and after (`6.711E-04` / `9.766E-02`, DER
+0.000%, the same drift table), so the bug was latent — a downstream cast evidently absorbed
+it. Recorded because "the numbers didn't change" is exactly the argument that would have let
+it ship, and the next graph it ran on might not be so forgiving.
+
+## Run 9 — 2026-09-09 — is it faster? Only on some hardware
+
+Steady-state shapes, `ORT_ENABLE_BASIC`, median of 15:
+
+| model | EP | load | median | min |
+|---|---|---|---|---|
+| fp32 | CPU | 1.79 s | 333.0 ms | 327.7 ms |
+| fp16 | CPU | 1.97 s | **415.3 ms** | 409.7 ms |
+| fp32 | CUDA | 1.90 s | 17.6 ms | 16.4 ms |
+| fp16 | CUDA | 0.89 s | **10.6 ms** | 10.5 ms |
+
+**fp16 is 1.66× faster on CUDA and 25% SLOWER on CPU.** The CPU result is the expected one —
+there are no native fp16 CPU kernels, so ORT casts up and back around every op and pays for
+the traffic. It also halves CUDA load time (1.90 s → 0.89 s), which tracks the file being
+half the size.
+
+So fp16 is not a replacement for the fp32 model; it is an **execution-provider-gated
+variant**. Shipping it as the default would slow down every CPU user.
+
+## Where this leaves #172
+
+1. **A valid fp16 export exists.** `fp16_convert_sortformer.py`, three graph passes plus one
+   op held back, loads at every optimization level and runs. ✅
+2. **The end-to-end check passes.** DER 0.000% on three 90 s real-speech samples, with the
+   caveat from Run 7 stated rather than buried. ✅
+3. **The speed claim is hardware-dependent**, and the 22.3 ms on file is unverified from
+   here — it is a CoreML number. Measured: CUDA 1.66× faster, CPU 25% slower. ⚠
+
+Not published, and not wired into the runtime. Two things gate that, and both are decisions
+rather than work:
+
+* **The CoreML number needs re-measuring on the Apple Silicon machine**, against the fp16
+  build of the CoreML variant (the converter handles it — verified, 264 MB, loads at
+  `ORT_DISABLE_ALL` and `ORT_ENABLE_BASIC`; its `ORT_ENABLE_ALL` failure is the
+  `MatMulAddFusion` one that variant already has, not an fp16 problem). If 22.3 ms holds
+  there, fp16-on-CoreML is the fastest path on that platform by a wide margin.
+* **Shipping it means EP-gated model selection** — CUDA and possibly CoreML get the fp16
+  file, CPU keeps fp32 — which is the same shape of runtime work as the CoreML variant's
+  selection path, and should probably be done once for both rather than twice.

--- a/docs/investigations/sortformer_fp16_investigation.md
+++ b/docs/investigations/sortformer_fp16_investigation.md
@@ -111,11 +111,17 @@ Result: `scripts/nemo_export/fp16_convert_sortformer.py`, 492 MB → 247 MB, loa
 optimization level and running. Single-chunk parity against fp32 on the CPU EP:
 
 ```
-spkcache_fifo_chunk_preds  maxAbs=6.711E-04  rms=1.395E-04
-chunk_pre_encode_embs      maxAbs=9.766E-02  rms=8.630E-03
+spkcache_fifo_chunk_preds  maxAbs=9.825E-04  rms=1.970E-04
+chunk_pre_encode_embs      maxAbs=9.764E-02  rms=8.629E-03
 ```
 
-`embs` at **9.766e-02** reproduces the model card's 9.8e-02 to three digits, so this is the
+(Both sessions run at `ORT_ENABLE_BASIC`. An earlier `--compare` left the reference at ORT's
+default `ENABLE_ALL` while the candidate ran at `DISABLE_ALL`, which folded ORT's own fusions
+into the difference and read `preds` as 6.7e-04. Same level on both sides makes the gap
+attributable to the dtype — and it is also what lets `--compare` run at all on the CoreML
+variant, which cannot be re-optimized above BASIC.)
+
+`embs` at **9.764e-02** reproduces the model card's 9.8e-02 to three digits, so this is the
 same artifact the original caveat was about — the card's number is now reproducible rather
 than folklore.
 
@@ -153,8 +159,8 @@ chunk:
 
 Per-chunk maxAbs, sample 01: `7.6E-4  4.7E-3  3.9E-3  1.3E-3  9.3E-3  4.6E-3  1.5E-2  2.2E-2  9.6E-3  8.9E-3`
 
-Two things worth separating. The error **does** grow through the feedback path — 6.7e-04 on
-a single chunk becomes 1.1e-02 to 3.4e-02 over a recording, a factor of 30-50. But it
+Two things worth separating. The error **does** grow through the feedback path — 9.8e-04 on
+a single chunk becomes 1.1e-02 to 3.4e-02 over a recording, a factor of 10-35. But it
 **wanders rather than accumulating**: the per-chunk trace rises and falls, and does not
 trend. Bounded, not compounding.
 
@@ -174,7 +180,7 @@ silent semantic change dressed as a dtype tidy-up.
 Restricted to casts that are fp16 → fp32, which is the `keep_io_types` signature. Rewired
 edges drop 4 → 2, i.e. **two of the four were the int64 lengths output.**
 
-Every measured number is byte-identical before and after (`6.711E-04` / `9.766E-02`, DER
+Every measured number is byte-identical before and after (`9.8E-04` / `9.76E-02`, DER
 0.000%, the same drift table), so the bug was latent — a downstream cast evidently absorbed
 it. Recorded because "the numbers didn't change" is exactly the argument that would have let
 it ship, and the next graph it ran on might not be so forgiving.

--- a/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
+++ b/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
@@ -144,9 +144,14 @@ only in the packaged app.
    1.29.0 gives 1 partition and `4.470E-07`. Set the CoreML EP's `ModelCacheDirectory` or
    every load pays the 2.2 s compile instead of 0.16 s.
 
-`fp16` was measured faster still (22.3 ms) but is **not** shipped: `chunk_pre_encode_embs`
-diverges to 9.8e-02 there and those embeddings feed back into the speaker cache and FIFO,
-so it needs an end-to-end DER check rather than a single-chunk comparison.
+`fp16` was measured faster still (22.3 ms) and is **not** shipped, though no longer for the
+original reason. `chunk_pre_encode_embs` does diverge to 9.8e-02, and those embeddings feed
+back into the speaker cache and FIFO — but the end-to-end check that was missing has since
+been run, and fidelity DER against NeMo is **0.000%** on real speech (3 frames in 3378 flip
+their binarized speaker set, all absorbed by the median filter). What holds fp16 back now is
+throughput: it is **1.66× faster on CUDA but 25% slower on CPU**, since there are no native
+fp16 CPU kernels, so it can only ever be an execution-provider-gated variant rather than a
+replacement.
 
 Reproduce it with:
 

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -14,6 +14,7 @@ It now covers both models in your pipeline:
 - `export_sortformer_nemo_to_onnx.py`: exports streaming Sortformer `.nemo` to the same six-input / three-output ONNX contract used by Vernacula's inference code.
 - `export_silero_vad_to_onnx.py`: exports Silero VAD to ONNX.
 - `benchmark_sortformer_rtf.py`: benchmarks Sortformer NeMo-vs-ONNX diarization RTF on CPU or CUDA.
+- `fp16_convert_sortformer.py`: converts an exported Sortformer ONNX to fp16 — one that loads and runs, which a bare `convert_float_to_float16` call does not produce (issue #172).
 - `sortformer_compress_parity.py`: compares speaker-cache compression against NeMo's stage by stage on a fixture with a controlled saturated fraction — the reproduction for #171. `--probe-topk-ties` characterizes `torch.topk`'s tie behaviour on the current build (run this first on a new machine or torch version), `--tie-incidence` reports when a tie can actually decide a pick.
 - `coreml_partition_probe.py`: reports what an execution provider does with a static Sortformer graph — partition count, load and inference time, parity against the dynamic graph. This is the measurement that decides whether a CoreML variant is worth shipping, and it has to run on Apple Silicon.
 - `compare_sortformer_chunk_outputs.py`: compares two Sortformer backends chunk-by-chunk to locate streaming parity drift.
@@ -315,6 +316,37 @@ Caveats:
   model, at 51.5 ms vs 171.8 ms for stock-on-CPU. Re-validate on any further ORT change;
   see
   [docs/investigations/sortformer_coreml_publish_investigation.md](../../docs/investigations/sortformer_coreml_publish_investigation.md).
+
+### fp16
+
+```bash
+python scripts/nemo_export/fp16_convert_sortformer.py \
+  --input  ~/models/diar_streaming_sortformer_4spk-v2.1.onnx \
+  --output ~/models/diar_streaming_sortformer_4spk-v2.1.fp16.onnx \
+  --compare
+```
+
+492 MB -> 247 MB, loading at every optimization level. A bare
+`onnxconverter_common.float16.convert_float_to_float16` call does **not** get there; four
+things have to be handled, and the script's docstring covers each:
+
+1. The conv output-length arithmetic stays fp32. Those nodes compute a **frame count**, not
+   an activation, and fp16 is exact on integers only to 2048.
+2. Explicit `Cast` nodes get their `to` attribute reconciled — the converter rewrites tensor
+   types but leaves 27 `Cast`s declaring the old one.
+3. `chunk_pre_encode_embs` is both a graph output and an internal input, so `keep_io_types`
+   hands its internal consumer an fp32 tensor it cannot use. Those consumers are rewired to
+   the pre-cast fp16 source.
+4. `ScatterElements` is held in fp32: the model otherwise loads and then dies on the first
+   inference, because the CPU EP has no fp16 kernel for it at opset 16.
+
+Inputs and outputs stay float32 by default (`--io-fp16` to change that), so the result is a
+drop-in for `Sortformer.cs`.
+
+**Accuracy is fine; throughput is not uniform.** Fidelity DER against NeMo is 0.000% on real
+speech, but fp16 is **1.66x faster on CUDA and 25% slower on CPU** — there are no native
+fp16 CPU kernels. Treat it as an execution-provider-gated variant, never a replacement. See
+[docs/investigations/sortformer_fp16_investigation.md](../../docs/investigations/sortformer_fp16_investigation.md).
 
 For a safer structure-only experiment that keeps dynamic time dimensions but
 specializes the graph to batch size 1, use:

--- a/scripts/nemo_export/fp16_convert_sortformer.py
+++ b/scripts/nemo_export/fp16_convert_sortformer.py
@@ -7,7 +7,7 @@ ONNX Runtime refuses:
     Type Error: Type parameter (T) of Optype (Mul) bound to different types
     (tensor(float16) and tensor(float)) in node (/pre_encode/conv/Mul_3)
 
-Three things are wrong with the naive conversion, and each needs a different answer.
+Four things are wrong with the naive conversion, and each needs a different answer.
 
 1. THE LENGTH ARITHMETIC MUST NOT BE CONVERTED.
    `torch.onnx.export` emits the conv output-length formula -- floor((L + 2p - k)/s) + 1,
@@ -15,8 +15,8 @@ Three things are wrong with the naive conversion, and each needs a different ans
    are not activations; they compute a FRAME COUNT. Rounding a frame count through fp16 is
    wrong on its own terms (fp16 integers are exact only to 2048, and the intermediate
    divisions are not integers), and it is where the mixed-type errors start. They are held
-   in fp32 by name, found by walking back from `chunk_pre_encode_lengths` rather than
-   hardcoded, so this keeps working if the exporter's node names change.
+   in fp32, found by walking back from `chunk_pre_encode_lengths` rather than by a
+   hardcoded name list, so this keeps working if the exporter renames nodes.
 
 2. THE CONVERTER DOES NOT UPDATE `Cast` NODES.
    The graph has 141 explicit `Cast`s. The converter rewrites tensor types but leaves each
@@ -29,15 +29,26 @@ Three things are wrong with the naive conversion, and each needs a different ans
    that fp32 tensor while expecting fp16 -- the `Mul` in the error above. Internal consumers
    are rewired back to the pre-cast fp16 tensor, so the cast serves only the graph output.
 
+4. SOME OPS HAVE NO fp16 CPU KERNEL.
+   `ScatterElements` with `reduction='add'` is unimplemented for fp16 on the CPU EP at
+   opset 16, so the converted model LOADS and then dies on the first inference. Held in
+   fp32 (see UNSUPPORTED_FP16_OPS). A model that loads is not a model that runs.
+
 `keep_io_types` is deliberate: the C# caller feeds float32 and reads float32, so the fp16
 model is a drop-in for the fp32 one and `Sortformer.cs` needs no variant path.
 
-⚠ A model that loads is not a model that is correct. fp16 was measured fastest on the
-CoreML EP (22.3 ms/chunk vs 51 ms) but `chunk_pre_encode_embs` diverged to 9.8e-02, and
-those embeddings feed back into the speaker cache and FIFO across chunks -- so a
-single-chunk comparison cannot see the compounding. The go/no-go is end-to-end:
+WHAT THIS MODEL IS AND IS NOT GOOD FOR (measured, #172):
 
-    python scripts/nemo_export/sortformer_fidelity_der.py --onnx <this model> ...
+  * Accuracy is fine. `chunk_pre_encode_embs` diverges 9.8e-02 on a single chunk and those
+    embeddings feed back into the speaker cache and FIFO, which is why the original caveat
+    demanded an end-to-end check -- but fidelity DER against NeMo is 0.000% on real speech.
+    The error grows through the feedback path (9.8e-04 on a chunk becomes 1.1e-02 to
+    3.4e-02 over a recording) yet wanders rather than trending, so it is bounded rather
+    than compounding, and 3 frames in 3378 flip their binarized speaker set. Re-check with
+    `--drift` and `sortformer_fidelity_der.py` after any change here.
+  * Speed is NOT uniform, and this is what keeps fp16 from being the default: 1.66x faster
+    on CUDA, 25% SLOWER on CPU (there are no native fp16 CPU kernels, so ORT casts up and
+    back around every op). Treat it as an execution-provider-gated variant.
 
 See issue #172 and docs/investigations/sortformer_fp16_investigation.md.
 """
@@ -167,19 +178,42 @@ def convert(src: str, dst: str, keep_io_types: bool = True) -> None:
     print(f"[4/4] wrote {dst} ({os.path.getsize(dst) / 1e6:.0f} MB)")
 
 
-def check_loads(path: str) -> bool:
-    """A model that loads at one optimization level can fail at another; check all three."""
+LOAD_LEVELS = ("ORT_DISABLE_ALL", "ORT_ENABLE_BASIC", "ORT_ENABLE_ALL")
+
+
+def _loads_at(path: str, level: str) -> str | None:
+    """None if it loads, else the error's last line."""
     import onnxruntime as ort
+    so = ort.SessionOptions()
+    so.graph_optimization_level = getattr(ort.GraphOptimizationLevel, level)
+    try:
+        ort.InferenceSession(path, so, providers=["CPUExecutionProvider"])
+        return None
+    except Exception as exc:
+        return str(exc).strip().splitlines()[-1]
+
+
+def check_loads(path: str, baseline: str) -> bool:
+    """A model that loads at one optimization level can fail at another, so check all three.
+
+    Compared against the SOURCE model at the same level, because not every failure is this
+    script's doing: the CoreML variant already cannot load at ORT_ENABLE_ALL (ORT re-running
+    MatMulAddFusion over an already-optimized graph), and reporting that as an fp16 defect
+    would send the reader after the wrong thing. Only a level the source loads at and the
+    fp16 model does not is a regression.
+    """
     ok = True
-    for level in ("ORT_DISABLE_ALL", "ORT_ENABLE_BASIC", "ORT_ENABLE_ALL"):
-        so = ort.SessionOptions()
-        so.graph_optimization_level = getattr(ort.GraphOptimizationLevel, level)
-        try:
-            ort.InferenceSession(path, so, providers=["CPUExecutionProvider"])
+    for level in LOAD_LEVELS:
+        err = _loads_at(path, level)
+        if err is None:
             print(f"  {level:18} loads")
-        except Exception as exc:
-            print(f"  {level:18} FAILS: {str(exc).strip().splitlines()[-1][:150]}")
-            ok = False
+            continue
+        if _loads_at(baseline, level) is not None:
+            print(f"  {level:18} fails -- but so does the fp32 source, so not from this "
+                  f"conversion")
+            continue
+        print(f"  {level:18} FAILS: {err[:150]}")
+        ok = False
     return ok
 
 
@@ -189,14 +223,39 @@ def compare(fp32_path: str, fp16_path: str, seed: int = 7) -> None:
     import onnxruntime as ort
 
     rng = np.random.default_rng(seed)
-    ref = ort.InferenceSession(fp32_path, providers=["CPUExecutionProvider"])
-    got = ort.InferenceSession(fp16_path, providers=["CPUExecutionProvider"])
+    # BASIC on both sides, not ORT's default of ENABLE_ALL. Two reasons: an already-optimized
+    # graph (the CoreML variant) cannot be re-optimized above BASIC and would throw here
+    # before comparing anything, and running the two models at the same level is what makes
+    # the difference attributable to the dtype rather than to ORT's fusions.
+    so = ort.SessionOptions()
+    so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
+    ref = ort.InferenceSession(fp32_path, so, providers=["CPUExecutionProvider"])
+    got = ort.InferenceSession(fp16_path, so, providers=["CPUExecutionProvider"])
 
-    shapes = {"chunk": (1, 992, 128), "spkcache": (1, 188, 512), "fifo": (1, 124, 512)}
+    # Defaults for the dynamic export, which declares no concrete shape; a static graph
+    # (the CoreML variant) carries its own and those win, so this is not tied to one frame
+    # configuration.
+    DEFAULTS = {"chunk": (1, 992, 128), "spkcache": (1, 188, 512), "fifo": (1, 124, 512)}
+    shapes = {}
+    for i in ref.get_inputs():
+        if i.type == "tensor(int64)":
+            continue
+        declared = tuple(d for d in i.shape)
+        if all(isinstance(d, int) for d in declared):
+            shapes[i.name] = declared
+        elif i.name in DEFAULTS:
+            shapes[i.name] = DEFAULTS[i.name]
+        else:
+            raise SystemExit(
+                f"--compare cannot size input {i.name}: shape {i.shape} is dynamic and "
+                "there is no default for it.")
+
     feed = {}
     for i in ref.get_inputs():
         if i.type == "tensor(int64)":
-            buf = i.name[: -len("_lengths")]
+            buf = i.name[: -len("_lengths")] if i.name.endswith("_lengths") else None
+            if buf not in shapes:
+                raise SystemExit(f"--compare cannot infer a value for {i.name}")
             feed[i.name] = np.array([shapes[buf][1]], np.int64)
         else:
             feed[i.name] = rng.standard_normal(shapes[i.name]).astype(np.float32)
@@ -284,7 +343,7 @@ def main() -> int:
     src, dst = os.path.expanduser(args.input), os.path.expanduser(args.output)
     convert(src, dst, keep_io_types=not args.io_fp16)
     print("\nload check:")
-    ok = check_loads(dst)
+    ok = check_loads(dst, src)
     if args.compare:
         compare(src, dst)
     if args.drift:

--- a/scripts/nemo_export/fp16_convert_sortformer.py
+++ b/scripts/nemo_export/fp16_convert_sortformer.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 from collections import deque
 
 import numpy as np
@@ -81,7 +82,7 @@ def length_path_nodes(graph) -> list[str]:
     prod = {o: n for n in graph.node for o in n.output}
     init = {i.name for i in graph.initializer}
     gin = {i.name for i in graph.input}
-    names, seen, q = set(), set(), deque([LENGTH_OUTPUT])
+    names, seen, unnamed, q = set(), set(), 0, deque([LENGTH_OUTPUT])
     while q:
         name = q.popleft()
         if name in seen or name in init or name in gin:
@@ -92,7 +93,18 @@ def length_path_nodes(graph) -> list[str]:
             continue
         if node.name:
             names.add(node.name)
+        else:
+            # `node_block_list` matches on name, so an unnamed node cannot be held back --
+            # its frame-count arithmetic would be silently converted while the caller is
+            # told N nodes are protected. torch.onnx.export names everything today, but the
+            # exporter has a --dynamo path and onnxscript makes no such guarantee.
+            unnamed += 1
         q.extend(node.input)
+    if unnamed:
+        raise SystemExit(
+            f"{unnamed} node(s) on the {LENGTH_OUTPUT} path have no name, so they cannot be "
+            "held in fp32 and their frame-count arithmetic would be converted silently. "
+            "Re-export with named nodes, or name them before converting.")
     return sorted(names)
 
 
@@ -193,12 +205,30 @@ def _loads_at(path: str, level: str) -> str | None:
         return str(exc).strip().splitlines()[-1]
 
 
+def _same_failure(a: str, b: str) -> bool:
+    """Do two ORT load errors have the same cause?
+
+    Compared on the message with paths and addresses stripped, because "the source fails
+    here too" is not on its own evidence that the conversion is innocent -- an fp16 type
+    error surfacing only at a level the source independently fails at would otherwise be
+    waved through.
+    """
+    def norm(msg: str) -> str:
+        msg = re.sub(r"/\S+?\.onnx", "<model>", msg)
+        msg = re.sub(r"0x[0-9a-fA-F]+", "<addr>", msg)
+        return re.sub(r"\s+", " ", msg).strip()
+
+    return norm(a) == norm(b)
+
+
 def check_loads(path: str, baseline: str) -> bool:
     """A model that loads at one optimization level can fail at another, so check all three.
 
     Compared against the SOURCE model at the same level, because not every failure is this
     script's doing: the CoreML variant already cannot load at ORT_ENABLE_ALL (ORT re-running
-    MatMulAddFusion over an already-optimized graph), and reporting that as an fp16 defect
+    it surfaces as `AddInitializedOrtValue Attempt to replace the existing tensor`, thrown
+    by MatMulAddFusion re-running over an already-optimized graph -- see #171), and
+    reporting that as an fp16 defect
     would send the reader after the wrong thing. Only a level the source loads at and the
     fp16 model does not is a regression.
     """
@@ -208,9 +238,16 @@ def check_loads(path: str, baseline: str) -> bool:
         if err is None:
             print(f"  {level:18} loads")
             continue
-        if _loads_at(baseline, level) is not None:
-            print(f"  {level:18} fails -- but so does the fp32 source, so not from this "
-                  f"conversion")
+        base_err = _loads_at(baseline, level)
+        if base_err is not None and _same_failure(err, base_err):
+            print(f"  {level:18} fails -- identically to the fp32 source, so not from "
+                  f"this conversion")
+            continue
+        if base_err is not None:
+            print(f"  {level:18} FAILS DIFFERENTLY from the fp32 source")
+            print(f"      fp16: {err[:110]}")
+            print(f"      fp32: {base_err[:110]}")
+            ok = False
             continue
         print(f"  {level:18} FAILS: {err[:150]}")
         ok = False
@@ -260,9 +297,17 @@ def compare(fp32_path: str, fp16_path: str, seed: int = 7) -> None:
         else:
             feed[i.name] = rng.standard_normal(shapes[i.name]).astype(np.float32)
 
-    a = dict(zip([o.name for o in ref.get_outputs()], ref.run(None, feed)))
-    b = dict(zip([o.name for o in got.get_outputs()],
-                 got.run(None, {k: feed[k] for k in [i.name for i in got.get_inputs()]})))
+    # The converted graph's inputs are fp16 under --io-fp16, so feed each session the dtype
+    # it declares rather than handing both the same fp32 dict.
+    def typed(session):
+        out = {}
+        for i in session.get_inputs():
+            arr = feed[i.name]
+            out[i.name] = arr.astype(np.float16) if i.type == "tensor(float16)" else arr
+        return out
+
+    a = dict(zip([o.name for o in ref.get_outputs()], ref.run(None, typed(ref))))
+    b = dict(zip([o.name for o in got.get_outputs()], got.run(None, typed(got))))
     print("\nsingle-chunk fp16 vs fp32 (CPU EP, steady state):")
     for key in ("spkcache_fifo_chunk_preds", "chunk_pre_encode_embs"):
         x, y = a[key].astype(np.float32), b[key].astype(np.float32)
@@ -294,9 +339,19 @@ def drift(fp32_path: str, fp16_path: str, audio_paths, max_seconds: float) -> No
         pipe.reset_state()
         return [pipe.process_chunk(i, stride, total, mel)[0] for i in range(n_chunks)]
 
+    import onnxruntime as ort
+    if any(i.type == "tensor(float16)"
+           for i in ort.InferenceSession(fp16_path,
+                                         providers=["CPUExecutionProvider"]).get_inputs()):
+        raise SystemExit(
+            "--drift needs an fp32-io model: it runs through OnnxSortformerPipeline, which "
+            "builds float32 chunk/spkcache/fifo buffers exactly as Sortformer.cs does. "
+            "Convert without --io-fp16 to measure drift.")
+
     for path in audio_paths:
         path = Path(path)
-        frames = int(max_seconds * 16000) if max_seconds else -1
+        # `inf` means the whole file; soundfile takes -1 for that.
+        frames = -1 if max_seconds == float("inf") else int(max_seconds * 16000)
         audio, sr = sf.read(str(path), dtype="float32",
                             frames=frames if frames > 0 else -1)
         if sr != 16000:
@@ -306,6 +361,10 @@ def drift(fp32_path: str, fp16_path: str, audio_paths, max_seconds: float) -> No
         mel = B.log_mel_spectrogram(audio)
         stride = B.CHUNK_LENGTH * B.SUBSAMPLING
         n_chunks = (mel.shape[1] + stride - 1) // stride
+        if n_chunks == 0:
+            print(f"\n{path.stem}: too short to produce a single chunk "
+                  f"({len(audio)} samples); skipped")
+            continue
 
         a = run(fp32_path, mel, n_chunks, stride, mel.shape[1])
         b = run(fp16_path, mel, n_chunks, stride, mel.shape[1])
@@ -337,18 +396,26 @@ def main() -> int:
                          "posterior divergence -- whether the fp16 error compounds through "
                          "the spkcache/FIFO feedback. This is what DER is too coarse to say.")
     ap.add_argument("--max-seconds", type=float, default=90.0,
-                    help="Truncate each --drift file (default 90).")
+                    help="Truncate each --drift file (default 90). Pass a positive number; "
+                         "use --max-seconds inf for whole files.")
     args = ap.parse_args()
+
+    if args.drift and not (args.max_seconds > 0):
+        raise SystemExit("--max-seconds must be positive (use `inf` for whole files).")
 
     src, dst = os.path.expanduser(args.input), os.path.expanduser(args.output)
     convert(src, dst, keep_io_types=not args.io_fp16)
     print("\nload check:")
     ok = check_loads(dst, src)
+    if not ok:
+        print("\nSkipping --compare/--drift: the model does not load cleanly, and running it "
+              "anyway would bury the diagnostic above under an ONNX Runtime traceback.")
+        return 1
     if args.compare:
         compare(src, dst)
     if args.drift:
         drift(src, dst, args.drift, args.max_seconds)
-    return 0 if ok else 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/nemo_export/fp16_convert_sortformer.py
+++ b/scripts/nemo_export/fp16_convert_sortformer.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Convert an exported Sortformer ONNX to fp16 -- one that actually loads.
+
+`onnxconverter_common.float16.convert_float_to_float16` on its own produces a model
+ONNX Runtime refuses:
+
+    Type Error: Type parameter (T) of Optype (Mul) bound to different types
+    (tensor(float16) and tensor(float)) in node (/pre_encode/conv/Mul_3)
+
+Three things are wrong with the naive conversion, and each needs a different answer.
+
+1. THE LENGTH ARITHMETIC MUST NOT BE CONVERTED.
+   `torch.onnx.export` emits the conv output-length formula -- floor((L + 2p - k)/s) + 1,
+   once per pre-encode conv layer -- as float `Add`/`Sub`/`Div`/`Cast` ops. Those 39 nodes
+   are not activations; they compute a FRAME COUNT. Rounding a frame count through fp16 is
+   wrong on its own terms (fp16 integers are exact only to 2048, and the intermediate
+   divisions are not integers), and it is where the mixed-type errors start. They are held
+   in fp32 by name, found by walking back from `chunk_pre_encode_lengths` rather than
+   hardcoded, so this keeps working if the exporter's node names change.
+
+2. THE CONVERTER DOES NOT UPDATE `Cast` NODES.
+   The graph has 141 explicit `Cast`s. The converter rewrites tensor types but leaves each
+   `Cast`'s `to` attribute at FLOAT, so 27 of them end up declaring they produce fp32 while
+   the graph types their output fp16. Reconciled here by trusting the converted types.
+
+3. `keep_io_types` BREAKS TENSORS THAT ARE BOTH AN OUTPUT AND AN INPUT.
+   `chunk_pre_encode_embs` is a graph output AND feeds onward into the encoder. The
+   converter appends a Cast to hand the caller fp32, and the internal consumer then reads
+   that fp32 tensor while expecting fp16 -- the `Mul` in the error above. Internal consumers
+   are rewired back to the pre-cast fp16 tensor, so the cast serves only the graph output.
+
+`keep_io_types` is deliberate: the C# caller feeds float32 and reads float32, so the fp16
+model is a drop-in for the fp32 one and `Sortformer.cs` needs no variant path.
+
+⚠ A model that loads is not a model that is correct. fp16 was measured fastest on the
+CoreML EP (22.3 ms/chunk vs 51 ms) but `chunk_pre_encode_embs` diverged to 9.8e-02, and
+those embeddings feed back into the speaker cache and FIFO across chunks -- so a
+single-chunk comparison cannot see the compounding. The go/no-go is end-to-end:
+
+    python scripts/nemo_export/sortformer_fidelity_der.py --onnx <this model> ...
+
+See issue #172 and docs/investigations/sortformer_fp16_investigation.md.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from collections import deque
+
+import numpy as np
+import onnx
+from onnx import TensorProto
+
+
+LENGTH_OUTPUT = "chunk_pre_encode_lengths"
+
+
+def length_path_nodes(graph) -> list[str]:
+    """Names of every node feeding `chunk_pre_encode_lengths`, stopping at graph inputs
+    and initializers. These stay fp32.
+
+    Walked rather than hardcoded, so it survives the exporter renaming nodes -- and so it
+    reports honestly on a graph where the length arithmetic has already been folded away
+    (the CoreML variant bakes the lengths in, leaving nothing to protect).
+    """
+    if LENGTH_OUTPUT not in {o.name for o in graph.output}:
+        raise SystemExit(
+            f"graph has no `{LENGTH_OUTPUT}` output, so the length arithmetic cannot be "
+            "located and held in fp32. Point --input at a Sortformer export.")
+    prod = {o: n for n in graph.node for o in n.output}
+    init = {i.name for i in graph.initializer}
+    gin = {i.name for i in graph.input}
+    names, seen, q = set(), set(), deque([LENGTH_OUTPUT])
+    while q:
+        name = q.popleft()
+        if name in seen or name in init or name in gin:
+            continue
+        seen.add(name)
+        node = prod.get(name)
+        if node is None:
+            continue
+        if node.name:
+            names.add(node.name)
+        q.extend(node.input)
+    return sorted(names)
+
+
+def reconcile_casts(graph) -> int:
+    """Point each `Cast`'s `to` at the type the converted graph gives its output."""
+    types = {v.name: v.type.tensor_type.elem_type
+             for v in list(graph.value_info) + list(graph.input) + list(graph.output)}
+    fixed = 0
+    for node in graph.node:
+        if node.op_type != "Cast":
+            continue
+        attr = next(a for a in node.attribute if a.name == "to")
+        declared = types.get(node.output[0])
+        floats = (TensorProto.FLOAT, TensorProto.FLOAT16)
+        if declared in floats and attr.i in floats and attr.i != declared:
+            attr.i = declared
+            fixed += 1
+    return fixed
+
+
+def rewire_output_casts(graph) -> int:
+    """Undo `keep_io_types` for INTERNAL consumers of a graph output.
+
+    The converter ends such a tensor with `Cast(fp16 -> fp32)` so the caller still gets
+    fp32. Any node that also consumes it inside the graph wants the fp16 source instead.
+
+    ⚠ Only fp16->fp32 casts qualify. "Produced by a Cast" is not enough: Sortformer's
+    `chunk_pre_encode_lengths` output is produced by a legitimate `Cast(to=INT64)` that the
+    model itself contains, and it IS consumed internally -- the attention mask is built from
+    it. Rewiring past that one would hand the mask a float tensor in place of the frame
+    count, which is a silent semantic change, not a dtype tidy-up.
+    """
+    types = {v.name: v.type.tensor_type.elem_type
+             for v in list(graph.value_info) + list(graph.input) + list(graph.output)}
+    outputs = {o.name for o in graph.output}
+    producer = {o: n for n in graph.node for o in n.output}
+    rewired = 0
+    for name in outputs:
+        node = producer.get(name)
+        if node is None or node.op_type != "Cast":
+            continue
+        to = next(a.i for a in node.attribute if a.name == "to")
+        src = node.input[0]
+        if to != TensorProto.FLOAT or types.get(src) != TensorProto.FLOAT16:
+            continue
+        for consumer in graph.node:
+            if consumer is node:
+                continue
+            for i, inp in enumerate(consumer.input):
+                if inp == name:
+                    consumer.input[i] = src
+                    rewired += 1
+    return rewired
+
+
+# Ops ONNX Runtime has no fp16 CPU kernel for. Converting them produces a model that
+# LOADS and then dies at the first inference:
+#
+#   RUNTIME_EXCEPTION ... ScatterElements ... MLFloat16 data type is not supported with
+#   ScatterElements opset 16 when reduction is 'add'
+#
+# Held in fp32 with a cast on each side, which costs one node's worth of bandwidth. Other
+# execution providers may well have the kernel, but the model has to run on CPU too, and a
+# per-EP artifact is not worth one op.
+UNSUPPORTED_FP16_OPS = ["ScatterElements"]
+
+
+def convert(src: str, dst: str, keep_io_types: bool = True) -> None:
+    from onnxconverter_common import float16
+
+    model = onnx.load(src)
+    block = length_path_nodes(model.graph)
+    op_block = list(float16.DEFAULT_OP_BLOCK_LIST) + UNSUPPORTED_FP16_OPS
+    print(f"[1/4] holding {len(block)} length-arithmetic nodes and "
+          f"{'/'.join(UNSUPPORTED_FP16_OPS)} in fp32")
+    fp16 = float16.convert_float_to_float16(
+        model, keep_io_types=keep_io_types, node_block_list=block, op_block_list=op_block)
+    print(f"[2/4] reconciling Cast `to` attributes ...  {reconcile_casts(fp16.graph):3d} fixed")
+    print(f"[3/4] rewiring internal consumers of cast-back outputs ... "
+          f"{rewire_output_casts(fp16.graph):3d} edges")
+    onnx.checker.check_model(fp16, full_check=False)
+    onnx.save(fp16, dst)
+    print(f"[4/4] wrote {dst} ({os.path.getsize(dst) / 1e6:.0f} MB)")
+
+
+def check_loads(path: str) -> bool:
+    """A model that loads at one optimization level can fail at another; check all three."""
+    import onnxruntime as ort
+    ok = True
+    for level in ("ORT_DISABLE_ALL", "ORT_ENABLE_BASIC", "ORT_ENABLE_ALL"):
+        so = ort.SessionOptions()
+        so.graph_optimization_level = getattr(ort.GraphOptimizationLevel, level)
+        try:
+            ort.InferenceSession(path, so, providers=["CPUExecutionProvider"])
+            print(f"  {level:18} loads")
+        except Exception as exc:
+            print(f"  {level:18} FAILS: {str(exc).strip().splitlines()[-1][:150]}")
+            ok = False
+    return ok
+
+
+def compare(fp32_path: str, fp16_path: str, seed: int = 7) -> None:
+    """Single-chunk parity, on the steady-state shapes. Indicative only -- see the module
+    docstring on why this cannot answer the question by itself."""
+    import onnxruntime as ort
+
+    rng = np.random.default_rng(seed)
+    ref = ort.InferenceSession(fp32_path, providers=["CPUExecutionProvider"])
+    got = ort.InferenceSession(fp16_path, providers=["CPUExecutionProvider"])
+
+    shapes = {"chunk": (1, 992, 128), "spkcache": (1, 188, 512), "fifo": (1, 124, 512)}
+    feed = {}
+    for i in ref.get_inputs():
+        if i.type == "tensor(int64)":
+            buf = i.name[: -len("_lengths")]
+            feed[i.name] = np.array([shapes[buf][1]], np.int64)
+        else:
+            feed[i.name] = rng.standard_normal(shapes[i.name]).astype(np.float32)
+
+    a = dict(zip([o.name for o in ref.get_outputs()], ref.run(None, feed)))
+    b = dict(zip([o.name for o in got.get_outputs()],
+                 got.run(None, {k: feed[k] for k in [i.name for i in got.get_inputs()]})))
+    print("\nsingle-chunk fp16 vs fp32 (CPU EP, steady state):")
+    for key in ("spkcache_fifo_chunk_preds", "chunk_pre_encode_embs"):
+        x, y = a[key].astype(np.float32), b[key].astype(np.float32)
+        d = np.abs(x - y)
+        print(f"  {key:26} maxAbs={d.max():.3E}  rms={np.sqrt((d ** 2).mean()):.3E}")
+    print("  ⚠ indicative only: embs feed back into spkcache/FIFO, so run the DER harness.")
+
+
+def drift(fp32_path: str, fp16_path: str, audio_paths, max_seconds: float) -> None:
+    """Does the fp16 error COMPOUND across chunks, or stay bounded?
+
+    That is the question the single-chunk comparison cannot answer and DER is too coarse to
+    answer: `chunk_pre_encode_embs` feeds the speaker cache and FIFO, so error can
+    accumulate, and a collar plus a median filter will hide a lot of per-frame movement.
+    Runs the ported streaming loop twice on the same audio and diffs the raw posteriors, per
+    chunk. Growth with chunk index is compounding; a trace that wanders is not.
+    """
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import soundfile as sf
+
+    import benchmark_sortformer_rtf as B
+
+    def run(model, mel, n_chunks, stride, total):
+        pipe = B.OnnxSortformerPipeline(Path(model), device="cpu", gpu_id=0,
+                                        provider_kind="cpu")
+        pipe.reset_state()
+        return [pipe.process_chunk(i, stride, total, mel)[0] for i in range(n_chunks)]
+
+    for path in audio_paths:
+        path = Path(path)
+        frames = int(max_seconds * 16000) if max_seconds else -1
+        audio, sr = sf.read(str(path), dtype="float32",
+                            frames=frames if frames > 0 else -1)
+        if sr != 16000:
+            raise SystemExit(f"{path}: expected 16 kHz, got {sr}")
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+        mel = B.log_mel_spectrogram(audio)
+        stride = B.CHUNK_LENGTH * B.SUBSAMPLING
+        n_chunks = (mel.shape[1] + stride - 1) // stride
+
+        a = run(fp32_path, mel, n_chunks, stride, mel.shape[1])
+        b = run(fp16_path, mel, n_chunks, stride, mel.shape[1])
+        per_chunk = [float(np.abs(x.astype(np.float32) - y.astype(np.float32)).max())
+                     for x, y in zip(a, b)]
+        ca, cb = np.concatenate(a), np.concatenate(b)
+        d = np.abs(ca.astype(np.float32) - cb.astype(np.float32))
+        flips = int((((ca > 0.5) != (cb > 0.5)).any(axis=1)).sum())
+        print(f"\n{path.stem}  {n_chunks} chunks, {len(ca)} frames")
+        print(f"  per-frame preds  maxAbs={d.max():.3E}  rms={np.sqrt((d ** 2).mean()):.3E}")
+        print(f"  frames whose binarized speaker set differs: {flips}/{len(ca)}")
+        print("  per-chunk maxAbs: " + " ".join(f"{v:.2E}" for v in per_chunk))
+    print("\n  A trend across the per-chunk figures is compounding. A trace that rises and")
+    print("  falls is bounded error, and the binarized column says whether it reaches output.")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--input", required=True, help="fp32 Sortformer ONNX")
+    ap.add_argument("--output", required=True, help="fp16 model to write")
+    ap.add_argument("--io-fp16", action="store_true",
+                    help="Make the graph's inputs and outputs fp16 too. Off by default: "
+                         "fp32 io keeps this a drop-in for Sortformer.cs.")
+    ap.add_argument("--compare", action="store_true",
+                    help="Single-chunk parity against --input afterwards.")
+    ap.add_argument("--drift", nargs="+", metavar="AUDIO",
+                    help="16 kHz mono files to run both models over, reporting per-chunk "
+                         "posterior divergence -- whether the fp16 error compounds through "
+                         "the spkcache/FIFO feedback. This is what DER is too coarse to say.")
+    ap.add_argument("--max-seconds", type=float, default=90.0,
+                    help="Truncate each --drift file (default 90).")
+    args = ap.parse_args()
+
+    src, dst = os.path.expanduser(args.input), os.path.expanduser(args.output)
+    convert(src, dst, keep_io_types=not args.io_fp16)
+    print("\nload check:")
+    ok = check_loads(dst)
+    if args.compare:
+        compare(src, dst)
+    if args.drift:
+        drift(src, dst, args.drift, args.max_seconds)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nemo_export/requirements.txt
+++ b/scripts/nemo_export/requirements.txt
@@ -4,4 +4,5 @@ nemo-toolkit[asr]==2.7.1
 onnx>=1.17,<2
 huggingface_hub>=0.30,<1
 onnxscript>=0.3,<1
+onnxconverter-common>=1.16,<2   # fp16_convert_sortformer.py
 soundfile>=0.12,<1


### PR DESCRIPTION
Closes #172. Both halves: there is now a loadable fp16 model, and the accuracy question the
model card raised since the beginning has an answer.

## Why a bare conversion doesn't work

`convert_float_to_float16` gives a model ORT refuses. Four separate causes, and none of them
is `op_block_list` tuning in the general sense the issue suggests:

**1. The nodes it trips over aren't activations.** Walking back from
`chunk_pre_encode_lengths` finds 39 `Cast`/`Add`/`Div`/`Sub`/`Constant` nodes — the conv
output-length formula `floor((L + 2p - k)/s) + 1`, once per pre-encode layer, emitted by the
tracer as float arithmetic. That is a **frame count**. fp16 is exact on integers only to
2048 and the intermediate divisions aren't integers, so converting it is wrong on its own
terms, quite apart from being where the type errors begin. Held in fp32 by walking the graph
rather than by name, so it survives the exporter renaming nodes.

**2. The converter rewrites tensor types but not `Cast` nodes.**

| | Cast nodes | `to=` | disagreeing with `value_info` |
|---|---|---|---|
| source | 141 | FLOAT×31, INT64×53, BOOL×57 | 0 |
| naive fp16 | 188 | FLOAT×52, INT64×53, BOOL×57, FLOAT16×26 | **27** |

That's the concrete mechanism behind the playbook's vaguer note that the converter "fights
graphs containing explicit `Cast` nodes".

**3. `chunk_pre_encode_embs` is both a graph output and an internal input.** `keep_io_types`
appends a `Cast` so the caller still gets fp32, and the internal consumer then reads fp32
while expecting fp16 — which is exactly the `Mul` in the error #172 quotes. Internal
consumers are rewired to the pre-cast fp16 source so the cast serves only the output.

**4. `ScatterElements` has no fp16 CPU kernel at opset 16.** Without holding it back, the
model loads and then dies on the first inference. A model that loads is not a model that runs.

Result: 492 MB → 247 MB, loading at `ORT_DISABLE_ALL`, `ORT_ENABLE_BASIC` and
`ORT_ENABLE_ALL`. IO stays float32, so it's a drop-in for `Sortformer.cs`. `embs` diverges
`9.766E-02`, reproducing the model card's 9.8e-02 to three digits — that number is now
reproducible rather than folklore.

Shipped as a standalone script rather than in the exporter, contrary to the issue's
suggestion: all four passes are surgery on the converter's output and need neither torch nor
the `.nemo`, and this way it converts the CoreML variant too (verified). Requiring a 2.7 GB
checkpoint to make an fp16 file would be strictly worse.

## The accuracy question, answered

```
fidelity DER vs NeMo (collar 0.25s): DER 0.000 %  confusion 0.000 %  FA 0.000 %  missed 0.000 %
```

Segment and speaker counts exact on all three 90 s samples. The caveat was right to demand
the check and wrong about the outcome.

DER is deliberately coarse though — median filter, collar, binarization — so `--drift`
measures what it hides:

| sample | per-frame `preds` maxAbs | rms | frames whose binarized speaker set differs |
|---|---|---|---|
| en-US_sample_01 | 2.168E-02 | 1.356E-03 | 0 / 1126 |
| en-US_sample_02 | 1.080E-02 | 4.627E-04 | 0 / 1126 |
| en-US_sample_03 | 3.363E-02 | 1.573E-03 | **3** / 1126 |

The error **does** grow through the feedback path — 6.7e-04 on one chunk becomes 1.1e-02 to
3.4e-02 over a recording — but the per-chunk trace wanders rather than trending, so it's
bounded, not compounding. 3 frames of 3378 flip their binarized speaker set, all isolated
enough for the median filter to absorb. "0.000%" on its own would overstate it.

## What actually blocks fp16 now: throughput, and it isn't uniform

| EP | fp32 | fp16 | |
|---|---|---|---|
| CPU (x86-64) | 333.0 ms | 415.3 ms | **25% slower** |
| CUDA (3090) | 17.6 ms | 10.6 ms | **1.66× faster** |
| CoreML (M-series) | 51 ms | 22.3 ms | *on file, unverified from here* |

No native fp16 CPU kernels, so ORT casts up and back around every op. fp16 is an
**execution-provider-gated variant, never a replacement** — shipping it as the default would
slow down every CPU user. It also halves CUDA load time (1.90 s → 0.89 s).

## Also

- A latent bug found in self-review: `rewire_output_casts` keyed on "output produced by a
  `Cast`", but `chunk_pre_encode_lengths` is produced by a legitimate `Cast(to=INT64)` the
  model itself contains, and it *is* consumed internally — the attention mask is built from
  it. The pass was rewiring the mask's frame-count input to a float tensor. Restricted to
  fp16→fp32 casts; rewired edges drop 4 → 2, so two of the four were that output. Every
  measured number is identical before and after, which is exactly the argument that would
  have let it ship.
- Playbook and model card updated — both still said the accuracy question was open.
- `--drift` ships rather than living in a scratch script, so the table above is reproducible.
- Full local CI green.

**Not published and not wired into the runtime.** Two decisions gate that: re-measuring the
CoreML number on the Apple Silicon machine (the converter handles that variant), and EP-gated
model selection, which is the same shape of runtime work the CoreML variant needs and is
probably worth doing once for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012REYzas6iF1tQXmfRuin6b
