### PR TITLE
parakeet: a CoreML-compilable encoder export, by hoisting the mask instead of baking it

### DIFF
--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -31,6 +31,23 @@ Net: **3.2× vs CPU, 1.8× vs WebGPU, and load went from 101 s to 2.1 s.**
 ⚠ **On ORT 1.24.4 — which is not the ORT the macOS build ships.** Read the first
 caveat at the bottom before treating any of this as a shipped speedup.
 
+## What this bought on Parakeet
+
+Measured on an M5, ORT **1.29.0**, the 0.6B TDT encoder (24 conformer layers,
+d_model 1024, full-context `rel_pos`). Techniques 1 and 6 only; no post-processing.
+
+| stage | partitions | inference (10 s bucket) |
+|---|---|---|
+| shipped dynamic model | *fails to compile* (`error -14`), 84 | — |
+| static bucket + mask hoisted to an input | **1** (1453/1453 nodes) | **58.2 ms** |
+| same graph, CPU EP | — | 146.9 ms |
+| shipped dynamic model, CPU EP | — | 143.6 ms |
+
+**2.5× vs CPU, holding at every bucket from 4 s to 30 s.** Parity against the shipped
+encoder is 2e-7…6e-6 on real speech, with 7/7 identical transcripts through the full
+TDT decode — and the mask rewrite is `0.000E+00` in PyTorch, so the residual is
+ONNX/EP float noise, not the technique.
+
 ## The core mental model
 
 The CoreML EP fuses only the ops it fully supports. Everything else stays on
@@ -119,6 +136,11 @@ value is enabling Technique 3 — it turns the masks into foldable constants.
 > inference per recording and keeps the output exact. Expect to find this shape
 > wherever "the axes are constant at runtime" turns out to mean "constant except
 > at the edges".
+>
+> **"There is no middle setting" holds only if the mask has to stay derived.** When
+> the lengths vary on *every* call there is no one-inference escape hatch and this
+> trade has no acceptable answer — take the mask out of the graph instead
+> (Technique 6). That is exact at any length and needs neither of these flags.
 
 ## Technique 3 — Delete all-False `Where` masks
 
@@ -165,6 +187,17 @@ the zero tensors. Match the zero constant's **dtype** to the padded tensor or
 Sortformer: 34 converted, 35 → **1** partition, 97 ms → 51 ms. Biggest
 throughput win of the four.
 
+> ⚠ **On ORT 1.29.0 this technique is a no-op: the CoreML EP now accepts `Pad`.**
+> Verified directly — a one-node `Pad` graph (constant mode, `[0,0,4,0,0,4]`) reports
+> `1 partition, 1/1 nodes supported`. Parakeet's encoder carries 48 `Pad`s and reaches
+> one partition with them left alone; converting them changed neither the partition
+> count nor the inference time (58.1 ms with `Pad`, 59.4 ms with `Concat` — noise).
+> The op table shipped in the `onnxruntime` wheel
+> (`tools/mobile_helpers/coreml_supported_mlprogram_ops.md`) still omits `Pad`, so it
+> is stale; probe rather than trust it. Keep the transform for 1.24.4, and check
+> before spending a fold round-trip on it — see the note under Technique 5 about what
+> that round-trip costs you.
+
 ## Technique 5 — Pre-transpose `Gemm` weights (the load-time fix)
 
 **Symptom:** enormous first-load and warm-load times, and a `model.mil` far
@@ -197,7 +230,105 @@ This is the highest-leverage item in the playbook and it generalizes to **any**
 transformer export, because `transB=0` is what `torch.onnx.export` emits by
 default.
 
-## Technique 6 — `ModelCacheDirectory`
+> **But the trigger is `Gemm` specifically, not "transformer".** Parakeet's encoder
+> traces to 289 `MatMul` and **zero** `Gemm` — its linears run on 3D `[B,T,D]`
+> activations, where the exporter emits `MatMul`, while Sortformer's ran on 2D
+> reshapes, where it emits `Gemm`. `MatMul`-with-constant-weight takes the binary
+> path already: 2.36 GB of weights produced a **4.5 MB** `model.mil`, versus
+> Sortformer's 1.49 GB for 0.39 GB. So check the op mix before assuming the
+> pathology, and diagnose it the way step 4 says — by `model.mil` size, not by
+> reasoning about the architecture.
+>
+> That matters more than it sounds, because applying this transform (or Technique 3
+> or 4) means folding the graph through ORT first, and **that round-trip is what
+> makes the artifact refuse to load above `ORT_ENABLE_BASIC`** (`MatMulAddFusion`;
+> see the anti-patterns). A graph that needs none of them never round-trips and has
+> no such contract term — Parakeet's ships straight from `torch.onnx.export` and
+> loads at every optimization level. Reach for the transforms when the partition
+> count says to, not by default.
+
+## Technique 6 — Hoist the mask into a graph input
+
+**Use when:** the "constant except at the edges" trade in Technique 2 has no
+acceptable answer, because the lengths genuinely vary on every call.
+
+Techniques 2 and 3 offer only two settings — bake a length that is sometimes wrong,
+or keep the whole data-dependent mask and stay fragmented. Sortformer escapes that
+because exactly one inference per recording is short, so the runtime can route it to
+the unspecialized graph. **A model whose every call has a different length has no
+such escape**, and the cost of pretending otherwise is not small: on Parakeet, baking
+the length moves the encoder output by 0.17–0.24 on valid frames and changes the
+transcript by 2–4% WER on 8–20 s segments, worse on short ones.
+
+There is a third setting. The mask is *derived* data — the only thing the length is
+used for. Take it out of the graph and accept it as an input:
+
+```
+audio_signal  [1, 128, F]     features, zero-padded to a fixed bucket
+pad_keep      [1, F]          1.0 for a real frame, 0.0 for padding
+```
+
+Now the shapes are static, the `Range`/`Less`/`Expand`/`ConstantOfShape` chain is
+**gone rather than folded**, and the masking is exact at any true length ≤ the
+bucket. Parakeet: 4955 → 1453 nodes, `Where` 90 → **0**, one partition, and parity
+against the shipped dynamic encoder of 2e-7…6e-6 with identical transcripts.
+
+**Do it in float, not bool.** Feed a keep-mask of 1.0/0.0 and rewrite each masking
+site as arithmetic — `Add`/`Mul` are CoreML-supported, and it sidesteps the question
+of whether the EP takes a bool input at all:
+
+| NeMo | rewrite | why it is exact |
+|---|---|---|
+| `scores.masked_fill(mask, -INF_VAL)` | `scores + (keep - 1) * INF_VAL` | masked entries become `s - 10000` instead of `-10000`; both underflow to 0 in the softmax, and both are zeroed by the next line anyway |
+| `softmax(...).masked_fill(mask, 0.0)` | `softmax(...) * keep` | identical |
+| `apply_channel_mask` | `x * keep` | already a multiply |
+
+**Patch the module instances, not the classes** (`types.MethodType`), so nothing
+else in the export process is affected.
+
+> ⚠ **Find every masking site first. There are more than the obvious one.** In NeMo's
+> conformer the length reaches masking at **four** resolutions: `_create_masks` builds
+> the attention and conv-module masks at the encoder rate, and — easy to miss —
+> `MaskedConvSequential` re-masks between *every strided conv in the subsampler*.
+> Hoisting only `_create_masks` left a **1e-2 error spread across all frames**, which
+> reads like a tolerance question rather than a bug, and does not look like a boundary
+> artifact. Do not chase it through ONNX: run the patched and unpatched modules
+> side by side in PyTorch on the same input and bisect the substitutions one at a
+> time. The target is `0.000E+00`, and it is reachable — anything else means a site
+> is still deriving its own mask.
+
+**The masks at different rates are usually slices of each other, not separate
+inputs.** Each subsampler stage halves the length as
+`L_k = (L_{k-1} - 1) // 2 + 1 = ceil(L_{k-1} / 2)`, and `keep[2i]` is 1 exactly while
+`2i < L` — which is `ceil(L / 2)` entries. So stage *k*'s mask is `keep[0::2]` applied
+*k* times, and one mel-rate input feeds all four via constant-parameter `Slice`
+(supported). Prove the identity exhaustively over every length before relying on it;
+it is a five-line check.
+
+**What it costs: bucketing.** Static shapes mean a fixed `F`, so a caller with
+variable input pads up to the next bucket and pays for the padding. Measured on an
+M5, one bucket per row:
+
+| bucket | CoreML | CPU EP | speedup |
+|---|---|---|---|
+| 400 frames (4 s) | 34.9 ms | 87.2 ms | 2.50× |
+| 1000 frames (10 s) | 58.2 ms | 146.9 ms | 2.52× |
+| 2000 frames (20 s) | 110.9 ms | 279.4 ms | 2.52× |
+| 3000 frames (30 s) | 165.2 ms | 445.7 ms | 2.70× |
+
+≈ 16 ms fixed + 4.75 ms per second of audio, so the speedup holds at every size and
+padding waste is proportional rather than catastrophic. Note the ladder is a
+*runtime* cost, not a download one: every bucket traces the same parameters in the
+same order, so the weight sidecars come out **byte-identical** — one shared
+`.data` file and an ~25 MB graph per bucket. Verify by digest rather than assuming;
+a torch or NeMo change that reorders the trace would break it silently.
+
+**The real per-bucket cost is the CoreML cache: ~4.4 GB each**, because the EP stores
+the weights twice — once in the `.mlpackage` under `Data/`, once in the compiled
+`.mlmodelc`. Four buckets is 18 GB on disk. Budget for it, prune stale entries, and
+let it argue for a short ladder.
+
+## Technique 7 — `ModelCacheDirectory`
 
 Set the CoreML provider option `ModelCacheDirectory` to persist the compiled
 model across processes. Necessary but not a substitute for Technique 5:
@@ -335,6 +466,12 @@ capability question (can we express this at all?) rather than a performance one.
 
 ## Diagnostic workflow for a new model
 
