### PR TITLE
fix(kokoro): a word-final vowel after a flap takes the tap ɾ, so it stays attached to its word

### DIFF
--- a/docs/investigations/kokoro_word_final_flap_investigation.md
+++ b/docs/investigations/kokoro_word_final_flap_investigation.md
@@ -1,0 +1,143 @@
+# Kokoro: a word-final vowel after a flap detaches from its word
+
+Reported from listening to a TTS export: in one sentence `data` sounded "almost date-like", as though the
+final vowel were not part of the word. Three earlier reports in the same session turned out to be lexicon
+defects in vernacula-phonemizer; this one is not, and the log records the two wrong mechanisms that were
+chased first, because both were plausible and both had supporting measurements.
+
+## Run 1 — 2026-09-11 11:15 — the duration hypothesis, and why it was wrong twice
+
+**First wrong answer.** Synthesized the reported phrase as a fragment and measured Kokoro's own `pred_dur`:
+the final vowel of `data` came out at 200ms. Concluded duration was not the problem and that the percept was
+a synthesis characteristic. That measurement was taken on a 46-rune fragment, which is not the utterance that
+was exported.
+
+**Second wrong answer.** Kokoro indexes its style vector by phoneme-string length (`ref_s = pack[len(ps)-1]`),
+so a longer input selects a later style row. Re-measuring at realistic lengths:
+
+```
+unit                 runes  refRow   data final vowel
+fragment                46      45   200ms
+the reported sentence  138     137    75ms
+a synthetic paragraph  346     345    50ms
+```
+
+A clean monotonic effect, and `KokoroTts.ChunkForSynthesis` packs to the 508-token BERT limit rather than to
+any prosodic unit — so long paragraphs do get the most compressed style rows. This looked like the answer and
+sentence-level chunking looked like the fix. It was still wrong: the real export's chunks are 39–396 chars and
+its five `data` tokens run 225–300ms, with no pathological compression. **A measurable effect is not
+automatically the reported one.**
+
+## Run 2 — 2026-09-11 11:40 — the real export, and the environment that actually conditions it
+
+Went to the exported job's sidecar (per-word timings) instead of reconstructing. Five `data` tokens; the
+reporter identified exactly one as wrong, and it is the LONGEST:
+
+```
+#   t        dur   context                    verdict
+1   21.43s  275ms  data -> were        (/w/)  fine
+2   41.03s  250ms  data -> collection  (/k/)  fine
+3   53.00s  300ms  data -> required    (/ɹ/)  BAD
+4   67.30s  225ms  data -> collection  (/k/)  fine
+5   73.52s  250ms  data -> collection  (/k/)  fine
+```
+
+Occurrences 3 and 4 are in the SAME chunk, which rules out every chunk-level explanation including the one
+from Run 1. Per-token durations for the two, from the same synthesis:
+
+```
+data -> /ɹ/   d=1  ˈ=3  A=3  T=3  ə=2    word 300ms   flap 75ms, vowel 50ms
+data -> /k/   d=1  ˈ=2  A=2  T=2  ə=2    word 225ms   flap 50ms, vowel 50ms
+```
+
+Before the rhotic the word inflates 33% — and the final schwa is the ONLY segment that does not inflate with
+it. The vowel ends up shorter than the consonant preceding it, which is what "too much space between the t
+and the a" describes. The reporter's phrasing, not any measurement of mine, is what located this.
+
+## Run 3 — 2026-09-11 11:55 — three candidate fixes, two of them wrong
+
+Substitutions tried in the real chunk, judged by ear:
+
+| variant | flap | vowel | verdict |
+|---|---|---|---|
+| `T` (current) | 75ms | 50ms | the bug |
+| `ː` added after the vowel | 75ms | 100ms | no better — lengthening the vowel is not the lever |
+| `ɐ` (near-open, vocab 70) | 75ms | 50ms | no better |
+| `ɾ` (tap, vocab 125) | 75ms | 50ms | **good** |
+| `d` (vocab 46) | 50ms | 50ms | **good**, but see below |
+
+`ɾ` and `T` have IDENTICAL flap durations, and `ɾ` still sounds right — so the flap:vowel ratio framing from
+Run 2 is not the whole story either; the substitution shifts the whole word's duration profile out of the bad
+state. Several different edits all work, so "which fixes it" stopped discriminating and the choice became
+which is safest.
+
+**`d` is disqualified.** It merges every flap minimal pair at the token level:
+
+```
+writer  ɹˈITəɹ -> ɹˈIdəɹ  ≡  rider   ɹˈIdəɹ
+latter  lˈæTəɹ -> lˈædəɹ  ≡  ladder  lˈædəɹ
+metal   mˈɛTəl -> mˈɛdəl  ≡  medal   mˈɛdəl
+atom    ˈæTəm  -> ˈædəm   ≡  Adam    ˈædəm
+```
+
+`T` is what preserves the underlying /t/. This is the argument that killed the change `KokoroFormat`'s own
+`("d̬", "d")` rule would otherwise have suggested by analogy — and it would not have shown up in any
+single-word test.
+
+**A global `T -> ɾ` is also unjustified.** A 10-flap passage (writer, noted, latter, meeting, better, little,
+water, metal, city, data) was judged good under BOTH the current `T` and an all-`ɾ` rendering. `T` is not
+broken in general, so swapping every flap to fix a rare environment is not warranted.
+
+## Run 4 — 2026-09-11 12:10 — how rare, and what actually conditions it
+
+Scanned every intervocalic flap in the whole export:
+
+```
+intervocalic flaps: 17
+  flap duration > following vowel: 4 (23.5%)
+
+  səpˈɔɹTɪŋ …   (supporting)  vowel word-INTERNAL, followed by ŋ   — not reported
+  ɹᵻlˈATᵻd …    (related)     word-INTERNAL, followed by d         — not reported
+  lˈɪməTᵻd …    (limited)     word-INTERNAL, followed by d         — not reported
+  dˈATə ɹikwˈ   (data)        vowel WORD-FINAL                     — the reported one
+```
+
+The ratio alone does not predict the percept: three rows share it and pass unnoticed. The discriminating
+feature is that the post-flap vowel is **word-final** — in the other three it is propped up by following
+consonants in the same word. That is the rule's actual condition.
+
+## Run 5 — 2026-09-11 12:20 — the guarded rule, and a scope estimate that was two orders of magnitude out
+
+```csharp
+private static readonly Regex WordFinalFlapRe =
+    new(@"T([əɐaeiouɑɔɛɪʊʌæɜAIOWYᵻ])(?=[ ,.;:!?…—]|$)", RegexOptions.Compiled);
+```
+
+Applied at the very end of `Render`, after the punctuation pass so the lookahead sees an attached mark, and
+en-us only. A stressed final vowel cannot match, because its stress mark sits between the `T` and the nucleus.
+
+**Scope was initially estimated at "maybe a dozen words" — reasoning from `data`'s shape without checking what
+else ends in flap + word-final vowel. The real figure is 1,356 lexicon rows:**
+
+```
+-y / -ie   700    city, pretty, duty, forty, activity, quality
+-a         396    data, beta, meta, pita
+other      260
+```
+
+`-ity` is one of the most productive suffixes in English, so this is a broad change, not a contained special
+case — which removed the main argument for preferring it over a global swap, and made `city` (standing in for
+700 words) the real acceptance test rather than `data`. Confirmed good by ear on a passage carrying `data`,
+`beta` and `city` as targets alongside `writer`, `latter`, `meeting`, `better`, `little`, `water`, `metal`,
+`noted`, `limited`, `supporting`, `related` as controls: `T` count 15 → 11, only the three targets moved.
+
+`dotnet test` on Vernacula.Tts.Tests: 184 passed, 4 skipped.
+
+### What this cost, and the lesson worth keeping
+
+Two fixes were proposed and nearly built on mechanisms that were real, measurable, and not the cause —
+chunk-length compression most of all, which would have shipped as sentence-level chunking and changed nothing
+about this bug, since the good and bad instances share a chunk. What finally isolated it was going to the
+actual exported artifact and its per-word sidecar rather than reconstructing the utterance, and taking the
+reporter's description of the artifact ("space between the t and the a") as the primary evidence. A/B WAVs
+sent for each hypothesis are what kept each wrong turn to one round instead of shipping.

--- a/src/Vernacula.Tts.Base/KokoroFormat.cs
+++ b/src/Vernacula.Tts.Base/KokoroFormat.cs
@@ -56,6 +56,20 @@ public static class KokoroFormat
         // ᵻ (U+1D7B) is deliberately unmapped: it is Kokoro vocab id 177, not out-of-vocab.
     ];
 
+    // A flap whose following vowel is WORD-FINAL and unstressed, realised as the tap ɾ (vocab 125)
+    // rather than the flap token T (vocab 36). Kokoro's duration predictor over-allocates T in this
+    // position — measured at 75ms against a 50ms vowel, where a word-INTERNAL flap gets 50ms — and a
+    // word-final vowel has no following segment to prop it up, so the vowel ends up shorter than the
+    // consonant before it and detaches from the word ("data" heard as "date" plus a stray schwa).
+    // ⚠ The guard is the LOOKAHEAD, and it is load-bearing: word-internal flaps (writer, meeting,
+    // better, related) must keep T, because T is what preserves the underlying /t/ — mapping them to
+    // d instead would merge writer/rider, latter/ladder, metal/medal at the token level. A stressed
+    // final vowel never matches either, since its stress mark sits between the T and the nucleus.
+    // Scope is ~1,356 lexicon words: the -a nouns (data, beta, meta) and, far more numerous, the
+    // -ity/-y family (city, quality, activity). docs/investigations/kokoro_word_final_flap_investigation.md.
+    private static readonly Regex WordFinalFlapRe =
+        new(@"T([əɐaeiouɑɔɛɪʊʌæɜAIOWYᵻ])(?=[ ,.;:!?…—]|$)", RegexOptions.Compiled);
+
     // A punctuation token the phonemizer emitted on its own, with the space that precedes it.
     // Kokoro's training data attaches punctuation to the word before it (`wˈɜɹld.`), and the
     // word-alignment code counts a run of non-space tokens as one word, so it must not stand alone.
@@ -88,6 +102,8 @@ public static class KokoroFormat
 
         ps = ps.Replace("o", "ɔ");         // misaki: espeak < 1.52 compatibility; O is already consumed
         ps = DetachedPunctRe.Replace(ps, "$1");
+        // en-us only: flapping is American, and en-GB never produces the T token.
+        if (!british) ps = WordFinalFlapRe.Replace(ps, "ɾ$1");   // after punctuation, so the lookahead sees it
         return ps;
     }
 }

--- a/tests/Vernacula.Tts.Tests/KokoroFormatTests.cs
+++ b/tests/Vernacula.Tts.Tests/KokoroFormatTests.cs
@@ -26,6 +26,29 @@ public class KokoroFormatTests
         => Assert.Equal(expected, KokoroFormat.Render(ipa));
 
     [Theory]
+    // A word-FINAL unstressed vowel after a flap takes the tap ɾ, not T: Kokoro's duration predictor
+    // over-allocates T there and the vowel detaches from the word.
+    [InlineData("ðə dˈeᶦt̬ə ɹᵻkwˈaᶦɚd", "ðə dˈAɾə ɹᵻkwˈIəɹd")]
+    // …including before a clause mark, which the punctuation pass has already attached by then.
+    [InlineData("ðə bˈeᶦt̬ə , ðə d̬ˈeᶦt̬ə .", "ðə bˈAɾə, ðə dˈAɾə.")]
+    // the -ity/-y family is the bulk of the rule's scope
+    [InlineData("ðə sˈɪt̬i hæz kwˈɑːlᵻt̬i", "ðə sˈɪɾi hæz kwˈɑlᵻɾi")]
+    // ⚠ word-INTERNAL flaps keep T — it is what preserves the underlying /t/, so writer stays
+    // distinct from rider. Mapping these to d would merge the pair at the token level.
+    [InlineData("ɹˈaᶦt̬ɚ ɹˈaᶦd̬ɚ lˈæt̬ɚ lˈæd̬ɚ", "ɹˈITəɹ ɹˈIdəɹ lˈæTəɹ lˈædəɹ")]
+    [InlineData("mˈiːt̬ɪŋ bˈɛt̬ɚ ɹᵻlˈeᶦt̬ᵻd lˈɪmᵻt̬ᵻd", "mˈiTɪŋ bˈɛTəɹ ɹᵻlˈATᵻd lˈɪmᵻTᵻd")]
+    public void WordFinalFlapBecomesATap(string ipa, string expected)
+        => Assert.Equal(expected, KokoroFormat.Render(ipa));
+
+    [Fact]
+    public void TheTapIsAKokoroToken()
+    {
+        var ps = KokoroFormat.Render("ðə dˈeᶦt̬ə");
+        Assert.Contains('ɾ', ps);
+        foreach (var ch in ps) Assert.True(KokoroVocab.Contains(ch), $"'{ch}' is not a Kokoro token");
+    }
+
+    [Theory]
     // GOAT is Q, length marks stay, SQUARE is ɛː, NEAR stays ɪə
     [InlineData("həlˈəᶷ wˈɜːɫd . ðˈɛə hˈɪə", "həlˈQ wˈɜːld. ðˈɛː hˈɪə")]
     [InlineData("ɡˈəᶷ hˈəᶷm nˈaᶷ !", "ɡˈQ hˈQm nˈW!")]


### PR DESCRIPTION
Reported from a TTS export: `data` sounded "almost date-like" — the final vowel not reading as part of the word.

## Mechanism

Kokoro's duration predictor inflates the word before a following rhotic, but the word-final vowel is the one segment that doesn't inflate with it:

```
data -> /ɹ/   d=1  ˈ=3  A=3  T=3  ə=2    word 300ms   flap 75ms, vowel 50ms   <- reported
data -> /k/   d=1  ˈ=2  A=2  T=2  ə=2    word 225ms   flap 50ms, vowel 50ms
```

The vowel ends up shorter than the consonant in front of it and detaches. Both rows are from the **same chunk of the same export**, which rules out every chunk-level explanation.

Rendering that vowel's flap as the tap `ɾ` (vocab 125) instead of `T` (36) fixes it — confirmed by ear on the original chunk. Applied at the end of `Render`, after the punctuation pass so the lookahead sees an attached mark, en-us only.

## The guard is load-bearing

Word-**internal** flaps must keep `T`, because `T` preserves the underlying /t/:

```
writer  ɹˈITəɹ -> ɹˈIdəɹ  ≡  rider
latter  lˈæTəɹ -> lˈædəɹ  ≡  ladder
metal   mˈɛTəl -> mˈɛdəl  ≡  medal
atom    ˈæTəm  -> ˈædəm   ≡  Adam
```

This is why the obvious analogy to this file's own `("d̬", "d")` rule is wrong — mapping flaps to `d` merges every one of those pairs at the token level, and no single-word test would have shown it.

A global `T -> ɾ` is also unjustified: a 10-flap passage (writer, noted, latter, meeting, better, little, water, metal, city, data) was judged good under **both** the current `T` and an all-`ɾ` rendering. `T` isn't broken in general.

## Scope

1,356 lexicon words — the `-a` nouns (data, beta, meta) and, far more numerous, the `-ity`/`-y` family (city, quality, activity). That makes **`city` the real acceptance test, not `data`**. Confirmed good by ear on a passage carrying data/beta/city as targets against writer, latter, meeting, better, little, water, metal, noted, limited, supporting, related as controls — `T` count 15 → 11, only the three targets moved.

## Tests

Cover the tap, the punctuation interaction, the `-ity` family, and the minimal pairs that must not move. `Vernacula.Tts.Tests`: 184 passed, 4 skipped.

## Log

`docs/investigations/kokoro_word_final_flap_investigation.md` records the two mechanisms chased first — both real and measurable, neither the cause. The chunk-length one (`ref_s = pack[len(ps)-1]`, so longer input selects a more compressed style row) would have shipped as sentence-level chunking and fixed nothing here, since the good and bad instances share a chunk. Kept because the effect is real and will mislead the next person the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkxqpYvUbjCpRDnFiNiVfx