### PR TITLE
cuda: measure cudnn_conv_algo_search across the other sessions (#191)

### DIFF
--- a/docs/investigations/cudnn_conv_algo_investigation.md
+++ b/docs/investigations/cudnn_conv_algo_investigation.md
@@ -1,0 +1,92 @@
+# cudnn_conv_algo_search across the app's CUDA sessions (#191)
+
+#190 found that ORT's CUDA EP defaults `cudnn_conv_algo_search` to **EXHAUSTIVE**, which
+benchmarks every cuDNN algorithm the first time it sees a conv input **shape** — and its algo
+cache does not retain every shape, so it re-tunes on every shape *change*. Kokoro paid 2.93x for
+that, because every synthesis call is a different chunk length.
+
+Only Kokoro opted in. This log asks the obvious follow-up: which of the app's other CUDA sessions
+are paying the same tax, and which would be hurt by "fixing" them.
+
+## Run 1 — 2026-09-11 18:05 — a generic sweep, and why it was invalid
+
+Generic probe: for each model, fill every symbolic axis with a scaled size, cycle five sizes, time
+EXHAUSTIVE vs DEFAULT.
+
+⚠ **Half the table was measuring a degenerate graph.** The generic shape-filler set every
+`length` input to **0** — parakeet, indicconformer and sortformer all take an explicit length
+alongside their features — and gave VoxLingua 640 audio samples, i.e. 40 ms. An encoder told its
+input is zero-length does not do the work being timed. `chatterbox flow_encoder` came out at
+0.87x (rejected) under those shapes and 1.17x (accepted) under real ones, which is the whole
+argument for redoing it.
+
+Generic shape inference is not good enough for this question; shapes are hand-built per model
+from here on, with every length input carrying the matching count.
+
+## Run 2 — 2026-09-11 18:15 — the real table
+
+Realistic shapes, five sizes cycled per model (so the shape CHANGES, which is the entire
+mechanism — timing one repeated shape measures the case where EXHAUSTIVE amortizes and reports
+the opposite answer, which is how `tests/KokoroPerf` misled in #190). RTX 3090, ORT 1.29:
+
+```
+model                             EXHAUSTIVE    DEFAULT    gain   verdict
+parakeet encoder                      401.7ms   1319.4ms   0.30x  EXHAUSTIVE wins
+indicconformer encoder                625.4ms   1129.0ms   0.55x  EXHAUSTIVE wins
+sortformer                            321.3ms    547.7ms   0.59x  EXHAUSTIVE wins
+diarizen segmentation                 218.5ms    270.8ms   0.81x  EXHAUSTIVE wins
+chatterbox flow_encoder                43.9ms     37.7ms   1.17x  DEFAULT wins
+chatterbox mel2wav (vocoder)          978.0ms    703.5ms   1.39x  DEFAULT wins
+voxlingua107 LID                      161.3ms     92.3ms   1.75x  DEFAULT wins
+chatterbox cfm_estimator              407.1ms    187.3ms   2.17x  DEFAULT wins
+diarizen wespeaker                    276.7ms     89.6ms   3.09x  DEFAULT wins
+```
+
+**The split is architectural, not incidental.** Conformer/transformer ASR encoders — depthwise
+separable convs with many distinct shapes — want EXHAUSTIVE and are hurt badly without it
+(Parakeet is **3.3x slower** on DEFAULT). Plain CNN stacks, vocoders and speaker-embedding nets
+want DEFAULT.
+
+⚠ This retroactively justifies #190's per-caller design. A global flip — the tempting reading of
+"Kokoro got 1.55x from this" — would have made ASR transcription over three times slower.
+
+## Run 3 — 2026-09-11 18:25 — does it change the numbers?
+
+Same inputs, both settings:
+
+```
+model                          max|diff|     rel L2    cosine
+diarizen wespeaker             5.83e-04   2.81e-03    0.999996428
+chatterbox mel2wav (vocoder)   1.00e-02   3.05e-03    0.999995360
+voxlingua107 LID (logits)      1.09e-03   3.93e-05    0.999999999
+chatterbox cfm_estimator       3.12e-02   1.07e-03    0.999999434
+```
+
+Ordinary fp32 conv-algorithm variation. For scale: TF32, which the repo already found compounds
+into *audible* noise through OmniVoice's diffusion loop, is ~1e-2 — an order of magnitude larger
+than this.
+
+## Taken, and deliberately not taken
+
+**Taken** — one-shot graphs, large gain, verified benign:
+
+- `WeSpeakerEmbedder` (3.09x). Runs once per speaker segment, so a long recording makes many
+  calls, each a different number of frames. Embedding cosine 0.999996, far inside what clustering
+  thresholds care about.
+- `VoxLinguaLid` (1.75x). Once per file, each a different clip length. Logits effectively
+  identical (cosine 1.000000000).
+
+**Not taken:**
+
+- ⚠ `chatterbox cfm_estimator` (2.17x) is an **iterative** CFM solver, called ~32 times per
+  synthesis, so a per-step difference compounds — precisely the failure mode TF32 produced in
+  OmniVoice. A single-step numerical check is not evidence about the integrated result. Needs a
+  real synthesis and a listen before adopting.
+- `chatterbox mel2wav` (1.39x) and `flow_encoder` (1.17x) are the **fallback** split graphs; the
+  path that normally runs is the merged `conditional_decoder_loop.onnx`, which was not measured
+  and contains the same iterative loop. Changing the fallback alone buys almost nothing.
+- The four EXHAUSTIVE-wins models keep ORT's default, which is already what they get.
+
+⚠ Measured with random inputs. That is sound for throughput and for the conv-algorithm delta, but
+it is not a quality check on real audio. The two changes taken are one-shot graphs whose outputs
+were compared directly; anything iterative needs the real thing.

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -525,7 +525,7 @@ public static class OrtSessionBuilder
     // ⚠ "DEFAULT" makes ORT log "Conv(...) running in Fallback mode. May be extremely slow." for
     // every decoder conv. Measured, that path is the FAST one here; the warning is not a defect
     // signal for this graph. docs/kokoro_onnx_investigation.md Run 24.
-    private static void AppendCuda(SessionOptions opts, bool disableTf32, string? convAlgoSearch = null)
+    public static void AppendCuda(SessionOptions opts, bool disableTf32, string? convAlgoSearch = null)
     {
         // Escape hatch for measuring the alternatives without a rebuild.
         convAlgoSearch = Environment.GetEnvironmentVariable("VERNACULA_ORT_CONV_ALGO") is { Length: > 0 } env

--- a/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
+++ b/src/Vernacula.Base/Inference/OrtSessionBuilder.cs
@@ -510,6 +510,17 @@ public static class OrtSessionBuilder
         }
     }
 
+    /// <summary>
+    /// Append the CUDA EP to <paramref name="opts"/>. Public because several sessions build their
+    /// own <see cref="SessionOptions"/> rather than going through <see cref="Create"/> and still
+    /// need these settings; prefer <see cref="Create"/> where you can.
+    /// </summary>
+    /// <param name="disableTf32">Force full-fp32 matmul. Needed wherever error compounds through
+    /// an iterative loop — see the note below.</param>
+    /// <param name="convAlgoSearch">cuDNN conv algorithm search strategy, or null for ORT's
+    /// default (EXHAUSTIVE). Which value wins depends on whether the graph's input SHAPE varies
+    /// per call, not on the model — measured per session in
+    /// docs/investigations/cudnn_conv_algo_investigation.md.</param>
     // Append the CUDA EP, optionally forcing full-fp32 matmul (use_tf32=0). TF32's ~1e-2
     // error is fine for one-shot models but COMPOUNDS catastrophically through OmniVoice's
     // iterative diffusion loop (audible noise) — see docs/omnivoice_onnx_investigation.md.

--- a/src/Vernacula.Base/VoxLinguaLid.cs
+++ b/src/Vernacula.Base/VoxLinguaLid.cs
@@ -32,6 +32,8 @@ namespace Vernacula.Base;
 /// </summary>
 public sealed class VoxLinguaLid : IDisposable
 {
+    private const string ConvAlgoSearch = "DEFAULT";   // see the CUDA branch below
+
     public const int SampleRate = 16_000;
     public const int NumClasses = 107;
     public const int EmbeddingDim = 256;
@@ -297,14 +299,19 @@ public sealed class VoxLinguaLid : IDisposable
                 case ExecutionProvider.Auto:
                     if (HardwareInfo.CanProbeCudaExecutionProvider())
                     {
-                        try { opts.AppendExecutionProvider_CUDA(0); }
+                        // cudnn_conv_algo_search=DEFAULT: every clip is a different number of
+                        // samples, so ORT's EXHAUSTIVE default re-benchmarks the convs on each
+                        // call and never amortizes. 1.75x measured (161 ms -> 92 ms over five
+                        // lengths, RTX 3090 / ORT 1.29), logits unchanged (cosine 1.000000000).
+                        // docs/investigations/cudnn_conv_algo_investigation.md.
+                        try { OrtSessionBuilder.AppendCuda(opts, disableTf32: false, ConvAlgoSearch); }
                         catch { /* fall through to CPU */ }
                     }
                     try { opts.AppendExecutionProvider_DML(0); }
                     catch { /* not available */ }
                     break;
                 case ExecutionProvider.Cuda:
-                    try { opts.AppendExecutionProvider_CUDA(0); }
+                    try { OrtSessionBuilder.AppendCuda(opts, disableTf32: false, ConvAlgoSearch); }
                     catch (EntryPointNotFoundException)
                     { throw new InvalidOperationException(HardwareInfo.CudaUnavailableMessage(providerMissing: true)); }
                     break;

--- a/src/Vernacula.Base/WeSpeakerEmbedder.cs
+++ b/src/Vernacula.Base/WeSpeakerEmbedder.cs
@@ -85,6 +85,13 @@ public sealed class WeSpeakerEmbedder : IDisposable
     /// <summary>Maximum audio (in seconds) taken from the centre of a region for embedding.</summary>
     public const int MaxEmbedWindowSec  = 5;
 
+    // Every embedding call is a different number of frames, so ORT's EXHAUSTIVE default
+    // re-benchmarks the convs on each one and never amortizes the tuning. Measured 3.09x
+    // (277 ms -> 90 ms over five varying lengths, RTX 3090 / ORT 1.29) with the embedding
+    // unchanged — cosine 0.999996 against EXHAUSTIVE, far inside what clustering cares about.
+    // docs/investigations/cudnn_conv_algo_investigation.md.
+    private const string ConvAlgoSearch = "DEFAULT";
+
     // ── Construction ───────────────────────────────────────────────────────
 
     /// <summary>
@@ -97,13 +104,6 @@ public sealed class WeSpeakerEmbedder : IDisposable
     /// When supplied, embeddings are projected 256→128 before clustering.
     /// </param>
     /// <param name="ep">ONNX execution provider.</param>
-    // Every embedding call is a different number of frames, so ORT's EXHAUSTIVE default
-    // re-benchmarks the convs on each one and never amortizes the tuning. Measured 3.09x
-    // (277 ms -> 90 ms over five varying lengths, RTX 3090 / ORT 1.29) with the embedding
-    // unchanged — cosine 0.999996 against EXHAUSTIVE, far inside what clustering cares about.
-    // docs/investigations/cudnn_conv_algo_investigation.md.
-    private const string ConvAlgoSearch = "DEFAULT";
-
     public WeSpeakerEmbedder(string modelPath, string? ldaDir = null,
         ExecutionProvider ep = ExecutionProvider.Auto)
     {

--- a/src/Vernacula.Base/WeSpeakerEmbedder.cs
+++ b/src/Vernacula.Base/WeSpeakerEmbedder.cs
@@ -97,6 +97,13 @@ public sealed class WeSpeakerEmbedder : IDisposable
     /// When supplied, embeddings are projected 256→128 before clustering.
     /// </param>
     /// <param name="ep">ONNX execution provider.</param>
+    // Every embedding call is a different number of frames, so ORT's EXHAUSTIVE default
+    // re-benchmarks the convs on each one and never amortizes the tuning. Measured 3.09x
+    // (277 ms -> 90 ms over five varying lengths, RTX 3090 / ORT 1.29) with the embedding
+    // unchanged — cosine 0.999996 against EXHAUSTIVE, far inside what clustering cares about.
+    // docs/investigations/cudnn_conv_algo_investigation.md.
+    private const string ConvAlgoSearch = "DEFAULT";
+
     public WeSpeakerEmbedder(string modelPath, string? ldaDir = null,
         ExecutionProvider ep = ExecutionProvider.Auto)
     {
@@ -137,12 +144,12 @@ public sealed class WeSpeakerEmbedder : IDisposable
                 case ExecutionProvider.Auto:
                     if (HardwareInfo.CanProbeCudaExecutionProvider())
                     {
-                        try { opts.AppendExecutionProvider_CUDA(0); } catch { }
+                        try { OrtSessionBuilder.AppendCuda(opts, disableTf32: false, ConvAlgoSearch); } catch { }
                     }
                     try { opts.AppendExecutionProvider_DML(0); }  catch { }
                     break;
                 case ExecutionProvider.Cuda:
-                    opts.AppendExecutionProvider_CUDA(0);
+                    OrtSessionBuilder.AppendCuda(opts, disableTf32: false, ConvAlgoSearch);
                     break;
                 case ExecutionProvider.DirectML:
                     opts.AppendExecutionProvider_DML(0);

--- a/tests/AsrBackendCoverage/SegmentedSynthesisBatchTests.cs
+++ b/tests/AsrBackendCoverage/SegmentedSynthesisBatchTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Vernacula.App.Models;
+using Vernacula.App.Services.Tts;
+using Vernacula.Tts.Base.Alignment;
+using Vernacula.Tts.Base.Markdown;
+using Xunit;
+
+namespace Vernacula.Tests.AsrBackendCoverage;
+
+/// <summary>
+/// Kokoro renders a GROUP of paragraphs per ONNX call (#190). The driver that arranges that
+/// lives in <see cref="SegmentedSynthesis"/> and is shared by every engine, so what it must not
+/// change is the part a user sees: paragraphs stream out in document order, each carrying its
+/// own audio, whether or not the engine batches.
+///
+/// These use fake synthesizers rather than a model, so they pin the arrangement itself —
+/// grouping, ordering and the solo first segment — which is exactly what an end-to-end run
+/// through a real engine cannot isolate.
+/// </summary>
+public class SegmentedSynthesisBatchTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "vernacula-tests", Guid.NewGuid().ToString("N"));
+
+    public SegmentedSynthesisBatchTests() => Directory.CreateDirectory(_dir);
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private const string Doc = """
+        One alpha.
+
+        Two bravo.
+
+        Three charlie.
+
+        Four delta.
+
+        Five echo.
+
+        Six foxtrot.
+        """;
+
+    // Audio a test can trace back to its segment: length encodes the paragraph's word count.
+    private static (float[], IReadOnlyList<AlignedWord>) Render(TextSegment seg)
+    {
+        var words = seg.Text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var audio = new float[100 * words.Length];
+        var aligned = words.Select((w, i) => new AlignedWord
+        {
+            Text = w, StartSeconds = i, EndSeconds = i + 1,
+        }).ToList();
+        return (audio, aligned);
+    }
+
+    private TtsRequest NewRequest(string tag) =>
+        new(Doc, Path.Combine(_dir, $"{tag}.wav"), "af_heart");
+
+    private (List<int> order, List<int> audioLengths, List<string> texts) Run(
+        int batchSize, bool batched, List<int> groupSizes)
+    {
+        var order = new List<int>();
+        var lens = new List<int>();
+        var texts = new List<string>();
+        SegmentedSynthesis.SegmentBatchSynthesizer? batchFn = null;
+        if (batched)
+            batchFn = (segs, _) =>
+            {
+                groupSizes.Add(segs.Count);
+                return segs.Select(Render).ToList();
+            };
+
+        SegmentedSynthesis.Run(
+            NewRequest(batched ? "batched" : "plain"), 24000, "test",
+            (seg, _) => Render(seg),
+            ev => { order.Add(ev.ChunkIndex); lens.Add(ev.Audio24k.Length); texts.Add(ev.ChunkText); },
+            null, CancellationToken.None, batchFn, batchSize);
+        return (order, lens, texts);
+    }
+
+    [Fact]
+    public void BatchingChangesNothingAUserSees()
+    {
+        var plainGroups = new List<int>();
+        var plain = Run(1, batched: false, plainGroups);
+        var batchGroups = new List<int>();
+        var batched = Run(4, batched: true, batchGroups);
+
+        Assert.Equal(plain.order, batched.order);                 // same streaming order
+        Assert.Equal(plain.audioLengths, batched.audioLengths);   // each paragraph keeps its own audio
+        Assert.Equal(plain.texts, batched.texts);
+        Assert.Equal(Enumerable.Range(0, plain.order.Count), plain.order);
+    }
+
+    [Fact]
+    public void TheFirstSegmentIsRenderedAloneSoPlaybackStartsNoLater()
+    {
+        var groups = new List<int>();
+        var r = Run(4, batched: true, groups);
+        // 6 paragraphs, batch 4: segment 0 solo (never handed to the batch fn), then 4, then 1.
+        Assert.Equal([4, 1], groups);
+        Assert.Equal(6, r.order.Count);
+    }
+
+    [Fact]
+    public void ASingleParagraphDocumentDoesNotBatch()
+    {
+        var groups = new List<int>();
+        var order = new List<int>();
+        SegmentedSynthesis.Run(
+            new TtsRequest("Only one.", Path.Combine(_dir, "one.wav"), "af_heart"), 24000, "test",
+            (seg, _) => Render(seg),
+            ev => order.Add(ev.ChunkIndex), null, CancellationToken.None,
+            (segs, _) => { groups.Add(segs.Count); return segs.Select(Render).ToList(); }, 4);
+        Assert.Empty(groups);
+        Assert.Equal([0], order);
+    }
+
+    [Fact]
+    public void AShortReturnFromTheBatchSynthesizerSaysSoPlainly()
+    {
+        // The delegate's contract is one result per segment, in order. Three backends can
+        // implement it; a short return must not surface as an IndexOutOfRange deep inside.
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            SegmentedSynthesis.Run(
+                NewRequest("short"), 24000, "test",
+                (seg, _) => Render(seg), null, null, CancellationToken.None,
+                (segs, _) => segs.Take(segs.Count - 1).Select(Render).ToList(), 4));
+        Assert.Contains("results for", ex.Message);
+    }
+}


### PR DESCRIPTION
Closes the measurement #191 asked for, and acts on it where the evidence supports acting.

## The answer is not "turn it on everywhere"

#190 found ORT's CUDA EP re-benchmarks a conv on every input **shape change**, and left only Kokoro opted in to `DEFAULT` on the suspicion other sessions paid the same tax. Measured on an RTX 3090 / ORT 1.29, cycling five realistic input sizes per model so the shape actually varies:

| model | gain from DEFAULT | verdict |
|---|---|---|
| diarizen wespeaker | **3.09×** | DEFAULT |
| chatterbox cfm_estimator | 2.17× | DEFAULT |
| voxlingua107 LID | **1.75×** | DEFAULT |
| chatterbox mel2wav (vocoder) | 1.39× | DEFAULT |
| chatterbox flow_encoder | 1.17× | DEFAULT |
| diarizen segmentation | 0.81× | EXHAUSTIVE |
| sortformer | 0.59× | EXHAUSTIVE |
| indicconformer encoder | 0.55× | EXHAUSTIVE |
| parakeet encoder | **0.30×** | EXHAUSTIVE |

⚠ **The split is architectural.** Conformer ASR encoders want EXHAUSTIVE and are hurt badly without it — Parakeet is **3.3× slower** on DEFAULT. Plain CNN stacks, vocoders and speaker-embedding nets want DEFAULT. A global flip, which is the tempting reading of "Kokoro got 1.55× from this", would have made transcription over three times slower. That is the case for #190's per-caller design rather than a global setting.

## Taken

- **`WeSpeakerEmbedder`** (3.09×) — runs once per speaker segment, so a long recording makes many calls, each a different frame count.
- **`VoxLinguaLid`** (1.75×) — once per clip, each a different length.

Both are one-shot graphs and their outputs were compared directly under both settings: embedding cosine **0.999996**, logits **1.000000000**. For scale, TF32 — which the repo already found compounds into audible noise through OmniVoice's diffusion loop — is ~1e-2, an order of magnitude larger than the differences here.

`OrtSessionBuilder.AppendCuda` is now public so these sites can reach it; they hand-roll their EP appending rather than going through `Create`.

## Deliberately not taken

- ⚠ **`cfm_estimator`'s 2.17× is real but it is an iterative CFM solver**, called ~32 times per synthesis, where a per-step difference compounds — precisely the failure mode TF32 produced in OmniVoice. A single-step numerical check says nothing about the integrated result. Needs a real synthesis and a listen.
- `mel2wav` and `flow_encoder` are the **fallback** split graphs. The path that normally runs is the merged `conditional_decoder_loop.onnx`, which was not measured and contains the same iterative loop, so changing the fallback alone buys close to nothing.
- The four EXHAUSTIVE-wins models keep ORT's default, which is already what they get.

## The first sweep was invalid

⚠ Kept in the log rather than quietly redone. A generic shape-filler set every `length` input to **0** — parakeet, indicconformer and sortformer all take one alongside their features — and gave VoxLingua **640 samples**, i.e. 40 ms. `flow_encoder` read 0.87× (reject) under those shapes and 1.17× (accept) under real ones. Generic shape inference is not good enough for this question.

## Test gap

#191 also listed `SegmentedSynthesis` as untestable because it is internal to `Vernacula.Avalonia`. That was my own error — the project already grants `InternalsVisibleTo` to `AsrBackendCoverage`, so no infrastructure was needed. Four tests now pin the batching driver with fake synthesizers, which is what an end-to-end run through a real engine cannot isolate:

- batching changes nothing a user sees (streaming order, per-paragraph audio, text)
- the first segment is rendered alone, so time-to-first-audio is unchanged
- a one-paragraph document does not batch
- a short return from the delegate fails with a clear message, not `IndexOutOfRange`

## Limits

⚠ Measured with random inputs. Sound for throughput and for the conv-algorithm delta, not a quality check on real audio — which is why only one-shot graphs whose outputs were compared directly were changed.

Tests: 225 + 95 + 184, all passing. Investigation: `docs/investigations/cudnn_conv_algo_investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkxqpYvUbjCpRDnFiNiVfx