+0. **Ask what the varying axes actually are, and how the caller uses them.** This
+   decides which branch of the playbook you are on before you measure anything.
+   Constant at runtime, or constant except at the edges → Techniques 1–3, and read
+   Technique 2's warning. Genuinely different on every call → Technique 6, and do not
+   spend time on the bake-a-length path; it was measured on Parakeet and it costs
+   2–4% WER.
 1. **Does it compile?** Load with the CoreML EP. `error -14` → Technique 1.
 2. **Count partitions.** The EP logs it at warning level:
    ```
@@ -347,22 +484,64 @@ capability question (can we express this at all?) rather than a performance one.
    `Node(s) placed on [CPUExecutionProvider]`. Group by op type — the offenders
    are usually two or three types repeated per layer.
 4. **Check `model.mil` size** in the cache dir against the model's real weight
-   volume. Much larger → Technique 5.
+   volume. Much larger → Technique 5. (Sortformer: 1.49 GB for 0.39 GB of weights.
+   Parakeet: 4.5 MB for 2.36 GB — nothing to fix.)
 5. **Verify parity at every step**, against the *original* model, not the
-   previous step — errors compound quietly otherwise.
+   previous step — errors compound quietly otherwise. **Verify in the framework
+   before you verify through ONNX**: when a rewrite changes what the model computes,
+   a PyTorch-vs-PyTorch comparison isolates it from export and EP noise, and gives
+   you a real `0.000E+00` to aim at rather than a tolerance to argue about.
+   Bisect substitutions one at a time — the mask hoist looked like a 1e-2 tolerance
+   question until that turned it into "three masking sites are still missing".
 
 ## Applying to other models
 
 | model | outlook |
 |---|---|
 | Sortformer | **Done.** Axes constant at runtime; ideal case. |
-| Parakeet encoder | Plausible. Length genuinely varies → needs bucketing, and padding waste is a real cost. Technique 5 applies regardless. |
-| Parakeet TDT decoder | Poor. `Loop` subgraphs are badly handled by the CoreML EP; `OrtSessionBuilder` already carries a `.ort` workaround for Loop graphs (issue #56). Likely stays CPU. |
+| Parakeet encoder | **Done, via Technique 6.** One partition, 2.5× over CPU at every bucket, bit-exact. Baking the length (the Sortformer recipe) was measured and rejected — 2–4% WER. |
+| Parakeet TDT decoder | **Measured, and not worth it** — and not a `Loop` graph, as recorded here previously. It is 42 nodes with two `LSTM`s, stepped from C#. With its shapes frozen (they are all constant in the greedy path) it puts **23 of 27 nodes on CoreML**, only `LSTM` declining — and runs at **0.652 ms vs 0.643 ms on CPU**. The work per call is too small to pay for two partition boundaries. See "when not to bother" below. |
+| `nemo128` preprocessor | **No.** 6 partitions, 31/89 nodes, and CoreML is *slower*: 2.95 ms vs 1.71 ms. `Parakeet.cs` already pins it to CPU, correctly. It is 1% of pipeline time. |
+| Silero VAD | **Cannot.** Fails to compile outright — `Error compiling model: Failed to parse the model specification`; it carries three `If` subgraphs. Costs 2.0 ms per second of audio (1.2 s for a 10-minute recording), once per recording. |
 | KV-cache decoders (Cohere, Qwen3, VibeVoice, Granite) | Untested. Fixed cache lengths would help; per-step dynamic KV growth is the obstacle. |
 | Conv-heavy (Silero VAD, DeepFilterNet3, WeSpeaker) | Promising — conv is the ANE's strength and these graphs are simpler. Start here for quick wins. |
 
-**Technique 5 is worth applying to every model unconditionally**, including ones
-never going near CoreML — it is bit-exact and costs nothing.
+### When not to bother — profile the pipeline, not the model
+
+Partition count tells you whether a graph *can* go fast. It says nothing about
+whether the pipeline gets faster, and two of the three checks below are cheaper than
+any of the techniques above.
+
+**Is the model actually where the time goes?** Measured over 72.5 s of real speech,
+ten segments, timing each ORT session separately:
+
+| stage | share | after the encoder's 2.5× |
+|---|---|---|
+| `nemo128` preprocessor | 1.0% | 1.8% |
+| encoder | 77.9% | 58.5% |
+| `decoder_joint` (×20–94 calls per segment) | 21.2% | 39.8% |
+
+A 2.5× on the encoder is **1.88× end to end**. Everything else in the stack was
+either slower on CoreML or unable to compile, so that is the whole prize — and it is
+worth knowing before, not after.
+
+**Is the per-call work big enough to pay for the boundary?** A partition boundary
+costs a copy and a sync each way. `decoder_joint` reaches 23/27 nodes on the EP and
+still does not move (0.652 vs 0.643 ms) because each call is one frame and one token.
+Small-and-frequent loses to CoreML even when it partitions well; the encoder wins
+because each call is 10 s of audio through 24 layers.
+
+**Does a runtime fallback hide the answer?** The first `decoder_joint` probe reported
+2 partitions and identical timing — because its CoreML partitions then failed to
+compile on unbounded dims and silently fell back to CPU. The capability report and
+the timing were both "fine" while nothing ran on the EP. Freeze shapes (Technique 1)
+*before* concluding anything from a timing comparison, and check the log for
+`has unbounded dimension` rather than trusting a clean partition count.
+
+**Technique 5 is worth applying to every model that has `Gemm` nodes**, including
+ones never going near CoreML — it is bit-exact and costs nothing. Check first: a
+`MatMul`-only export (Parakeet) does not have the problem, and applying the transform
+means a fold round-trip that adds a load-level contract term.
 
 ## Tooling
 
@@ -372,6 +551,13 @@ never going near CoreML — it is bit-exact and costs nothing.
 - `scripts/nemo_export/coreml_optimize_sortformer.py` — Techniques 3–5 plus
   `--verify` against the original model. The graph transforms are model-agnostic;
   only the verification harness is Sortformer-specific.
+- `scripts/nemo_export/export_parakeet_coreml_encoder.py` — Techniques 1 and 6 for the
+  Parakeet encoder: static buckets, mask hoisted to a `pad_keep` input, all four
+  masking sites rewritten as arithmetic. Needs **no** post-processing — the raw export
+  is already one partition — and emits one shared weight sidecar for every bucket.
+- `scripts/nemo_export/coreml_partition_probe.py` — the partition/timing/load-level
+  probe. `--ep` selects what you measure *and* what you can see: a load-level matrix
+  is only meaningful per-EP.
 
 ## Caveats
 

--- a/docs/coreml_onnx_playbook.md
+++ b/docs/coreml_onnx_playbook.md
@@ -270,7 +270,9 @@ pad_keep      [1, F]          1.0 for a real frame, 0.0 for padding
 
 Now the shapes are static, the `Range`/`Less`/`Expand`/`ConstantOfShape` chain is
 **gone rather than folded**, and the masking is exact at any true length ≤ the
-bucket. Parakeet: 4955 → 1453 nodes, `Where` 90 → **0**, one partition, and parity
+bucket. Parakeet: 4955 → 4104 nodes at export (ORT's load-time BASIC fold takes it
+the rest of the way to 1453 — that part is not this technique's doing), `Where` 90 →
+**0**, `Range`/`Less`/`Equal`/`Expand` gone, one partition, and parity
 against the shipped dynamic encoder of 2e-7…6e-6 with identical transcripts.
 
 **Do it in float, not bool.** Feed a keep-mask of 1.0/0.0 and rewrite each masking
@@ -444,12 +446,20 @@ replacing the runtime.
 EP cannot currently express:
 
 1. **Stateful models** (macOS 14+). CoreML natively supports state tensors held
-   across predictions — the natural fit for KV-cache decoders and for the
-   Parakeet TDT decoder, both of which the CoreML EP handles poorly because they
-   are `Loop` subgraphs. This is the strongest argument.
+   across predictions — the natural fit for KV-cache decoders. ⚠ This used to name
+   the Parakeet TDT decoder as the strongest case, on the grounds that it is a `Loop`
+   subgraph. It is not a `Loop` subgraph, and it has since been measured: frozen, it
+   already puts 23 of 27 nodes on the EP and runs at 0.652 ms against 0.643 ms on
+   CPU. Its problem is that each call is too small to pay for a partition boundary,
+   which a native path would not fix. The untested KV-cache decoders are the real
+   case here.
 2. **Enumerated / flexible shapes.** CoreML accepts a declared *set* of allowed
    input shapes and compiles for each. That could handle Parakeet's variable
-   audio length better than ONNX-side bucketing, without padding waste.
+   audio length better than ONNX-side bucketing, without padding waste — and there is
+   now a number on what bucketing costs: **4.4 GB of compiled cache per bucket**,
+   which is the ladder's real constraint. Note the padding waste itself is mild
+   (≈16 ms fixed + 4.75 ms per second of audio), so this is a disk-footprint argument
+   rather than a throughput one.
 3. **`coremltools` compression.** Its fp16, palettization and quantization are
    better calibrated than `onnxconverter-common`, which fights graphs containing
    explicit `Cast` nodes (see the fp16 section).

--- a/docs/investigations/parakeet_coreml_encoder_investigation.md
+++ b/docs/investigations/parakeet_coreml_encoder_investigation.md
@@ -261,7 +261,8 @@ remaining work is all on the C# side or is a product decision:
 2. **`Parakeet.cs` has no CoreML path.** It batches up to 32 segments padded to the
    batch max and reads `encoded_lengths` off the model. The CoreML path is batch-1,
    picks a bucket per segment, builds `pad_keep`, and computes the encoded length
-   itself (`calc_encoded_length`, three iterations of `(L + 2 - 3) // 2 + 1`).
+   itself (`calc_encoded_length`, folding the `subsampler_stages` the export report
+   records -- three ×2 stages for this checkpoint).
    Dropping batching costs nothing — Run 8 shows batch-1 is the best CPU case anyway
    — and the expected end-to-end gain is **1.88×**, not 2.5×, because the decoder is
    then 40% of the pipeline.

--- a/docs/investigations/parakeet_coreml_encoder_investigation.md
+++ b/docs/investigations/parakeet_coreml_encoder_investigation.md
@@ -1,0 +1,271 @@
+# Parakeet encoder — CoreML variant investigation
+
+Goal: give the Parakeet TDT encoder a CoreML-compilable export, the way
+`docs/coreml_onnx_playbook.md` did for Sortformer. The playbook's recipe turns out
+not to transfer, and the reason is worth the write-up.
+
+## Environment
+
+- MacBook / **Apple M5**, 24 GB, macOS 25.6.0. The machine that decides this, since
+  it is the only one with CoreML.
+- export venv `.venv-nemo-export`, python 3.12.14, `nemo-toolkit 2.7.1`,
+  `torch 2.14.0`, `onnx 1.22.0`, **`onnxruntime 1.29.0`** — the version an
+  `EP=Cpu` osx-arm64 build takes (`Directory.Build.props` pins 1.24.4 for DirectML
+  only).
+- source checkpoint `nvidia/parakeet-tdt-0.6b-v3` (`parakeet-tdt-0.6b-v3.nemo`,
+  2,509,332,480 B).
+- reference bundle: the published `christopherthompson81/sortformer_parakeet_onnx`
+  `encoder-model.onnx` (41,842,955 B) + `encoder-model.onnx.data`
+  (2,435,420,160 B, md5 `2f53c7ed168d73ea305ac2f53bdac097`) — both match the
+  manifest.
+- speech: `~/Programming/test_speech_audio/en-US_sample_0{1,2,3}.wav`, three ~10 min
+  16 kHz mono conversations.
+
+The model: `ConformerEncoder`, 24 layers, d_model 1024, 8 heads, `rel_pos` with
+`att_context_size [-1, -1]` (**full context**), `dw_striding` subsampling ×8,
+conv kernel 9, 128 mel bins.
+
+## Run 1 — the stock graph, on CoreML
+
+```
+CoreMLExecutionProvider::GetCapability ... partitions: 84, nodes: 2325, supported: 2022
+Failed to create MLModel ... error code: -14
+E5RT ... Failed to PropagateInputTensorShapes: Invalid tensor rank 0 inferred from: ios18.squeeze
+```
+
+Exactly the playbook's Technique 1 symptom. The raw graph is 4955 nodes:
+289 `MatMul` and **zero `Gemm`**, 90 `Where`, 48 `Pad`, and a large
+`Shape`/`Gather`/`Reshape`/`ConstantOfShape` mass from the tracer.
+
+`decoder_joint-model.onnx` was inspected at the same time, because the playbook
+records it as a `Loop` graph. **It is not.** 42 nodes, two `LSTM`s, stepped once per
+output token from `Parakeet.cs`. `LSTM` is absent from the CoreML EP's op set, so it
+stays on CPU — but for a different reason than recorded, and it is the wrong thing to
+accelerate regardless.
+
+## Run 2 — does the Sortformer recipe transfer? No.
+
+The playbook reaches one partition by baking every length constant so the attention
+mask folds to an all-False constant. Sortformer affords that because exactly one
+chunk per recording is short. Parakeet's segments are arbitrary — the question is
+what baking costs.
+
+Measured on real speech: pad the features to a bucket, then run the **shipped**
+encoder twice, once with the honest `length` and once with the padded length, and
+compare over valid frames. Transcripts come from a Python port of `Parakeet.cs`'s
+greedy TDT loop (`MaxTokensPerStep` and all), so WER is against the model's own
+output, not a reference transcript.
+
+| segment | encoder maxAbs (valid frames) | WER vs. honest-length output |
+|---|---|---|
+| 8 s | 0.234 | 0.040 |
+| 12 s | 0.179 | 0.000 |
+| 20 s | 0.167 | 0.024 |
+| 3 s | 0.140 | 0.33 – 0.50 |
+| 5 s | 0.170 | 0.06 – 0.18 |
+
+The error saturates almost immediately with padding — +10% padding is as bad as
++100% — so it is "the mask is gone", not "the padding is large". **There is no
+setting of the Sortformer recipe that is acceptable here**, and no one-inference
+escape hatch: every segment pays.
+
+Padding with real trailing *silence* instead of zeros (letting the preprocessor see
+it) was measured in the same run and is no better — 0.04 to 0.15 WER.
+
+## Run 3 — the property that makes a third option possible
+
+With an **honest** mask, the stock encoder is padding-invariant:
+
+| segment | pad to +10% | +50% | +100% |
+|---|---|---|---|
+| 3 s | 3.6e-07 | 3.6e-07 | 3.6e-07 |
+| 8 s | 0.0 | 0.0 | 0.0 |
+| 20 s | 8.1e-07 | 8.1e-07 | 8.1e-07 |
+
+So a static-shape graph does not need a constant length — it needs the mask, and the
+mask can be an *input*. That is the whole design:
+
+```
+audio_signal  [1, 128, F]     zero-padded mel features
+pad_keep      [1, F]          1.0 real / 0.0 padding
+```
+
+Exact at any true length ≤ the bucket, and the `Range`/`Less`/`Expand`/
+`ConstantOfShape` chain is gone rather than folded.
+
+## Run 4 — the first attempt was wrong, and wrong in a way that looks like tolerance
+
+Hoisting `_create_masks` and rewriting the three `masked_fill`s per layer as
+arithmetic gave a graph with `Where` 90 → 17, static shapes, and parity of **2e-2**
+against the reference. Which reads like a tolerance question.
+
+It was not. Bisecting in PyTorch rather than through ONNX (patched vs. unpatched
+modules, same input) showed:
+
+* the error was **spread across every frame**, not concentrated at the padding
+  boundary — so not a boundary artifact;
+* it was **zero whenever the true length was a multiple of 8**, and nonzero otherwise;
+* the three arithmetic substitutions were individually exact — control, attention-only,
+  conv-only and both-arithmetic all produced the *same* 9.67e-3, i.e. the rewrite was
+  innocent;
+* `enc.pre_encode(x, lengths=300)` vs `lengths=1000` differ by **2823**.
+
+`length` does not only build the attention mask. `MaskedConvSequential` re-masks
+between **every strided conv in the subsampler** — four resolutions in total, not one.
+Hoisting one of them and leaving three deriving their own masks is a silent 1e-2.
+
+The fix is that all four masks are exact stride-2 decimations of each other:
+`L_k = (L_{k-1} - 1) // 2 + 1 = ceil(L_{k-1} / 2)`, and `keep[2i]` is 1 exactly while
+`2i < L`, which is `ceil(L / 2)` entries. Verified exhaustively for every length in
+five bucket sizes: 0 mismatches. So one mel-rate input feeds all four through
+constant-parameter `Slice`s.
+
+With that, PyTorch parity against the stock encoder is **`0.000E+00`** at true lengths
+300, 301, 500, 799, 800, 997 and 1000 — bit-exact, not close.
+
+## Run 5 — the export, and what it did not need
+
+`scripts/nemo_export/export_parakeet_coreml_encoder.py`. Graph: 4955 → 4104 nodes,
+`Where` **90 → 0**, `Range`/`Less`/`Equal`/`Expand` all gone, both inputs static.
+
+Running it through the playbook's post-processing (BASIC fold + Pad→Concat) works —
+1453 nodes, 48 `Pad`s converted, every shape resolved, 0 unresolved dims — and is
+**unnecessary**:
+
+| graph | partitions | inference (10 s bucket) |
+|---|---|---|
+| raw export | 1 (1453/1453) | 58.1 ms |
+| folded + Pad→Concat | 1 (1453/1453) | 59.4 ms |
+
+ORT's load-time BASIC fold does the same work, and the CoreML EP in 1.29.0 **accepts
+`Pad`** — confirmed on a one-node graph, `1 partition, 1/1 supported`. (The op table
+shipped in the wheel still omits `Pad`; it is stale.)
+
+That is worth more than the 1.3 ms, because the fold round-trip is what gave the
+Sortformer artifact its `ORT_ENABLE_BASIC or it will not load` contract term
+(`MatMulAddFusion`). Checked here on the CPU EP: the raw export loads at `basic`,
+`extended` **and** `all`. No contract term.
+
+Technique 5 also does not apply — 289 `MatMul`, 0 `Gemm`. `model.mil` came out at
+**4.5 MB** against 2.36 GB of weights, versus Sortformer's 1.49 GB for 0.39 GB.
+
+## Run 6 — measurements
+
+M5, ORT 1.29.0, one bucket per row, `ModelCacheDirectory` set:
+
+| bucket | CoreML | CPU EP (same graph) | speedup | cold | warm |
+|---|---|---|---|---|---|
+| 400 (4 s) | 34.9 ms | 87.2 ms | 2.50× | 22.0 s | 0.98 s |
+| 1000 (10 s) | 58.2 ms | 146.9 ms | 2.52× | 22.3 s | 0.98 s |
+| 2000 (20 s) | 110.9 ms | 279.4 ms | 2.52× | 23.4 s | 1.07 s |
+| 3000 (30 s) | 165.2 ms | 445.7 ms | 2.70× | 25 s | 1.1 s |
+
+Shipped dynamic graph on the CPU EP, 1000 frames: **143.6 ms**. So ≈16 ms fixed +
+4.75 ms per second of audio, and the 2.5× holds at every size — no crossover where
+padding waste eats the win.
+
+Parity through ONNX against the shipped encoder, seven real-speech segments of
+3–9.5 s: **2.2e-07 … 5.8e-06**, and **7/7 transcripts identical** through the full
+TDT decode.
+
+## Run 7 — the buckets are nearly free to ship
+
+Every bucket traces the same parameters in the same order, so the weight sidecars are
+byte-identical — and identical to the **published** `encoder-model.onnx.data`
+(md5 `2f53c7ed168d73ea305ac2f53bdac097`). Confirmed by repointing a bucket graph's
+external-data locations at the shipped file and running it.
+
+So the variant adds **no weight download**: one `.onnx` per bucket, 10.6 / 25.3 /
+49.9 / 74.5 MB for 4 / 10 / 20 / 30 s. The size scales with the bucket because
+`linear_pos(pos_emb)` folds to a per-layer constant of `(2T-1) × 1024` floats — that
+is a runtime win (one fewer matmul per layer) paid for in file size, and it cannot be
+shared because `linear_pos` differs per layer.
+
+The exporter verifies the sharing by digest rather than assuming it, and prints the
+md5 so it can be diffed against the published manifest.
+
+**The real per-bucket cost is the CoreML cache: 4.4 GB each**, because the EP stores
+the weights twice — `Data/com.microsoft.OnnxRuntime/weights/weight.bin` and
+`compiled_model.mlmodelc/weights/weight.bin`, 2,358,295,904 B apiece. Four buckets is
+18 GB. That, not download size, is what should decide how long the ladder is.
+
+## Run 8 — is the encoder enough? (the other three models)
+
+Asked directly: does `decoder_joint`, `nemo128` or `silero_vad` also need a CoreML
+variant before this stack counts as CoreML-ready? Measured rather than argued.
+
+**Where the time goes.** Ten segments, 72.5 s of real speech, timing each ORT session
+separately (`session.run` only, so the ported Python decode loop's own overhead is
+excluded):
+
+| stage | ms | share | after the encoder's 2.5× |
+|---|---|---|---|
+| `nemo128` | 14.8 | 1.0% | 1.8% |
+| encoder | 1210.7 | 77.9% | 58.5% |
+| `decoder_joint` | 329.3 | 21.2% | 39.8% |
+
+20–94 decoder calls per segment at a very steady **0.66–0.69 ms** each. Amdahl:
+2.5× on the encoder is **1.88× end to end**.
+
+**`decoder_joint` — measured no.** The first probe reported 2 partitions / 18 of 26
+nodes and timing identical to CPU (0.649 vs 0.657 ms), which looks like "CoreML gains
+nothing". It was not a fair test: the log carried
+`Input: encoder_outputs has unbounded dimension which is not supported`, so its CoreML
+partitions failed to compile and ORT fell back to CPU. Both readings were "fine" while
+nothing ran on the EP.
+
+Every one of its axes *is* constant in the greedy path (batch 1, one encoder frame,
+one target token, `[2,1,640]` states), so freezing them is legitimate. Frozen:
+**2 partitions, 23 of 27 nodes on CoreML, 0 unbounded-dim errors, only `LSTM` left on
+CPU** — and **0.652 ms vs 0.643 ms**. No gain. The per-call work is one frame and one
+token; it cannot pay for two partition boundaries.
+
+**`nemo128` — no.** 6 partitions, 31 of 89 nodes, and CoreML is **1.7× slower**
+(2.95 ms vs 1.71 ms). `Parakeet.cs` already constructs it with plain `SessionOptions`
+rather than `OrtSessionBuilder.Create(ep)`; that is correct and should stay.
+
+**`silero_vad` — cannot.** Fails to compile outright:
+`Error compiling model: Failed to parse the model specification`. The graph carries
+three `If` subgraphs. It costs 0.065 ms per 512-sample window, i.e. **2.0 ms per
+second of audio — 1.2 s for a 10-minute recording**, once per recording rather than
+per segment.
+
+**Batching, the last open caveat.** The concern was that `Parakeet.cs` batches up to
+32 segments while the CoreML path is batch-1, so the 2.5× might not survive. It does
+— CPU batching is not a win to give up:
+
+| batch | total | per segment |
+|---|---|---|
+| 1 | 141.8 ms | **141.8 ms** |
+| 2 | 445.3 ms | 222.7 ms |
+| 4 | 682.0 ms | 170.5 ms |
+| 8 | 1301.6 ms | 162.7 ms |
+| 16 | 2618.6 ms | 163.7 ms |
+
+Batch-1 is the *best* CPU case; the CPU EP already saturates its threads on a single
+segment. So the batch-1 CoreML design gives up nothing.
+
+Conclusion: **the encoder was the only worthwhile target in this stack.** The next win
+after it is not a CoreML variant of anything — it is the decoder's 40%, which wants
+batched greedy decoding across segments (NeMo's label-looping decoder) or int8, both
+outside this line of work.
+
+## Where this leaves the variant
+
+Done and validated as an artifact. **Not yet consumable from the app**, and the
+remaining work is all on the C# side or is a product decision:
+
+1. **The bucket ladder is unchosen.** It should come from the segment-length
+   distribution the diarizer and VAD actually produce, weighed against 4.4 GB of
+   cache per bucket. Nothing in `Config.cs` caps segment length today.
+2. **`Parakeet.cs` has no CoreML path.** It batches up to 32 segments padded to the
+   batch max and reads `encoded_lengths` off the model. The CoreML path is batch-1,
+   picks a bucket per segment, builds `pad_keep`, and computes the encoded length
+   itself (`calc_encoded_length`, three iterations of `(L + 2 - 3) // 2 + 1`).
+   Dropping batching costs nothing — Run 8 shows batch-1 is the best CPU case anyway
+   — and the expected end-to-end gain is **1.88×**, not 2.5×, because the decoder is
+   then 40% of the pipeline.
+3. **fp16 is untested here** and would halve both the sidecar and the 4.4 GB cache.
+   The playbook's fp16 section is Sortformer-specific; on CoreML it was the fastest
+   variant measured there.
+4. **Not published.** No HF upload, no manifest entry.

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -10,6 +10,7 @@ It now covers both models in your pipeline:
 ## Files
 
 - `export_parakeet_nemo_to_onnx.py`: exports Parakeet `.nemo` to the split ONNX package used by Vernacula.
+- `export_parakeet_coreml_encoder.py`: exports the Parakeet encoder as static-shape buckets that the CoreML EP compiles as a single partition, with the padding mask hoisted to a `pad_keep` input instead of baked to a constant. 2.5× over the CPU EP and bit-exact — see below.
 - `export_nfa_ctc_to_onnx.py`: exports a NeMo CTC ASR `.nemo` (pure CTC or hybrid RNNT+CTC with the CTC head selected) to the ONNX bundle the C# Viterbi forced aligner consumes (issue #36 / Chatterbox Stage 1 #9).
 - `export_sortformer_nemo_to_onnx.py`: exports streaming Sortformer `.nemo` to the same six-input / three-output ONNX contract used by Vernacula's inference code.
 - `export_silero_vad_to_onnx.py`: exports Silero VAD to ONNX.
@@ -105,6 +106,50 @@ Batching notes:
 - `nemo128.onnx` currently exports successfully on this toolchain, but in practice still behaves
   like a batch-1 preprocessor export. That means post-diarization encoder batching is available
   today, while full waveform-to-text batching still needs more export work.
+
+### Apple CoreML encoder buckets
+
+The shipped `encoder-model.onnx` cannot compile under the CoreML EP at all
+(`error -14`: unbounded dimensions). This produces graphs that can.
+
+```bash
+python scripts/nemo_export/export_parakeet_coreml_encoder.py \
+  --nemo ~/models/parakeet-tdt-0.6b-v3/parakeet-tdt-0.6b-v3.nemo \
+  --output-dir ~/models/parakeet_coreml \
+  --frames 400 --frames 1000 --frames 2000 --frames 3000
+```
+
+Contract, per bucket of `F` mel frames:
+
+| | |
+|---|---|
+| in | `audio_signal [1, 128, F]` — mel features, zero-padded to `F` |
+| in | `pad_keep [1, F]` — 1.0 for a real frame, 0.0 for padding |
+| out | `outputs [1, 1024, T]`, `T = calc_encoded_length(F)` |
+
+Two caller obligations, both of which fail silently rather than loudly:
+
+* **`pad_keep` must be honest.** All-ones on a short segment is exactly the
+  bake-the-length behaviour this export exists to avoid — worth 2–4% WER.
+* **There is no `encoded_lengths` output**, because there is no length input. Compute
+  it with `calc_encoded_length` (three iterations of `(L + 2 - 3) // 2 + 1`) and
+  ignore output frames past it.
+
+Unlike the Sortformer CoreML variant this needs **no** post-processing pass and has
+no load-level contract term: the raw export is already a single partition and loads
+at every optimization level. Measured on an M5 under ORT 1.29.0 — 2.5× the CPU EP at
+every bucket from 4 s to 30 s, parity 2e-7…6e-6, identical transcripts.
+
+All buckets share one weight sidecar, byte-identical to the published
+`encoder-model.onnx.data`, so the buckets add no weight download. The script verifies
+that by digest and prints the md5 to compare against the manifest.
+
+Costs to budget for: the CoreML cache is **~4.4 GB per bucket** (the EP stores the
+weights twice), and the `.onnx` grows with the bucket because `linear_pos(pos_emb)`
+folds to a per-layer constant.
+
+Background and measurements: `docs/coreml_onnx_playbook.md` (Technique 6) and
+`docs/investigations/parakeet_coreml_encoder_investigation.md`.
 
 ## NFA (CTC) Export
 

--- a/scripts/nemo_export/README.md
+++ b/scripts/nemo_export/README.md
@@ -125,15 +125,18 @@ Contract, per bucket of `F` mel frames:
 |---|---|
 | in | `audio_signal [1, 128, F]` — mel features, zero-padded to `F` |
 | in | `pad_keep [1, F]` — 1.0 for a real frame, 0.0 for padding |
-| out | `outputs [1, 1024, T]`, `T = calc_encoded_length(F)` |
+| out | `outputs [1, 1024, T]`, `T = calc_encoded_length(F, stages)` |
 
 Two caller obligations, both of which fail silently rather than loudly:
 
 * **`pad_keep` must be honest.** All-ones on a short segment is exactly the
   bake-the-length behaviour this export exists to avoid — worth 2–4% WER.
 * **There is no `encoded_lengths` output**, because there is no length input. Compute
-  it with `calc_encoded_length` (three iterations of `(L + 2 - 3) // 2 + 1`) and
-  ignore output frames past it.
+  it by folding the `subsampler_stages` the report records
+  (`out = (in + pad0 + pad1 - kernel) // stride + 1` per strided stage; three ×2
+  stages for this checkpoint) and ignore output frames past it. The stages are
+  reported rather than hardcoded because a different checkpoint's geometry would
+  otherwise trim the output at the wrong frame with no failure signal.
 
 Unlike the Sortformer CoreML variant this needs **no** post-processing pass and has
 no load-level contract term: the raw export is already a single partition and loads

--- a/scripts/nemo_export/export_parakeet_coreml_encoder.py
+++ b/scripts/nemo_export/export_parakeet_coreml_encoder.py
@@ -53,15 +53,14 @@ The caller's obligations:
 * zero-pad the mel features to the bucket and set `pad_keep` to match the true
   frame count. Passing all-ones for a short segment is the mistake this design
   exists to avoid.
-* compute the true output length itself (`calc_encoded_length`, the same formula
-  NeMo's `calc_length` uses) and ignore encoder output past it. The graph has no
-  length output because it has no length input.
+* compute the true output length itself with `calc_encoded_length` and the
+  `subsampler_stages` recorded in the report, and ignore encoder output past it. The
+  graph has no length output because it has no length input.
 """
 from __future__ import annotations
 
 import argparse
 import json
-import math
 from pathlib import Path
 from typing import Any
 
@@ -84,44 +83,128 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def calc_encoded_length(frames: int, *, sampling_num: int = 3, kernel: int = 3,
-                        stride: int = 2, all_paddings: int = 2) -> int:
-    """NeMo's `calc_length` for the dw_striding subsampler, in plain ints.
+def subsampler_stages(encoder: Any) -> list:
+    """The (kernel, stride, padding) of each strided conv in the subsampler.
 
-    The C# caller needs the identical formula, since the graph no longer reports
-    an encoded length of its own.
+    Read off the loaded model rather than hardcoded, because two things downstream
+    have to agree with the real graph: `calc_encoded_length` (which the C# caller
+    reimplements) and the stride-2 decimation in `_patch_masking`. A ×4-subsampling
+    or different-kernel checkpoint would otherwise export a self-consistent graph
+    while the reported frame count was wrong, with no failure signal.
+
+    Mirrors what `MaskedConvSequential.forward` itself consults: `layer.stride[0]`,
+    `layer.kernel_size[0]`, and `layer.padding` (or the CausalConv2D paddings).
+    """
+    stages = []
+    for layer in encoder.pre_encode.conv:
+        stride = getattr(layer, "stride", None)
+        if stride is None or stride == (1, 1):
+            continue
+        if hasattr(layer, "_left_padding"):
+            padding = (layer._left_padding, layer._right_padding)
+        else:
+            padding = layer.padding
+        stages.append((int(layer.kernel_size[0]), int(stride[0]),
+                       (int(padding[0]), int(padding[1]))))
+    if not stages:
+        raise SystemExit("found no strided conv in encoder.pre_encode.conv -- this "
+                         "export cannot infer the subsampling geometry.")
+    return stages
+
+
+def calc_encoded_length(frames: int, stages: list) -> int:
+    """NeMo's subsampler length arithmetic, in plain ints.
+
+    The C# caller needs the identical formula, since the graph no longer reports an
+    encoded length of its own. `coreml-encoder-report.json` records `stages` so the
+    caller reimplements the geometry this checkpoint actually has.
     """
     length = frames
-    for _ in range(sampling_num):
-        length = math.floor((length + all_paddings - kernel) / stride) + 1
+    for kernel, stride, padding in stages:
+        length = (length + padding[0] + padding[1] - kernel) // stride + 1
     return length
 
 
-def check_mask_decimation(frames: int, *, sampling_num: int = 3, kernel: int = 3,
-                          stride: int = 2, all_paddings: int = 2) -> None:
-    """Prove `keep[0::2]` is the stage mask, for every true length in this bucket.
+def check_mask_decimation(frames: int, stages: list) -> None:
+    """Prove `keep[:, 0::2]` is the stage mask, for every true length in this bucket.
 
     The whole export rests on this: the subsampler's per-stage masks are
     `arange(T_k) < length_k`, and the graph instead decimates one input mask by 2.
-    That is only the same tensor because `length_k = ceil(length_{k-1} / 2)` and
-    `keep[2i]` is 1 exactly while `2i < length`. It is cheap to check outright, and a
-    NeMo change to `calculate_conv_output_size` would otherwise cost a silent 1e-2
-    that looks like a tolerance question.
+    That is only the same tensor when `length_k = ceil(length_{k-1} / 2)`, since
+    `keep[2i]` is 1 exactly while `2i < length`.
+
+    Calls **NeMo's own** `calculate_conv_output_size` on the geometry read off the
+    loaded model. An earlier version of this check recomputed the formula inline with
+    the geometry hardcoded, which made it a tautology -- `(x + 2 - 3) // 2 + 1` *is*
+    `ceil(x / 2)`, so it could never fail, and it would not have noticed NeMo
+    changing the arithmetic at all. That is the opposite of the guarantee it exists
+    to give.
     """
+    from nemo.collections.asr.parts.submodules.subsampling import calculate_conv_output_size
+
+    for stage, (kernel, stride, padding) in enumerate(stages):
+        if stride != 2:
+            raise SystemExit(
+                f"subsampler stage {stage} has stride {stride}, not 2. "
+                f"`_patch_masking` decimates the mask with a hardcoded `keep[:, 0::2]`, "
+                f"which is only correct at stride 2 -- do not ship this export.")
+
     for length in range(1, frames + 1):
-        kept, current = length, length
-        width = frames
-        for _ in range(sampling_num):
-            width = (width + all_paddings - kernel) // stride + 1
+        kept = current = length
+        for stage, (kernel, stride, padding) in enumerate(stages):
             # what the decimated mask keeps: indices 2i < kept, i.e. ceil(kept / 2)
             kept = -(-kept // 2)
-            current = (current + all_paddings - kernel) // stride + 1
+            current = int(calculate_conv_output_size(current, kernel, stride, padding))
             if kept != current:
                 raise SystemExit(
                     f"mask decimation does not match NeMo's arithmetic at bucket "
-                    f"{frames}, true length {length}: decimated mask keeps {kept} "
-                    f"frames, calc_length says {current}. The stride-2 slice in "
-                    f"_patch_masking is no longer valid -- do not ship this export.")
+                    f"{frames}, true length {length}, subsampler stage {stage}: the "
+                    f"decimated mask keeps {kept} frames, calculate_conv_output_size "
+                    f"says {current}. The stride-2 slice in `_patch_masking` is no "
+                    f"longer valid -- do not ship this export.")
+
+
+def require_supported_encoder(encoder: Any) -> None:
+    """Refuse any encoder whose masking this export does not actually reproduce.
+
+    `create_masks` below returns only the padding mask. NeMo's real `_create_masks`
+    builds `att_mask` from `att_context_size`/`att_context_style` FIRST -- `triu`/`tril`
+    for a limited regular context, a chunk mask for `chunked_limited` -- and only then
+    ANDs the padding mask into it. On a limited-context checkpoint this export would
+    therefore produce a graph that attends over the whole utterance: wrong, silent, and
+    invisible to a parity check run against the same wrong assumption.
+
+    None of these are hypothetical variations on some other model; they are all
+    settings real NeMo conformer checkpoints ship with.
+    """
+    problems = []
+    if encoder.self_attention_model != "rel_pos":
+        problems.append(
+            f"self_attention_model is {encoder.self_attention_model!r}, not 'rel_pos'. "
+            "'rel_pos_local_attn' uses the Longformer attention, which never calls the "
+            "patched forward_attention at all.")
+    if list(encoder.att_context_size) != [-1, -1]:
+        problems.append(
+            f"att_context_size is {list(encoder.att_context_size)}, not [-1, -1]. A "
+            "limited context contributes a triangular/chunked mask that this export drops.")
+    if encoder.att_context_style != "regular":
+        problems.append(
+            f"att_context_style is {encoder.att_context_style!r}, not 'regular'.")
+    if getattr(encoder, "reduction_position", None) is not None:
+        problems.append(
+            f"reduction_position is {encoder.reduction_position}, not None. The encoder "
+            "re-creates its masks mid-stack after reduction_subsampling, and the hoisted "
+            "mask would then be the wrong length.")
+    sdpa = {bool(getattr(layer.self_attn, "use_pytorch_sdpa", False)) for layer in encoder.layers}
+    if sdpa != {False}:
+        problems.append(
+            "use_pytorch_sdpa is True on at least one layer. That path bypasses "
+            "forward_attention and calls masked_fill_ on the mask directly, which fails "
+            "on the float keep tensor.")
+    if problems:
+        raise SystemExit(
+            "this checkpoint's encoder is not one this export reproduces faithfully:\n  - "
+            + "\n  - ".join(problems))
 
 
 def _patch_masking(torch: Any, encoder: Any) -> None:
@@ -203,6 +286,10 @@ def _patch_masking(torch: Any, encoder: Any) -> None:
         # Returning the hoisted mask here is what takes mask construction out of the
         # graph entirely. att_keep[i, j] = keep[i] * keep[j] -- a masked query row
         # keeps nothing, matching NeMo's symmetric `pad_mask & pad_mask.T`.
+        #
+        # This is the PADDING mask only. It is the whole mask solely because
+        # require_supported_encoder has established att_context_size == [-1, -1] and
+        # att_context_style == 'regular', where NeMo's triu/tril contribute nothing.
         keep = self._exp_enc_keep
         return keep, keep.unsqueeze(2) * keep.unsqueeze(1)
 
@@ -236,14 +323,24 @@ def build_wrapper(torch: Any, nn: Any, model: Any, frames: int) -> Any:
 
 
 def _all_tensors(graph: Any):
-    """Every tensor that can carry external data: initializers AND the tensors sitting
-    inside `Constant` node attributes, which the exporter spills too."""
+    """Every tensor that can carry external data: initializers, the tensors sitting
+    inside `Constant` node attributes (which the exporter spills too), and the same
+    again inside any subgraph.
+
+    Subgraphs are latent for this trace -- it has no `If`/`Loop` -- but
+    `repoint_external_data` is the step the whole shared-sidecar claim rests on, and
+    a tensor it missed would point at a per-tensor file that consolidation deleted.
+    """
     yield from graph.initializer
     for node in graph.node:
         for attr in node.attribute:
             if attr.HasField("t"):
                 yield attr.t
             yield from attr.tensors
+            if attr.HasField("g"):
+                yield from _all_tensors(attr.g)
+            for sub in attr.graphs:
+                yield from _all_tensors(sub)
 
 
 def consolidate_external_data(onnx_path: Path, sidecar: str) -> None:
@@ -262,6 +359,13 @@ def consolidate_external_data(onnx_path: Path, sidecar: str) -> None:
     stale = {kv.value for t in _all_tensors(meta.graph) for kv in t.external_data
              if kv.key == "location"}
     model = onnx.load(str(onnx_path))          # pulls the loose files into memory
+    # onnx APPENDS: save_external_data opens the target "r+b" and seeks to the end, so
+    # writing over a sidecar left by an earlier --overwrite run doubles its size. It
+    # fails silently, because the new offsets point into the appended tail and the
+    # graph still loads -- but the digest no longer matches the published weights.
+    target = onnx_path.parent / sidecar
+    if target.exists():
+        target.unlink()
     onnx.save_model(model, str(onnx_path), save_as_external_data=True,
                     all_tensors_to_one_file=True, location=sidecar, size_threshold=0)
     for loc in stale:
@@ -292,8 +396,9 @@ def repoint_external_data(onnx_path: Path, sidecar: str) -> None:
     onnx.save_model(model, str(onnx_path))
 
 
-def export_bucket(torch: Any, nn: Any, model: Any, frames: int, dst: Path, opset: int) -> dict:
-    encoded = calc_encoded_length(frames)
+def export_bucket(torch: Any, nn: Any, model: Any, frames: int, dst: Path, opset: int,
+                  stages: list) -> dict:
+    encoded = calc_encoded_length(frames, stages)
     wrapper = build_wrapper(torch, nn, model, frames)
 
     audio_signal = torch.randn(1, model.encoder._feat_in, frames)
@@ -324,7 +429,7 @@ def export_bucket(torch: Any, nn: Any, model: Any, frames: int, dst: Path, opset
     }
 
 
-def share_weights(out_dir: Path, exported: list, sidecar: str) -> bool:
+def share_weights(out_dir: Path, exported: list, sidecar: str, overwrite: bool) -> bool:
     """Collapse the per-bucket weight sidecars into one, if they are byte-identical.
 
     Every bucket traces the same parameters in the same order, so the sidecars come
@@ -337,7 +442,28 @@ def share_weights(out_dir: Path, exported: list, sidecar: str) -> bool:
         print("  ! the buckets' weight files differ; keeping one sidecar per bucket")
         return False
     keep = out_dir / (exported[0]["file"] + ".data")
-    keep.replace(out_dir / sidecar)
+    target = out_dir / sidecar
+
+    # --weights-name defaults to the PUBLISHED sidecar's filename, and pointing
+    # --output-dir at the existing model directory is the natural thing to do given
+    # that reusing those weights is the point. So do not overwrite it blind.
+    if target.exists() and target != keep:
+        if md5(target) == exported[0]["weights_md5"]:
+            print(f"  {sidecar} already present and identical; keeping it")
+            keep.unlink()
+            for bucket in exported[1:]:
+                (out_dir / (bucket["file"] + ".data")).unlink()
+            for bucket in exported:
+                repoint_external_data(out_dir / bucket["file"], sidecar)
+            return True
+        if not overwrite:
+            raise SystemExit(
+                f"{target} exists and its contents differ from the weights just "
+                f"exported. That is the published sidecar's filename, so overwriting it "
+                f"would replace the shipped weights with different bytes. Re-run with "
+                f"--overwrite to replace it, or pass --weights-name to write elsewhere.")
+        print(f"  ! replacing {sidecar}, whose contents differ from this export")
+    keep.replace(target)
     for bucket in exported[1:]:
         (out_dir / (bucket["file"] + ".data")).unlink()
     for bucket in exported:
@@ -354,12 +480,6 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     buckets = sorted(set(args.frames))
-    for frames in buckets:
-        if frames % 8 != 0:
-            raise SystemExit(
-                f"--frames {frames} is not a multiple of 8. The subsampler strides by 8, "
-                "so a bucket that is not a multiple of 8 wastes frames and makes the "
-                "caller's pad_keep arithmetic fiddlier for nothing.")
 
     import torch
     from torch import nn
@@ -368,6 +488,19 @@ def main() -> None:
     model = ASRModel.restore_from(str(nemo_path), map_location="cpu")
     model.freeze()
     model.eval()
+    require_supported_encoder(model.encoder)
+    stages = subsampler_stages(model.encoder)
+    total_stride = 1
+    for _, stride, _ in stages:
+        total_stride *= stride
+    print(f"subsampler: {len(stages)} strided stages, total stride {total_stride} "
+          f"(kernel/stride/padding {stages})")
+
+    for frames in buckets:
+        if frames % total_stride != 0:
+            raise SystemExit(
+                f"--frames {frames} is not a multiple of the subsampler's total stride "
+                f"({total_stride}). A bucket that is not wastes frames for nothing.")
 
     exported = []
     for frames in buckets:
@@ -375,11 +508,11 @@ def main() -> None:
         if dst.exists() and not args.overwrite:
             raise SystemExit(f"{dst} exists. Re-run with --overwrite.")
         print(f"exporting {frames} mel frames ({frames / 100:.1f} s) -> {dst.name} ...")
-        check_mask_decimation(frames)
-        exported.append(export_bucket(torch, nn, model, frames, dst, args.opset))
+        check_mask_decimation(frames, stages)
+        exported.append(export_bucket(torch, nn, model, frames, dst, args.opset, stages))
         print(f"  {exported[-1]['bytes'] / 1e6:.0f} MB graph, {exported[-1]['encoded_frames']} encoded frames")
 
-    shared = share_weights(out_dir, exported, args.weights_name)
+    shared = share_weights(out_dir, exported, args.weights_name, args.overwrite)
     weights = out_dir / args.weights_name
     if shared:
         print(f"  all {len(exported)} buckets share {args.weights_name} "
@@ -392,6 +525,10 @@ def main() -> None:
         "opset": args.opset,
         "weights_file": args.weights_name if shared else "one per bucket",
         "weights_md5": exported[0]["weights_md5"] if shared else None,
+        # The C# caller reimplements calc_encoded_length; record the geometry it must
+        # use rather than leaving it to assume this checkpoint's x8 dw_striding.
+        "subsampler_stages": [
+            {"kernel": k, "stride": st, "padding": list(p)} for k, st, p in stages],
         "inputs": {
             "audio_signal": "[1, 128, mel_frames] float32, zero-padded mel features",
             "pad_keep": "[1, mel_frames] float32, 1.0 real / 0.0 padding",
@@ -400,8 +537,9 @@ def main() -> None:
         "caller_obligations": [
             "pad_keep must reflect the TRUE frame count; all-ones on a short segment "
             "reproduces the accuracy loss this export exists to avoid",
-            "the graph has no encoded_lengths output -- compute it with calc_encoded_length "
-            "and ignore output frames past it",
+            "the graph has no encoded_lengths output -- compute it by folding "
+            "subsampler_stages below (out = (in + pad0 + pad1 - kernel) // stride + 1 per "
+            "stage) and ignore output frames past it",
         ],
         "buckets": exported,
     }

--- a/scripts/nemo_export/export_parakeet_coreml_encoder.py
+++ b/scripts/nemo_export/export_parakeet_coreml_encoder.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Export the Parakeet conformer encoder as a static-shape graph the CoreML
+execution provider can compile, WITHOUT baking a constant length.
+
+    python scripts/nemo_export/export_parakeet_coreml_encoder.py \
+        --nemo ~/models/parakeet-tdt-0.6b-v3/parakeet-tdt-0.6b-v3.nemo \
+        --output-dir ~/models/parakeet_coreml --frames 1000 --frames 2000
+
+Why this is not the Sortformer recipe
+-------------------------------------
+docs/coreml_onnx_playbook.md reaches one CoreML partition by making every length
+a graph constant, which folds the attention padding mask to an all-False constant
+that Technique 3 then deletes. Sortformer can afford that: its lengths really are
+constant, apart from the final chunk of a recording, which the runtime routes to
+the stock graph instead.
+
+Parakeet cannot. Segment lengths are arbitrary, so a constant length would be
+wrong for essentially every segment, and there is no one-inference-per-file escape
+hatch. Measured on real speech (see the investigation log), baking the length moves
+the encoder output by 0.17-0.24 on valid frames and changes the transcript by
+2-4% WER on 8-20 s segments, worse on short ones.
+
+What this does instead: HOIST THE MASK
+--------------------------------------
+Masking is the only thing `length` is used for, and the encoder is padding-invariant
+to 4e-7 as long as the mask is honest (verified at +10%/+50%/+100% padding). So the
+graph takes the mask as an INPUT rather than deriving it from a length:
+
+    audio_signal  [1, 128, F]        mel features, zero-padded to the bucket
+    pad_keep      [1, F]             1.0 for a real mel frame, 0.0 for padding
+
+That removes the `Range`/`Less`/`Expand`/`ConstantOfShape` chain that made every
+downstream shape data-dependent, and it keeps the masking exact for any true length
+<= the bucket.
+
+`length` reaches masking at FOUR resolutions, not one, and missing any of them is a
+silent 1e-2 error rather than a failure:
+
+* `MaskedConvSequential` re-masks between every strided conv in the subsampler, at
+  the mel rate and after each of the three strides;
+* `_create_masks` builds the attention and conv-module masks at the encoder rate.
+
+All four are exact stride-2 decimations of each other, so the graph derives them from
+the single mel-rate input with constant-parameter `Slice`s (`Slice` with constant
+starts/ends/steps is CoreML-supported). `check_mask_decimation` re-proves that
+identity for every length in the bucket before each export, so a NeMo change to the
+subsampler's arithmetic fails here rather than silently costing 1e-2. The
+`masked_fill`s become `+bias` / `*keep` arithmetic (`Add`/`Mul`, also supported), so
+no `Where` survives to fragment the graph.
+
+The caller's obligations:
+
+* zero-pad the mel features to the bucket and set `pad_keep` to match the true
+  frame count. Passing all-ones for a short segment is the mistake this design
+  exists to avoid.
+* compute the true output length itself (`calc_encoded_length`, the same formula
+  NeMo's `calc_length` uses) and ignore encoder output past it. The graph has no
+  length output because it has no length input.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--nemo", required=True, help="Path to the .nemo checkpoint.")
+    p.add_argument("--output-dir", required=True,
+                   help="Directory to write encoder-model.coreml-<frames>.onnx into.")
+    p.add_argument("--frames", type=int, action="append", required=True, metavar="N",
+                   help="Mel-frame bucket to export (100 frames = 1 s). Repeatable; "
+                        "one graph is written per bucket.")
+    p.add_argument("--opset", type=int, default=17)
+    p.add_argument("--weights-name", default="encoder-model.onnx.data",
+                   help="Filename every bucket's external weights point at. Defaults to "
+                        "the published encoder's sidecar, which these weights are "
+                        "byte-identical to -- so the buckets add no weight download.")
+    p.add_argument("--overwrite", action="store_true")
+    return p.parse_args()
+
+
+def calc_encoded_length(frames: int, *, sampling_num: int = 3, kernel: int = 3,
+                        stride: int = 2, all_paddings: int = 2) -> int:
+    """NeMo's `calc_length` for the dw_striding subsampler, in plain ints.
+
+    The C# caller needs the identical formula, since the graph no longer reports
+    an encoded length of its own.
+    """
+    length = frames
+    for _ in range(sampling_num):
+        length = math.floor((length + all_paddings - kernel) / stride) + 1
+    return length
+
+
+def check_mask_decimation(frames: int, *, sampling_num: int = 3, kernel: int = 3,
+                          stride: int = 2, all_paddings: int = 2) -> None:
+    """Prove `keep[0::2]` is the stage mask, for every true length in this bucket.
+
+    The whole export rests on this: the subsampler's per-stage masks are
+    `arange(T_k) < length_k`, and the graph instead decimates one input mask by 2.
+    That is only the same tensor because `length_k = ceil(length_{k-1} / 2)` and
+    `keep[2i]` is 1 exactly while `2i < length`. It is cheap to check outright, and a
+    NeMo change to `calculate_conv_output_size` would otherwise cost a silent 1e-2
+    that looks like a tolerance question.
+    """
+    for length in range(1, frames + 1):
+        kept, current = length, length
+        width = frames
+        for _ in range(sampling_num):
+            width = (width + all_paddings - kernel) // stride + 1
+            # what the decimated mask keeps: indices 2i < kept, i.e. ceil(kept / 2)
+            kept = -(-kept // 2)
+            current = (current + all_paddings - kernel) // stride + 1
+            if kept != current:
+                raise SystemExit(
+                    f"mask decimation does not match NeMo's arithmetic at bucket "
+                    f"{frames}, true length {length}: decimated mask keeps {kept} "
+                    f"frames, calc_length says {current}. The stride-2 slice in "
+                    f"_patch_masking is no longer valid -- do not ship this export.")
+
+
+def _patch_masking(torch: Any, encoder: Any) -> None:
+    """Replace every length-derived mask in the encoder with a slice of one input mask.
+
+    Patched onto the module INSTANCES, not the classes, so nothing else in the
+    process is affected.
+
+    Every substitution is exact, not an approximation:
+
+    * `arange(T_k) < length_k` at subsampler stage k is exactly `keep[0::2]` applied k
+      times to the mel-rate mask. `length_k = (length_{k-1} - 1) // 2 + 1 =
+      ceil(length_{k-1} / 2)`, and `keep[2i]` is 1 exactly while `2i < length`, i.e.
+      for `ceil(length / 2)` entries. Checked exhaustively over every length in
+      several bucket sizes.
+    * `apply_channel_mask` is already a multiply, so reusing the float keep is
+      literally the same op.
+    * `scores.masked_fill(mask, -INF_VAL)` sets masked scores to exactly -10000;
+      adding `(keep - 1) * INF_VAL` makes them `score - 10000`. Scores are O(30),
+      so both underflow to zero in the softmax against a max of the same order,
+      and both are then multiplied to exactly zero by the second mask anyway.
+    * `softmax(...).masked_fill(mask, 0.0)` is exactly `softmax(...) * keep`.
+    """
+    import types
+
+    from nemo.collections.asr.parts.submodules.multi_head_attention import INF_VAL
+
+    def masked_conv_forward(self, x, lengths):
+        # NeMo re-masks around every layer and recomputes the mask after every
+        # stride. Same schedule here, with the mask decimated instead of rebuilt.
+        keep = encoder._exp_mel_keep
+        x = x.unsqueeze(1)                                      # [B, 1, T, F]
+        for layer in self:
+            x = x * keep.reshape(1, 1, -1, 1)
+            x = layer(x)
+            if hasattr(layer, "stride") and layer.stride != (1, 1):
+                keep = keep[:, 0::2]
+        x = x * keep.reshape(1, 1, -1, 1)
+        # The encoder-rate mask, for _create_masks. forward_internal always calls
+        # pre_encode before it, so this is set by the time it is read.
+        encoder._exp_enc_keep = keep
+        # The real return value is the frame count, which this export discards -- the
+        # caller computes it with calc_encoded_length instead.
+        return x, lengths
+
+    def forward_attention(self, value, scores, mask):
+        # `mask` is a float keep tensor [B, T1, T2] here, not NeMo's bool mask.
+        keep = mask.unsqueeze(1)                                  # [B, 1, T1, T2]
+        scores = scores + (keep - 1.0) * INF_VAL
+        attn = torch.softmax(scores, dim=-1) * keep
+        p_attn = self.dropout(attn)
+        x = torch.matmul(p_attn, value)
+        x = x.transpose(1, 2).reshape(value.size(0), -1, self.h * self.d_k)
+        return self.linear_out(x)
+
+    def conv_forward(self, x, pad_mask=None, cache=None):
+        # `pad_mask` is a float keep tensor [B, T] here. `cache` is unused: this
+        # export has no streaming path.
+        x = x.transpose(1, 2)
+        x = self.pointwise_conv1(x)
+        if self.pointwise_activation == "glu_":
+            x = torch.nn.functional.glu(x, dim=1)
+        else:
+            x = self.pointwise_activation(x)
+        if pad_mask is not None:
+            x = x * pad_mask.unsqueeze(1)
+        x = self.depthwise_conv(x)
+        if self.norm_type == "layer_norm":
+            x = x.transpose(1, 2)
+            x = self.batch_norm(x)
+            x = x.transpose(1, 2)
+        else:
+            x = self.batch_norm(x)
+        x = self.activation(x)
+        x = self.pointwise_conv2(x)
+        return x.transpose(1, 2)
+
+    def create_masks(self, **_kwargs):
+        # Returning the hoisted mask here is what takes mask construction out of the
+        # graph entirely. att_keep[i, j] = keep[i] * keep[j] -- a masked query row
+        # keeps nothing, matching NeMo's symmetric `pad_mask & pad_mask.T`.
+        keep = self._exp_enc_keep
+        return keep, keep.unsqueeze(2) * keep.unsqueeze(1)
+
+    encoder.pre_encode.conv.forward = types.MethodType(
+        masked_conv_forward, encoder.pre_encode.conv)
+    for layer in encoder.layers:
+        layer.self_attn.forward_attention = types.MethodType(forward_attention, layer.self_attn)
+        layer.conv.forward = types.MethodType(conv_forward, layer.conv)
+    encoder._create_masks = types.MethodType(create_masks, encoder)
+
+
+def build_wrapper(torch: Any, nn: Any, model: Any, frames: int) -> Any:
+    encoder = model.encoder
+    _patch_masking(torch, encoder)
+
+    class ParakeetCoreMLEncoder(nn.Module):
+        def __init__(self, inner: Any) -> None:
+            super().__init__()
+            self.inner = inner
+
+        def forward(self, audio_signal: Any, pad_keep: Any) -> Any:
+            self.inner._exp_mel_keep = pad_keep
+            # `length` reaches nothing that matters any more: every masking site now
+            # reads the hoisted mask, and the frame count it computes is discarded
+            # with the second output.
+            length = torch.full((audio_signal.size(0),), frames, dtype=torch.int64)
+            encoded, _ = self.inner(audio_signal=audio_signal, length=length)
+            return encoded
+
+    return ParakeetCoreMLEncoder(encoder).eval()
+
+
+def _all_tensors(graph: Any):
+    """Every tensor that can carry external data: initializers AND the tensors sitting
+    inside `Constant` node attributes, which the exporter spills too."""
+    yield from graph.initializer
+    for node in graph.node:
+        for attr in node.attribute:
+            if attr.HasField("t"):
+                yield attr.t
+            yield from attr.tensors
+
+
+def consolidate_external_data(onnx_path: Path, sidecar: str) -> None:
+    """Collapse the exporter's one-file-per-tensor external data into a single sidecar.
+
+    The encoder's weights are 2.4 GB, well past the 2 GB protobuf ceiling, so
+    torch.onnx.export spills them -- and it spills them as ~300 separate files
+    named after the tensors, dumped straight into the output directory.
+    """
+    import onnx
+
+    # Read the locations BEFORE the data: a full load resolves external_data into
+    # raw_data and clears the field, so asking the loaded model where its tensors
+    # came from silently returns nothing and leaves ~300 stale files behind.
+    meta = onnx.load(str(onnx_path), load_external_data=False)
+    stale = {kv.value for t in _all_tensors(meta.graph) for kv in t.external_data
+             if kv.key == "location"}
+    model = onnx.load(str(onnx_path))          # pulls the loose files into memory
+    onnx.save_model(model, str(onnx_path), save_as_external_data=True,
+                    all_tensors_to_one_file=True, location=sidecar, size_threshold=0)
+    for loc in stale:
+        p = onnx_path.parent / loc
+        if p.exists() and p.name != sidecar:
+            p.unlink()
+
+
+def md5(path: Path) -> str:
+    import hashlib
+
+    h = hashlib.md5()
+    with path.open("rb") as fh:
+        for block in iter(lambda: fh.read(1 << 22), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def repoint_external_data(onnx_path: Path, sidecar: str) -> None:
+    """Point every external tensor at `sidecar` without touching the weights."""
+    import onnx
+
+    model = onnx.load(str(onnx_path), load_external_data=False)
+    for tensor in _all_tensors(model.graph):
+        for kv in tensor.external_data:
+            if kv.key == "location":
+                kv.value = sidecar
+    onnx.save_model(model, str(onnx_path))
+
+
+def export_bucket(torch: Any, nn: Any, model: Any, frames: int, dst: Path, opset: int) -> dict:
+    encoded = calc_encoded_length(frames)
+    wrapper = build_wrapper(torch, nn, model, frames)
+
+    audio_signal = torch.randn(1, model.encoder._feat_in, frames)
+    pad_keep = torch.ones(1, frames)
+
+    with torch.inference_mode():
+        torch.onnx.export(
+            wrapper,
+            (audio_signal, pad_keep),
+            str(dst),
+            input_names=["audio_signal", "pad_keep"],
+            output_names=["outputs"],
+            dynamic_axes=None,          # fully static: Technique 1
+            opset_version=opset,
+            dynamo=False,
+            do_constant_folding=True,
+        )
+    own_sidecar = dst.name + ".data"
+    consolidate_external_data(dst, own_sidecar)
+
+    return {
+        "file": dst.name,
+        "mel_frames": frames,
+        "encoded_frames": encoded,
+        "seconds": round(frames / 100.0, 2),
+        "bytes": dst.stat().st_size,
+        "weights_md5": md5(dst.parent / own_sidecar),
+    }
+
+
+def share_weights(out_dir: Path, exported: list, sidecar: str) -> bool:
+    """Collapse the per-bucket weight sidecars into one, if they are byte-identical.
+
+    Every bucket traces the same parameters in the same order, so the sidecars come
+    out identical and shipping one per bucket would be N x 2.4 GB of the same bytes.
+    Verified by digest rather than assumed -- a torch or NeMo change that reorders
+    the trace would break the sharing silently otherwise.
+    """
+    digests = {b["weights_md5"] for b in exported}
+    if len(digests) != 1:
+        print("  ! the buckets' weight files differ; keeping one sidecar per bucket")
+        return False
+    keep = out_dir / (exported[0]["file"] + ".data")
+    keep.replace(out_dir / sidecar)
+    for bucket in exported[1:]:
+        (out_dir / (bucket["file"] + ".data")).unlink()
+    for bucket in exported:
+        repoint_external_data(out_dir / bucket["file"], sidecar)
+    return True
+
+
+def main() -> None:
+    args = parse_args()
+    nemo_path = Path(args.nemo).expanduser().resolve()
+    out_dir = Path(args.output_dir).expanduser().resolve()
+    if not nemo_path.exists():
+        raise SystemExit(f".nemo file not found: {nemo_path}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    buckets = sorted(set(args.frames))
+    for frames in buckets:
+        if frames % 8 != 0:
+            raise SystemExit(
+                f"--frames {frames} is not a multiple of 8. The subsampler strides by 8, "
+                "so a bucket that is not a multiple of 8 wastes frames and makes the "
+                "caller's pad_keep arithmetic fiddlier for nothing.")
+
+    import torch
+    from torch import nn
+    from nemo.collections.asr.models import ASRModel
+
+    model = ASRModel.restore_from(str(nemo_path), map_location="cpu")
+    model.freeze()
+    model.eval()
+
+    exported = []
+    for frames in buckets:
+        dst = out_dir / f"encoder-model.coreml-{frames}.onnx"
+        if dst.exists() and not args.overwrite:
+            raise SystemExit(f"{dst} exists. Re-run with --overwrite.")
+        print(f"exporting {frames} mel frames ({frames / 100:.1f} s) -> {dst.name} ...")
+        check_mask_decimation(frames)
+        exported.append(export_bucket(torch, nn, model, frames, dst, args.opset))
+        print(f"  {exported[-1]['bytes'] / 1e6:.0f} MB graph, {exported[-1]['encoded_frames']} encoded frames")
+
+    shared = share_weights(out_dir, exported, args.weights_name)
+    weights = out_dir / args.weights_name
+    if shared:
+        print(f"  all {len(exported)} buckets share {args.weights_name} "
+              f"({weights.stat().st_size / 1e9:.2f} GB, md5 {exported[0]['weights_md5']})")
+        print("  ^ compare that md5 against the published encoder-model.onnx.data: if it "
+              "matches, these graphs need no new weight download")
+
+    report = {
+        "nemo_file": str(nemo_path),
+        "opset": args.opset,
+        "weights_file": args.weights_name if shared else "one per bucket",
+        "weights_md5": exported[0]["weights_md5"] if shared else None,
+        "inputs": {
+            "audio_signal": "[1, 128, mel_frames] float32, zero-padded mel features",
+            "pad_keep": "[1, mel_frames] float32, 1.0 real / 0.0 padding",
+        },
+        "outputs": {"outputs": "[1, 1024, encoded_frames] float32"},
+        "caller_obligations": [
+            "pad_keep must reflect the TRUE frame count; all-ones on a short segment "
+            "reproduces the accuracy loss this export exists to avoid",
+            "the graph has no encoded_lengths output -- compute it with calc_encoded_length "
+            "and ignore output frames past it",
+        ],
+        "buckets": exported,
+    }
+    with (out_dir / "coreml-encoder-report.json").open("w", encoding="utf-8", newline="\n") as fh:
+        json.dump(report, fh, indent=2)
+        fh.write("\n")
+    print(f"wrote {out_dir / 'coreml-encoder-report.json'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why the playbook's recipe doesn't transfer

`docs/coreml_onnx_playbook.md` reaches one CoreML partition by making every length a graph constant, which folds the attention mask to an all-False constant that Technique 3 deletes. Sortformer affords that because exactly one chunk per recording is short and the runtime routes it to the stock graph.

Parakeet's segments are arbitrary. Measured on real speech, baking the length moves the encoder output by **0.17–0.24** on valid frames and changes the transcript by **2–4% WER** on 8–20 s segments (worse on short ones), with no one-inference-per-file escape hatch — every segment pays.

## What this does instead

The encoder is padding-invariant to 4e-7 when the mask is honest, so the mask leaves the graph rather than folding away:

```
audio_signal  [1, 128, F]     mel features, zero-padded to the bucket
pad_keep      [1, F]          1.0 real / 0.0 padding
```

Static shapes, no `Range`/`Less`/`Expand`/`ConstantOfShape` chain, and masking that stays **exact at any true length ≤ the bucket**.

The subtlety worth reading: **`length` feeds masking at four resolutions, not one.** `MaskedConvSequential` re-masks between every strided conv in the subsampler; `_create_masks` builds the attention and conv-module masks at the encoder rate. Hoisting only the latter left a 1e-2 error spread across *all* frames — which reads as a tolerance question rather than a bug, and doesn't look like a boundary artifact. All four masks are exact stride-2 decimations of the mel-rate mask, so one input feeds them all through constant-parameter `Slice`s. `check_mask_decimation` re-proves that identity per bucket at export time, so a NeMo change to the subsampler's arithmetic fails loudly.

## Measured (M5, ORT 1.29.0 — the version an `EP=Cpu` osx-arm64 build takes)

| | partitions | 10 s bucket |
|---|---|---|
| stock `encoder-model.onnx` on CoreML | *fails*, `error -14`, 84 | — |
| this export | **1** (1453/1453 nodes) | **58.2 ms** |
| same graph, CPU EP | — | 146.9 ms |
| stock encoder, CPU EP | — | 143.6 ms |

**2.5× over CPU at every bucket from 4 s to 30 s.** Parity 2e-7…6e-6 against the shipped encoder, **7/7 identical transcripts** through the full TDT decode, and the mask rewrite is `0.000E+00` in PyTorch — bit-exact, so the residual is ONNX/EP float noise.

Two things it *doesn't* need: no post-processing pass (the raw export is already one partition), and therefore no `ORT_ENABLE_BASIC or it will not load` contract term — that came from the fold round-trip. All buckets share one weight sidecar, **byte-identical to the published `encoder-model.onnx.data`**, so they add no weight download.

## Playbook corrections, all verified here

The playbook was written from one model; several of its claims don't hold on 1.29.0 or generalise:

- **`Pad` is supported by the CoreML EP now** — confirmed on a one-node graph (`1 partition, 1/1`). Technique 4 is a no-op there; the op table shipped in the wheel is stale.
- **Technique 5 is `Gemm`-specific.** Parakeet traces to 289 `MatMul` and zero `Gemm`; `model.mil` is 4.5 MB against 2.36 GB of weights vs Sortformer's 1.49 GB for 0.39 GB.
- **The TDT decoder is not a `Loop` graph** — 42 nodes with two `LSTM`s, stepped from C#.
- New **"when not to bother"** section: profiling puts the encoder at 77.9% and `decoder_joint` at 21.2%, so this is **1.88× end to end**, not 2.5×. `decoder_joint`, `nemo128` and `silero_vad` were each measured and rejected rather than assumed — including the trap that `decoder_joint`'s first probe reported a clean partition count and CPU-identical timing *because* its partitions had silently fallen back on unbounded dims.

## Not in this PR

Docs + export tooling only; no runtime changes. Still open: the bucket ladder is unchosen (it should come from the segment lengths the diarizer/VAD produce, weighed against **4.4 GB of CoreML cache per bucket**), `Parakeet.cs` has no CoreML path, fp16 is untested, and nothing is published to HF. Full log in `docs/investigations/parakeet_coreml_encoder_investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScgtSfnRpoWAUzFrzGWDyo