### PR TITLE
hf: document the Parakeet CoreML encoder buckets on the model card

### DIFF
--- a/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
+++ b/scripts/hf_readmes/sortformer_parakeet_onnx/README.md
@@ -34,6 +34,7 @@ co-located here so a single download brings up the full pipeline.
 - **DFT-basis mel frontend replaces `torch.stft`.** ORT's STFT op diverged from NeMo (cosine ≈ 0.23 on first inspection); the replacement uses precomputed cos/sin basis matrices as Conv1D weights, with center-padded windows and standard ops only. Restored bit-for-bit parity to the NeMo reference.
 - **Streaming Sortformer 6→3 ONNX contract.** NeMo's `concat_and_pad()` isn't ONNX-traceable; the custom exporter replaces dynamic per-batch slicing with fixed-shape ops at 992 chunk frames (124 subsampled at 8× downsampling). Inputs: `chunk, chunk_lengths, spkcache, spkcache_lengths, fifo, fifo_lengths`. Outputs: `spkcache_fifo_chunk_preds, chunk_pre_encode_embs, chunk_pre_encode_lengths`.
 - **CoreML-compilable Sortformer variant for Apple Silicon.** The stock diarization graph cannot be compiled by ONNX Runtime's CoreML EP at all (`Failed to create MLModel … error code: -14`), so the Neural Engine was unreachable on macOS. `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` is a fully static re-export plus four value-preserving graph rewrites that compile as a **single** CoreML partition — 51.5 ms/chunk vs 171.8 ms on CPU (M5, ORT 1.29.0). It is a **steady-state-only** graph with a different input contract; read [Sortformer CoreML variant](#sortformer-coreml-variant) before using it.
+- **CoreML-compilable Parakeet encoder for Apple Silicon.** The stock encoder cannot be compiled by the CoreML EP either (same `error code: -14`, 84 partitions). `encoder-model.coreml-<frames>.onnx` are static-shape buckets that take the padding mask as an **input** (`pad_keep`) rather than baking a constant length, so they compile as a **single** partition and stay exact at any true length ≤ the bucket — 58.2 ms vs 146.9 ms on CPU at a 10 s bucket, ~2.5× at every size. They reuse the existing `encoder-model.onnx.data`, so they add no weight download. Different input contract; read [Parakeet CoreML encoder buckets](#parakeet-coreml-encoder-buckets) first.
 - **Dynamic-batch encoder + dynamic-batch joint decoder** for Parakeet TDT (preprocessor still batch-1 post-export). INT8 variants of encoder, decoder-joint, and Sortformer ship for CPU-only inference.
 - **Chunk-by-chunk parity diagnostic** ([`compare_sortformer_chunk_outputs.py`](https://github.com/christopherthompson81/vernacula/blob/main/scripts/nemo_export/compare_sortformer_chunk_outputs.py)) compares NeMo vs ONNX state evolution across streaming chunks to localise drift to either model output or carry-state.
 - **Preprocessor export sweep** ([`tune_nemo128_export.py`](https://github.com/christopherthompson81/vernacula/blob/main/scripts/nemo_export/tune_nemo128_export.py)) scores wrapper / custom / DFT modes against a legacy reference with feature-level and encoder-output deltas — the tooling that picked the DFT path in the first bullet.
@@ -51,6 +52,7 @@ co-located here so a single download brings up the full pipeline.
 | `diar_streaming_sortformer_4spk-v2.1.onnx` | [`nvidia/diar_streaming_sortformer_4spk-v2.1`](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) | Streaming 4-speaker diarization |
 | `diar_streaming_sortformer_4spk-v2.1_int8.onnx` | (quantized) | INT8-quantized diarization |
 | `diar_streaming_sortformer_4spk-v2.1.coreml.onnx` | Sortformer | Static steady-state diarization graph for the CoreML EP — **different contract**, see below |
+| `encoder-model.coreml-{400,1000,2000,3000}.onnx` | Parakeet TDT v3 | Static-shape encoder buckets for the CoreML EP — **different contract**, reuse `encoder-model.onnx.data`, see below |
 | `sortformer/diar_streaming_sortformer_4spk-v2.1.onnx` | Sortformer | Same graph in subdir layout for legacy clients |
 | `silero_vad.onnx` | [snakers4/silero-vad](https://github.com/snakers4/silero-vad) | Voice activity detection |
 | `config.json`, `manifest.json` | Vernacula | Runtime config + per-file MD5 hashes |
@@ -171,6 +173,89 @@ python scripts/nemo_export/coreml_optimize_sortformer.py \
 The techniques generalize; see
 [`docs/coreml_onnx_playbook.md`](https://github.com/christopherthompson81/vernacula/blob/main/docs/coreml_onnx_playbook.md).
 
+## Parakeet CoreML encoder buckets
+
+`encoder-model.coreml-{400,1000,2000,3000}.onnx` are static-shape re-exports of the
+Parakeet encoder that ONNX Runtime's CoreML EP compiles as a **single partition**. The
+stock `encoder-model.onnx` cannot be compiled by it at all — `Failed to create MLModel …
+error code: -14`, 84 partitions — so the Neural Engine was unreachable for ASR on macOS.
+
+**These four files add no weight download.** Their external weights are byte-identical to
+the `encoder-model.onnx.data` already in this repo (md5 `2f53c7ed168d73ea305ac2f53bdac097`)
+and every bucket points at that same file, so each bucket costs only its own graph:
+10 / 24 / 48 / 71 MiB. Keep `encoder-model.onnx.data` beside them.
+
+### Contract — different from `encoder-model.onnx`
+
+| | |
+|---|---|
+| in | `audio_signal [1, 128, F]` — mel features, zero-padded to the bucket's `F` |
+| in | `pad_keep [1, F]` — `1.0` for a real mel frame, `0.0` for padding |
+| out | `outputs [1, 1024, T]` |
+
+`F` is 400 / 1000 / 2000 / 3000 mel frames (4 / 10 / 20 / 30 s at a 10 ms hop);
+`T` is 50 / 125 / 250 / 375.
+
+Two caller obligations, **both of which fail silently rather than loudly**:
+
+1. **`pad_keep` must reflect the true frame count.** Passing all-ones for a short
+   segment is exactly the "bake the length" behaviour this export exists to avoid; it
+   moves the encoder output by 0.17–0.24 on valid frames and changes the transcript by
+   2–4% WER on 8–20 s segments, worse on short ones.
+2. **There is no `encoded_lengths` output**, because there is no `length` input. Compute
+   it yourself by folding the subsampler geometry —
+   `out = (in + pad0 + pad1 - kernel) // stride + 1`, three ×2 stages with kernel 3 and
+   padding 1+1 for this checkpoint — and ignore output frames past it.
+
+Within those, the graph is **exact at any true length ≤ the bucket**: the padding mask is
+an input rather than a baked constant, so nothing is approximated.
+
+### Why a mask input rather than the Sortformer recipe
+
+The Sortformer variant above reaches one partition by making every length a graph
+constant. Parakeet's segment lengths are arbitrary, so a constant length would be wrong
+for essentially every call, with no one-inference-per-file escape hatch. Instead the mask
+leaves the graph and becomes an input. Note the length feeds masking at **four**
+resolutions in NeMo's conformer — `MaskedConvSequential` re-masks between every strided
+conv in the subsampler, on top of the attention and conv-module masks — and all four are
+exact stride-2 decimations of the mel-rate mask, so one input drives them all.
+
+### Measured (M5, ORT 1.29.0)
+
+| | partitions | inference | CPU EP, same graph |
+|---|---|---|---|
+| stock `encoder-model.onnx` on CoreML | *fails to compile*, 84 | — | — |
+| bucket 400 (4 s) | **1** | **34.9 ms** | 87.2 ms |
+| bucket 1000 (10 s) | **1** | **58.2 ms** | 146.9 ms |
+| bucket 2000 (20 s) | **1** | **110.9 ms** | 279.4 ms |
+| bucket 3000 (30 s) | **1** | **165.2 ms** | 445.7 ms |
+
+≈ **2.5× the CPU EP at every size** (stock graph on CPU at 1000 frames: 143.6 ms).
+Parity against the stock encoder is 2e-7…6e-6 on real speech with identical transcripts
+through the full TDT decode; the mask rewrite itself is bit-exact (`0.000E+00`) in PyTorch.
+
+Unlike the Sortformer variant these need **no** post-processing pass and carry **no**
+load-level restriction — they load at any `GraphOptimizationLevel`.
+
+⚠ **Budget for the compiled cache: ~4.4 GB per bucket**, because the EP stores the weights
+twice (once in the `.mlpackage`, once in the compiled `.mlmodelc`). That, not download
+size, is what should decide how many buckets you deploy.
+
+⚠ **Not yet wired into Vernacula.** These are published so the runtime work can proceed
+against a fixed artifact; the app has no CoreML path for Parakeet yet, and which buckets
+it will ship is still open. End to end the encoder is ~78% of ASR time, so a 2.5× there is
+~1.9× overall — the TDT decoder's per-step `LSTM` is the remaining share and does not
+benefit from CoreML (measured: 0.652 ms vs 0.643 ms on CPU).
+
+Built with
+[`export_parakeet_coreml_encoder.py`](https://github.com/christopherthompson81/vernacula/blob/main/scripts/nemo_export/export_parakeet_coreml_encoder.py):
+
+```bash
+python scripts/nemo_export/export_parakeet_coreml_encoder.py \
+  --nemo parakeet-tdt-0.6b-v3.nemo --output-dir out \
+  --frames 400 --frames 1000 --frames 2000 --frames 3000
+```
+
 ## Export provenance
 
 Exported via [`scripts/nemo_export/`](https://github.com/christopherthompson81/vernacula/tree/main/scripts/nemo_export)
@@ -179,6 +264,7 @@ in the [Vernacula](https://github.com/christopherthompson81/vernacula) repo, whi
 - `export_parakeet_nemo_to_onnx.py` — Parakeet `.nemo` → split ONNX with TDT decoder state wired explicitly
 - `export_sortformer_nemo_to_onnx.py` — Streaming Sortformer `.nemo` → six-input / three-output ONNX contract
 - `export_silero_vad_to_onnx.py` — Silero VAD → ONNX
+- `export_parakeet_coreml_encoder.py` — Parakeet encoder → static-shape CoreML buckets with the padding mask hoisted to an input
 
 The Parakeet export traces the RNNT/TDT decoder loop into a separate joint
 graph so each step is a fixed-shape ORT call. Sortformer is exported as a


### PR DESCRIPTION
Follow-up to #179. The artifacts are now published; this syncs the repo's copy of the model card, which `upload_to_hf.py` treats as the single source of truth for what's on HF.

## What was published

`encoder-model.coreml-{400,1000,2000,3000}.onnx` → [`christopherthompson81/sortformer_parakeet_onnx`](https://huggingface.co/christopherthompson81/sortformer_parakeet_onnx), and the manifest extended **10 → 14 entries**.

The manifest was merged into the live one rather than regenerated: every original entry was verified byte-identical before upload and `version: 2` preserved. Confirmed against the published copy afterwards — all 10 originals intact and unchanged.

## Two things the card has to carry that the filenames don't

1. **The contract differs from `encoder-model.onnx`** — `pad_keep` in, no `encoded_lengths` out — and *both* caller obligations fail silently rather than loudly. An all-ones `pad_keep` is exactly the bake-the-length behaviour the export exists to avoid (2–4% WER); there's no length output to trim by, so callers must fold the subsampler geometry themselves.
2. **The weights are byte-identical to the already-published `encoder-model.onnx.data`** and every bucket points at it. So the four files cost ~153 MiB of graphs and **no weight download** — but only while the sidecar stays beside them, which is worth saying out loud.

It also records the ~4.4 GB of compiled CoreML cache per bucket (the thing that should decide how many get deployed), and that these aren't wired into the app yet — so nobody reads the 2.5× as a shipped end-to-end number. It's ~1.9× overall, since the encoder is ~78% of ASR time.

## Verified after upload

- published md5s match the manifest (`112bd440…` round-tripped local → remote → manifest)
- a **freshly downloaded** bucket, run against the **already-published** sidecar: 7/7 identical transcripts, parity 1.7e-07…4.2e-07

Docs only — no runtime or export changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScgtSfnRpoWAUzFrzGWDyo