### PR TITLE
docs: make the Windows publish command pasteable as-is

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -74,11 +74,16 @@ dotnet build -c Release -p:EP=Cuda -p:Platform=x64
 dotnet publish -c Release -f net10.0 -p:EP=Cuda -p:Platform=x64 \
   -r linux-x64 --self-contained true \
   -o ~/apps/vernacula-desktop
+```
 
-# The same on Windows
-dotnet publish -c Release -f net10.0-windows -p:EP=Cuda -p:Platform=x64 \
-  -r win-x64 --self-contained true \
-  -o %USERPROFILE%/apps/vernacula-desktop
+The same on Windows, in PowerShell — the line continuation is a backtick, not `\`:
+
+```powershell
+cd src/Vernacula.Avalonia
+
+dotnet publish -c Release -f net10.0-windows -p:EP=Cuda -p:Platform=x64 `
+  -r win-x64 --self-contained true `
+  -o "$env:USERPROFILE/apps/vernacula-desktop"
 ```
 
 For a Linux end-user install, the `install.sh` script at the repo root runs a self-contained publish and registers the `.desktop` entry for you — see [Installation](installation.md).


### PR DESCRIPTION
The Windows publish command sat inside the bash block as a comment, with `\` line
continuations and `%USERPROFILE%`:

```bash
# The same on Windows
dotnet publish -c Release -f net10.0-windows -p:EP=Cuda -p:Platform=x64 \
  -r win-x64 --self-contained true \
  -o %USERPROFILE%/apps/vernacula-desktop
```

Pasted into PowerShell — which is where a Windows user actually is — none of that works. `\`
is not a line continuation there, so the shell runs the first line on its own and then two
orphan fragments; and `%USERPROFILE%` is cmd syntax that PowerShell leaves as a literal, so
the output lands in a directory named `%USERPROFILE%`.

Now its own ```powershell block:

```powershell
cd src/Vernacula.Avalonia

dotnet publish -c Release -f net10.0-windows -p:EP=Cuda -p:Platform=x64 `
  -r win-x64 --self-contained true `
  -o "$env:USERPROFILE/apps/vernacula-desktop"
```

Backtick continuations, `$env:USERPROFILE`, and quoted — the default profile path contains a
space on plenty of machines. It repeats the `cd` so the block stands alone instead of
depending on having scrolled up and run the bash one, which is the whole point of splitting
it out.

Syntax verified by inspection; there is no Windows host here to run it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012REYzas6iF1tQXmfRuin6b
