### PR TITLE
build: default EP to what the architecture can actually run

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,8 +17,24 @@
        each csproj body, so the version below is decided first: a project that sets EP in its own
        PropertyGroup would be setting it too late and would restore, say, a DirectML package at the
        CUDA version, which does not exist. Pass EP on the command line, or set it in this file. -->
+  <!-- ⚠ THE EP DEFAULT HAS TO KNOW THE ARCHITECTURE, so the arch is worked out first. Defaulting
+       to Cuda unconditionally made `dotnet run` fail on Apple Silicon with "EP=Cuda is x64-only
+       ... use -p:EP=Cpu": an error telling the developer to type the one value the build could
+       have worked out for itself, on every single build. There is no CUDA runtime for arm64 at all, so
+       Cuda is never a possible default there; it is only a sensible one on x64.
+
+       Note the runtime identifier wins over the host when publishing cross-platform, since the
+       host architecture says nothing about the target then. RuntimeIdentifier set in a csproj BODY
+       arrives too late to be seen here and falls back to the host, which is correct for a local
+       build and why the guard below re-checks at execution time. -->
   <PropertyGroup>
-    <EP Condition="'$(EP)' == ''">Cuda</EP>
+    <_OrtTargetArch Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier.Substring($([MSBuild]::Add($(RuntimeIdentifier.LastIndexOf('-')), 1))))</_OrtTargetArch>
+    <_OrtTargetArch Condition="'$(_OrtTargetArch)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant())</_OrtTargetArch>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EP Condition="'$(EP)' == '' AND '$(_OrtTargetArch)' == 'x64'">Cuda</EP>
+    <EP Condition="'$(EP)' == ''">Cpu</EP>
     <OnnxRuntimeVersion Condition="'$(EP)' == 'DirectML'">1.24.4</OnnxRuntimeVersion>
     <OnnxRuntimeVersion Condition="'$(OnnxRuntimeVersion)' == ''">1.29.0</OnnxRuntimeVersion>
   </PropertyGroup>
@@ -93,10 +109,7 @@
 
        The runtime identifier wins when publishing cross-platform, since the host architecture says
        nothing about the target then. -->
-  <PropertyGroup>
-    <_OrtTargetArch Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier.Substring($([MSBuild]::Add($(RuntimeIdentifier.LastIndexOf('-')), 1))))</_OrtTargetArch>
-    <_OrtTargetArch Condition="'$(_OrtTargetArch)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant())</_OrtTargetArch>
-  </PropertyGroup>
+  <!-- _OrtTargetArch is computed near the top of this file, because the EP default needs it. -->
 
   <Target Name="RejectCudaOffX64"
           Condition="'$(EP)' == 'Cuda' AND '$(_OrtTargetArch)' != 'x64'">

--- a/docs/building.md
+++ b/docs/building.md
@@ -24,16 +24,36 @@ rm -f /path/to/models/*.opt.*
 
 The first run after that is slower while the graphs are rebuilt.
 
+## Execution provider (`-p:EP=`)
+
+`EP` selects which ONNX Runtime package is restored: `Cuda`, `Cpu` or `DirectML`.
+
+**It defaults to whatever the architecture can actually run** — `Cuda` on x64, `Cpu`
+everywhere else — so on Apple Silicon (and any other arm64 host) a plain `dotnet build` or
+`dotnet run` is correct and needs no flag. There is no CUDA build of ONNX Runtime for
+arm64, so `Cuda` was never a possible default there; it only ever produced a build error
+telling you to pass the one value the build could work out for itself.
+
+Pass `EP` explicitly to override: a CPU-only build on an x64 machine, or DirectML on
+Windows. `-p:EP=Cuda` on arm64 is still rejected, with an error saying why.
+
+⚠ On macOS, `Cpu` is also the build that carries the **CoreML and WebGPU** natives — the
+plain `osx-arm64` ONNX Runtime package is the one that ships them. "CPU" names the package,
+not the providers you end up with.
+
 ## Vernacula.CLI
 
 ```bash
 cd src/Vernacula.CLI
 
-# GPU (CUDA)
+# GPU (CUDA) — the default on x64
 dotnet build -c Release -p:EP=Cuda -p:Platform=x64
 
 # CPU only
 dotnet build -c Release -p:EP=Cpu -p:Platform=x64
+
+# Apple Silicon: no flag needed
+dotnet build -c Release
 ```
 
 ## Vernacula.Avalonia


### PR DESCRIPTION
`dotnet run --project src/Vernacula.Avalonia -f net10.0` fails on Apple Silicon:

```
error EP=Cuda is x64-only: Microsoft.ML.OnnxRuntime.Gpu ships win-x64 and linux-x64
natives and nothing for arm64 ... Use -p:EP=Cpu on this platform.
```

`EP` defaulted to `Cuda` unconditionally. There is no CUDA build of ONNX Runtime for arm64 at all, so on every arm64 host that default wasn't merely suboptimal — it was **impossible**, and the build's only response was to tell the developer to type the one value it could have worked out for itself. On every build.

It now defaults to **`Cuda` on x64, `Cpu` everywhere else** — exactly what the guard was already asserting.

The guard stays. An explicit `-p:EP=Cuda` on arm64 is still an error: that's someone stating a wrong intention, which is different from declining to state one.

This needed the architecture known *before* the EP default rather than after, so `_OrtTargetArch` moves to the top of the file. Its "runtime identifier wins over the host" rule is unchanged, and the guard still re-checks at execution time.

## Verified on arm64

| | result |
|---|---|
| bare `dotnet build` | succeeds, `EP=Cpu` |
| `-p:EP=Cuda` | still rejected, same message |
| `-p:EP=Cudaa` | still rejected as unknown |
| `-p:RuntimeIdentifier=linux-x64` | still defaults to `Cuda` |
| test suite, no flag | 94 passed |

## Docs

`docs/building.md` gains a section on what `EP` selects and when it needs passing — including the bit that's easy to get backwards on macOS: `Cpu` is also the package that carries the **CoreML and WebGPU** natives, so it names the package, not the providers you end up with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScgtSfnRpoWAUzFrzGWDyo